### PR TITLE
LNK-2344: Add telemetry export to azure monitor

### DIFF
--- a/DotNet/Audit/Application/Audit/Commands/CreateAuditEvent/CreateAuditEventCommand.cs
+++ b/DotNet/Audit/Application/Audit/Commands/CreateAuditEvent/CreateAuditEventCommand.cs
@@ -2,7 +2,6 @@
 using LantanaGroup.Link.Audit.Domain.Entities;
 using LantanaGroup.Link.Audit.Infrastructure;
 using LantanaGroup.Link.Audit.Infrastructure.Logging;
-using LantanaGroup.Link.Audit.Infrastructure.Telemetry;
 using OpenTelemetry.Trace;
 using System.Diagnostics;
 using static LantanaGroup.Link.Audit.Settings.AuditConstants;

--- a/DotNet/Audit/Application/Models/TelemetryConfig.cs
+++ b/DotNet/Audit/Application/Models/TelemetryConfig.cs
@@ -4,12 +4,13 @@ namespace LantanaGroup.Link.Audit.Application.Models
 {
     public class TelemetryConfig
     {
+        public bool Enabled { get; set; } = true;
         public bool EnableTracing { get; set; } = true;
         public bool EnableMetrics { get; set; } = true;
         public bool EnableRuntimeInstrumentation { get; set; } = false;
-        public string TraceExporterEndpoint { get; set; } = string.Empty;
-        public string MetricsEndpoint { get; set; } = string.Empty;
-        public string TelemetryCollectorEndpoint { get; set; } = string.Empty;
-
-    }
+        public bool EnableOtelCollector = true;
+        public string? OtelCollectorEndpoint { get; set; }
+        public bool EnableAzureMonitor { get; set; } = false;
+        public string? AzureMonitorConnectionString { get; set; }
+    }    
 }

--- a/DotNet/Audit/Application/Models/TelemetryConfig.cs
+++ b/DotNet/Audit/Application/Models/TelemetryConfig.cs
@@ -7,6 +7,7 @@ namespace LantanaGroup.Link.Audit.Application.Models
         public bool Enabled { get; set; } = true;
         public bool EnableTracing { get; set; } = true;
         public bool EnableMetrics { get; set; } = true;
+        public string? MeterName { get; set; }
         public bool EnableRuntimeInstrumentation { get; set; } = false;
         public bool EnableOtelCollector = true;
         public string? OtelCollectorEndpoint { get; set; }

--- a/DotNet/Audit/Audit.csproj
+++ b/DotNet/Audit/Audit.csproj
@@ -23,6 +23,7 @@
 
   <ItemGroup>
 	<PackageReference Include="Azure.Identity" Version="1.11.0" />
+	<PackageReference Include="Azure.Monitor.OpenTelemetry.AspNetCore" Version="1.1.0" />
 	<PackageReference Include="com.lantanagroup.link.Shared" Version="2.*" />
 	<PackageReference Include="AspNetCore.HealthChecks.UI.Client" Version="8.0.1" />
 	<PackageReference Include="Confluent.Kafka.Extensions.OpenTelemetry" Version="0.3.0" />

