### PR TITLE
Auto migrate extension

### DIFF
--- a/DotNet/Census/Program.cs
+++ b/DotNet/Census/Program.cs
@@ -178,6 +178,8 @@ static void RegisterServices(WebApplicationBuilder builder)
 
 static void SetupMiddleware(WebApplication app)
 {
+    app.AutoMigrateEF<CensusContext>();
+    
     //if (app.Environment.IsDevelopment())
     //{
     app.UseSwagger();

--- a/DotNet/Shared/Application/Extensions/EFMigrations.cs
+++ b/DotNet/Shared/Application/Extensions/EFMigrations.cs
@@ -1,0 +1,22 @@
+﻿using LantanaGroup.Link.Shared.Settings;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace LantanaGroup.Link.Shared.Application.Extensions;
+
+public static class EFMigrations
+{
+    public static void AutoMigrateEF<T>(this WebApplication app) where T : DbContext
+    {
+        if (app.Configuration.GetValue<bool>(ConfigurationConstants.AppSettings.AutoMigrate, false))
+        {
+            using (var scope = app.Services.CreateScope())
+            {
+                var dbContext = scope.ServiceProvider.GetRequiredService<T>();
+                dbContext.Database.Migrate();
+            }
+        }
+    }
+}

--- a/DotNet/Shared/Settings/ConfigurationConstants.cs
+++ b/DotNet/Shared/Settings/ConfigurationConstants.cs
@@ -8,6 +8,7 @@ namespace LantanaGroup.Link.Shared.Settings
             public const string ServiceInformation = "ServiceInformation";
             public const string Telemetry = "Telemetry";
             public const string CORS = "CORS";
+            public const string AutoMigrate = "AutoMigrate";
         }
     }
 }


### PR DESCRIPTION
Adding app extension method to auto migrate EF for a DbContext
Applying auto migrate to the Census service, other services to come later