### PR TITLE
LNK-2376: Update shared project telemetry (Diagnostic names, extension methods)

### DIFF
--- a/DotNet/Account/Infrastructure/ServiceActivitySource.cs
+++ b/DotNet/Account/Infrastructure/ServiceActivitySource.cs
@@ -1,17 +1,17 @@
 ﻿using LantanaGroup.Link.Account.Domain.Entities;
+using LantanaGroup.Link.Account.Settings;
 using System.Diagnostics;
 
-namespace LantanaGroup.Link.Account.Services
+namespace LantanaGroup.Link.Account.Infrastructure
 {
     public class ServiceActivitySource
     {
         private static string _version = string.Empty;
-        public static string ServiceName = "Link Account Service";
+        public static string ServiceName = AccountConstants.ServiceName;
         public static ActivitySource Instance { get; private set; } = new ActivitySource(ServiceName, _version);
 
         public static void Initialize(ServiceInformation serviceInfo)
         {
-            ServiceName = serviceInfo.Name;
             _version = serviceInfo.Version;
             Instance = new ActivitySource(ServiceName, _version);
         }

--- a/DotNet/Account/Program.cs
+++ b/DotNet/Account/Program.cs
@@ -2,6 +2,7 @@ using Azure.Identity;
 using HealthChecks.UI.Client;
 using LantanaGroup.Link.Account.Application.Interfaces.Infrastructure;
 using LantanaGroup.Link.Account.Domain.Entities;
+using LantanaGroup.Link.Account.Infrastructure;
 using LantanaGroup.Link.Account.Infrastructure.Health;
 using LantanaGroup.Link.Account.Infrastructure.Telemetry;
 using LantanaGroup.Link.Account.Repositories;

--- a/DotNet/Account/Services/AccountService.cs
+++ b/DotNet/Account/Services/AccountService.cs
@@ -7,6 +7,7 @@ using LantanaGroup.Link.Account.Domain.Entities;
 using LantanaGroup.Link.Account.Protos;
 using LantanaGroup.Link.Account.Repositories;
 using LantanaGroup.Link.Shared.Application.Converters;
+using LantanaGroup.Link.Shared.Application.Models.Telemetry;
 using LantanaGroup.Link.Shared.Application.Services;
 
 namespace LantanaGroup.Link.Account.Services
@@ -118,7 +119,7 @@ namespace LantanaGroup.Link.Account.Services
             }
 
             _metrics.IncrementAccountAddedCounter([
-                new KeyValuePair<string, object?>("facility", newAccount.FacilityIds)
+                new KeyValuePair<string, object?>(DiagnosticNames.FacilityId, newAccount.FacilityIds)
             ]);
 
             return _mapperModelToMessage.Map<AccountModel, AccountMessage>(newAccount);

--- a/DotNet/Audit/Application/Audit/Commands/CreateAuditEvent/CreateAuditEventCommand.cs
+++ b/DotNet/Audit/Application/Audit/Commands/CreateAuditEvent/CreateAuditEventCommand.cs
@@ -2,7 +2,8 @@
 using LantanaGroup.Link.Audit.Domain.Entities;
 using LantanaGroup.Link.Audit.Infrastructure;
 using LantanaGroup.Link.Audit.Infrastructure.Logging;
-using LantanaGroup.Link.Audit.Infrastructure.Telemetry;
+using LantanaGroup.Link.Shared.Application.Extensions.Telemetry;
+using LantanaGroup.Link.Shared.Application.Models.Telemetry;
 using OpenTelemetry.Trace;
 using System.Diagnostics;
 using static LantanaGroup.Link.Audit.Settings.AuditConstants;
@@ -33,7 +34,14 @@ namespace LantanaGroup.Link.Audit.Application.Commands
         /// <exception cref="ApplicationException"></exception>
         public async Task<AuditLog> Execute(CreateAuditEventModel model, CancellationToken cancellationToken = default)
         {
-            using Activity? activity = ServiceActivitySource.Instance.StartActivity("Create Audit Event Command");
+            using Activity? activity = ServiceActivitySource.Instance
+                .StartActivityWithTags(DiagnosticNames.CreateAuditEvent,
+                [
+                    new KeyValuePair<string, object?>(DiagnosticNames.Service, model.ServiceName),
+                    new KeyValuePair<string, object?>(DiagnosticNames.FacilityId, model.FacilityId),
+                    new KeyValuePair<string, object?>(DiagnosticNames.AuditLogAction, model.Action),
+                    new KeyValuePair<string, object?>(DiagnosticNames.Resource, model.Resource)
+                ]);                                    
 
             if (string.IsNullOrWhiteSpace(model.ServiceName))
             {
@@ -50,13 +58,7 @@ namespace LantanaGroup.Link.Audit.Application.Commands
             }
             catch (Exception ex)
             {
-                Activity.Current?.SetStatus(ActivityStatusCode.Error);
-                Activity.Current?.RecordException(ex, new TagList { 
-                    { "service.name", model.ServiceName },
-                    { "facility", model.FacilityId },
-                    { "action", model.Action },
-                    { "resource", model.Resource }
-                });
+                Activity.Current?.SetStatus(ActivityStatusCode.Error, ex.Message);
                 _logger.LogDebug(new EventId(AuditLoggingIds.GenerateItems, "Audit Service - Create event"), ex, "New audit event creation failed for '{auditLogAction}' of resource '{auditLogResource}' in the '{auditLogServiceName}' service.", auditLog.Action, auditLog.Resource, auditLog.ServiceName);
                 throw;
             }
@@ -64,10 +66,10 @@ namespace LantanaGroup.Link.Audit.Application.Commands
             //Log creation of new audit event                                 
             _logger.LogAuditEventCreation(auditLog);
             _metrics.IncrementAuditableEventCounter([
-                new KeyValuePair<string, object?>("service", auditLog.ServiceName),
-                new KeyValuePair<string, object?>("facility", auditLog.FacilityId),
-                new KeyValuePair<string, object?>("action", auditLog.Action),
-                new KeyValuePair<string, object?>("resource", auditLog.Resource)
+                new KeyValuePair<string, object?>(DiagnosticNames.Service, auditLog.ServiceName),
+                new KeyValuePair<string, object?>(DiagnosticNames.FacilityId, auditLog.FacilityId),
+                new KeyValuePair<string, object?>(DiagnosticNames.AuditLogAction, auditLog.Action),
+                new KeyValuePair<string, object?>(DiagnosticNames.Resource, auditLog.Resource)
             ]);                
           
             return auditLog;           

--- a/DotNet/Audit/Application/Audit/Queries/GetAuditEvent/GetAuditEventQuery.cs
+++ b/DotNet/Audit/Application/Audit/Queries/GetAuditEvent/GetAuditEventQuery.cs
@@ -2,6 +2,8 @@
 using LantanaGroup.Link.Audit.Application.Models;
 using LantanaGroup.Link.Audit.Domain.Entities;
 using LantanaGroup.Link.Audit.Infrastructure;
+using LantanaGroup.Link.Shared.Application.Extensions.Telemetry;
+using LantanaGroup.Link.Shared.Application.Models.Telemetry;
 using System.Diagnostics;
 
 namespace LantanaGroup.Link.Audit.Application.Audit.Queries
@@ -27,7 +29,10 @@ namespace LantanaGroup.Link.Audit.Application.Audit.Queries
         /// <exception cref="ApplicationException"></exception>
         public async Task<AuditModel> Execute(AuditId id, CancellationToken cancellationToken = default)
         {
-            using Activity? activity = ServiceActivitySource.Instance.StartActivity("Get Audit Event By Id Query");            
+            using Activity? activity = ServiceActivitySource.Instance.StartActivityWithTags("Get Audit Event By Id Query",
+            [
+                new KeyValuePair<string, object?>(DiagnosticNames.AuditId, id)
+            ]);            
             
             var result = await _datastore.GetAsync(id, true, cancellationToken);
             AuditModel? auditEvent = null;

--- a/DotNet/Audit/Application/Audit/Queries/GetAuditEventsList/GetAuditEventListQuery.cs
+++ b/DotNet/Audit/Application/Audit/Queries/GetAuditEventsList/GetAuditEventListQuery.cs
@@ -1,6 +1,7 @@
 ﻿using LantanaGroup.Link.Audit.Application.Interfaces;
 using LantanaGroup.Link.Audit.Application.Models;
 using LantanaGroup.Link.Audit.Infrastructure;
+using LantanaGroup.Link.Audit.Infrastructure.Telemetry;
 using System.Diagnostics;
 
 namespace LantanaGroup.Link.Audit.Application.Audit.Queries
@@ -27,6 +28,8 @@ namespace LantanaGroup.Link.Audit.Application.Audit.Queries
         public async Task<PagedAuditModel> Execute(AuditSearchFilterRecord searchFilter, CancellationToken cancellationToken = default)
         {
             using Activity? activity = ServiceActivitySource.Instance.StartActivity("List Audit Event Query");
+            activity?.EnrichWithAuditSearchFilter(searchFilter);
+
 
             var (result, metadata) = await _datastore.SearchAsync(searchFilter.SearchText, searchFilter.FilterFacilityBy, searchFilter.FilterCorrelationBy, 
                 searchFilter.FilterServiceBy, searchFilter.FilterActionBy, searchFilter.FilterUserBy, searchFilter.SortBy, searchFilter.SortOrder, 

--- a/DotNet/Audit/Application/Audit/Queries/GetFacilityAuditEvents/GetFacilityAuditEventsQuery.cs
+++ b/DotNet/Audit/Application/Audit/Queries/GetFacilityAuditEvents/GetFacilityAuditEventsQuery.cs
@@ -1,6 +1,8 @@
 ﻿using LantanaGroup.Link.Audit.Application.Interfaces;
 using LantanaGroup.Link.Audit.Application.Models;
 using LantanaGroup.Link.Audit.Infrastructure;
+using LantanaGroup.Link.Shared.Application.Extensions.Telemetry;
+using LantanaGroup.Link.Shared.Application.Models.Telemetry;
 using System.Diagnostics;
 
 namespace LantanaGroup.Link.Audit.Application.Audit.Queries
@@ -23,7 +25,14 @@ namespace LantanaGroup.Link.Audit.Application.Audit.Queries
         /// <exception cref="ApplicationException"></exception>
         public async Task<PagedAuditModel> Execute(string facilityId, string? sortBy, SortOrder? sortOrder, int pageNumber, int PageSize, CancellationToken cancellationToken = default)
         {
-            using Activity? activity = ServiceActivitySource.Instance.StartActivity("Get All Audit Events Query");
+            using Activity? activity = ServiceActivitySource.Instance.StartActivityWithTags("Get All Audit Events Query",
+            [
+                new KeyValuePair<string, object?>(DiagnosticNames.FacilityId, facilityId),
+                new KeyValuePair<string, object?>(DiagnosticNames.SortBy, sortBy),
+                new KeyValuePair<string, object?>(DiagnosticNames.SortOrder, sortOrder),
+                new KeyValuePair<string, object?>(DiagnosticNames.PageSize, PageSize),
+                new KeyValuePair<string, object?>(DiagnosticNames.PageNumber, pageNumber)
+            ]);
 
             var (result, metadata) = await _datastore.GetByFacilityAsync(facilityId, sortBy, sortOrder, PageSize, pageNumber, cancellationToken);
 

--- a/DotNet/Audit/Infrastructure/ServiceActivitySource.cs
+++ b/DotNet/Audit/Infrastructure/ServiceActivitySource.cs
@@ -1,4 +1,5 @@
 ﻿using LantanaGroup.Link.Audit.Application.Models;
+using LantanaGroup.Link.Audit.Settings;
 using System.Diagnostics;
 
 namespace LantanaGroup.Link.Audit.Infrastructure
@@ -6,12 +7,11 @@ namespace LantanaGroup.Link.Audit.Infrastructure
     public static class ServiceActivitySource
     {
         private static string _version = string.Empty;
-        public static string ServiceName = "Link Audit Service";
+        public static string ServiceName = AuditConstants.ServiceName;
         public static ActivitySource Instance { get; private set; } = new ActivitySource(ServiceName, _version);
 
         public static void Initialize(ServiceInformation serviceInfo)
         {
-            ServiceName = serviceInfo.Name;
             _version = serviceInfo.Version;
             Instance = new ActivitySource(ServiceName, _version);
         }

--- a/DotNet/Audit/Infrastructure/Telemetry/EnrichWithAuditSearchFilter.cs
+++ b/DotNet/Audit/Infrastructure/Telemetry/EnrichWithAuditSearchFilter.cs
@@ -1,0 +1,23 @@
+﻿using LantanaGroup.Link.Audit.Application.Models;
+using LantanaGroup.Link.Shared.Application.Models.Telemetry;
+using System.Diagnostics;
+
+namespace LantanaGroup.Link.Audit.Infrastructure.Telemetry
+{
+    public static class AuditActivityExtensions
+    {
+        public static void EnrichWithAuditSearchFilter(this Activity activity, AuditSearchFilterRecord searchFilter)
+        {
+            //activity.AddTag(DiagnosticNames.SearchText, searchFilter.SearchText);
+            activity.AddTag(DiagnosticNames.FacilityFilter, searchFilter.FilterFacilityBy);
+            activity.AddTag(DiagnosticNames.CorrelationFilter, searchFilter.FilterCorrelationBy);
+            activity.AddTag(DiagnosticNames.ServiceFilter, searchFilter.FilterServiceBy);
+            activity.AddTag(DiagnosticNames.ActionFilter, searchFilter.FilterActionBy);
+            activity.AddTag(DiagnosticNames.UserFilter, searchFilter.FilterUserBy);
+            activity.AddTag(DiagnosticNames.SortBy, searchFilter.SortBy);
+            activity.AddTag(DiagnosticNames.SortOrder, searchFilter.SortOrder);
+            activity.AddTag(DiagnosticNames.PageSize, searchFilter.PageSize);
+            activity.AddTag(DiagnosticNames.PageNumber, searchFilter.PageNumber);
+        }
+    }
+}

--- a/DotNet/Audit/Presentation/Controllers/AuditController.cs
+++ b/DotNet/Audit/Presentation/Controllers/AuditController.cs
@@ -3,6 +3,7 @@ using LantanaGroup.Link.Audit.Application.Interfaces;
 using LantanaGroup.Link.Audit.Application.Models;
 using LantanaGroup.Link.Audit.Domain.Entities;
 using LantanaGroup.Link.Audit.Infrastructure.Logging;
+using LantanaGroup.Link.Shared.Application.Models.Telemetry;
 using Microsoft.AspNetCore.Mvc;
 using System.Diagnostics;
 using System.Text.Json;
@@ -63,7 +64,7 @@ namespace LantanaGroup.Link.Audit.Presentation.Controllers
         {           
             //capture audit search duration metric
             using var _ = _auditServiceMetrics.MeasureAuditSearchDuration([
-                new KeyValuePair<string, object?>("pageSize", pageSize)
+                new KeyValuePair<string, object?>(DiagnosticNames.PageSize, pageSize)
             ]);
 
             try
@@ -88,6 +89,7 @@ namespace LantanaGroup.Link.Audit.Presentation.Controllers
             }
             catch (Exception ex)
             {
+                Activity.Current?.SetStatus(ActivityStatusCode.Error, ex.Message);
                 AuditSearchFilterRecord searchFilter = _auditFactory.CreateAuditSearchFilterRecord(searchText, filterFacilityBy, filterCorrelationBy, filterServiceBy, filterActionBy, filterUserBy, sortBy, sortOrder, pageSize, pageNumber);
                 _logger.LogAuditEventListQueryException(ex.Message, searchFilter);
                 throw;
@@ -131,6 +133,7 @@ namespace LantanaGroup.Link.Audit.Presentation.Controllers
             }
             catch (Exception ex)
             {
+                Activity.Current?.SetStatus(ActivityStatusCode.Error, ex.Message);
                 ex.Data.Add("audit-log.id", id);
                 _logger.LogGetAuditEventByIdException(id.ToString(), ex.Message);
                 throw;
@@ -182,6 +185,7 @@ namespace LantanaGroup.Link.Audit.Presentation.Controllers
             }
             catch (Exception ex)
             {
+                Activity.Current?.SetStatus(ActivityStatusCode.Error, ex.Message);
                 _logger.LogGetFacilityAuditEventsQueryException(facilityId, ex.Message);
                 throw;
             }

--- a/DotNet/Audit/Presentation/Controllers/AuditController.cs
+++ b/DotNet/Audit/Presentation/Controllers/AuditController.cs
@@ -5,6 +5,7 @@ using LantanaGroup.Link.Audit.Domain.Entities;
 using LantanaGroup.Link.Audit.Infrastructure.Logging;
 using LantanaGroup.Link.Shared.Application.Models.Telemetry;
 using Microsoft.AspNetCore.Mvc;
+using OpenTelemetry.Trace;
 using System.Diagnostics;
 using System.Text.Json;
 
@@ -90,6 +91,7 @@ namespace LantanaGroup.Link.Audit.Presentation.Controllers
             catch (Exception ex)
             {
                 Activity.Current?.SetStatus(ActivityStatusCode.Error, ex.Message);
+                Activity.Current?.RecordException(ex);
                 AuditSearchFilterRecord searchFilter = _auditFactory.CreateAuditSearchFilterRecord(searchText, filterFacilityBy, filterCorrelationBy, filterServiceBy, filterActionBy, filterUserBy, sortBy, sortOrder, pageSize, pageNumber);
                 _logger.LogAuditEventListQueryException(ex.Message, searchFilter);
                 throw;
@@ -134,6 +136,7 @@ namespace LantanaGroup.Link.Audit.Presentation.Controllers
             catch (Exception ex)
             {
                 Activity.Current?.SetStatus(ActivityStatusCode.Error, ex.Message);
+                Activity.Current?.RecordException(ex);
                 ex.Data.Add("audit-log.id", id);
                 _logger.LogGetAuditEventByIdException(id.ToString(), ex.Message);
                 throw;
@@ -186,6 +189,7 @@ namespace LantanaGroup.Link.Audit.Presentation.Controllers
             catch (Exception ex)
             {
                 Activity.Current?.SetStatus(ActivityStatusCode.Error, ex.Message);
+                Activity.Current?.RecordException(ex);
                 _logger.LogGetFacilityAuditEventsQueryException(facilityId, ex.Message);
                 throw;
             }

--- a/DotNet/Census/Application/Commands/ConsumePatientIdsAcquiredEventCommand.cs
+++ b/DotNet/Census/Application/Commands/ConsumePatientIdsAcquiredEventCommand.cs
@@ -4,6 +4,7 @@ using LantanaGroup.Link.Census.Application.Models;
 using LantanaGroup.Link.Census.Application.Models.Messages;
 using LantanaGroup.Link.Census.Domain.Entities;
 using LantanaGroup.Link.Shared.Application.Models;
+using LantanaGroup.Link.Shared.Application.Models.Telemetry;
 using MediatR;
 
 namespace LantanaGroup.Link.Census.Application.Commands;
@@ -56,8 +57,10 @@ public class ConsumePaitentIdsAcquiredEventHandler : IRequestHandler<ConsumePati
                 patient.ModifyDate = DateTime.UtcNow;
                 patientUpdates.Add(patient);
 
-                _metrics.IncrementPatientIdentifiedCounter([ 
-                    new KeyValuePair<string, object?>("facility", request.FacilityId)                     
+                _metrics.IncrementPatientAdmittedCounter([ 
+                    new KeyValuePair<string, object?>(DiagnosticNames.FacilityId, request.FacilityId),
+                    new KeyValuePair<string, object?>(DiagnosticNames.PatientId, patient.PatientId),
+                    new KeyValuePair<string, object?>(DiagnosticNames.PatientEvent, PatientEvents.Admit.ToString())
                 ]);
             }
         }
@@ -70,7 +73,7 @@ public class ConsumePaitentIdsAcquiredEventHandler : IRequestHandler<ConsumePati
                 patient.IsDischarged = true;
                 patient.DischargeDate = DateTime.UtcNow;
                 patient.ModifyDate = DateTime.UtcNow;
-                patientUpdates.Add(patient);
+                patientUpdates.Add(patient);                
             }
         }
 
@@ -92,6 +95,12 @@ public class ConsumePaitentIdsAcquiredEventHandler : IRequestHandler<ConsumePati
                     },
                     TopicName = KafkaTopic.PatientEvent.ToString()
                 });
+
+                _metrics.IncrementPatientDischargedCounter([
+                    new KeyValuePair<string, object?>(DiagnosticNames.FacilityId, request.FacilityId),
+                    new KeyValuePair<string, object?>(DiagnosticNames.PatientId, patient.PatientId),
+                    new KeyValuePair<string, object?>(DiagnosticNames.PatientEvent, PatientEvents.Discharge.ToString())
+                ]);
             }
         }
 

--- a/DotNet/Census/Application/Interfaces/ICensusServiceMetrics.cs
+++ b/DotNet/Census/Application/Interfaces/ICensusServiceMetrics.cs
@@ -2,6 +2,7 @@
 {
     public interface ICensusServiceMetrics
     {
-        void IncrementPatientIdentifiedCounter(List<KeyValuePair<string, object?>> tags);
+        void IncrementPatientAdmittedCounter(List<KeyValuePair<string, object?>> tags);
+        void IncrementPatientDischargedCounter(List<KeyValuePair<string, object?>> tags);
     }
 }

--- a/DotNet/Census/Application/Services/CensusServiceMetrics.cs
+++ b/DotNet/Census/Application/Services/CensusServiceMetrics.cs
@@ -11,13 +11,20 @@ namespace LantanaGroup.Link.Census.Application.Services
         public CensusServiceMetrics(IMeterFactory meterFactory)
         {
             Meter meter = meterFactory.Create(MeterName);
-            PatientIdentifiedCounter = meter.CreateCounter<long>("link_census_service.patient_identified.count");
+            PatientAdmittedCounter = meter.CreateCounter<long>("link_census_service.patient_admitted.count");
+            PatientDischargedCounter = meter.CreateCounter<long>("link_census_service.patient_discharged.count");
         }
 
-        public Counter<long> PatientIdentifiedCounter { get; private set; }
-        public void IncrementPatientIdentifiedCounter(List<KeyValuePair<string, object?>> tags)
+        public Counter<long> PatientAdmittedCounter { get; private set; }
+        public void IncrementPatientAdmittedCounter(List<KeyValuePair<string, object?>> tags)
         {
-            PatientIdentifiedCounter.Add(1, tags.ToArray());
+            PatientAdmittedCounter.Add(1, tags.ToArray());
+        }
+
+        public Counter<long> PatientDischargedCounter { get; private set; }
+        public void IncrementPatientDischargedCounter(List<KeyValuePair<string, object?>> tags)
+        {
+            PatientDischargedCounter.Add(1, tags.ToArray());
         }
     }
 }