--- a/DotNet/Audit/Infrastructure/Extensions/TelemetryServiceExtension.cs
+++ b/DotNet/Audit/Infrastructure/Extensions/TelemetryServiceExtension.cs
@@ -1,0 +1,121 @@
+﻿using Azure.Identity;
+using Azure.Monitor.OpenTelemetry.AspNetCore;
+using Confluent.Kafka.Extensions.OpenTelemetry;
+using LantanaGroup.Link.Audit.Application.Interfaces;
+using LantanaGroup.Link.Audit.Application.Models;
+using LantanaGroup.Link.Audit.Infrastructure.Telemetry;
+using OpenTelemetry.Metrics;
+using OpenTelemetry.Resources;
+using OpenTelemetry.Trace;
+
+namespace LantanaGroup.Link.Audit.Infrastructure.Extensions
+{
+    public static class TelemetryServiceExtension
+    {
+        public static IServiceCollection AddOpenTelemetryService(this IServiceCollection services, Action<TelemetryServiceOptions> options)
+        {
+            var telemetryServiceOptions = new TelemetryServiceOptions();
+            options.Invoke(telemetryServiceOptions);
+
+            var otel = services.AddOpenTelemetry();
+
+            //configure OpenTelemetry resources with application name
+            otel.ConfigureResource(resource => resource
+                .AddService(
+                    serviceName: ServiceActivitySource.Instance.Name,
+                    serviceVersion: ServiceActivitySource.Instance.Version
+                ));
+
+            //Add Tracing if enabled
+            if (telemetryServiceOptions.EnableTracing)
+            {
+                otel.WithTracing(tracerProviderBuilder =>
+                    tracerProviderBuilder
+                        .AddSource(ServiceActivitySource.Instance.Name)
+                        .AddAspNetCoreInstrumentation(options =>
+                        {
+                            options.Filter = (httpContext) => httpContext.Request.Path != "/health"; //do not capture traces for the health check endpoint                                                           
+                        })
+                        .AddHttpClientInstrumentation(options =>
+                        {
+                            options.FilterHttpRequestMessage = (httpContext) =>
+                            {
+                                return !(httpContext.RequestUri is not null
+                                    && (
+                                        httpContext.RequestUri.PathAndQuery.StartsWith("/loki") ||
+                                        httpContext.RequestUri.PathAndQuery.Contains("swagger") ||
+                                        httpContext.RequestUri.PathAndQuery.StartsWith("/health")
+                                    ));
+                            };
+                        })
+                        .AddSource("Yarp.ReverseProxy")
+                        .AddConfluentKafkaInstrumentation());
+
+                //Configure Exporters
+                if (telemetryServiceOptions.EnableOtelCollector)
+                {
+                    otel.WithTracing(exportOptions =>
+                    {
+                        if (string.IsNullOrEmpty(telemetryServiceOptions.OtelCollectorEndpoint)) { throw new NullReferenceException("No OTEL collector endpoint was found."); }
+                        exportOptions.AddOtlpExporter(opts => { opts.Endpoint = new Uri(telemetryServiceOptions.OtelCollectorEndpoint); });
+                    });
+                }
+            }          
+
+            //Add metrics if enabled
+            if (telemetryServiceOptions.EnableMetrics)
+            {
+                otel.WithMetrics(metricsProviderBuilder =>
+                    metricsProviderBuilder
+                        .AddAspNetCoreInstrumentation()
+                        .AddProcessInstrumentation());
+
+                if (telemetryServiceOptions.EnableRuntimeInstrumentation)
+                {
+                    otel.WithMetrics(metricsProviderBuilder =>
+                        metricsProviderBuilder
+                            .AddRuntimeInstrumentation());
+                }
+
+                if (telemetryServiceOptions.Environment.IsDevelopment())
+                {
+                    otel.WithTracing(tracerProviderBuilder =>
+                        tracerProviderBuilder
+                         .AddConsoleExporter());
+
+                    //metrics are very verbose, only enable console exporter if you really want to see metric details
+                    //otel.WithMetrics(metricsProviderBuilder =>
+                    //    metricsProviderBuilder
+                    //        .AddConsoleExporter());                
+                }
+
+                //Configure Exporters
+                if (telemetryServiceOptions.EnableOtelCollector)
+                {
+                    otel.WithMetrics(exportOptions =>
+                    {
+                        if (string.IsNullOrEmpty(telemetryServiceOptions.OtelCollectorEndpoint)) { throw new NullReferenceException("No OTEL collector endpoint was found."); }
+                        exportOptions.AddOtlpExporter(opts => { opts.Endpoint = new Uri(telemetryServiceOptions.OtelCollectorEndpoint); });
+                    });
+                }               
+            }
+
+            //Add Azure Monitor if enabled
+            if (telemetryServiceOptions.EnableAzureMonitor)
+            {               
+                otel.UseAzureMonitor(options => 
+                {
+                    options.Credential = new DefaultAzureCredential();
+                    options.ConnectionString = telemetryServiceOptions.AzureMonitorConnectionString;
+                });
+            }
+
+            return services;
+        }
+
+        public class TelemetryServiceOptions : TelemetryConfig
+        {
+            public IWebHostEnvironment Environment { get; set; } = null!;          
+        }
+    }
+}

