### PR TITLE
Java shared project no longer using maven feed

### DIFF
--- a/Java/measureeval/Dockerfile
+++ b/Java/measureeval/Dockerfile
@@ -2,17 +2,14 @@ ARG SHARED_BOTW_FEED_TOKEN_ARG
 
 # Stage 1: Build the Spring Boot application
 FROM maven:3.8.7-openjdk-18-slim AS build
-ARG SHARED_BOTW_FEED_TOKEN_ARG
 WORKDIR /app
-COPY . /app
-ENV SHARED_BOTW_FEED_TOKEN=$SHARED_BOTW_FEED_TOKEN_ARG
-COPY .m2/settings.xml /root/.m2/settings.xml
-RUN mvn clean install -DskipTests
-RUN mv target/measureeval-*.jar target/measureeval.jar
+COPY Java/ ./
+RUN mvn clean install -pl measureeval -am
+RUN mv measureeval/target/measureeval-*.jar measureeval/target/measureeval.jar
 
 # Stage 2: Run the Spring Boot application
 FROM openjdk:17-jdk-alpine
 WORKDIR /app
 COPY --from=build /app/target/measureeval.jar measureeval.jar
 EXPOSE 8080
-CMD ["java", "-jar", "measureeval.jar"]
+CMD ["java", "-jar", "measureeval.jar", "--add-opens java.base/java.util=ALL-UNNAMED"]

--- a/Java/measureeval/Dockerfile
+++ b/Java/measureeval/Dockerfile
@@ -11,5 +11,5 @@ RUN mv measureeval/target/measureeval-*.jar measureeval/target/measureeval.jar
 FROM openjdk:17-jdk-alpine
 WORKDIR /app
 COPY --from=build /app/target/measureeval.jar measureeval.jar
-EXPOSE 8080
+EXPOSE 31819
 CMD ["java", "-jar", "measureeval.jar", "--add-opens java.base/java.util=ALL-UNNAMED"]

--- a/Java/measureeval/Dockerfile
+++ b/Java/measureeval/Dockerfile
@@ -11,5 +11,5 @@ RUN mv measureeval/target/measureeval-*.jar measureeval/target/measureeval.jar
 FROM openjdk:17-jdk-alpine
 WORKDIR /app
 COPY --from=build /app/target/measureeval.jar measureeval.jar
-EXPOSE 31819
+EXPOSE 5135
 CMD ["java", "-jar", "measureeval.jar", "--add-opens java.base/java.util=ALL-UNNAMED"]

--- a/Java/measureeval/pom.xml
+++ b/Java/measureeval/pom.xml
@@ -4,15 +4,12 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.2.3</version>
-        <relativePath/>
+        <groupId>com.lantanagroup.link</groupId>
+        <artifactId>main</artifactId>
+        <version>0.0.1-SNAPSHOT</version>
     </parent>
 
-    <groupId>com.lantanagroup.link</groupId>
     <artifactId>measureeval</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
     <name>Measure Evaluation Service</name>
     <description>Micro service for evaluating data against digital quality measures</description>
 
@@ -23,26 +20,10 @@
         <maven.compiler.target>17</maven.compiler.target>
         <spring.boot>3.2.3</spring.boot>
         <mssql>12.6.1.jre11</mssql>
-        <lombok>1.18.30</lombok>
         <kafka.streams>3.7.0</kafka.streams>
         <spring.kafka>3.1.2</spring.kafka>
         <junit>4.13.2</junit>
-        <repo.id>Shared_BOTW_Feed</repo.id>
-        <repo.url>https://pkgs.dev.azure.com/lantanagroup/nhsnlink/_packaging/Shared_BOTW_Feed/maven/v1</repo.url>
     </properties>
-
-    <repositories>
-        <repository>
-            <id>${repo.id}</id>
-            <url>${repo.url}</url>
-            <releases>
-                <enabled>true</enabled>
-            </releases>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-        </repository>
-    </repositories>
 
     <dependencies>
         <dependency>
@@ -63,11 +44,6 @@
             <groupId>org.springframework.security</groupId>
             <artifactId>spring-security-test</artifactId>
             <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.projectlombok</groupId>
