### PR TITLE
Supporting runtime config in Demo App

### DIFF
--- a/DemoApp/.gitignore
+++ b/DemoApp/.gitignore
@@ -40,3 +40,5 @@ testem.log
 # System files
 .DS_Store
 Thumbs.db
+
+app.config.local.json

--- a/DemoApp/angular.json
+++ b/DemoApp/angular.json
@@ -91,6 +91,11 @@
         },
         "serve": {
           "builder": "@angular-devkit/build-angular:dev-server",
+          "options": {
+            "browserTarget": "proxy-for-angular:build",
+            "proxyConfig": "proxy.conf.js",
+            "port": 4200
+          },
           "configurations": {
             "production": {
               "browserTarget": "DemoApp:build:production"

--- a/DemoApp/proxy.conf.js
+++ b/DemoApp/proxy.conf.js
@@ -1,0 +1,7 @@
+module.exports = [
+  {
+    context: ['/proxy-api/**'],
+    target: process.env['BASE_API_URL'] || 'http://localhost:7777',
+    secure: false,
+  }
+];

--- a/DemoApp/src/app/app.module.ts
+++ b/DemoApp/src/app/app.module.ts
@@ -22,17 +22,13 @@ import { MatSelectModule } from '@angular/material/select';
 
 import { LoadingIndicatorComponent } from './components/core/loading-indicator/loading-indicator.component';
 
-import { environment } from '../environments/environment';
 import { HttpInterceptorProviders } from './interceptors/interceptor.barrel';
-import { DataAcquisitionFhirQueryConfigFormComponent } from './components/data-acquisition/data-acquisition-fhir-query-config-form/data-acquisition-fhir-query-config-form.component';
-import { DataAcquisitionFhirQueryConfigDialogComponent } from './components/data-acquisition/data-acquisition-fhir-query-config-dialog/data-acquisition-fhir-query-config-dialog.component';
-import { DataAcquisitionFhirListConfigDialogComponent } from './components/data-acquisition/data-acquisition-fhir-list-config-dialog/data-acquisition-fhir-list-config-dialog.component';
-import { DataAcquisitionFhirListConfigFormComponent } from './components/data-acquisition/data-acquisition-fhir-list-config-form/data-acquisition-fhir-list-config-form.component';
-import { DataAcquisitionAuthenticationConfigFormComponent } from './components/data-acquisition/data-acquisition-authentication-config-form/data-acquisition-authentication-config-form.component';
-import { DataAcquisitionAuthenticationConfigDialogComponent } from './components/data-acquisition/data-acquisition-authentication-config-dialog/data-acquisition-authentication-config-dialog.component';
-import { MatDateSelectionModel } from '@angular/material/datepicker';
+import { APP_INITIALIZER } from '@angular/core';
+import { AppConfigService } from './services/app-config.service';
 
-
+export function initConfig(appConfig: AppConfigService) {
+  return () => appConfig.loadConfig();
+}
 
 @NgModule({
   declarations: [
@@ -41,7 +37,7 @@ import { MatDateSelectionModel } from '@angular/material/datepicker';
   imports: [
     OAuthModule.forRoot({
       resourceServer: {
-        allowedUrls: [`${environment.baseApiUrl}/api`],
+        // allowedUrls: [`${environment.baseApiUrl}/api`], TODO: Not sure how to get this from a run-time config
         sendAccessToken: true
       }
     }),
@@ -63,6 +59,12 @@ import { MatDateSelectionModel } from '@angular/material/datepicker';
     MatSelectModule,
   ],
   providers: [
+    {
+      provide: APP_INITIALIZER,
+      useFactory: initConfig,
+      deps: [AppConfigService],
+      multi: true,
+    },
     StyleManagerService,
     HttpInterceptorProviders
   ],

--- a/DemoApp/src/app/services/app-config.service.ts
+++ b/DemoApp/src/app/services/app-config.service.ts
@@ -1,0 +1,86 @@
+import { HttpClient } from "@angular/common/http";
+import { AuthConfig } from 'angular-oauth2-oidc';
+import { Injectable } from "@angular/core";
+
+export interface AppConfig {
+  baseApiUrl: string;
+  idpIssuer: string;
+  idpClientId: string;
+  idpClientSecret: string;
+  idpScope: string;
+  redirectUri: string;
+  loginUrl: string
+}
+
+@Injectable({
+  providedIn: 'root'
+})
+export class AppConfigService {
+  public config?: AppConfig;
+
+  loaded = false;
+
+  constructor(private http: HttpClient) { }
+
+  async loadConfig(): Promise<void> {
+    try {
+      this.config = await this.http.get<AppConfig>('/assets/app.config.json').toPromise();
+    } catch (ex) {
+      throw new Error('Failed to acquire app configuration: ' + ex);
+    }
+
+    try {
+      const localConfig = await this.http.get<AppConfig>('/assets/app.config.local.json').toPromise();
+      Object.assign(<any> this.config, localConfig);
+      console.log(`Loaded local configuration.`);
+    } catch (ex) {
+      console.log(`No local configuration found.`);
+    }
+
+    this.loaded = true;
+  }
+
+  getRedirectUri() {
+    if (!this.loaded || !this.config) throw new Error('Config not loaded');
+    return this.config.redirectUri || window.location.origin + '/';
+  }
+
+  getLoginUrl() {
+    if (!this.loaded || !this.config) throw new Error('Config not loaded');
+    return this.config.loginUrl || window.location.origin + '/';
+  }
+
+  getAuthCodeFlowConfig(): AuthConfig {
+    if (!this.loaded || !this.config) throw new Error('Config not loaded');
+
+    return {
+      // Url of the Identity Provider
+      issuer: this.config.idpIssuer,
+
+      // URL of the SPA to redirect the user to after login
+      redirectUri: this.getRedirectUri(),
+      loginUrl: this.getLoginUrl(),
+
+      // The SPA's id. The SPA is registerd with this id at the auth-server 
+      clientId: this.config.idpClientId,
+
+      dummyClientSecret: this.config.idpClientSecret,
+
+      // Just needed if your auth server demands a secret. In general, this
+      // is a sign that the auth server is not configured with SPAs in mind
+      // and it might not enforce further best practices vital for security
+      // such applications.
+      // dummyClientSecret: 'secret',
+
+      responseType: 'code',
+
+      // set the scope for the permissions the client should request
+      // The first four are defined by OIDC.
+      // Important: Request offline_access to get a refresh token
+      // The api scope is a usecase specific one
+      scope: this.config.idpScope,
+
+      showDebugInformation: true
+    };
+  }
+}

--- a/DemoApp/src/app/services/auth.service.ts
+++ b/DemoApp/src/app/services/auth.service.ts
@@ -1,9 +1,9 @@
 import { Injectable } from '@angular/core';
 import { OAuthService } from 'angular-oauth2-oidc';
 import { UserProfileService } from './user-profile.service';
-import { authCodeFlowConfig } from '../config/auth-code-flow.config';
 import { filter } from 'rxjs';
 import { UserProfile } from '../models/user-pofile.model';
+import { AppConfigService } from './app-config.service';
 
 
 @Injectable({
@@ -13,10 +13,10 @@ export class AuthService {
   userProfile!: UserProfile;
   
 
-  constructor(private oauthService: OAuthService, private profileService: UserProfileService) {
+  constructor(private oauthService: OAuthService, private profileService: UserProfileService, appConfigService: AppConfigService) {
 
     if (!this.oauthService.hasValidAccessToken()) {
-      this.oauthService.configure(authCodeFlowConfig);
+      this.oauthService.configure(appConfigService.getAuthCodeFlowConfig());
       this.oauthService.loadDiscoveryDocumentAndLogin();
       this.oauthService.setupAutomaticSilentRefresh();
 

--- a/DemoApp/src/app/services/gateway/audit.service.ts
+++ b/DemoApp/src/app/services/gateway/audit.service.ts
@@ -5,14 +5,13 @@ import { catchError, map, retry, tap } from 'rxjs/operators';
 import { PagedAuditModel } from '../../models/audit/paged-audit-model.model';
 import { environment } from '../../../environments/environment';
 import { ErrorHandlingService } from '../error-handling.service';
+import { AppConfigService } from '../app-config.service';
 
 @Injectable({
   providedIn: 'root'
 })
 export class AuditService {
-  private baseApiUrl = `${environment.baseApiUrl}/api`;
-
-  constructor(private http: HttpClient, private errorHandler: ErrorHandlingService) { }
+  constructor(private http: HttpClient, private errorHandler: ErrorHandlingService, public appConfigService: AppConfigService) { }
 
   list(searchText: string, filterFacilityBy: string, filterCorrelationBy: string, filterServiceBy: string,
     filterActionBy: string, filterUserBy: string, sortBy: string, pageSize: number, pageNumber: number): Observable<PagedAuditModel> {
@@ -20,7 +19,7 @@ export class AuditService {
     //java based paging is zero based, so increment page number by 1
     pageNumber = pageNumber + 1;
 
-    return this.http.get<PagedAuditModel>(`${this.baseApiUrl}/audit?searchText=${searchText}&filterFacilityBy=${filterFacilityBy}&filterCorrelationBy=${filterCorrelationBy}&filterServiceBy=${filterServiceBy}&filterActionBy=${filterActionBy}&filterUserBy=${filterUserBy}&sortBy=${sortBy}&pageSize=${pageSize}&pageNumber=${pageNumber}`)
+    return this.http.get<PagedAuditModel>(`${this.appConfigService.config?.baseApiUrl}/audit?searchText=${searchText}&filterFacilityBy=${filterFacilityBy}&filterCorrelationBy=${filterCorrelationBy}&filterServiceBy=${filterServiceBy}&filterActionBy=${filterActionBy}&filterUserBy=${filterUserBy}&sortBy=${sortBy}&pageSize=${pageSize}&pageNumber=${pageNumber}`)
     .pipe(
       tap(_ => console.log(`fetched audit logs.`)),
       map((response: PagedAuditModel) => {

--- a/DemoApp/src/app/services/gateway/census/census.service.ts
+++ b/DemoApp/src/app/services/gateway/census/census.service.ts
@@ -6,14 +6,13 @@ import { ICensusConfiguration } from 'src/app/interfaces/census/census-config-mo
 import { Observable, catchError, map, tap } from 'rxjs';
 import { IEntityCreatedResponse } from 'src/app/interfaces/entity-created-response.model';
 import { IEntityDeletedResponse } from 'src/app/interfaces/entity-deleted-response.interface';
+import { AppConfigService } from '../../app-config.service';
 
 @Injectable({
   providedIn: 'root'
 })
 export class CensusService {
-  private baseApiUrl = `${environment.baseApiUrl}/api`;
-
-  constructor(private http: HttpClient, private errorHandler: ErrorHandlingService) { }
+  constructor(private http: HttpClient, private errorHandler: ErrorHandlingService, public appConfigService: AppConfigService) { }
 
   createConfiguration(facilityId: string, scheduledTrigger: string): Observable<IEntityCreatedResponse> {
     let census: ICensusConfiguration = {
@@ -21,7 +20,7 @@ export class CensusService {
       scheduledTrigger: scheduledTrigger
     };
 
-    return this.http.post<IEntityCreatedResponse>(`${this.baseApiUrl}/census/config`, census)
+    return this.http.post<IEntityCreatedResponse>(`${this.appConfigService.config?.baseApiUrl}/census/config`, census)
       .pipe(
         tap(_ => console.log(`Request for configuration creation was sent.`)),
         map((response: IEntityCreatedResponse) => {
@@ -37,7 +36,7 @@ export class CensusService {
       scheduledTrigger: scheduledTrigger
     };
 
-    return this.http.put<IEntityCreatedResponse>(`${this.baseApiUrl}/census/config/${facilityId}`, census)
+    return this.http.put<IEntityCreatedResponse>(`${this.appConfigService.config?.baseApiUrl}/census/config/${facilityId}`, census)
       .pipe(
         tap(_ => console.log(`Request for configuration update was sent.`)),
         map((response: IEntityCreatedResponse) => {
@@ -48,7 +47,7 @@ export class CensusService {
   }
 
   getConfiguration(facilityId: string): Observable<ICensusConfiguration> {
-    return this.http.get<ICensusConfiguration>(`${this.baseApiUrl}/census/config/${facilityId}`)
+    return this.http.get<ICensusConfiguration>(`${this.appConfigService.config?.baseApiUrl}/census/config/${facilityId}`)
       .pipe(
         tap(_ => console.log(`Fetched configuration.`)),
         catchError((error) => this.errorHandler.handleError(error))
@@ -56,7 +55,7 @@ export class CensusService {
   }
 
   deleteConfiguration(facilityId: string): Observable<IEntityDeletedResponse> {
-    return this.http.delete<IEntityDeletedResponse>(`${this.baseApiUrl}/census/config/${facilityId}`)
+    return this.http.delete<IEntityDeletedResponse>(`${this.appConfigService.config?.baseApiUrl}/census/config/${facilityId}`)
       .pipe(
         tap(_ => console.log(`Request for configuration deletion was sent.`)),
         catchError((error) => this.errorHandler.handleError(error))

--- a/DemoApp/src/app/services/gateway/data-acquisition/data-acquisition.service.ts
+++ b/DemoApp/src/app/services/gateway/data-acquisition/data-acquisition.service.ts
@@ -10,17 +10,16 @@ import { IEntityDeletedResponse } from 'src/app/interfaces/entity-deleted-respon
 import { IDataAcquisitionQueryConfigModel } from 'src/app/interfaces/data-acquisition/data-acquisition-fhir-query-config-model.interface';
 import { IDataAcquisitionFhirListConfigModel } from 'src/app/interfaces/data-acquisition/data-acquisition-fhir-list-config-model.interface';
 import { IDataAcquisitionAuthenticationConfigModel } from '../../../interfaces/data-acquisition/data-acquisition-auth-config-model.interface';
+import { AppConfigService } from '../../app-config.service';
 
 @Injectable({
   providedIn: 'root'
 })
 export class DataAcquisitionService {
-  private baseApiUrl = `${environment.baseApiUrl}/api`;
-
-  constructor(private http: HttpClient, private errorHandler: ErrorHandlingService) { }
+  constructor(private http: HttpClient, private errorHandler: ErrorHandlingService, public appConfigService: AppConfigService) { }
 
   getFhirQueryConfiguration(facilityId: string): Observable<IDataAcquisitionQueryConfigModel> {
-    return this.http.get<IDataAcquisitionQueryConfigModel>(`${this.baseApiUrl}/data/query/${facilityId}/config`)
+    return this.http.get<IDataAcquisitionQueryConfigModel>(`${this.appConfigService.config?.baseApiUrl}/data/query/${facilityId}/config`)
       .pipe(
         tap(_ => console.log(`Fetched FHIR query configuration.`)),
         catchError((error) => this.errorHandler.handleError(error))
@@ -28,7 +27,7 @@ export class DataAcquisitionService {
   }
 
   createFhirQueryConfiguration(facilityId: string, fhirQueryConfig: IDataAcquisitionQueryConfigModel): Observable<IEntityCreatedResponse> {
-    return this.http.post<IEntityCreatedResponse>(`${this.baseApiUrl}/data/query/config`, fhirQueryConfig)
+    return this.http.post<IEntityCreatedResponse>(`${this.appConfigService.config?.baseApiUrl}/data/query/config`, fhirQueryConfig)
       .pipe(
         tap(_ => console.log(`Request for FHIR query configuration creation was sent.`)),
         map((response: IEntityCreatedResponse) => {
@@ -39,7 +38,7 @@ export class DataAcquisitionService {
   }
 
   updateFhirQueryConfiguration(facilityId: string, fhirQueryConfig: IDataAcquisitionQueryConfigModel): Observable<IEntityCreatedResponse> {
-    return this.http.put<IEntityCreatedResponse>(`${this.baseApiUrl}/data/query/${facilityId}/config`, fhirQueryConfig)
+    return this.http.put<IEntityCreatedResponse>(`${this.appConfigService.config?.baseApiUrl}/data/query/${facilityId}/config`, fhirQueryConfig)
       .pipe(
         tap(_ => console.log(`Request for FHIR query configuration update was sent.`)),
         map((response: IEntityCreatedResponse) => {
@@ -50,7 +49,7 @@ export class DataAcquisitionService {
   }
 
   deleteFhirQueryConfiguration(facilityId: string): Observable<IEntityDeletedResponse> {
-    return this.http.delete<IEntityDeletedResponse>(`${this.baseApiUrl}/data/query/${facilityId}/config`)
+    return this.http.delete<IEntityDeletedResponse>(`${this.appConfigService.config?.baseApiUrl}/data/query/${facilityId}/config`)
       .pipe(
         tap(_ => console.log(`Request for FHIR query configuration deletion was sent.`)),
         catchError((error) => this.errorHandler.handleError(error))
@@ -58,7 +57,7 @@ export class DataAcquisitionService {
   }
 
   getFhirListConfiguration(facilityId: string): Observable<IDataAcquisitionFhirListConfigModel> {
-    return this.http.get<IDataAcquisitionFhirListConfigModel>(`${this.baseApiUrl}/data/list/${facilityId}/config`)
+    return this.http.get<IDataAcquisitionFhirListConfigModel>(`${this.appConfigService.config?.baseApiUrl}/data/list/${facilityId}/config`)
       .pipe(
         tap(_ => console.log(`Fetched FHIR list configuration.`)),
         catchError((error) => this.errorHandler.handleError(error))
@@ -66,7 +65,7 @@ export class DataAcquisitionService {
   }
 
   createFhirListConfiguration(facilityId: string, fhirListConfig: IDataAcquisitionFhirListConfigModel): Observable<IEntityCreatedResponse> {
-    return this.http.post<IEntityCreatedResponse>(`${this.baseApiUrl}/data/list/config`, fhirListConfig)
+    return this.http.post<IEntityCreatedResponse>(`${this.appConfigService.config?.baseApiUrl}/data/list/config`, fhirListConfig)
       .pipe(
         tap(_ => console.log(`Request for FHIR list configuration creation was sent.`)),
         map((response: IEntityCreatedResponse) => {
@@ -77,7 +76,7 @@ export class DataAcquisitionService {
   }
 
   updateFhirListConfiguration(facilityId: string, fhirListConfig: IDataAcquisitionFhirListConfigModel): Observable<IEntityCreatedResponse> {
-    return this.http.put<IEntityCreatedResponse>(`${this.baseApiUrl}/data/list/${facilityId}/config`, fhirListConfig)
+    return this.http.put<IEntityCreatedResponse>(`${this.appConfigService.config?.baseApiUrl}/data/list/${facilityId}/config`, fhirListConfig)
       .pipe(
         tap(_ => console.log(`Request for FHIR list configuration update was sent.`)),
         map((response: IEntityCreatedResponse) => {
@@ -88,7 +87,7 @@ export class DataAcquisitionService {
   }
 
   deleteFhirListConfiguration(facilityId: string): Observable<IEntityDeletedResponse> {
-    return this.http.delete<IEntityDeletedResponse>(`${this.baseApiUrl}/data/list/${facilityId}/config`)
+    return this.http.delete<IEntityDeletedResponse>(`${this.appConfigService.config?.baseApiUrl}/data/list/${facilityId}/config`)
       .pipe(
         tap(_ => console.log(`Request for FHIR list configuration deletion was sent.`)),
         catchError((error) => this.errorHandler.handleError(error))
@@ -96,7 +95,7 @@ export class DataAcquisitionService {
   }
 
   getAuthenticationConfig(facilityId: string, queryConfigType: string) {
-    return this.http.get<IDataAcquisitionAuthenticationConfigModel>(`${this.baseApiUrl}/data/auth/${facilityId}/config/${queryConfigType}`)
+    return this.http.get<IDataAcquisitionAuthenticationConfigModel>(`${this.appConfigService.config?.baseApiUrl}/data/auth/${facilityId}/config/${queryConfigType}`)
     .pipe(
         tap(_ => console.log(`Fetched authentication configuration.`)),
         catchError((error) => this.errorHandler.handleError(error))
@@ -104,7 +103,7 @@ export class DataAcquisitionService {
   }
 
   createAuthenticationConfig(facilityId: string, queryConfigType: string, authenticationConfig: IDataAcquisitionAuthenticationConfigModel): Observable<IEntityCreatedResponse> {
-    return this.http.post<IEntityCreatedResponse>(`${this.baseApiUrl}/data/auth/${facilityId}/config/${queryConfigType}`, authenticationConfig)
+    return this.http.post<IEntityCreatedResponse>(`${this.appConfigService.config?.baseApiUrl}/data/auth/${facilityId}/config/${queryConfigType}`, authenticationConfig)
       .pipe(
         tap(_ => console.log(`Request for authentication configuration creation was sent.`)),
         map((response: IEntityCreatedResponse) => {
@@ -115,7 +114,7 @@ export class DataAcquisitionService {
   }
 
   updateAuthenticationConfig(facilityId: string, queryConfigType: string, authenticationConfig: IDataAcquisitionAuthenticationConfigModel): Observable<IEntityCreatedResponse> {
-    return this.http.put<IEntityCreatedResponse>(`${this.baseApiUrl}/data/auth/${facilityId}/config/${queryConfigType}`, authenticationConfig)
+    return this.http.put<IEntityCreatedResponse>(`${this.appConfigService.config?.baseApiUrl}/data/auth/${facilityId}/config/${queryConfigType}`, authenticationConfig)
       .pipe(
         tap(_ => console.log(`Request for authentication configuration update was sent.`)),
         map((response: IEntityCreatedResponse) => {
@@ -126,7 +125,7 @@ export class DataAcquisitionService {
   }
 
 deleteAuthenticationConfig(facilityId: string, queryConfigType: string): Observable<IEntityDeletedResponse> {
-    return this.http.delete<IEntityDeletedResponse>(`${this.baseApiUrl}/data/auth/${facilityId}/config/${queryConfigType}`)
+    return this.http.delete<IEntityDeletedResponse>(`${this.appConfigService.config?.baseApiUrl}/data/auth/${facilityId}/config/${queryConfigType}`)
       .pipe(
         tap(_ => console.log(`Request for authentication configuration deletion was sent.`)),
         catchError((error) => this.errorHandler.handleError(error))

--- a/DemoApp/src/app/services/gateway/measure-definition/measure.service.ts
+++ b/DemoApp/src/app/services/gateway/measure-definition/measure.service.ts
@@ -6,17 +6,16 @@ import { Observable, catchError, map, tap } from 'rxjs';
 import { IEntityCreatedResponse } from 'src/app/interfaces/entity-created-response.model';
 import { IEntityDeletedResponse } from 'src/app/interfaces/entity-deleted-response.interface';
 import { IMeasureDefinitionConfigModel } from '../../../interfaces/measure-definition/measure-definition-config-model.interface';
+import { AppConfigService } from '../../app-config.service';
 
 @Injectable({
   providedIn: 'root'
 })
 export class MeasureDefinitionService {
-  private baseApiUrl = `${environment.baseApiUrl}/api`;
-
-  constructor(private http: HttpClient, private errorHandler: ErrorHandlingService) { }
+  constructor(private http: HttpClient, private errorHandler: ErrorHandlingService, public appConfigService: AppConfigService) { }
 
   createMeasureDefinitionConfiguration(measureConfiguration: IMeasureDefinitionConfigModel): Observable<IEntityCreatedResponse> {
-    return this.http.post<IEntityCreatedResponse>(`${this.baseApiUrl}/measure/config`, measureConfiguration)
+    return this.http.post<IEntityCreatedResponse>(`${this.appConfigService.config?.baseApiUrl}/measure/config`, measureConfiguration)
       .pipe(
         tap(_ => console.log(`Request for configuration creation was sent.`)),
         map((response: IEntityCreatedResponse) => {
@@ -28,7 +27,7 @@ export class MeasureDefinitionService {
 
   updateMeasureDefinitionConfiguration(measureConfiguration: IMeasureDefinitionConfigModel): Observable<IEntityCreatedResponse> {
 
-    return this.http.put<IEntityCreatedResponse>(`${this.baseApiUrl}/measure/config/${measureConfiguration.bundleId}`, measureConfiguration)
+    return this.http.put<IEntityCreatedResponse>(`${this.appConfigService.config?.baseApiUrl}/measure/config/${measureConfiguration.bundleId}`, measureConfiguration)
       .pipe(
         tap(_ => console.log(`Request for configuration update was sent.`)),
         map((response: IEntityCreatedResponse) => {
@@ -39,7 +38,7 @@ export class MeasureDefinitionService {
   }
 
   getMeasureDefinitionConfiguration(bundleId: string): Observable<IMeasureDefinitionConfigModel> {
-    return this.http.get<IMeasureDefinitionConfigModel>(`${this.baseApiUrl}/measure/config/${bundleId}`)
+    return this.http.get<IMeasureDefinitionConfigModel>(`${this.appConfigService.config?.baseApiUrl}/measure/config/${bundleId}`)
       .pipe(
         tap(_ => console.log(`Fetched configuration.`)),
         catchError((error) => this.errorHandler.handleError(error))
@@ -47,7 +46,7 @@ export class MeasureDefinitionService {
   }
 
   deleteMeasureDefinitionConfiguration(bundleId: string): Observable<IEntityDeletedResponse> {
-    return this.http.delete<IEntityDeletedResponse>(`${this.baseApiUrl}/measure/config/${bundleId}`)
+    return this.http.delete<IEntityDeletedResponse>(`${this.appConfigService.config?.baseApiUrl}/measure/config/${bundleId}`)
       .pipe(
         tap(_ => console.log(`Request for configuration deletion was sent.`)),
         catchError((error) => this.errorHandler.handleError(error))
@@ -55,7 +54,7 @@ export class MeasureDefinitionService {
   }
 
    getMeasureDefinitionConfigurations(): Observable<IMeasureDefinitionConfigModel[]> {
-     return this.http.get<IMeasureDefinitionConfigModel[]>(`${this.baseApiUrl}/measure/config/measures`)
+     return this.http.get<IMeasureDefinitionConfigModel[]>(`${this.appConfigService.config?.baseApiUrl}/measure/config/measures`)
        .pipe(
          tap(_ => console.log(`Fetched measure definitions.`)),
          map((response: IMeasureDefinitionConfigModel[]) => {

--- a/DemoApp/src/app/services/gateway/notification.service.ts
+++ b/DemoApp/src/app/services/gateway/notification.service.ts
@@ -10,21 +10,20 @@ import { IEntityCreatedResponse } from '../../interfaces/entity-created-response
 import { IFacilityChannel, INotificationConfiguration } from '../../interfaces/notification/notification-configuration-model.interface';
 import { PagedNotificationConfigurationModel } from '../../models/notification/paged-notification-configuration-model.model';
 import { IEntityDeletedResponse } from '../../interfaces/entity-deleted-response.interface';
+import { AppConfigService } from '../app-config.service';
 
 @Injectable({
   providedIn: 'root'
 })
 export class NotificationService {
-  private baseApiUrl = `${environment.baseApiUrl}/api`;
-
-  constructor(private http: HttpClient) { }
+  constructor(private http: HttpClient, public appConfigService: AppConfigService) { }
 
   list(searchText: string, filterFacilityBy: string, filterNotificationTypeBy: string, createdOnStart: Date | null, createdOnEnd: Date | null, sentOnStart: Date | null, sentOnEnd: Date | null, sortBy: string, pageSize: number, pageNumber: number): Observable<PagedNotificationModel> {
 
     //java based paging is zero based, so increment page number by 1
     pageNumber = pageNumber + 1;
 
-    return this.http.get<PagedNotificationModel>(`${this.baseApiUrl}/notification?searchText=${searchText}&filterFacilityBy=${filterFacilityBy}&filterNotificationTypeBy=${filterNotificationTypeBy}&sortBy=${sortBy}&pageSize=${pageSize}&pageNumber=${pageNumber}`)
+    return this.http.get<PagedNotificationModel>(`${this.appConfigService.config?.baseApiUrl}/notification?searchText=${searchText}&filterFacilityBy=${filterFacilityBy}&filterNotificationTypeBy=${filterNotificationTypeBy}&sortBy=${sortBy}&pageSize=${pageSize}&pageNumber=${pageNumber}`)
       .pipe(
         tap(_ => console.log(`Fetched notifications.`)),
         map((response: PagedNotificationModel) => {
@@ -47,7 +46,7 @@ export class NotificationService {
         correlationId: null
     };
 
-    return this.http.post<IEntityCreatedResponse>(`${this.baseApiUrl}/notification`, notification)
+    return this.http.post<IEntityCreatedResponse>(`${this.appConfigService.config?.baseApiUrl}/notification`, notification)
       .pipe(
         tap(_ => console.log(`Request for notification creation was sent.`)),
         map((response: IEntityCreatedResponse) => {
@@ -58,7 +57,7 @@ export class NotificationService {
   }
 
   getFacilityConfiguration(facilityId: string): Observable<INotificationConfiguration> {
-    return this.http.get<INotificationConfiguration>(`${this.baseApiUrl}/notification/configuration/facility/${facilityId}`)
+    return this.http.get<INotificationConfiguration>(`${this.appConfigService.config?.baseApiUrl}/notification/configuration/facility/${facilityId}`)
       .pipe(
         tap(_ => console.log(`Fetched notification configuration`)),
         map((response: INotificationConfiguration) => {
@@ -73,7 +72,7 @@ export class NotificationService {
     //java based paging is zero based, so increment page number by 1
     pageNumber = pageNumber + 1;
 
-    return this.http.get<PagedNotificationConfigurationModel>(`${this.baseApiUrl}/notification/configuration?searchText=${searchText}&filterFacilityBy=${filterFacilityBy}&sortBy=${sortBy}&pageSize=${pageSize}&pageNumber=${pageNumber}`)
+    return this.http.get<PagedNotificationConfigurationModel>(`${this.appConfigService.config?.baseApiUrl}/notification/configuration?searchText=${searchText}&filterFacilityBy=${filterFacilityBy}&sortBy=${sortBy}&pageSize=${pageSize}&pageNumber=${pageNumber}`)
       .pipe(
         tap(_ => console.log(`Fetched notification configurations.`)),
         map((response: PagedNotificationConfigurationModel) => {
@@ -93,7 +92,7 @@ export class NotificationService {
       channels: channels
     };
 
-    return this.http.post<IEntityCreatedResponse>(`${this.baseApiUrl}/notification/configuration`, notificationConfiguration)
+    return this.http.post<IEntityCreatedResponse>(`${this.appConfigService.config?.baseApiUrl}/notification/configuration`, notificationConfiguration)
       .pipe(
         tap(_ => console.log(`Request for notification configuration creation was sent.`)),
         map((response: IEntityCreatedResponse) => {
@@ -111,7 +110,7 @@ export class NotificationService {
       channels: channels
     };
 
-    return this.http.put<IEntityCreatedResponse>(`${this.baseApiUrl}/notification/configuration`, notificationConfiguration)
+    return this.http.put<IEntityCreatedResponse>(`${this.appConfigService.config?.baseApiUrl}/notification/configuration`, notificationConfiguration)
       .pipe(
         tap(_ => console.log(`Request for notification configuration update was sent.`)),
         map((response: IEntityCreatedResponse) => {
@@ -122,7 +121,7 @@ export class NotificationService {
   }
 
   deleteFacilityConfiguration(id: string): Observable<IEntityDeletedResponse> {
-    return this.http.delete<IEntityDeletedResponse>(`${this.baseApiUrl}/notification/configuration/${id}`)
+    return this.http.delete<IEntityDeletedResponse>(`${this.appConfigService.config?.baseApiUrl}/notification/configuration/${id}`)
       .pipe(
         tap(_ => console.log(`Request for notification configuration deletion was sent.`)),
         map((response: IEntityDeletedResponse) => {

--- a/DemoApp/src/app/services/gateway/report/report.service.ts
+++ b/DemoApp/src/app/services/gateway/report/report.service.ts
@@ -6,14 +6,13 @@ import { IReportConfigModel } from 'src/app/interfaces/report/report-config-mode
 import { Observable, catchError, map, tap } from 'rxjs';
 import { IEntityCreatedResponse } from 'src/app/interfaces/entity-created-response.model';
 import { IEntityDeletedResponse } from 'src/app/interfaces/entity-deleted-response.interface';
+import { AppConfigService } from '../../app-config.service';
 
 @Injectable({
   providedIn: 'root'
 })
 export class ReportService {
-  private baseApiUrl = `${environment.baseApiUrl}/api`;
-
-  constructor(private http: HttpClient, private errorHandler: ErrorHandlingService) { }
+  constructor(private http: HttpClient, private errorHandler: ErrorHandlingService, public appConfigService: AppConfigService) { }
 
   createReportConfiguration(facilityId: string, reportType: string, bundlingType: string): Observable<IEntityCreatedResponse> {
     let report: IReportConfigModel = {
@@ -23,7 +22,7 @@ export class ReportService {
       bundlingType: bundlingType
     };
 
-    return this.http.post<IEntityCreatedResponse>(`${this.baseApiUrl}/report/config`, report)
+    return this.http.post<IEntityCreatedResponse>(`${this.appConfigService.config?.baseApiUrl}/report/config`, report)
       .pipe(
         tap(_ => console.log(`Request for configuration creation was sent.`)),
         map((response: IEntityCreatedResponse) => {
@@ -41,7 +40,7 @@ export class ReportService {
       bundlingType: bundlingType
     };
 
-    return this.http.put<IEntityCreatedResponse>(`${this.baseApiUrl}/report/config/${reportConfigId}`, report)
+    return this.http.put<IEntityCreatedResponse>(`${this.appConfigService.config?.baseApiUrl}/report/config/${reportConfigId}`, report)
       .pipe(
         tap(_ => console.log(`Request for configuration update was sent.`)),
         map((response: IEntityCreatedResponse) => {
@@ -52,7 +51,7 @@ export class ReportService {
   }
 
   getReportConfiguration(reportConfigId: string): Observable<IReportConfigModel> {
-    return this.http.get<IReportConfigModel>(`${this.baseApiUrl}/report/config/${reportConfigId}`)
+    return this.http.get<IReportConfigModel>(`${this.appConfigService.config?.baseApiUrl}/report/config/${reportConfigId}`)
       .pipe(
         tap(_ => console.log(`Fetched configuration.`)),
         catchError((error) => this.errorHandler.handleError(error))
@@ -60,7 +59,7 @@ export class ReportService {
   }
 
   deleteReportConfiguration(reportConfigId: string): Observable<IEntityDeletedResponse> {
-    return this.http.delete<IEntityDeletedResponse>(`${this.baseApiUrl}/report/config/${reportConfigId}`)
+    return this.http.delete<IEntityDeletedResponse>(`${this.appConfigService.config?.baseApiUrl}/report/config/${reportConfigId}`)
       .pipe(
         tap(_ => console.log(`Request for configuration deletion was sent.`)),
         catchError((error) => this.errorHandler.handleError(error))
@@ -68,7 +67,7 @@ export class ReportService {
   }
 
   getReportConfigurations(facilityId: string): Observable<IReportConfigModel[]> {
-    return this.http.get<IReportConfigModel[]>(`${this.baseApiUrl}/report/config/reports/${facilityId}`)
+    return this.http.get<IReportConfigModel[]>(`${this.appConfigService.config?.baseApiUrl}/report/config/reports/${facilityId}`)
       .pipe(
         tap(_ => console.log(`Fetched reports.`)),
         map((response: IReportConfigModel[]) => {

--- a/DemoApp/src/app/services/gateway/tenant/tenant.service.ts
+++ b/DemoApp/src/app/services/gateway/tenant/tenant.service.ts
@@ -5,14 +5,13 @@ import { HttpClient, HttpErrorResponse } from '@angular/common/http';
 import { IFacilityConfigModel, IScheduledTaskModel } from 'src/app/interfaces/tenant/facility-config-model.interface';
 import { Observable, catchError, map, tap } from 'rxjs';
 import { IEntityCreatedResponse } from 'src/app/interfaces/entity-created-response.model';
+import { AppConfigService } from '../../app-config.service';
 
 @Injectable({
   providedIn: 'root'
 })
 export class TenantService {
-  private baseApiUrl = `${environment.baseApiUrl}/api`;
-
-  constructor(private http: HttpClient, private errorHandler: ErrorHandlingService) { }
+  constructor(private http: HttpClient, private errorHandler: ErrorHandlingService, public appConfigService: AppConfigService) { }
 
   createFacility(facilityId: string, facilityName: string, scheduledTasks: IScheduledTaskModel[]): Observable<IEntityCreatedResponse> {
     let facility: IFacilityConfigModel = {
@@ -21,7 +20,7 @@ export class TenantService {
       scheduledTasks: scheduledTasks
     };
 
-    return this.http.post<IEntityCreatedResponse>(`${this.baseApiUrl}/tenant/facility`, facility)
+    return this.http.post<IEntityCreatedResponse>(`${this.appConfigService.config?.baseApiUrl}/tenant/facility`, facility)
       .pipe(
         tap(_ => console.log(`Request for facility creation was sent.`)),
         map((response: IEntityCreatedResponse) => {
@@ -39,7 +38,7 @@ export class TenantService {
       scheduledTasks: scheduledTasks
     };
 
-    return this.http.put<IEntityCreatedResponse>(`${this.baseApiUrl}/tenant/facility/${id}`, facility)
+    return this.http.put<IEntityCreatedResponse>(`${this.appConfigService.config?.baseApiUrl}/tenant/facility/${id}`, facility)
       .pipe(
         tap(_ => console.log(`Request for facility update was sent.`)),
         map((response: IEntityCreatedResponse) => {
@@ -50,7 +49,7 @@ export class TenantService {
   }
 
   getFacilityConfiguration(facilityId: string): Observable<IFacilityConfigModel> {
-    return this.http.get<IFacilityConfigModel>(`${this.baseApiUrl}/tenant/facility/${facilityId}`)
+    return this.http.get<IFacilityConfigModel>(`${this.appConfigService.config?.baseApiUrl}/tenant/facility/${facilityId}`)
       .pipe(
         tap(_ => console.log(`Fetched facility configuration.`)),
         catchError((error) => this.errorHandler.handleError(error))
@@ -58,7 +57,7 @@ export class TenantService {
   }
 
   listFacilities(facilityId: string, facilityName: string): Observable<IFacilityConfigModel[]> {
-    return this.http.get<IFacilityConfigModel[]>(`${this.baseApiUrl}/tenant/facility?facilityId=${facilityId}&facilityName=${facilityName}`)
+    return this.http.get<IFacilityConfigModel[]>(`${this.appConfigService.config?.baseApiUrl}/tenant/facility?facilityId=${facilityId}&facilityName=${facilityName}`)
       .pipe(
         tap(_ => console.log(`Fetched facilities.`)),
         catchError((error) => this.errorHandler.handleError(error))

--- a/DemoApp/src/app/services/gateway/testing.service.ts
+++ b/DemoApp/src/app/services/gateway/testing.service.ts
@@ -9,14 +9,13 @@ import { ErrorHandlingService } from '../error-handling.service';
 import { IPatientEvent } from '../../interfaces/testing/patient-event.interface';
 import { IDataAcquisitionRequested, IScheduledReport } from '../../interfaces/testing/data-acquisition-requested.interface';
 import { IReportScheduled } from '../../interfaces/testing/report-scheduled.interface';
+import { AppConfigService } from '../app-config.service';
 
 @Injectable({
   providedIn: 'root'
 })
 export class TestService {
-  private baseApiUrl = `${environment.baseApiUrl}/api`;
-
-  constructor(private http: HttpClient, private errorHandler: ErrorHandlingService) { }
+  constructor(private http: HttpClient, private errorHandler: ErrorHandlingService, public appConfigService: AppConfigService) { }
 
   generateReportScheduledEvent(facilityId: string, reportType: string, startDate: Date, endDate: Date): Observable<IEntityCreatedResponse> {
     let event: IReportScheduled = {
@@ -26,7 +25,7 @@ export class TestService {
       endDate: endDate
     };
 
-    return this.http.post<IEntityCreatedResponse>(`${this.baseApiUrl}/testing/report-scheduled`, event)
+    return this.http.post<IEntityCreatedResponse>(`${this.appConfigService.config?.baseApiUrl}/testing/report-scheduled`, event)
       .pipe(
         tap(_ => console.log(`Request for a new report scheduled event was sent.`)),
         map((response: IEntityCreatedResponse) => {
@@ -44,7 +43,7 @@ export class TestService {
       eventType: eventType
     };
 
-    return this.http.post<IEntityCreatedResponse>(`${this.baseApiUrl}/testing/patient-event`, event)
+    return this.http.post<IEntityCreatedResponse>(`${this.appConfigService.config?.baseApiUrl}/testing/patient-event`, event)
       .pipe(
         tap(_ => console.log(`Request for a new patient event was sent.`)),
         map((response: IEntityCreatedResponse) => {
@@ -62,7 +61,7 @@ export class TestService {
       reports: reports
     };
 
-    return this.http.post<IEntityCreatedResponse>(`${this.baseApiUrl}/testing/data-acquisition-requested-event`, event)
+    return this.http.post<IEntityCreatedResponse>(`${this.appConfigService.config?.baseApiUrl}/testing/data-acquisition-requested-event`, event)
       .pipe(
         tap(_ => console.log(`Request for a new data acquisition requested event was sent.`)),
         map((response: IEntityCreatedResponse) => {

--- a/DemoApp/src/assets/app.config.json
+++ b/DemoApp/src/assets/app.config.json
@@ -1,0 +1,8 @@
+{
+  "production": false,
+  "baseApiUrl": "/api",
+  "idpIssuer": "",
+  "idpClientId": "",
+  "idpClientSecret": "",
+  "idpScope": "openid profile email botwdemogatewayapi.read botwdemogatewayapi.write botwdemogatewayapi.delete"
+}

--- a/DemoApp/src/environments/environment.prod.ts
+++ b/DemoApp/src/environments/environment.prod.ts
@@ -1,10 +1,3 @@
 export const environment = {
-  production: true,
-  baseApiUrl: "http://localhost:7777",
-  idpIssuer: "",
-  idpClientId: '',
-  idpClientSecret: '',
-  idpScope: 'openid profile email botwdemogatewayapi.read botwdemogatewayapi.write',
-  redirectUri: window.location.origin + '/',
-  loginUrl: window.location.origin + '/',
+  production: true
 };

--- a/DemoApp/src/environments/environment.ts
+++ b/DemoApp/src/environments/environment.ts
@@ -3,15 +3,7 @@
 // The list of file replacements can be found in `angular.json`.
 
 export const environment = {
-  production: false,
-  baseApiUrl: "http://localhost:7777",
-  idpIssuer : "",
-  idpClientId: '',
-  idpClientSecret: '',
-  idpScope: 'openid profile email botwdemogatewayapi.read botwdemogatewayapi.write botwdemogatewayapi.delete',
-  redirectUri: window.location.origin + '/',
-  loginUrl: window.location.origin + '/',
-
+  production: false
 };
 
 /*


### PR DESCRIPTION
Adding proxy to angular to allow angular to proxy /proxy-api/ to localhost:7777 to avoid cors when testing

Moving `environment` to `AppConfigService`
`AppConfigService` loads settings from a runtime `/assets/app.config.json` and optionally `/assets/app.config.local.json`