--- a/DotNet/Census/Application/Services/ServiceActivitySource.cs
+++ b/DotNet/Census/Application/Services/ServiceActivitySource.cs
@@ -1,16 +1,16 @@
-﻿using System.Diagnostics;
+﻿using LantanaGroup.Link.Census.Application.Settings;
+using System.Diagnostics;
 
 namespace LantanaGroup.Link.Census.Application.Services
 {
     public class ServiceActivitySource
     {
         private static string _version = string.Empty;
-        public static string ServiceName = "Link Audit Service";
+        public static string ServiceName = CensusConstants.ServiceName;
         public static ActivitySource Instance { get; private set; } = new ActivitySource(ServiceName, _version);
 
         public static void Initialize(ServiceInformation serviceInfo)
         {
-            ServiceName = serviceInfo.Name;
             _version = serviceInfo.Version;
             Instance = new ActivitySource(ServiceName, _version);
         }

--- a/DotNet/DataAcquisition/Application/Repositories/FhirApi/FhirApiRepository.cs
+++ b/DotNet/DataAcquisition/Application/Repositories/FhirApi/FhirApiRepository.cs
@@ -157,8 +157,9 @@ public class FhirApiRepository : IFhirApiRepository
         CancellationToken cancellationToken = default)
     {
         using var _ = _metrics.MeasureDataRequestDuration([
-            new KeyValuePair<string, object?>(DiagnosticNames.FacilityId, facilityId),           
-            new KeyValuePair<string, object?>(DiagnosticNames.PatientId, "Patient")
+            new KeyValuePair<string, object?>(DiagnosticNames.FacilityId, facilityId),  
+            new KeyValuePair<string, object?>(DiagnosticNames.PatientId, patientId),
+            new KeyValuePair<string, object?>(DiagnosticNames.Resource, "Patient")
         ]);
 
         var fhirClient = GenerateFhirClient(baseUrl);

--- a/DotNet/DataAcquisition/Application/Repositories/FhirApi/FhirApiRepository.cs
+++ b/DotNet/DataAcquisition/Application/Repositories/FhirApi/FhirApiRepository.cs
@@ -9,6 +9,7 @@ using LantanaGroup.Link.DataAcquisition.Application.Models.Factory.ParameterQuer
 using LantanaGroup.Link.DataAcquisition.Application.Models.Kafka;
 using LantanaGroup.Link.DataAcquisition.Domain.Models;
 using LantanaGroup.Link.DataAcquisition.Domain.Models.QueryConfig;
+using LantanaGroup.Link.Shared.Application.Models.Telemetry;
 using MediatR;
 using System.Net.Http.Headers;
 
@@ -156,8 +157,8 @@ public class FhirApiRepository : IFhirApiRepository
         CancellationToken cancellationToken = default)
     {
         using var _ = _metrics.MeasureDataRequestDuration([
-            new KeyValuePair<string, object?>("facility", facilityId),           
-            new KeyValuePair<string, object?>("resource", "Patient")
+            new KeyValuePair<string, object?>(DiagnosticNames.FacilityId, facilityId),           
+            new KeyValuePair<string, object?>(DiagnosticNames.PatientId, "Patient")
         ]);
 
         var fhirClient = GenerateFhirClient(baseUrl);
@@ -197,10 +198,10 @@ public class FhirApiRepository : IFhirApiRepository
         try
         {
             using var _ = _metrics.MeasureDataRequestDuration([
-                new KeyValuePair<string, object?>("facility", facilityId),
-                new KeyValuePair<string, object?>("patient", patientId),
-                new KeyValuePair<string, object?>("query.type", queryType),
-                new KeyValuePair<string, object?>("resource", resourceType)
+                new KeyValuePair<string, object?>(DiagnosticNames.FacilityId, facilityId),
+                new KeyValuePair<string, object?>(DiagnosticNames.PatientId, patientId),
+                new KeyValuePair<string, object?>(DiagnosticNames.QueryType, queryType),
+                new KeyValuePair<string, object?>(DiagnosticNames.Resource, resourceType)
             ]);
 
             var resultBundle = await fhirClient.SearchAsync(searchParams, resourceType);
@@ -235,10 +236,10 @@ public class FhirApiRepository : IFhirApiRepository
         CancellationToken cancellationToken = default)
     {
         using var _ = _metrics.MeasureDataRequestDuration([
-            new KeyValuePair<string, object?>("facility", facilityId),
-            new KeyValuePair<string, object?>("patient", patientId),
-            new KeyValuePair<string, object?>("query.type", queryType),
-            new KeyValuePair<string, object?>("resource", resourceType)
+            new KeyValuePair<string, object?>(DiagnosticNames.FacilityId, facilityId),
+            new KeyValuePair<string, object?>(DiagnosticNames.PatientId, patientId),
+            new KeyValuePair<string, object?>(DiagnosticNames.QueryType, queryType),
+            new KeyValuePair<string, object?>(DiagnosticNames.Resource, resourceType)
         ]);
 
         DomainResource? readResource = resourceType switch
@@ -389,10 +390,10 @@ public class FhirApiRepository : IFhirApiRepository
     private void IncrementResourceAcquiredMetric(string? patientIdReference, string? facilityId, string? queryType, string resourceType)
     {
         _metrics.IncrementResourceAcquiredCounter([
-            new KeyValuePair<string, object?>("facility", facilityId),
-            new KeyValuePair<string, object?>("patient", patientIdReference), //TODO: Can we keep this?
-            new KeyValuePair<string, object?>("query.type", queryType),
-            new KeyValuePair<string, object?>("resource", resourceType)
+            new KeyValuePair<string, object?>(DiagnosticNames.FacilityId, facilityId),
+            new KeyValuePair<string, object?>(DiagnosticNames.PatientId, patientIdReference), //TODO: Can we keep this?
+            new KeyValuePair<string, object?>(DiagnosticNames.QueryType, queryType),
+            new KeyValuePair<string, object?>(DiagnosticNames.Resource, resourceType)
         ]);
     }
 }

--- a/DotNet/DataAcquisition/Application/Services/ServiceActivitySource.cs
+++ b/DotNet/DataAcquisition/Application/Services/ServiceActivitySource.cs
@@ -1,4 +1,5 @@
 ﻿using LantanaGroup.Link.DataAcquisition.Application.Models;
+using LantanaGroup.Link.DataAcquisition.Application.Settings;
 using System.Diagnostics;
 
 namespace LantanaGroup.Link.DataAcquisition.Application.Services
@@ -6,12 +7,11 @@ namespace LantanaGroup.Link.DataAcquisition.Application.Services
     public class ServiceActivitySource
     {
         private static string _version = string.Empty;
-        public static string ServiceName = "Link DataAcquisition Service";
+        public static string ServiceName = DataAcquisitionConstants.ServiceName;
         public static ActivitySource Instance { get; private set; } = new ActivitySource(ServiceName, _version);
 
         public static void Initialize(ServiceInformation serviceInfo)
         {
-            ServiceName = serviceInfo.Name;
             _version = serviceInfo.Version;
             Instance = new ActivitySource(ServiceName, _version);
         }

--- a/DotNet/LinkAdmin.BFF/Application/Commands/Integration/CreateDataAcquisitionRequested/CreateDataAcquisitionRequested.cs
+++ b/DotNet/LinkAdmin.BFF/Application/Commands/Integration/CreateDataAcquisitionRequested/CreateDataAcquisitionRequested.cs
@@ -4,6 +4,7 @@ using LantanaGroup.Link.LinkAdmin.BFF.Infrastructure;
 using LantanaGroup.Link.LinkAdmin.BFF.Infrastructure.Logging;
 using LantanaGroup.Link.Shared.Application.Interfaces;
 using LantanaGroup.Link.Shared.Application.Models;
+using OpenTelemetry.Trace;
 using System.Diagnostics;
 
 namespace LantanaGroup.Link.LinkAdmin.BFF.Application.Commands.Integration
@@ -54,6 +55,7 @@ namespace LantanaGroup.Link.LinkAdmin.BFF.Application.Commands.Integration
                     catch (Exception ex)
                     {
                         Activity.Current?.SetStatus(ActivityStatusCode.Error);
+                        Activity.Current?.RecordException(ex);
                         _logger.LogKafkaProducerException(nameof(KafkaTopic.PatientEvent), ex.Message);
                         throw;
                     }
@@ -63,6 +65,7 @@ namespace LantanaGroup.Link.LinkAdmin.BFF.Application.Commands.Integration
             catch (Exception ex)
             {
                 Activity.Current?.SetStatus(ActivityStatusCode.Error);
+                Activity.Current?.RecordException(ex);
                 _logger.LogKafkaProducerException(nameof(KafkaTopic.PatientEvent), ex.Message);
                 throw;
             }

--- a/DotNet/LinkAdmin.BFF/Application/Commands/Integration/CreatePatientEvent/CreatePatientEvent.cs
+++ b/DotNet/LinkAdmin.BFF/Application/Commands/Integration/CreatePatientEvent/CreatePatientEvent.cs
@@ -4,6 +4,7 @@ using LantanaGroup.Link.LinkAdmin.BFF.Infrastructure;
 using LantanaGroup.Link.LinkAdmin.BFF.Infrastructure.Logging;
 using LantanaGroup.Link.Shared.Application.Interfaces;
 using LantanaGroup.Link.Shared.Application.Models;
+using OpenTelemetry.Trace;
 using System.Diagnostics;
 using System.Text;
 
@@ -55,6 +56,7 @@ namespace LantanaGroup.Link.LinkAdmin.BFF.Application.Commands.Integration
                     catch (Exception ex)
                     {
                         Activity.Current?.SetStatus(ActivityStatusCode.Error);
+                        Activity.Current?.RecordException(ex);
                         _logger.LogKafkaProducerException(nameof(KafkaTopic.PatientEvent), ex.Message);
                         throw;
                     }
@@ -64,6 +66,7 @@ namespace LantanaGroup.Link.LinkAdmin.BFF.Application.Commands.Integration
             catch (Exception ex)
             {
                 Activity.Current?.SetStatus(ActivityStatusCode.Error);
+                Activity.Current?.RecordException(ex);
                 _logger.LogKafkaProducerException(nameof(KafkaTopic.PatientEvent), ex.Message);
                 throw;
             }

--- a/DotNet/LinkAdmin.BFF/Application/Commands/Integration/CreateReportScheduled/CreateReportScheduled.cs
+++ b/DotNet/LinkAdmin.BFF/Application/Commands/Integration/CreateReportScheduled/CreateReportScheduled.cs
@@ -4,6 +4,7 @@ using LantanaGroup.Link.LinkAdmin.BFF.Infrastructure;
 using LantanaGroup.Link.LinkAdmin.BFF.Infrastructure.Logging;
 using LantanaGroup.Link.Shared.Application.Interfaces;
 using LantanaGroup.Link.Shared.Application.Models;
+using OpenTelemetry.Trace;
 using System.Diagnostics;
 using System.Text.Json;
 
@@ -75,6 +76,7 @@ namespace LantanaGroup.Link.LinkAdmin.BFF.Application.Commands.Integration
                     catch (Exception ex)
                     {
                         Activity.Current?.SetStatus(ActivityStatusCode.Error);
+                        Activity.Current?.RecordException(ex);
                         _logger.LogKafkaProducerException(correlationId, ex.Message);
                         throw;
                     }
@@ -84,6 +86,7 @@ namespace LantanaGroup.Link.LinkAdmin.BFF.Application.Commands.Integration
             catch (Exception ex)
             {
                 Activity.Current?.SetStatus(ActivityStatusCode.Error);
+                Activity.Current?.RecordException(ex);
                 _logger.LogKafkaProducerException(nameof(KafkaTopic.PatientEvent), ex.Message);
                 throw;
             }

--- a/DotNet/LinkAdmin.BFF/Application/Commands/Security/CreateLinkBearerToken/CreateLinkBearerToken.cs
+++ b/DotNet/LinkAdmin.BFF/Application/Commands/Security/CreateLinkBearerToken/CreateLinkBearerToken.cs
@@ -6,6 +6,7 @@ using LantanaGroup.Link.LinkAdmin.BFF.Settings;
 using Microsoft.AspNetCore.DataProtection;
 using Microsoft.Extensions.Caching.Distributed;
 using Microsoft.IdentityModel.Tokens;
+using OpenTelemetry.Trace;
 using System.Diagnostics;
 using System.IdentityModel.Tokens.Jwt;
 using System.Security.Claims;
@@ -72,9 +73,10 @@ namespace LantanaGroup.Link.LinkAdmin.BFF.Application.Commands.Security
                 return jwt;
 
             }
-            catch (Exception)
+            catch (Exception ex)
             {
                 Activity.Current?.SetStatus(ActivityStatusCode.Error);
+                Activity.Current?.RecordException(ex);
                 throw;
             }
             

--- a/DotNet/LinkAdmin.BFF/Application/Commands/Security/RefreshSigningKey/IRefreshSigningKey.cs
+++ b/DotNet/LinkAdmin.BFF/Application/Commands/Security/RefreshSigningKey/IRefreshSigningKey.cs
@@ -1,7 +1,9 @@
-﻿namespace LantanaGroup.Link.LinkAdmin.BFF.Application.Commands.Security
+﻿using System.Security.Claims;
+
+namespace LantanaGroup.Link.LinkAdmin.BFF.Application.Commands.Security
 {
     public interface IRefreshSigningKey
     {
-        Task<bool> ExecuteAsync();
+        Task<bool> ExecuteAsync(ClaimsPrincipal user);
     }
 }

--- a/DotNet/LinkAdmin.BFF/Application/Commands/Security/RefreshSigningKey/RefreshSigningKey.cs
+++ b/DotNet/LinkAdmin.BFF/Application/Commands/Security/RefreshSigningKey/RefreshSigningKey.cs
@@ -1,9 +1,14 @@
 ﻿using LantanaGroup.Link.LinkAdmin.BFF.Application.Interfaces.Infrastructure;
 using LantanaGroup.Link.LinkAdmin.BFF.Application.Interfaces.Services;
+using LantanaGroup.Link.LinkAdmin.BFF.Infrastructure;
 using LantanaGroup.Link.LinkAdmin.BFF.Infrastructure.Logging;
 using LantanaGroup.Link.LinkAdmin.BFF.Settings;
+using LantanaGroup.Link.Shared.Application.Extensions.Telemetry;
+using LantanaGroup.Link.Shared.Application.Models.Telemetry;
 using Microsoft.AspNetCore.DataProtection;
 using Microsoft.Extensions.Caching.Distributed;
+using System.Diagnostics;
+using System.Security.Claims;
 using System.Security.Cryptography;
 
 namespace LantanaGroup.Link.LinkAdmin.BFF.Application.Commands.Security
@@ -26,8 +31,13 @@ namespace LantanaGroup.Link.LinkAdmin.BFF.Application.Commands.Security
         }
 
         //TODO: Add back data protection once key persience is implemented
-        public async Task<bool> ExecuteAsync()
+        public async Task<bool> ExecuteAsync(ClaimsPrincipal user)
         {
+            using Activity? activity = ServiceActivitySource.Instance.StartActivityWithTags("Refresh Link Bearer Service Signing Key",
+            [
+                new KeyValuePair<string, object?>(DiagnosticNames.UserId, user.Claims.First(c => c.Type == "sub").Value)
+            ]);
+
             var key = GenerateRandomKey(64); // 64 bytes = 512 bits
 
             //update secret manager

--- a/DotNet/LinkAdmin.BFF/Infrastructure/Extensions/Security/InitializeSecurity.cs
+++ b/DotNet/LinkAdmin.BFF/Infrastructure/Extensions/Security/InitializeSecurity.cs
@@ -116,7 +116,7 @@ namespace LantanaGroup.Link.LinkAdmin.BFF.Infrastructure.Extensions.Security
             }
 
             // Add Link Bearer Token authorization schema if feature is enabled
-            if (configuration.GetValue<bool>("EnableBearerTokenFeature"))
+            if (configuration.GetValue<bool>("LinkBearerService:EnableTokenGenrationEndpoint"))
             {
                 if (!LinkAdminConstants.AuthenticationSchemes.LinkBearerToken.Equals(defaultChallengeScheme))
                     authSchemas.Add(LinkAdminConstants.AuthenticationSchemes.LinkBearerToken);

--- a/DotNet/LinkAdmin.BFF/Infrastructure/ServiceActivitySource.cs
+++ b/DotNet/LinkAdmin.BFF/Infrastructure/ServiceActivitySource.cs
@@ -6,15 +6,14 @@ namespace LantanaGroup.Link.LinkAdmin.BFF.Infrastructure
 {
     public static class ServiceActivitySource
     {
-        private static string _version = string.Empty;
+        public static string Version = string.Empty;
         public static string ServiceName = LinkAdminConstants.ServiceName;
-        public static ActivitySource Instance { get; private set; } = new ActivitySource(ServiceName, _version);
+        public static ActivitySource Instance { get; private set; } = new ActivitySource(ServiceName, Version);
 
-        public static void Initialize(ServiceInformation serviceInfo)
+        public static void Initialize(string version)
         {
-            ServiceName = serviceInfo.Name;
-            _version = serviceInfo.Version;
-            Instance = new ActivitySource(ServiceName, _version);
+            Version = version;
+            Instance = new ActivitySource(ServiceName, Version);
         }
     }
 }

--- a/DotNet/LinkAdmin.BFF/LinkAdmin.BFF.csproj
+++ b/DotNet/LinkAdmin.BFF/LinkAdmin.BFF.csproj
@@ -2,6 +2,8 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
+	<Version>1.0.0-beta</Version>
+	<IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <InvariantGlobalization>true</InvariantGlobalization>

--- a/DotNet/LinkAdmin.BFF/Program.cs
+++ b/DotNet/LinkAdmin.BFF/Program.cs
@@ -273,11 +273,10 @@ static void SetupMiddleware(WebApplication app)
 
     // Configure swagger
     if (app.Configuration.GetValue<bool>(LinkAdminConstants.AppSettingsSectionNames.EnableSwagger))
-    {
-        //var serviceInformation = app.Configuration.GetSection(LinkAdminConstants.AppSettingsSectionNames.ServiceInformation).Get<ServiceInformation>();
+    {       
         app.UseSwagger(opts => { opts.RouteTemplate = "api/swagger/{documentname}/swagger.json"; });
         app.UseSwaggerUI(opts => {
-            opts.SwaggerEndpoint("/swagger/v1/swagger.json", $"{ServiceActivitySource.ServiceName} - {ServiceActivitySource.Version}");
+            opts.SwaggerEndpoint("/api/swagger/v1/swagger.json", $"{ServiceActivitySource.ServiceName} - {ServiceActivitySource.Version}");
             opts.RoutePrefix = "api/swagger";
         });
     }
@@ -290,7 +289,7 @@ static void SetupMiddleware(WebApplication app)
     app.UseAuthorization(); 
 
     // Register endpoints
-    app.MapGet("/api/info", (HttpContext ctx) => Results.Ok($"Welcome to {ServiceActivitySource.Instance.Name} version {ServiceActivitySource.Instance.Version}!")).AllowAnonymous();
+    app.MapGet("/api/info", () => Results.Ok($"Welcome to {ServiceActivitySource.Instance.Name} version {ServiceActivitySource.Instance.Version}!")).AllowAnonymous();
 
     var apis = app.Services.GetServices<IApi>();
     foreach (var api in apis)

--- a/DotNet/LinkAdmin.BFF/Program.cs
+++ b/DotNet/LinkAdmin.BFF/Program.cs
@@ -44,7 +44,7 @@ static void RegisterServices(WebApplicationBuilder builder)
 {
 
     //Initialize activity source
-    var version = Assembly.GetExecutingAssembly().GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion ?? "1.0.0";
+    var version = Assembly.GetExecutingAssembly().GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion ?? string.Empty;
     ServiceActivitySource.Initialize(version);
 
     // load external configuration source if specified

--- a/DotNet/Normalization/Application/Services/ServiceActivitySource.cs
+++ b/DotNet/Normalization/Application/Services/ServiceActivitySource.cs
@@ -1,4 +1,5 @@
 ﻿using LantanaGroup.Link.Normalization.Application.Models;
+using LantanaGroup.Link.Normalization.Application.Settings;
 using System.Diagnostics;
 
 namespace LantanaGroup.Link.Normalization.Application.Services
@@ -6,12 +7,11 @@ namespace LantanaGroup.Link.Normalization.Application.Services
     public class ServiceActivitySource
     {
         private static string _version = string.Empty;
-        public static string ServiceName = "Link Audit Service";
+        public static string ServiceName = NormalizationConstants.ServiceName;
         public static ActivitySource Instance { get; private set; } = new ActivitySource(ServiceName, _version);
 
         public static void Initialize(ServiceInformation serviceInfo)
         {
-            ServiceName = serviceInfo.Name;
             _version = serviceInfo.Version;
             Instance = new ActivitySource(ServiceName, _version);
         }

--- a/DotNet/Normalization/Listeners/ResourceAcquiredListener.cs
+++ b/DotNet/Normalization/Listeners/ResourceAcquiredListener.cs
@@ -15,6 +15,7 @@ using LantanaGroup.Link.Shared.Application.Error.Interfaces;
 using LantanaGroup.Link.Shared.Application.Interfaces;
 using LantanaGroup.Link.Shared.Application.Models;
 using LantanaGroup.Link.Shared.Application.Models.Kafka;
+using LantanaGroup.Link.Shared.Application.Models.Telemetry;
 using LantanaGroup.Link.Shared.Application.Utilities;
 using MediatR;
 using Microsoft.Extensions.Options;
@@ -211,12 +212,12 @@ public class ResourceAcquiredListener : BackgroundService
                             };
 
                             _metrics.IncrementResourceNormalizedCounter(new List<KeyValuePair<string, object?>>() {
-                                new KeyValuePair<string, object?>("facility", messageMetaData.facilityId),
-                                new KeyValuePair<string, object?>("correlation.id", messageMetaData.correlationId),
-                                new KeyValuePair<string, object?>("patient", message.Message.Value.PatientId),
-                                new KeyValuePair<string, object?>("resource", operationCommandResult.Resource.TypeName),
-                                new KeyValuePair<string, object?>("query.type", message.Message.Value.QueryType),
-                                new KeyValuePair<string, object?>("normalization.operation", op.Value.GetType().Name)
+                                new KeyValuePair<string, object?>(DiagnosticNames.FacilityId, messageMetaData.facilityId),
+                                new KeyValuePair<string, object?>(DiagnosticNames.CorrelationId, messageMetaData.correlationId),
+                                new KeyValuePair<string, object?>(DiagnosticNames.PatientId, message.Message.Value.PatientId),
+                                new KeyValuePair<string, object?>(DiagnosticNames.Resource, operationCommandResult.Resource.TypeName),
+                                new KeyValuePair<string, object?>(DiagnosticNames.QueryType, message.Message.Value.QueryType),
+                                new KeyValuePair<string, object?>(DiagnosticNames.NormalizationOperation, op.Value.GetType().Name)
                             });
                         }
                     }

--- a/DotNet/Notification/Application/Notification/Commands/CreateNotificationCommand/CreateNotificationCommand.cs
+++ b/DotNet/Notification/Application/Notification/Commands/CreateNotificationCommand/CreateNotificationCommand.cs
@@ -5,6 +5,7 @@ using LantanaGroup.Link.Notification.Domain.Entities;
 using LantanaGroup.Link.Notification.Infrastructure;
 using LantanaGroup.Link.Notification.Infrastructure.Logging;
 using LantanaGroup.Link.Shared.Application.Models;
+using LantanaGroup.Link.Shared.Application.Models.Telemetry;
 using System.Diagnostics;
 
 namespace LantanaGroup.Link.Notification.Application.Notification.Commands
@@ -94,17 +95,16 @@ namespace LantanaGroup.Link.Notification.Application.Notification.Commands
 
                     //add id to current activity
                     var currentActivity = Activity.Current;
-                    currentActivity?.AddTag("notification.id", entity.Id);
+                    currentActivity?.AddTag(DiagnosticNames.NotificationId, entity.Id);
                     if (entity.FacilityId != null)
                     {
-                        currentActivity?.AddTag("facility.id", entity.FacilityId);
+                        currentActivity?.AddTag(DiagnosticNames.FacilityId, entity.FacilityId);
                     }
-
 
                     //update notification creation metric counter                    
                     _metrics.IncrementNotificationCreatedCounter([ 
-                        new KeyValuePair<string, object?>("facility", entity.FacilityId), 
-                        new KeyValuePair<string, object?>("type", entity.NotificationType)
+                        new KeyValuePair<string, object?>(DiagnosticNames.FacilityId, entity.FacilityId), 
+                        new KeyValuePair<string, object?>(DiagnosticNames.NotificationType, entity.NotificationType)
                     ]);
 
                     //Log creation of new notification configuration
@@ -113,9 +113,8 @@ namespace LantanaGroup.Link.Notification.Application.Notification.Commands
                 }              
             }
             catch (Exception ex)