-            <artifactId>lombok</artifactId>
-            <version>${lombok}</version>
         </dependency>
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
@@ -108,49 +84,13 @@
             <scope>test</scope>
         </dependency>
 
-        <!-- Hibernate and MSSQL -->
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-data-mongodb</artifactId>
-        </dependency>
-
-        <!-- OPEN API -->
-        <dependency>
-            <groupId>org.springdoc</groupId>
-            <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
-            <version>2.2.0</version>
-        </dependency>
-
-        <!-- Azure App Config -->
-        <dependency>
-            <groupId>com.azure.spring</groupId>
-            <artifactId>spring-cloud-azure-appconfiguration-config-web</artifactId>
-            <version>5.11.0</version>
-        </dependency>
-
         <!-- SHARED LIBRARY -->
         <dependency>
             <groupId>com.lantanagroup.link</groupId>
             <artifactId>shared</artifactId>
-            <version>0.0.1-SNAPSHOT</version>
+            <version>${project.version}</version>
+            <scope>compile</scope>
         </dependency>
     </dependencies>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.springframework.boot</groupId>
-                <artifactId>spring-boot-maven-plugin</artifactId>
-                <configuration>
-                    <excludes>
-                        <exclude>
-                            <groupId>org.projectlombok</groupId>
-                            <artifactId>lombok</artifactId>
-                        </exclude>
-                    </excludes>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
 
 </project>

--- a/Java/measureeval/src/main/java/com/lantanagroup/link/measureeval/MeasureEvalApplicationConfig.java
+++ b/Java/measureeval/src/main/java/com/lantanagroup/link/measureeval/MeasureEvalApplicationConfig.java
@@ -1,9 +1,11 @@
 package com.lantanagroup.link.measureeval;
 
 import com.lantanagroup.link.shared.kafka.KafkaErrorHandler;
+import com.lantanagroup.link.shared.mongo.FhirConversions;
 import com.lantanagroup.link.shared.security.SecurityHelper;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.mongodb.core.convert.MongoCustomConversions;
 import org.springframework.kafka.listener.CommonErrorHandler;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.web.SecurityFilterChain;
@@ -31,5 +33,10 @@ public class MeasureEvalApplicationConfig {
     @Bean
     SecurityFilterChain web(HttpSecurity http) throws Exception {
         return SecurityHelper.build(http);
+    }
+
+    @Bean
+    MongoCustomConversions customConversions() {
+        return new FhirConversions();
     }
 }