--- a/DotNet/Audit/Infrastructure/Extensions/TelemetryServiceExtension.cs
+++ b/DotNet/Audit/Infrastructure/Extensions/TelemetryServiceExtension.cs
@@ -2,6 +2,7 @@
 using Azure.Monitor.OpenTelemetry.AspNetCore;
 using Confluent.Kafka.Extensions.OpenTelemetry;
 using LantanaGroup.Link.Audit.Application.Models;
+using LantanaGroup.Link.Audit.Settings;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Resources;
 using OpenTelemetry.Trace;
@@ -10,6 +11,36 @@ namespace LantanaGroup.Link.Audit.Infrastructure.Extensions
 {
     public static class TelemetryServiceExtension
     {
+
+        public static IServiceCollection AddLinkTelemetry(this IServiceCollection services, IConfiguration configuration, Action<TelemetryServiceOptions> options)
+        {
+            var initTelemetryOptions = new TelemetryServiceOptions();
+            options.Invoke(initTelemetryOptions);
+
+            var telemetryConfig = configuration.GetSection(AuditConstants.AppSettingsSectionNames.Telemetry).Get<TelemetryConfig>()
+            ?? throw new NullReferenceException("Telemetry Configuration was null.");
+
+            services.AddOpenTelemetryService(options => {
+                options.Environment = initTelemetryOptions.Environment;
+                options.EnableMetrics = telemetryConfig.EnableMetrics;
+                options.MeterName = $"Link.{AuditConstants.ServiceName}";
+                options.EnableTracing = telemetryConfig.EnableTracing;
+                options.EnableRuntimeInstrumentation = telemetryConfig.EnableRuntimeInstrumentation;
+
+                //configure OTEL Collector
+                options.EnableOtelCollector = telemetryConfig.EnableOtelCollector;
+                options.OtelCollectorEndpoint = telemetryConfig.EnableOtelCollector ?
+                    telemetryConfig.OtelCollectorEndpoint : null;
+
+                //configure Azure Monitor
+                options.EnableAzureMonitor = telemetryConfig.EnableAzureMonitor;
+                options.AzureMonitorConnectionString = telemetryConfig.EnableAzureMonitor ?
+                    configuration.GetConnectionString("AzureMonitor") : null;
+            });
+
+            return services;
+        }
+
         public static IServiceCollection AddOpenTelemetryService(this IServiceCollection services, Action<TelemetryServiceOptions> options)
         {
             var telemetryServiceOptions = new TelemetryServiceOptions();

--- a/DotNet/Audit/Infrastructure/Telemetry/AuditServiceMetrics.cs
+++ b/DotNet/Audit/Infrastructure/Telemetry/AuditServiceMetrics.cs
@@ -1,4 +1,5 @@
 ﻿using LantanaGroup.Link.Audit.Application.Interfaces;
+using LantanaGroup.Link.Audit.Settings;
 using System;
 using System.Diagnostics.Metrics;
 
@@ -6,7 +7,7 @@ namespace LantanaGroup.Link.Audit.Infrastructure.Telemetry
 {
     public class AuditServiceMetrics : IAuditServiceMetrics
     {
-        public const string MeterName = "LinkAuditService";
+        public const string MeterName = $"Link.{AuditConstants.ServiceName}";
 
         private readonly Histogram<double> _auditSearchDuration;
         private readonly TimeProvider _timeProvider;

--- a/DotNet/Audit/Program.cs
+++ b/DotNet/Audit/Program.cs
@@ -210,26 +210,9 @@ static void RegisterServices(WebApplicationBuilder builder)
         
     if (builder.Configuration.GetValue<bool>("TelemetryConfig:Enabled"))
     {
-        var telemetryConfig = builder.Configuration.GetSection(AuditConstants.AppSettingsSectionNames.Telemetry).Get<TelemetryConfig>() 
-            ?? throw new NullReferenceException("Telemetry Configuration was null.");
-        
-        builder.Services.AddOpenTelemetryService(options => {
+        builder.Services.AddLinkTelemetry(builder.Configuration, options => {
             options.Environment = builder.Environment;
-            options.EnableMetrics = telemetryConfig.EnableMetrics;
-            options.MeterName = $"Link.{AuditConstants.ServiceName}";
-            options.EnableTracing = telemetryConfig.EnableTracing;
-            options.EnableRuntimeInstrumentation = telemetryConfig.EnableRuntimeInstrumentation;
-            
-            //configure OTEL Collector
-            options.EnableOtelCollector = telemetryConfig.EnableOtelCollector;
-            options.OtelCollectorEndpoint = telemetryConfig.EnableOtelCollector ? 
-                telemetryConfig.OtelCollectorEndpoint : null;
-            
-            //configure Azure Monitor
-            options.EnableAzureMonitor = telemetryConfig.EnableAzureMonitor;
-            options.AzureMonitorConnectionString = telemetryConfig.EnableAzureMonitor ? 
-                builder.Configuration.GetConnectionString("AzureMonitor") : null;            
-        });
+        });        
 
         builder.Services.AddSingleton<IAuditServiceMetrics, AuditServiceMetrics>();
     }

--- a/DotNet/Audit/Program.cs
+++ b/DotNet/Audit/Program.cs
@@ -216,6 +216,7 @@ static void RegisterServices(WebApplicationBuilder builder)
         builder.Services.AddOpenTelemetryService(options => {
             options.Environment = builder.Environment;
             options.EnableMetrics = telemetryConfig.EnableMetrics;
+            options.MeterName = $"Link.{AuditConstants.ServiceName}";
             options.EnableTracing = telemetryConfig.EnableTracing;
             options.EnableRuntimeInstrumentation = telemetryConfig.EnableRuntimeInstrumentation;
             

--- a/DotNet/Audit/appsettings.Development.json
+++ b/DotNet/Audit/appsettings.Development.json
@@ -11,10 +11,11 @@
   },
   "DatabaseProvider": "SqlServer",
   "TelemetryConfig": {
-    "EnableRuntimeInstrumentation": false,
-    "TraceExporterEndpoint": "http://localhost:4317/",
-    "MetricsEndpoint": "http://localhost:9101",
-    "TelemetryCollectorEndpoint": "http://localhost:55690"
+    "Enabled": true,
+    "EnableRuntimeInstrumentation": true,
+    "EnableOtelCollector": true,
+    "OtelCollectorEndpoint": "http://localhost:55690",
+    "EnableAzureMonitor": true   
   },
   "AllowedHosts": "*",
   "Kestrel": {

--- a/DotNet/Audit/appsettings.json
+++ b/DotNet/Audit/appsettings.json
@@ -18,10 +18,11 @@
     "ValidTypes": [ "at+jwt", "JWT" ]
   },
   "TelemetryConfig": {
+    "Enabled": false,
     "EnableRuntimeInstrumentation": false,
-    "TraceExporterEndpoint": "http://localhost:4317/",
-    "MetricsEndpoint": "http://localhost:9101",
-    "TelemetryCollectorEndpoint": "http://localhost:55690"
+    "EnableOtelCollector": false,
+    "OtelCollectorEndpoint": "",
+    "EnableAzureMonitor": false
   },
   "EnableSwagger": true,
   "Logging": {

--- a/DotNet/Notification/Application/Extensions/ServiceCollectionExtensions.cs
+++ b/DotNet/Notification/Application/Extensions/ServiceCollectionExtensions.cs
@@ -32,14 +32,14 @@ namespace LantanaGroup.Link.Notification.Application.Extensions
                             options.Filter = (httpContext) => httpContext.Request.Path != "/health"; //do not capture traces for the health check endpoint                            
                         })
                         .AddConfluentKafkaInstrumentation()
-                        .AddOtlpExporter(opts => { opts.Endpoint = new Uri(telemetryConfig.TelemetryCollectorEndpoint); }));
+                        .AddOtlpExporter(opts => { opts.Endpoint = new Uri(telemetryConfig.OtelCollectorEndpoint); }));
 
             otel.WithMetrics(metricsProviderBuilder =>
                     metricsProviderBuilder
                         .AddAspNetCoreInstrumentation()
                         .AddProcessInstrumentation()
                         .AddMeter("LinkNotificationService")
-                        .AddOtlpExporter(opts => { opts.Endpoint = new Uri(telemetryConfig.TelemetryCollectorEndpoint); }));
+                        .AddOtlpExporter(opts => { opts.Endpoint = new Uri(telemetryConfig.OtelCollectorEndpoint); }));
 
             if (telemetryConfig.EnableRuntimeInstrumentation)
             {

--- a/DotNet/Notification/Application/Models/TelemetryConfig.cs
+++ b/DotNet/Notification/Application/Models/TelemetryConfig.cs
@@ -2,13 +2,15 @@
 {
     public class TelemetryConfig
     {
+        public bool Enabled { get; set; } = true;
         public bool EnableTracing { get; set; } = true;
         public bool EnableMetrics { get; set; } = true;
+        public string? MeterName { get; set; }
         public bool EnableRuntimeInstrumentation { get; set; } = false;
-        public string TraceExporterEndpoint { get; set; } = string.Empty;
-        public string MetricsEndpoint { get; set; } = string.Empty;
-        public string TelemetryCollectorEndpoint { get; set; } = string.Empty;
-
+        public bool EnableOtelCollector = true;
+        public string? OtelCollectorEndpoint { get; set; }
+        public bool EnableAzureMonitor { get; set; } = false;
+        public string? AzureMonitorConnectionString { get; set; }
     }
    
 }

--- a/DotNet/Notification/Infrastructure/Extensions/TelemetryServiceExtension.cs
+++ b/DotNet/Notification/Infrastructure/Extensions/TelemetryServiceExtension.cs
@@ -1,12 +1,12 @@
 ﻿using Azure.Identity;
 using Azure.Monitor.OpenTelemetry.AspNetCore;
 using Confluent.Kafka.Extensions.OpenTelemetry;
-using LantanaGroup.Link.Audit.Application.Models;
+using LantanaGroup.Link.Notification.Application.Models;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Resources;
 using OpenTelemetry.Trace;
 
-namespace LantanaGroup.Link.Audit.Infrastructure.Extensions
+namespace LantanaGroup.Link.Notification.Infrastructure.Extensions
 {
     public static class TelemetryServiceExtension
     {
@@ -69,7 +69,7 @@ namespace LantanaGroup.Link.Audit.Infrastructure.Extensions
                         .AddProcessInstrumentation());
 
                 if (!string.IsNullOrEmpty(telemetryServiceOptions.MeterName))
-                { 
+                {
                     otel.WithMetrics(metricsProviderBuilder =>
                         metricsProviderBuilder
                             .AddMeter(telemetryServiceOptions.MeterName));

--- a/DotNet/Notification/Infrastructure/Telemetry/NotificationServiceMetrics.cs
+++ b/DotNet/Notification/Infrastructure/Telemetry/NotificationServiceMetrics.cs
@@ -1,11 +1,12 @@
 ﻿using LantanaGroup.Link.Notification.Application.Interfaces;
+using LantanaGroup.Link.Notification.Settings;
 using System.Diagnostics.Metrics;
 
 namespace LantanaGroup.Link.Notification.Infrastructure.Telemetry
 {  
     public class NotificationServiceMetrics : INotificationServiceMetrics
     {
-        public const string MeterName = "LinkNotificationService";
+        public const string MeterName = $"Link.{NotificationConstants.ServiceName}";
 
         public NotificationServiceMetrics(IMeterFactory meterFactory)
         {

--- a/DotNet/Notification/Notification.csproj
+++ b/DotNet/Notification/Notification.csproj
@@ -25,6 +25,7 @@
   <ItemGroup>
     <PackageReference Include="AspNetCore.HealthChecks.UI.Client" Version="8.*" />
     <PackageReference Include="Azure.Identity" Version="1.*" />
+    <PackageReference Include="Azure.Monitor.OpenTelemetry.AspNetCore" Version="1.1.0" />
     <PackageReference Include="com.lantanagroup.link.Shared" Version="2.*" />
     <PackageReference Include="Confluent.Kafka.Extensions.OpenTelemetry" Version="0.*" />
     <PackageReference Include="Grpc.AspNetCore" Version="2.*" />

--- a/DotNet/Notification/Program.cs
+++ b/DotNet/Notification/Program.cs
@@ -239,26 +239,9 @@ static void RegisterServices(WebApplicationBuilder builder)
 
     if (builder.Configuration.GetValue<bool>("TelemetryConfig:Enabled"))
     {
-        var telemetryConfig = builder.Configuration.GetSection(NotificationConstants.AppSettingsSectionNames.Telemetry).Get<TelemetryConfig>()
-            ?? throw new NullReferenceException("Telemetry Configuration was null.");
-
-        builder.Services.AddOpenTelemetryService(options => {
+        builder.Services.AddLinkTelemetry(builder.Configuration, options => { 
             options.Environment = builder.Environment;
-            options.EnableMetrics = telemetryConfig.EnableMetrics;
-            options.MeterName = $"Link.{NotificationConstants.ServiceName}";
-            options.EnableTracing = telemetryConfig.EnableTracing;
-            options.EnableRuntimeInstrumentation = telemetryConfig.EnableRuntimeInstrumentation;
-
-            //configure OTEL Collector
-            options.EnableOtelCollector = telemetryConfig.EnableOtelCollector;
-            options.OtelCollectorEndpoint = telemetryConfig.EnableOtelCollector ?
-                telemetryConfig.OtelCollectorEndpoint : null;
-
-            //configure Azure Monitor
-            options.EnableAzureMonitor = telemetryConfig.EnableAzureMonitor;
-            options.AzureMonitorConnectionString = telemetryConfig.EnableAzureMonitor ?
-                builder.Configuration.GetConnectionString("AzureMonitor") : null;
-        });
+        });        
 
         builder.Services.AddSingleton<INotificationServiceMetrics, NotificationServiceMetrics>();
     }

--- a/DotNet/Notification/appsettings.Development.json
+++ b/DotNet/Notification/appsettings.Development.json
@@ -26,10 +26,11 @@
     "Email": true
   },
   "TelemetryConfig": {
-    "EnableRuntimeInstrumentation": false,
-    "TraceExporterEndpoint": "http://localhost:4317/",
-    "MetricsEndpoint": "http://localhost:9101",
-    "TelemetryCollectorEndpoint": "http://localhost:55690"
+    "Enabled": true,
+    "EnableRuntimeInstrumentation": true,
+    "EnableOtelCollector": true,
+    "OtelCollectorEndpoint": "http://localhost:55690",
+    "EnableAzureMonitor": false
   },
   "Logging": {
     "LogLevel": {

--- a/DotNet/Notification/appsettings.json
+++ b/DotNet/Notification/appsettings.json
@@ -33,10 +33,11 @@
     "ValidTypes": [ "at+jwt", "JWT" ]
   },
   "TelemetryConfig": {
+    "Enabled": false,
     "EnableRuntimeInstrumentation": false,
-    "TraceExporterEndpoint": "http://localhost:4317/",
-    "MetricsEndpoint": "http://localhost:9101",
-    "TelemetryCollectorEndpoint": "http://localhost:55690"
+    "EnableOtelCollector": false,
+    "OtelCollectorEndpoint": "",
+    "EnableAzureMonitor": false
   },
   "AllowReflection": false,
   "EnableSwagger": true,
@@ -46,7 +47,7 @@
       "Microsoft": "Warning",
       "System": "Warning"
     }
-  },  
+  },
   "Serilog": {
     "Using": [ "Serilog.Sinks.Console", "Serilog.Sinks.Grafana.Loki" ],
     "MinimumLevel": {


### PR DESCRIPTION
- Updated telemetry config to include azure monitor as an export option
- Created telemetry extension methods in audit and notification
- Created convenience method to allow for standard configuration to be used if you do not wish to manually config the telemetry
- Fixed broken meters in audit and notification
- Updated azure app config to account for the new options, left previous options in place to avoid breaking other services
- Added azure monitor connection string environment variable in the audit and notification azure container apps.