### PR TITLE
LNK-2206-Audit-log-database-performance-adjustments

### DIFF
--- a/Audit.Specification/StepDefinitions/CreateAuditEventStepDefinitions.cs
+++ b/Audit.Specification/StepDefinitions/CreateAuditEventStepDefinitions.cs
@@ -43,7 +43,7 @@ namespace LantanaGroup.Link.Audit.Specification.StepDefinitions
 
             //set up audit entity
             auditEntity = new AuditLog();
-            auditEntity.Id = AuditId.NewId();
+            auditEntity.AuditId = AuditId.NewId();
             auditEntity.FacilityId = FacilityId;
             auditEntity.ServiceName = ServiceName;
             auditEntity.CorrelationId = CorrelationId;
@@ -135,7 +135,7 @@ namespace LantanaGroup.Link.Audit.Specification.StepDefinitions
 
             Task<AuditLog> outcome = command.Execute(createAuditEventModel);
 
-            createdAuditEventId = outcome.Result.Id;
+            createdAuditEventId = outcome.Result.AuditId;
 
         }
 

--- a/Audit/Application/Audit/Queries/GetAuditEvent/GetAuditEventQuery.cs
+++ b/Audit/Application/Audit/Queries/GetAuditEvent/GetAuditEventQuery.cs
@@ -35,7 +35,7 @@ namespace LantanaGroup.Link.Audit.Application.Audit.Queries
             {
                 auditEvent = new AuditModel
                 {
-                    Id = result.Id.Value.ToString(),
+                    Id = result.AuditId.Value.ToString(),
                     FacilityId = result.FacilityId,
                     ServiceName = result.ServiceName,
                     EventDate = result.EventDate,

--- a/Audit/Application/Audit/Queries/GetAuditEventsList/GetAuditEventListQuery.cs
+++ b/Audit/Application/Audit/Queries/GetAuditEventsList/GetAuditEventListQuery.cs
@@ -8,9 +8,9 @@ namespace LantanaGroup.Link.Audit.Application.Audit.Queries
     public class GetAuditEventListQuery : IGetAuditEventListQuery
     {
         private readonly ILogger<GetAuditEventListQuery> _logger;
-        private readonly IAuditRepository _datastore;
+        private readonly ISearchRepository _datastore;
 
-        public GetAuditEventListQuery(ILogger<GetAuditEventListQuery> logger, IAuditRepository datastore) 
+        public GetAuditEventListQuery(ILogger<GetAuditEventListQuery> logger, ISearchRepository datastore) 
         {
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
             _datastore = datastore ?? throw new ArgumentNullException(nameof(datastore));
@@ -38,7 +38,7 @@ namespace LantanaGroup.Link.Audit.Application.Audit.Queries
 
                 List<AuditModel> auditEvents = result.Select(x => new AuditModel
                 {
-                    Id = x.Id.Value.ToString(),
+                    Id = x.AuditId.Value.ToString(),
                     FacilityId = x.FacilityId,
                     CorrelationId = x.CorrelationId,
                     ServiceName = x.ServiceName,

--- a/Audit/Application/Audit/Queries/GetFacilityAuditEvents/GetFacilityAuditEventsQuery.cs
+++ b/Audit/Application/Audit/Queries/GetFacilityAuditEvents/GetFacilityAuditEventsQuery.cs
@@ -29,7 +29,7 @@ namespace LantanaGroup.Link.Audit.Application.Audit.Queries
 
             List<AuditModel> auditEvents = result.Select(x => new AuditModel
             {
-                Id = x.Id.Value.ToString(),
+                Id = x.AuditId.Value.ToString(),
                 FacilityId = x.FacilityId,
                 ServiceName = x.ServiceName,
                 EventDate = x.EventDate,

--- a/Audit/Application/Factory/AuditFactory.cs
+++ b/Audit/Application/Factory/AuditFactory.cs
@@ -73,7 +73,7 @@ namespace LantanaGroup.Link.Audit.Application.Factory
             using Activity? activity = ServiceActivitySource.Instance.StartActivity("Audit Factory - Create Audit Entity");
 
             AuditLog audit = new AuditLog();
-            audit.Id = AuditId.NewId();
+            audit.AuditId = AuditId.NewId();
             audit.FacilityId = facilityId;
             audit.ServiceName = serviceName;
             audit.CorrelationId = correlationId;

--- a/Audit/Application/Interfaces/IAuditRepository.cs
+++ b/Audit/Application/Interfaces/IAuditRepository.cs
@@ -3,7 +3,7 @@ using LantanaGroup.Link.Audit.Domain.Entities;
 
 namespace LantanaGroup.Link.Audit.Application.Interfaces
 {
-    public interface IAuditRepository : ISearchRepository
+    public interface IAuditRepository
     {
         Task<bool> AddAsync(AuditLog entity, CancellationToken cancellationToken = default);
         Task<AuditLog?> GetAsync(AuditId id, bool noTracking = false, CancellationToken cancellationToken = default);

--- a/Audit/Audit.csproj
+++ b/Audit/Audit.csproj
@@ -28,12 +28,12 @@
 	<PackageReference Include="Confluent.Kafka.Extensions.OpenTelemetry" Version="0.3.0" />
 	<PackageReference Include="Grpc.AspNetCore" Version="2.61.0" />
 	<PackageReference Include="Grpc.AspNetCore.Server.Reflection" Version="2.61.0" />
-	<PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.2" />
-	<PackageReference Include="Microsoft.Azure.AppConfiguration.AspNetCore" Version="7.0.0" />
-	<PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.2" />
-	<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.2" />
-	<PackageReference Include="Microsoft.Extensions.Compliance.Redaction" Version="8.2.0" />
-	<PackageReference Include="Microsoft.Extensions.Telemetry" Version="8.2.0" />
+	<PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.3" />
+	<PackageReference Include="Microsoft.Azure.AppConfiguration.AspNetCore" Version="7.1.0" />
+	<PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.3" />
+	<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.3" />
+	<PackageReference Include="Microsoft.Extensions.Compliance.Redaction" Version="8.3.0" />
+	<PackageReference Include="Microsoft.Extensions.Telemetry" Version="8.3.0" />
 	<PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.19.6" />
 	<PackageReference Include="MongoDB.Driver" Version="2.24.0" />
 	<PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.7.0" />
@@ -41,6 +41,7 @@
 	<PackageReference Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="1.5.0-rc.1" />
 	<PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.7.0" />
 	<PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.7.1" />
+	<PackageReference Include="OpenTelemetry.Instrumentation.EntityFrameworkCore" Version="1.0.0-beta.10" />
 	<PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.7.1" />
 	<PackageReference Include="OpenTelemetry.Instrumentation.Process" Version="0.5.0-beta.4" />
 	<PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.7.0" />
@@ -51,7 +52,7 @@
 	<PackageReference Include="Serilog.Sinks.Grafana.Loki" Version="8.3.0" />
 	<PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
 	<PackageReference Include="Swashbuckle.AspNetCore.Swagger" Version="6.5.0" />
-	<PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="7.3.1" />
+	<PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="7.4.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Audit/Domain/Entities/AuditEntity.cs
+++ b/Audit/Domain/Entities/AuditEntity.cs
@@ -11,7 +11,8 @@ namespace LantanaGroup.Link.Audit.Domain.Entities
    
     public class AuditLog : BaseEntity
     {
-        public AuditId Id { get; set; }
+        public long Id { get; set; }
+        public AuditId AuditId { get; set; }
         public string? FacilityId { get; set; } = string.Empty;
         public string? ServiceName { get; set; }
         public string? CorrelationId { get; set; }

--- a/Audit/Infrastructure/Extensions/ServiceCollectionExtensions.cs
+++ b/Audit/Infrastructure/Extensions/ServiceCollectionExtensions.cs
@@ -31,6 +31,7 @@ namespace LantanaGroup.Link.Audit.Infrastructure.Extensions
                             {
                                 options.Filter = (httpContext) => httpContext.Request.Path != "/health"; //do not capture traces for the health check endpoint                                                           
                             })
+                        .AddEntityFrameworkCoreInstrumentation()
                         .AddConfluentKafkaInstrumentation()
                         .AddOtlpExporter(opts => { opts.Endpoint = new Uri(telemetryConfig.TelemetryCollectorEndpoint); }));
 

--- a/Audit/Persistance/Configurations/AuditLogConfigurations.cs
+++ b/Audit/Persistance/Configurations/AuditLogConfigurations.cs
@@ -14,10 +14,11 @@ namespace LantanaGroup.Link.Audit.Persistance.Configurations
         private void ConfigureAuditLogTable(EntityTypeBuilder<AuditLog> builder)
         {           
             builder.ToTable("AuditLogs");
+            
+            builder.HasKey(b => b.Id).IsClustered();
 
             //configure strongly typed ID
-            builder.HasKey(b => b.Id).IsClustered(false);
-            builder.Property(b => b.Id)
+            builder.Property(b => b.AuditId)
                 .ValueGeneratedNever()
                 .HasConversion(
                     id => id.Value,
@@ -26,6 +27,14 @@ namespace LantanaGroup.Link.Audit.Persistance.Configurations
             builder.HasIndex(b => b.FacilityId);
 
             builder.HasIndex(b => b.UserId);
+
+            builder.HasIndex(b => b.ServiceName);
+
+            builder.HasIndex(b => b.Action);
+
+            builder.HasIndex(b => b.EventDate);
+
+            builder.HasIndex(b => b.CreatedOn);
 
             builder.Property(b => b.ServiceName)
                 .HasMaxLength(100);

--- a/Audit/Persistance/Repositories/AuditLogRepository.cs
+++ b/Audit/Persistance/Repositories/AuditLogRepository.cs
@@ -1,7 +1,6 @@
 ﻿using LantanaGroup.Link.Audit.Application.Interfaces;
 using LantanaGroup.Link.Audit.Application.Models;
 using LantanaGroup.Link.Audit.Domain.Entities;
-using LantanaGroup.Link.Audit.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using System.Linq.Expressions;
 
@@ -27,7 +26,7 @@ namespace LantanaGroup.Link.Audit.Persistance.Repositories
         public async Task<AuditLog?> GetAsync(AuditId id, bool noTracking = false, CancellationToken cancellationToken = default)
         {
             var log = noTracking ?
-                await _dbContext.AuditLogs.AsNoTracking().FirstOrDefaultAsync(x => x.Id == id, cancellationToken) :
+                await _dbContext.AuditLogs.AsNoTracking().FirstOrDefaultAsync(x => x.AuditId == id, cancellationToken) :
                 await _dbContext.AuditLogs.FindAsync(id, cancellationToken);
 
             return log;
@@ -56,79 +55,7 @@ namespace LantanaGroup.Link.Audit.Persistance.Repositories
             var result = (logs, metadata);
 
             return result;
-        }
-
-        public async Task<(IEnumerable<AuditLog>, PaginationMetadata)> SearchAsync(string? searchText, string? filterFacilityBy, string? filterCorrelationBy, string? filterServiceBy, string? filterActionBy, string? filterUserBy, string? sortBy, SortOrder? sortOrder, int pageSize, int pageNumber, CancellationToken cancellationToken = default)
-        {            
-            IEnumerable<AuditLog> logs;
-            var query = _dbContext.AuditLogs.AsNoTracking().AsQueryable();
-
-            #region Build Query
-            if (searchText is not null && searchText.Length > 0)
-            {
-                query = query.Where(x =>
-                    (x.CorrelationId != null && x.CorrelationId.Contains(searchText)) ||
-                    (x.Resource != null && x.Resource.Contains(searchText)) ||
-                    (x.User != null && x.User.Contains(searchText)) ||
-                    (x.Notes != null && x.Notes.Contains(searchText)) ||
-                    (x.PropertyChanges != null && x.PropertyChanges.Any(y => y.NewPropertyValue.Contains(searchText)))
-                );
-            }
-
-            if (filterFacilityBy is not null && filterFacilityBy.Length > 0)
-            {
-                query = query.Where(x => x.FacilityId == filterFacilityBy);
-            }
-
-            if (filterCorrelationBy is not null && filterCorrelationBy.Length > 0)
-            {
-                query = query.Where(x => x.CorrelationId == filterCorrelationBy);
-            }
-
-            if (filterServiceBy is not null && filterServiceBy.Length > 0)
-            {
-                query = query.Where(x => x.ServiceName == filterServiceBy);
-            }
-
-            if (filterActionBy is not null && filterActionBy.Length > 0)
-            {
-                query = query.Where(x => x.Action == filterActionBy);
-            }
-
-            if (filterUserBy is not null && filterUserBy.Length > 0)
-            {
-                query = query.Where(x => x.User == filterUserBy);
-            }
-
-            #endregion
-
-            query = sortOrder switch
-            {
-                SortOrder.Ascending => query.OrderBy(SetSortBy<AuditLog>(sortBy)),
-                SortOrder.Descending => query.OrderByDescending(SetSortBy<AuditLog>(sortBy)),
-                _ => query.OrderBy(x => x.CreatedOn)
-            };
-
-            using (ServiceActivitySource.Instance.StartActivity("Get filtered search result"))
-            {
-                logs = await query
-                    .Skip((pageNumber - 1) * pageSize)
-                    .Take(pageSize)
-                    .ToListAsync(cancellationToken);
-            }
-
-            // get count of all records
-            int count = 0;
-            using (ServiceActivitySource.Instance.StartActivity("Get total count"))
-            {
-                count = await query.CountAsync(cancellationToken);
-            }
-            PaginationMetadata metadata = new PaginationMetadata(pageSize, pageNumber, count);
-
-            var result = (logs, metadata);
-
-            return result;
-        }
+        }       
 
         /// <summary>
         /// Creates a sort expression for the given sortBy parameter

--- a/Audit/Persistance/Repositories/MsSqlAuditLogSearchRepository.cs
+++ b/Audit/Persistance/Repositories/MsSqlAuditLogSearchRepository.cs
@@ -1,0 +1,117 @@
+﻿using LantanaGroup.Link.Audit.Application.Interfaces;
+using LantanaGroup.Link.Audit.Application.Models;
+using LantanaGroup.Link.Audit.Domain.Entities;
+using LantanaGroup.Link.Audit.Infrastructure;
+using Microsoft.EntityFrameworkCore;
+using System.Linq.Expressions;
+
+namespace LantanaGroup.Link.Audit.Persistance.Repositories
+{
+    public class MsSqlAuditLogSearchRepository : ISearchRepository
+    {
+        private readonly ILogger<AuditLogRepository> _logger;
+        private readonly AuditDbContext _dbContext;
+
+        public MsSqlAuditLogSearchRepository(ILogger<AuditLogRepository> logger, AuditDbContext dbContext)
+        {
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+            _dbContext = dbContext ?? throw new ArgumentNullException(nameof(dbContext));
+        }
+
+        public async Task<(IEnumerable<AuditLog>, PaginationMetadata)> SearchAsync(string? searchText, string? filterFacilityBy, string? filterCorrelationBy, string? filterServiceBy, string? filterActionBy, string? filterUserBy, string? sortBy, SortOrder? sortOrder, int pageSize, int pageNumber, CancellationToken cancellationToken = default)
+        {
+            IEnumerable<AuditLog> logs;
+            var query = _dbContext.AuditLogs.AsNoTracking().AsQueryable();
+
+            #region Build Query
+            if (searchText is not null && searchText.Length > 0)
+            {
+                query = query.Where(x =>
+                    (x.CorrelationId != null && x.CorrelationId.Contains(searchText)) ||
+                    (x.Resource != null && x.Resource.Contains(searchText)) ||
+                    (x.User != null && x.User.Contains(searchText)) ||
+                    (x.Notes != null && x.Notes.Contains(searchText)) ||
+                    (x.PropertyChanges != null && x.PropertyChanges.Any(y => y.NewPropertyValue.Contains(searchText)))
+                );
+            }
+
+            if (filterFacilityBy is not null && filterFacilityBy.Length > 0)
+            {
+                query = query.Where(x => x.FacilityId == filterFacilityBy);
+            }
+
+            if (filterCorrelationBy is not null && filterCorrelationBy.Length > 0)
+            {
+                query = query.Where(x => x.CorrelationId == filterCorrelationBy);
+            }
+
+            if (filterServiceBy is not null && filterServiceBy.Length > 0)
+            {
+                query = query.Where(x => x.ServiceName == filterServiceBy);
+            }
+
+            if (filterActionBy is not null && filterActionBy.Length > 0)
+            {
+                query = query.Where(x => x.Action == filterActionBy);
+            }
+
+            if (filterUserBy is not null && filterUserBy.Length > 0)
+            {
+                query = query.Where(x => x.User == filterUserBy);
+            }
+
+            #endregion
+
+            query = sortOrder switch
+            {
+                SortOrder.Ascending => query.OrderBy(SetSortBy<AuditLog>(sortBy)),
+                SortOrder.Descending => query.OrderByDescending(SetSortBy<AuditLog>(sortBy)),
+                _ => query.OrderBy(x => x.CreatedOn)
+            };
+
+            using (ServiceActivitySource.Instance.StartActivity("Get filtered search result"))
+            {
+                logs = await query
+                    .Skip((pageNumber - 1) * pageSize)
+                    .Take(pageSize)
+                    .ToListAsync(cancellationToken);
+            }
+
+            // get count of all records
+            int count = 0;
+            using (ServiceActivitySource.Instance.StartActivity("Get total count"))
+            {
+                count = await query.CountAsync(cancellationToken);
+            }
+            PaginationMetadata metadata = new PaginationMetadata(pageSize, pageNumber, count);
+
+            var result = (logs, metadata);
+
+            return result;
+        }
+
+        /// <summary>
+        /// Creates a sort expression for the given sortBy parameter
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="sortBy"></param>
+        /// <returns></returns>
+        private Expression<Func<T, object>> SetSortBy<T>(string? sortBy)
+        {
+            var sortKey = sortBy switch
+            {
+                "FacilityId" => "FacilityId",
+                "Action" => "Action",
+                "ServiceName" => "ServiceName",
+                "Resource" => "Resource",
+                "CreatedOn" => "CreatedOn",
+                _ => "CreatedOn"
+            };
+
+            var parameter = Expression.Parameter(typeof(T), "p");
+            var sortExpression = Expression.Lambda<Func<T, object>>(Expression.Convert(Expression.Property(parameter, sortKey), typeof(object)), parameter);
+
+            return sortExpression;
+        }
+    }
+}

--- a/Audit/Program.cs
+++ b/Audit/Program.cs
@@ -138,6 +138,7 @@ static void RegisterServices(WebApplicationBuilder builder)
 
     //Add repositories
     builder.Services.AddScoped<IAuditRepository, AuditLogRepository>();
+    builder.Services.AddScoped<ISearchRepository, MsSqlAuditLogSearchRepository>();
 
     //Add health checks
     builder.Services.AddHealthChecks()
@@ -240,6 +241,14 @@ static void SetupMiddleware(WebApplication app)
         var serviceInformation = app.Configuration.GetSection(AuditConstants.AppSettingsSectionNames.ServiceInformation).Get<ServiceInformation>();
         app.UseSwagger();
         app.UseSwaggerUI(opts => opts.SwaggerEndpoint("/swagger/v1/swagger.json", serviceInformation != null ? $"{serviceInformation.Name} - {serviceInformation.Version}" : "Link Audit Service"));
+    }
+
+    //TODO: Discuss migrations rather than ensure created
+    // Ensure database created (temporary), not for production
+    using (var scope = app.Services.CreateScope())
+    {
+        var context = scope.ServiceProvider.GetRequiredService<AuditDbContext>();
+        context.Database.EnsureCreated();
     }
 
     app.UseRouting();

--- a/AuditTests/AuditMongoRepoTests.cs
+++ b/AuditTests/AuditMongoRepoTests.cs
@@ -39,7 +39,7 @@ namespace LantanaGroup.Link.AuditUnitTests
             //create audit entities
             AuditLog _auditEvent = new AuditLog();
             #region Setup for _auditEvent
-            _auditEvent.Id = AuditId.FromString(_auditId);
+            _auditEvent.AuditId = AuditId.FromString(_auditId);
             _auditEvent.FacilityId = FacilityId;
             _auditEvent.ServiceName = ServiceName;
             _auditEvent.CorrelationId = CorrelationId;
@@ -72,7 +72,7 @@ namespace LantanaGroup.Link.AuditUnitTests
         [Test]
         public void TestAddAuditEntity() {
             var auditEntity = new AuditLog();
-            auditEntity.Id = AuditId.NewId();
+            auditEntity.AuditId = AuditId.NewId();
 
             InitializeMongoAuditEventCollection();
             //TODO How to make mongo repo more testable

--- a/AuditTests/CreateAuditEventCommandTests.cs
+++ b/AuditTests/CreateAuditEventCommandTests.cs
@@ -53,7 +53,7 @@ namespace LantanaGroup.Link.AuditUnitTests
 
             //set up audit entity
             _auditEvent = new AuditLog();
-            _auditEvent.Id = AuditId.NewId();
+            _auditEvent.AuditId = AuditId.NewId();
             _auditEvent.FacilityId = FacilityId;
             _auditEvent.ServiceName = ServiceName;
             _auditEvent.CorrelationId = CorrelationId;

--- a/AuditTests/GetAuditEventListQueryTests.cs
+++ b/AuditTests/GetAuditEventListQueryTests.cs
@@ -70,7 +70,7 @@ namespace LantanaGroup.Link.AuditUnitTests
 
             //set up audit entity
             _auditEvent = new AuditLog();
-            _auditEvent.Id = AuditId.FromString(_auditId);
+            _auditEvent.AuditId = AuditId.FromString(_auditId);
             _auditEvent.FacilityId = FacilityId;
             _auditEvent.ServiceName = ServiceName;
             _auditEvent.CorrelationId = CorrelationId;
@@ -112,7 +112,7 @@ namespace LantanaGroup.Link.AuditUnitTests
                 .Setup(p => p.CreateAuditSearchFilterRecord(searchText, filterFacilityBy, filterCorrelationBy, filterServiceBy, filterActionBy, filterUserBy, sortBy, SortOrder.Ascending, pageSize, pageNumber))
                 .Returns(_auditSearchFilterRecord);
 
-            _mocker.GetMock<IAuditRepository>()
+            _mocker.GetMock<ISearchRepository>()
                 .Setup(p => p.SearchAsync(searchText, filterFacilityBy, filterCorrelationBy, filterServiceBy, filterActionBy, filterUserBy, sortBy, SortOrder.Ascending, pageSize, pageNumber, CancellationToken.None))
                 .ReturnsAsync(output);                
         }               
@@ -122,7 +122,7 @@ namespace LantanaGroup.Link.AuditUnitTests
         {
             Task<PagedAuditModel> _foundAuditEvents = _query.Execute(_auditSearchFilterRecord);
 
-            _mocker.GetMock<IAuditRepository>().Verify(p => p.SearchAsync(searchText, filterFacilityBy, filterCorrelationBy, filterServiceBy, filterActionBy, filterUserBy, sortBy, SortOrder.Ascending, pageSize, pageNumber, CancellationToken.None), Times.Once());
+            _mocker.GetMock<ISearchRepository>().Verify(p => p.SearchAsync(searchText, filterFacilityBy, filterCorrelationBy, filterServiceBy, filterActionBy, filterUserBy, sortBy, SortOrder.Ascending, pageSize, pageNumber, CancellationToken.None), Times.Once());
 
         }
 

--- a/AuditTests/GetAuditEventQueryTests.cs
+++ b/AuditTests/GetAuditEventQueryTests.cs
@@ -38,7 +38,7 @@ namespace LantanaGroup.Link.AuditUnitTests
 
             //set up audit entity
             _auditEvent = new AuditLog();
-            _auditEvent.Id = AuditId.FromString(_auditId);
+            _auditEvent.AuditId = AuditId.FromString(_auditId);
             _auditEvent.FacilityId = FacilityId;
             _auditEvent.ServiceName = ServiceName;
             _auditEvent.CorrelationId = CorrelationId;


### PR DESCRIPTION
- Added an identity column to act as the primary key for the audit log table
- added additional indexes
- refactored the search method into it's own repository to allow for optimized provider specific search method
- fixed unit tests
- Updated NuGet packages
- Added entity framework open telemetry instrumentation