### PR TITLE
Java Logging to Loki

### DIFF
--- a/Java/pom.xml
+++ b/Java/pom.xml
@@ -22,6 +22,7 @@
     <properties>
         <cqf-fhir.version>3.0.0</cqf-fhir.version>
         <hapi-fhir.version>7.0.0</hapi-fhir.version>
+        <janino.version>2.6.1</janino.version>
     </properties>
 
     <modules>
@@ -33,6 +34,18 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
+                <groupId>org.codehaus.janino</groupId>
+                <artifactId>commons-compiler</artifactId>
+                <version>${janino.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.codehaus.janino</groupId>
+                <artifactId>janino</artifactId>
+                <version>${janino.version}</version>
+            </dependency>
+
+            <dependency>
                 <groupId>com.azure.spring</groupId>
                 <artifactId>spring-cloud-azure-appconfiguration-config-web</artifactId>
                 <version>5.11.0</version>
@@ -42,6 +55,12 @@
                 <groupId>org.springdoc</groupId>
                 <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
                 <version>2.5.0</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.github.loki4j</groupId>
+                <artifactId>loki-logback-appender</artifactId>
+                <version>1.4.1</version>
             </dependency>
 
             <dependency>

--- a/Java/shared/pom.xml
+++ b/Java/shared/pom.xml
@@ -23,6 +23,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter</artifactId>
         </dependency>

--- a/Java/shared/src/main/java/com/lantanagroup/link/shared/config/LokiConfig.java
+++ b/Java/shared/src/main/java/com/lantanagroup/link/shared/config/LokiConfig.java
@@ -1,0 +1,13 @@
+package com.lantanagroup.link.shared.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
+
+@Getter @Setter
+@ConfigurationProperties(prefix = "loki")
+public class LokiConfig {
+    private boolean enabled = false;
+    private String url;
+}

--- a/Java/validation/pom.xml
+++ b/Java/validation/pom.xml
@@ -96,6 +96,21 @@
             <artifactId>hapi-fhir-caching-caffeine</artifactId>
             <scope>runtime</scope>
         </dependency>
+
+        <dependency>
+            <groupId>com.github.loki4j</groupId>
+            <artifactId>loki-logback-appender</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.codehaus.janino</groupId>
+            <artifactId>commons-compiler</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.codehaus.janino</groupId>
+            <artifactId>janino</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/Java/validation/src/main/java/com/lantanagroup/link/validation/ValidationApplicationConfig.java
+++ b/Java/validation/src/main/java/com/lantanagroup/link/validation/ValidationApplicationConfig.java
@@ -5,6 +5,7 @@ import com.lantanagroup.link.validation.model.PatientEvaluatedModel;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.info.License;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
@@ -12,6 +13,7 @@ import org.springframework.kafka.core.ConsumerFactory;
 import org.springframework.kafka.listener.CommonErrorHandler;
 
 @Configuration
+@ConfigurationPropertiesScan("com.lantanagroup.link.shared.config")
 public class ValidationApplicationConfig extends BaseSpringConfig {
     @Bean
     ConcurrentKafkaListenerContainerFactory<String, PatientEvaluatedModel> kafkaListenerContainerFactory(

--- a/Java/validation/src/main/java/com/lantanagroup/link/validation/controllers/CategoryController.java
+++ b/Java/validation/src/main/java/com/lantanagroup/link/validation/controllers/CategoryController.java
@@ -50,6 +50,7 @@ public class CategoryController {
     @Operation(summary = "Get all categories")
     @GetMapping
     public List<CategoryEntity> getCategories() {
+        String val = System.getProperty("loki.enabled");
         return this.categoryRepository.findAll()
                 .stream().peek(category -> category.setRequireAllRuleSets(null))
                 .toList();

--- a/Java/validation/src/main/resources/application.yml
+++ b/Java/validation/src/main/resources/application.yml
@@ -1,5 +1,8 @@
 artifact:
   init: true
+loki:
+  enabled: false
+  url: ''
 server:
   port: 31820
 springdoc:

--- a/Java/validation/src/main/resources/logback.xml
+++ b/Java/validation/src/main/resources/logback.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration scan="true" scanPeriod="10 seconds">
+    <springProperty scope="context" name="loki_enabled" source="loki.enabled"/>
+    <springProperty scope="context" name="loki_url" source="loki.url"/>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <if condition='property("loki_enabled").equalsIgnoreCase("true")'>
+        <then>
+            <appender name="LOKI" class="com.github.loki4j.logback.Loki4jAppender">
+                <http>
+                    <url>${loki_url}/loki/api/v1/push</url>
+                </http>
+                <format>
+                    <label>
+                        <pattern>app=link-cloud,component=Validation</pattern>
+                        <readMarkers>true</readMarkers>
+                    </label>
+                    <message>
+                        <pattern>
+                            {
+                            "level":"%level",
+                            "class":"%logger{36}",
+                            "thread":"%thread",
+                            "message": "%message",
+                            "requestId": "%X{X-Request-ID}"
+                            }
+                        </pattern>
+                    </message>
+                </format>
+                <batchMaxItems>25</batchMaxItems>
+            </appender>
+        </then>
+    </if>
+
+    <root level="INFO">
+        <appender-ref ref="STDOUT" />
+
+        <if condition='property("loki_enabled").equalsIgnoreCase("true")'>
+            <then>
+                <appender-ref ref="LOKI" />
+            </then>
+        </if>
+    </root>
+</configuration>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -612,6 +612,8 @@ services:
       spring.datasource.password: ${LINK_DB_PASS}
       spring.kafka.bootstrap-servers: kafka_b:9094
       spring.jpa.hibernate.ddl-auto: update
+      loki.enabled: true
+      loki.url: http://loki:3100
     ports:
       - "8075:8075"
     build:


### PR DESCRIPTION
Adding loki log appender and config to validation service
Still need to add it to measureeval service
Defaults in application.yml DONT use loki
When loki is enabled but URL is not provided to loki, the error/exception is rather ugly, but has enough info to figure out why
Env variable override with:
* loki.enabled=true
* loki.url=http://localhost:3100
Logging to loki enabled in docker-compose