-            {               
-                var currentActivity = Activity.Current;
-                currentActivity?.SetStatus(ActivityStatusCode.Error);
+            {
+                Activity.Current?.SetStatus(ActivityStatusCode.Error, ex.Message);
                 _logger.LogNotificationCreationException(model, ex.Message);
                 throw;
             }

--- a/DotNet/Notification/Infrastructure/ServiceActivitySource.cs
+++ b/DotNet/Notification/Infrastructure/ServiceActivitySource.cs
@@ -1,4 +1,5 @@
 ﻿using LantanaGroup.Link.Notification.Application.Models;
+using LantanaGroup.Link.Notification.Settings;
 using System.Diagnostics;
 
 namespace LantanaGroup.Link.Notification.Infrastructure
@@ -6,12 +7,11 @@ namespace LantanaGroup.Link.Notification.Infrastructure
     public static class ServiceActivitySource
     {
         private static string _version = string.Empty;
-        public static string ServiceName = "Link Notification Service";
+        public static string ServiceName = NotificationConstants.ServiceName;
         public static ActivitySource Instance { get; private set; } = new ActivitySource(ServiceName, _version);
 
         public static void Initialize(ServiceInformation serviceInfo)
         {
-            ServiceName = serviceInfo.Name;
             _version = serviceInfo.Version;
             Instance = new ActivitySource(ServiceName, _version);
         }

--- a/DotNet/PatientsToQuery/Application/Services/ServiceActivitySource.cs
+++ b/DotNet/PatientsToQuery/Application/Services/ServiceActivitySource.cs
@@ -1,4 +1,5 @@
 ﻿using PatientsToQuery.Application.Models;
+using PatientsToQuery.Settings;
 using System.Diagnostics;
 
 namespace PatientsToQuery.Application.Services
@@ -6,12 +7,11 @@ namespace PatientsToQuery.Application.Services
     public class ServiceActivitySource
     {
         private static string _version = string.Empty;
-        public static string ServiceName = "Link PatientToQuery Service";
+        public static string ServiceName = PatientsToQueryConstants.ServiceName;
         public static ActivitySource Instance { get; private set; } = new ActivitySource(ServiceName, _version);
 
         public static void Initialize(ServiceInformation serviceInfo)
         {
-            ServiceName = serviceInfo.Name;
             _version = serviceInfo.Version;
             Instance = new ActivitySource(ServiceName, _version);
         }

--- a/DotNet/QueryDispatch/Application/Services/ServiceActivitySource.cs
+++ b/DotNet/QueryDispatch/Application/Services/ServiceActivitySource.cs
@@ -1,4 +1,5 @@
 ﻿using QueryDispatch.Application.Models;
+using QueryDispatch.Application.Settings;
 using System.Diagnostics;
 
 namespace QueryDispatch.Application.Services
@@ -6,12 +7,11 @@ namespace QueryDispatch.Application.Services
     public class ServiceActivitySource
     {
         private static string _version = string.Empty;
-        public static string ServiceName = "Link QueryDispatch Service";
+        public static string ServiceName = QueryDispatchConstants.ServiceName;
         public static ActivitySource Instance { get; private set; } = new ActivitySource(ServiceName, _version);
 
         public static void Initialize(ServiceInformation serviceInfo)
         {
-            ServiceName = serviceInfo.Name;
             _version = serviceInfo.Version;
             Instance = new ActivitySource(ServiceName, _version);
         }

--- a/DotNet/Report/Services/ServiceActivitySource.cs
+++ b/DotNet/Report/Services/ServiceActivitySource.cs
@@ -1,4 +1,5 @@
 ﻿using LantanaGroup.Link.Report.Application.Models;
+using LantanaGroup.Link.Report.Settings;
 using System.Diagnostics;
 
 namespace LantanaGroup.Link.Report.Services
@@ -6,12 +7,11 @@ namespace LantanaGroup.Link.Report.Services
     public class ServiceActivitySource
     {
         private static string _version = string.Empty;
-        public static string ServiceName = "Link Report Service";
+        public static string ServiceName = ReportConstants.ServiceName;
         public static ActivitySource Instance { get; private set; } = new ActivitySource(ServiceName, _version);
 
         public static void Initialize(ServiceInformation serviceInfo)
         {
-            ServiceName = serviceInfo.Name;
             _version = serviceInfo.Version;
             Instance = new ActivitySource(ServiceName, _version);
         }

--- a/DotNet/Shared/Application/Extensions/Telemetry/ActvityExtensions.cs
+++ b/DotNet/Shared/Application/Extensions/Telemetry/ActvityExtensions.cs
@@ -1,0 +1,15 @@
+﻿using System.Diagnostics;
+
+namespace LantanaGroup.Link.Shared.Application.Extensions.Telemetry
+{
+    public static class ActvityExtensions
+    {
+        public static Activity? StartActivityWithTags(this ActivitySource activitySource, string activityName, List<KeyValuePair<string, object?>> tags)
+        {
+            return activitySource.StartActivity(activityName, 
+                ActivityKind.Internal, 
+                Activity.Current?.Context ?? new ActivityContext(),
+                tags);
+        }
+    }
+}

--- a/DotNet/Shared/Application/Extensions/Telemetry/TelemetryServiceExtension.cs
+++ b/DotNet/Shared/Application/Extensions/Telemetry/TelemetryServiceExtension.cs
@@ -46,6 +46,7 @@ namespace LantanaGroup.Link.Shared.Application.Extensions
                     options.EnableMetrics = telemetryConfig.EnableMetrics;
                     options.MeterName = $"Link.{initTelemetryOptions.ServiceName}";
                     options.EnableRuntimeInstrumentation = telemetryConfig.EnableRuntimeInstrumentation;
+                    options.InstrumentEntityFramework = telemetryConfig.InstrumentEntityFramework;
 
                     //configure OTEL Collector
                     options.EnableOtelCollector = telemetryConfig.EnableOtelCollector;

--- a/DotNet/Shared/Application/Models/PatientEvents.cs
+++ b/DotNet/Shared/Application/Models/PatientEvents.cs
@@ -1,5 +1,6 @@
 ﻿namespace LantanaGroup.Link.Shared.Application.Models;
 public enum PatientEvents
 {
+    Admit,
     Discharge
 }

--- a/DotNet/Shared/Application/Models/Telemetry/DiagnosticNames.cs
+++ b/DotNet/Shared/Application/Models/Telemetry/DiagnosticNames.cs
@@ -20,6 +20,7 @@
         public const string PeriodStart = "period.start";
         public const string PeriodEnd = "period.end";
         public const string PageSize = "page.size";
+        public const string UserId = "user.id";
 
         //Diagnostic activity names
         public const string CreateAuditEvent = "Create Audit Event";

--- a/DotNet/Shared/Application/Models/Telemetry/DiagnosticNames.cs
+++ b/DotNet/Shared/Application/Models/Telemetry/DiagnosticNames.cs
@@ -1,0 +1,27 @@
+﻿namespace LantanaGroup.Link.Shared.Application.Models.Telemetry
+{
+    public static class DiagnosticNames
+    {
+        //Diagnostic tag names
+        public const string Service = "service";
+        public const string CorrelationId = "correlation.id";
+        public const string FacilityId = "facility.id";
+        public const string PatientId = "patient.id";
+        public const string PatientEvent = "patient.event";
+        public const string QueryType = "query.type";
+        public const string Resource = "resource";
+        public const string NormalizationOperation = "normalization.operation";
+        public const string AuditLogAction = "audit.log.action";
+        public const string NotificationId = "notification.id";
+        public const string NotificationType = "notification.type";
+        public const string NotificationChannel = "notification.channel";
+        public const string RecipientCount = "recipient.count";
+        public const string ReportType = "report.type";
+        public const string PeriodStart = "period.start";
+        public const string PeriodEnd = "period.end";
+        public const string PageSize = "page.size";
+
+        //Diagnostic activity names
+        public const string CreateAuditEvent = "Create Audit Event";
+    }
+}

--- a/DotNet/Shared/Application/Models/Telemetry/DiagnosticNames.cs
+++ b/DotNet/Shared/Application/Models/Telemetry/DiagnosticNames.cs
@@ -11,6 +11,7 @@
         public const string QueryType = "query.type";
         public const string Resource = "resource";
         public const string NormalizationOperation = "normalization.operation";
+        public const string AuditId = "audit.id";
         public const string AuditLogAction = "audit.log.action";
         public const string NotificationId = "notification.id";
         public const string NotificationType = "notification.type";
@@ -18,9 +19,20 @@
         public const string RecipientCount = "recipient.count";
         public const string ReportType = "report.type";
         public const string PeriodStart = "period.start";
-        public const string PeriodEnd = "period.end";
-        public const string PageSize = "page.size";
+        public const string PeriodEnd = "period.end";        
         public const string UserId = "user.id";
+
+        //Diagnostic tags Searching
+        public const string SearchText = "search.text";
+        public const string FacilityFilter = "facility.filter";
+        public const string CorrelationFilter = "correlation.filter";
+        public const string ServiceFilter = "service.filter";
+        public const string ActionFilter = "action.filter";
+        public const string UserFilter = "user.filter";
+        public const string SortBy = "sort.by";
+        public const string SortOrder = "sort.order";
+        public const string PageNumber = "page.number";
+        public const string PageSize = "page.size";
 
         //Diagnostic activity names
         public const string CreateAuditEvent = "Create Audit Event";

--- a/DotNet/Submission/Application/Services/ServiceActivitySource.cs
+++ b/DotNet/Submission/Application/Services/ServiceActivitySource.cs
@@ -12,7 +12,6 @@ namespace LantanaGroup.Link.Submission.Application.Services
 
         public static void Initialize(ServiceInformation serviceInfo)
         {
-            ServiceName = serviceInfo.Name;
             _version = serviceInfo.Version;
             Instance = new ActivitySource(ServiceName, _version);
         }

--- a/DotNet/Tenant/Jobs/ReportScheduledJob.cs
+++ b/DotNet/Tenant/Jobs/ReportScheduledJob.cs
@@ -1,6 +1,7 @@
 ﻿using Confluent.Kafka;
 using LantanaGroup.Link.Shared.Application.Interfaces;
 using LantanaGroup.Link.Shared.Application.Models;
+using LantanaGroup.Link.Shared.Application.Models.Telemetry;
 using LantanaGroup.Link.Tenant.Config;
 using LantanaGroup.Link.Tenant.Entities;
 using LantanaGroup.Link.Tenant.Interfaces;
@@ -86,10 +87,10 @@ namespace LantanaGroup.Link.Tenant.Jobs
                 await producer.ProduceAsync(KafkaTopic.ReportScheduled.ToString(), message);
 
                 _metrics.IncrementReportScheduledCounter([
-                    new KeyValuePair<string, object?>("facility", facility.FacilityId),
-                    new KeyValuePair<string, object?>("reportType", reportType),
-                    new KeyValuePair<string, object?>("period.start", startDate),
-                    new KeyValuePair<string, object?>("period.end", endDate)
+                    new KeyValuePair<string, object?>(DiagnosticNames.FacilityId, facility.FacilityId),
+                    new KeyValuePair<string, object?>(DiagnosticNames.ReportType, reportType),
+                    new KeyValuePair<string, object?>(DiagnosticNames.PeriodStart, startDate),
+                    new KeyValuePair<string, object?>(DiagnosticNames.PeriodEnd, endDate)
                 ]);
 
             }

--- a/DotNet/Tenant/Services/ServiceActivitySource.cs
+++ b/DotNet/Tenant/Services/ServiceActivitySource.cs
@@ -1,4 +1,5 @@
-﻿using LantanaGroup.Link.Tenant.Models;
+﻿using LantanaGroup.Link.Tenant.Config;
+using LantanaGroup.Link.Tenant.Models;
 using System.Diagnostics;
 
 namespace LantanaGroup.Link.Tenant.Services
@@ -6,12 +7,11 @@ namespace LantanaGroup.Link.Tenant.Services
     public class ServiceActivitySource
     {
         private static string _version = string.Empty;
-        public static string ServiceName = "Tenant Service";
+        public static string ServiceName = TenantConstants.ServiceName;
         public static ActivitySource Instance { get; private set; } = new ActivitySource(ServiceName, _version);
 
         public static void Initialize(ServiceInformation serviceInfo)
         {
-            ServiceName = serviceInfo.Name;
             _version = serviceInfo.Version;
             Instance = new ActivitySource(ServiceName, _version);
         }


### PR DESCRIPTION
- Added `DiagnosticNames` class for consistent names used in telemetry across services
- Updated existing service metrics to use new diagnostic names class.
- Fixed bug that was causing the custom traces to not be captured. The service name int he activity source and the service name in the open telemetry configuration were not matching for most services.
- Fixed a configuration issue that was preventing link admin from accepting bearer tokens created by link admin