--- a/Java/measureeval/src/main/java/com/lantanagroup/link/measureeval/controllers/HealthController.java
+++ b/Java/measureeval/src/main/java/com/lantanagroup/link/measureeval/controllers/HealthController.java
@@ -5,7 +5,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/_health")
+@RequestMapping("/health")
 public class HealthController {
     @GetMapping
     public String health() {

--- a/Java/measureeval/src/main/java/com/lantanagroup/link/measureeval/controllers/MeasureDefinitionController.java
+++ b/Java/measureeval/src/main/java/com/lantanagroup/link/measureeval/controllers/MeasureDefinitionController.java
@@ -29,7 +29,7 @@ public class MeasureDefinitionController {
             measureDefinition.setId(md.getId());
             measureDefinition.setMeasureId(md.getMeasureId());
             measureDefinition.setMeasureName(md.getMeasureName());
-            measureDefinition.setMeasureUrl(md.getMeasureUrl());
+            measureDefinition.setMeasureDefinitionUrl(md.getMeasureDefinitionUrl());
             measureDefinition.setLastUpdated(md.getLastUpdated());
             return measureDefinition;
         }).toList();

--- a/Java/measureeval/src/main/java/com/lantanagroup/link/measureeval/controllers/MeasureDefinitionController.java
+++ b/Java/measureeval/src/main/java/com/lantanagroup/link/measureeval/controllers/MeasureDefinitionController.java
@@ -1,22 +1,38 @@
 package com.lantanagroup.link.measureeval.controllers;
 
+import com.lantanagroup.link.measureeval.entities.MeasureDefinition;
 import com.lantanagroup.link.measureeval.models.UpdateMeasureDefinitionResponse;
+import com.lantanagroup.link.measureeval.repositories.MeasureDefinitionRepository;
 import com.lantanagroup.link.measureeval.services.MeasureDefinitionCache;
 import org.hl7.fhir.r4.model.Bundle;
 import org.springframework.http.HttpStatus;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.server.ResponseStatusException;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/measure-definition")
 public class MeasureDefinitionController {
     private final MeasureDefinitionCache measureDefinitionCache;
+    private final MeasureDefinitionRepository measureDefinitionRepository;
 
-    public MeasureDefinitionController(MeasureDefinitionCache measureDefinitionCache) {
+    public MeasureDefinitionController(MeasureDefinitionCache measureDefinitionCache, MeasureDefinitionRepository measureDefinitionRepository) {
         this.measureDefinitionCache = measureDefinitionCache;
+        this.measureDefinitionRepository = measureDefinitionRepository;
+    }
+
+    @GetMapping
+    public List<MeasureDefinition> getAll() {
+        return this.measureDefinitionRepository.findAll().stream().map(md -> {
+            MeasureDefinition measureDefinition = new MeasureDefinition();
+            measureDefinition.setId(md.getId());
+            measureDefinition.setMeasureId(md.getMeasureId());
+            measureDefinition.setMeasureName(md.getMeasureName());
+            measureDefinition.setMeasureUrl(md.getMeasureUrl());
+            measureDefinition.setLastUpdated(md.getLastUpdated());
+            return measureDefinition;
+        }).toList();
     }
 
     @PutMapping

--- a/Java/measureeval/src/main/java/com/lantanagroup/link/measureeval/entities/MeasureDefinition.java
+++ b/Java/measureeval/src/main/java/com/lantanagroup/link/measureeval/entities/MeasureDefinition.java
@@ -1,0 +1,30 @@
+package com.lantanagroup.link.measureeval.entities;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Getter;
+import lombok.Setter;
+import org.hl7.fhir.r4.model.Bundle;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Field;
+
+import java.time.Instant;
+
+@Getter @Setter
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class MeasureDefinition {
+    @Id
+    private String id;
+
+    @Field("measureDefinitionId")
+    private String measureId;
+
+    @Field("measureDefinitionName")
+    private String measureName;
+
+    @Field("url")
+    private String measureUrl;
+
+    private Instant lastUpdated;
+
+    private Bundle bundle;
+}

--- a/Java/measureeval/src/main/java/com/lantanagroup/link/measureeval/entities/MeasureDefinition.java
+++ b/Java/measureeval/src/main/java/com/lantanagroup/link/measureeval/entities/MeasureDefinition.java
@@ -21,8 +21,11 @@ public class MeasureDefinition {
     @Field("measureDefinitionName")
     private String measureName;
 
+    /**
+     * The URL of where to get the measure definition from
+     */
     @Field("url")
-    private String measureUrl;
+    private String measureDefinitionUrl;
 
     private Instant lastUpdated;
 

--- a/Java/measureeval/src/main/java/com/lantanagroup/link/measureeval/repositories/MeasureDefinitionRepository.java
+++ b/Java/measureeval/src/main/java/com/lantanagroup/link/measureeval/repositories/MeasureDefinitionRepository.java
@@ -1,0 +1,7 @@
+package com.lantanagroup.link.measureeval.repositories;
+
+import com.lantanagroup.link.measureeval.entities.MeasureDefinition;
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+public interface MeasureDefinitionRepository extends MongoRepository<MeasureDefinition, String>{
+}

--- a/Java/measureeval/src/main/java/com/lantanagroup/link/measureeval/services/MeasureDefinitionCache.java
+++ b/Java/measureeval/src/main/java/com/lantanagroup/link/measureeval/services/MeasureDefinitionCache.java
@@ -1,10 +1,17 @@
 package com.lantanagroup.link.measureeval.services;
 
+import com.lantanagroup.link.measureeval.repositories.MeasureDefinitionRepository;
 import org.hl7.fhir.r4.model.Bundle;
 import org.springframework.stereotype.Service;
 
 @Service
 public class MeasureDefinitionCache {
+    private final MeasureDefinitionRepository measureDefinitionRepository;
+
+    public MeasureDefinitionCache(MeasureDefinitionRepository measureDefinitionRepository) {
+        this.measureDefinitionRepository = measureDefinitionRepository;
+    }
+
     public Bundle getMeasureDefinition(String measureId) {
         return null;
     }

--- a/Java/measureeval/src/main/resources/application.yml
+++ b/Java/measureeval/src/main/resources/application.yml
@@ -1,5 +1,5 @@
 server:
-  port: 31819
+  port: 5135
 springdoc:
   api-docs:
     path: /api-docs

--- a/Java/measureeval/src/main/resources/application.yml
+++ b/Java/measureeval/src/main/resources/application.yml
@@ -1,3 +1,5 @@
+server:
+  port: 31819
 springdoc:
   api-docs:
     path: /api-docs

--- a/Java/pom.xml
+++ b/Java/pom.xml
@@ -3,6 +3,13 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>3.2.3</version>
+        <relativePath/>
+    </parent>
+
     <groupId>com.lantanagroup.link</groupId>
     <artifactId>main</artifactId>
     <version>0.0.1-SNAPSHOT</version>
@@ -10,10 +17,85 @@
     <description>Project/folder of Java modules/services for Link</description>
     <packaging>pom</packaging>
 
+    <properties>
+        <lombok>1.18.30</lombok>
+    </properties>
+
     <modules>
         <module>shared</module>
         <module>validation</module>
         <module>measureeval</module>
     </modules>
 
+    <dependencies>
+        <!-- Lombok -->
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <version>${lombok}</version>
+        </dependency>
+
+        <!-- Hibernate and Mongo -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-mongodb</artifactId>
+        </dependency>
+
+        <!-- OPEN API -->
+        <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+            <version>2.2.0</version>
+        </dependency>
+
+        <!-- Azure App Config -->
+        <dependency>
+            <groupId>com.azure.spring</groupId>
+            <artifactId>spring-cloud-azure-appconfiguration-config-web</artifactId>
+            <version>5.11.0</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <configuration>
+                    <excludes>
+                        <exclude>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                        </exclude>
+                    </excludes>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>17</source>
+                    <target>17</target>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <configuration>
+                    <excludes>
+                        <exclude>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                        </exclude>
+                    </excludes>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>repackage</id>
+                        <phase>none</phase>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/Java/shared/pom.xml
+++ b/Java/shared/pom.xml
@@ -3,10 +3,15 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>com.lantanagroup.link</groupId>
+    <parent>
+        <groupId>com.lantanagroup.link</groupId>
+        <artifactId>main</artifactId>
+        <version>0.0.1-SNAPSHOT</version>
+    </parent>
+
     <artifactId>shared</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
     <name>Shared Library</name>
+    <packaging>jar</packaging>
     <description>Shared functionality across all Link Java projects/modules</description>
 
     <properties>
@@ -14,36 +19,8 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
-        <repo.id>Shared_BOTW_Feed</repo.id>
-        <repo.url>https://pkgs.dev.azure.com/lantanagroup/nhsnlink/_packaging/Shared_BOTW_Feed/maven/v1</repo.url>
         <junit>4.13.2</junit>
     </properties>
-
-    <repositories>
-        <repository>
-            <id>${repo.id}</id>
-            <url>${repo.url}</url>
-            <releases>
-                <enabled>true</enabled>
-            </releases>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-        </repository>
-    </repositories>
-
-    <distributionManagement>
-        <repository>
-            <id>${repo.id}</id>
-            <url>${repo.url}</url>
-            <releases>
-                <enabled>true</enabled>
-            </releases>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-        </repository>
-    </distributionManagement>
 
     <dependencies>
         <dependency>
@@ -68,35 +45,4 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <source>17</source>
-                    <target>17</target>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.springframework.boot</groupId>
-                <artifactId>spring-boot-maven-plugin</artifactId>
-                <configuration>
-                    <excludes>
-                        <exclude>
-                            <groupId>org.projectlombok</groupId>
-                            <artifactId>lombok</artifactId>
-                        </exclude>
-                    </excludes>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>repackage</id>
-                        <phase>none</phase>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-    </build>
 </project>

--- a/Java/shared/src/main/java/com/lantanagroup/link/shared/fhir/FhirHelper.java
+++ b/Java/shared/src/main/java/com/lantanagroup/link/shared/fhir/FhirHelper.java
@@ -22,11 +22,15 @@ public class FhirHelper {
         return parser;
     }
 
-    public static void deserialize(String json) {
-        getParser().parseResource(json);
+    public static Resource deserialize(String json) {
+        return (Resource) getParser().parseResource(json);
     }
 
-    public static void serialize(Resource resource) {
-        getParser().encodeResourceToString(resource);
+    public static <T extends Resource> T deserialize(String json, Class<T> clazz) {
+        return getParser().parseResource(clazz, json);
+    }
+
+    public static String serialize(Resource resource) {
+        return getParser().encodeResourceToString(resource);
     }
 }

--- a/Java/shared/src/main/java/com/lantanagroup/link/shared/mongo/BundleDeserializer.java
+++ b/Java/shared/src/main/java/com/lantanagroup/link/shared/mongo/BundleDeserializer.java
@@ -1,0 +1,14 @@
+package com.lantanagroup.link.shared.mongo;
+
+import com.lantanagroup.link.shared.fhir.FhirHelper;
+import org.bson.Document;
+import org.hl7.fhir.r4.model.Bundle;
+import org.springframework.core.convert.converter.Converter;
+
+public class BundleDeserializer implements Converter<Document, Bundle> {
+    @Override
+    public Bundle convert(Document source) {
+        String json = source.toJson();
+        return (Bundle) FhirHelper.deserialize(json);
+    }
+}

--- a/Java/shared/src/main/java/com/lantanagroup/link/shared/mongo/BundleSerializer.java
+++ b/Java/shared/src/main/java/com/lantanagroup/link/shared/mongo/BundleSerializer.java
@@ -1,0 +1,14 @@
+package com.lantanagroup.link.shared.mongo;
+
+import com.lantanagroup.link.shared.fhir.FhirHelper;
+import org.bson.Document;
+import org.hl7.fhir.r4.model.Bundle;
+import org.springframework.core.convert.converter.Converter;
+
+public class BundleSerializer implements Converter<Bundle, Document> {
+    @Override
+    public Document convert(Bundle source) {
+        String json = FhirHelper.serialize(source);
+        return Document.parse(json);
+    }
+}

--- a/Java/shared/src/main/java/com/lantanagroup/link/shared/mongo/FhirConversions.java
+++ b/Java/shared/src/main/java/com/lantanagroup/link/shared/mongo/FhirConversions.java
@@ -1,0 +1,12 @@
+package com.lantanagroup.link.shared.mongo;
+
+import org.hl7.fhir.r4.model.Bundle;
+import org.springframework.data.mongodb.core.convert.MongoCustomConversions;
+
+import java.util.List;
+
+public class FhirConversions extends MongoCustomConversions {
+    public FhirConversions() {
+        super(List.of(new BundleDeserializer(), new BundleSerializer()));
+    }
+}

--- a/Java/shared/src/main/java/com/lantanagroup/link/shared/security/SecurityHelper.java
+++ b/Java/shared/src/main/java/com/lantanagroup/link/shared/security/SecurityHelper.java
@@ -28,4 +28,11 @@ public class SecurityHelper {
                 });
         return http.build();
     }
+
+    public static SecurityFilterChain buildAnonymous(HttpSecurity http) throws Exception {
+        return http.authorizeHttpRequests(authorizeRequests -> {
+                    authorizeRequests.anyRequest().permitAll();
+                })
+                .build();
+    }
 }

--- a/Java/validation/Dockerfile
+++ b/Java/validation/Dockerfile
@@ -9,5 +9,5 @@ RUN mv validation/target/validation-*.jar validation/target/validation.jar
 FROM openjdk:17-jdk-alpine
 WORKDIR /app
 COPY --from=build /app/target/validation.jar validation.jar
-EXPOSE 8080
+EXPOSE 31820
 CMD ["java", "-jar", "validation.jar", "--add-opens java.base/java.util=ALL-UNNAMED"]

--- a/Java/validation/Dockerfile
+++ b/Java/validation/Dockerfile
@@ -1,18 +1,13 @@
-ARG SHARED_BOTW_FEED_TOKEN_ARG
-
 # Stage 1: Build the Spring Boot application
 FROM maven:3.8.7-openjdk-18-slim AS build
-ARG SHARED_BOTW_FEED_TOKEN_ARG
 WORKDIR /app
-COPY . /app
-ENV SHARED_BOTW_FEED_TOKEN=$SHARED_BOTW_FEED_TOKEN_ARG
-COPY .m2/settings.xml /root/.m2/settings.xml
-RUN mvn clean install -DskipTests
-RUN mv target/validation-*.jar target/validation.jar
+COPY Java/ ./
+RUN mvn clean install -pl validation -am
+RUN mv validation/target/validation-*.jar validation/target/validation.jar
 
 # Stage 2: Run the Spring Boot application
 FROM openjdk:17-jdk-alpine
 WORKDIR /app
 COPY --from=build /app/target/validation.jar validation.jar
 EXPOSE 8080
-CMD ["java", "-jar", "validation.jar"]
+CMD ["java", "-jar", "validation.jar", "--add-opens java.base/java.util=ALL-UNNAMED"]

--- a/Java/validation/pom.xml
+++ b/Java/validation/pom.xml
@@ -4,15 +4,12 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.2.3</version>
-        <relativePath/>
+        <groupId>com.lantanagroup.link</groupId>
+        <artifactId>main</artifactId>
+        <version>0.0.1-SNAPSHOT</version>
     </parent>
 
-    <groupId>com.lantanagroup.link</groupId>
     <artifactId>validation</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
     <name>Validation Service</name>
     <description>Micro service for validating report submission data</description>
 
@@ -23,26 +20,10 @@
         <maven.compiler.target>17</maven.compiler.target>
         <spring.boot>3.2.3</spring.boot>
         <mssql>12.6.1.jre11</mssql>
-        <lombok>1.18.30</lombok>
         <kafka.streams>3.7.0</kafka.streams>
         <spring.kafka>3.1.2</spring.kafka>
         <junit>4.13.2</junit>
-        <repo.id>Shared_BOTW_Feed</repo.id>
-        <repo.url>https://pkgs.dev.azure.com/lantanagroup/nhsnlink/_packaging/Shared_BOTW_Feed/maven/v1</repo.url>
     </properties>
-
-    <repositories>
-        <repository>
-            <id>${repo.id}</id>
-            <url>${repo.url}</url>
-            <releases>
-                <enabled>true</enabled>
-            </releases>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-        </repository>
-    </repositories>
 
     <dependencies>
         <dependency>
@@ -63,11 +44,6 @@
             <groupId>org.springframework.security</groupId>
             <artifactId>spring-security-test</artifactId>
             <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.projectlombok</groupId>
-            <artifactId>lombok</artifactId>
-            <version>${lombok}</version>
         </dependency>
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
@@ -139,24 +115,8 @@
             <groupId>com.lantanagroup.link</groupId>
             <artifactId>shared</artifactId>
             <version>0.0.1-SNAPSHOT</version>
+            <scope>compile</scope>
         </dependency>
     </dependencies>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.springframework.boot</groupId>
-                <artifactId>spring-boot-maven-plugin</artifactId>
-                <configuration>
-                    <excludes>
-                        <exclude>
-                            <groupId>org.projectlombok</groupId>
-                            <artifactId>lombok</artifactId>
-                        </exclude>
-                    </excludes>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
 
 </project>

--- a/Java/validation/src/main/resources/application.yml
+++ b/Java/validation/src/main/resources/application.yml
@@ -1,3 +1,5 @@
+server:
+  port: 31820
 springdoc:
   api-docs:
     path: /api-docs


### PR DESCRIPTION
* Shared is directly referenced as a project
* Root POM includes dependencies that are used by both measureeval and validation services
* Added repository for measure definitions to measureeval
* Added REST controller for measure definitions and tested that mongo connection works
* Dockerfiles updated to build both destination service and shared module at same time