### PR TITLE
Improve FHIR ID deserialization

### DIFF
--- a/Java/measureeval/src/main/java/com/lantanagroup/link/measureeval/configs/KafkaConfig.java
+++ b/Java/measureeval/src/main/java/com/lantanagroup/link/measureeval/configs/KafkaConfig.java
@@ -26,6 +26,7 @@ import java.util.regex.Pattern;
 
 @Configuration
 public class KafkaConfig {
+    // TODO: Replace this and StreamUtils.mapKeys with getDeserializers
     private static Pattern getPattern(String topic) {
         return Pattern.compile(Pattern.quote(topic));
     }

--- a/Java/measureeval/src/main/java/com/lantanagroup/link/measureeval/entities/AbstractResource.java
+++ b/Java/measureeval/src/main/java/com/lantanagroup/link/measureeval/entities/AbstractResource.java
@@ -1,5 +1,7 @@
 package com.lantanagroup.link.measureeval.entities;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.lantanagroup.link.measureeval.serdes.FhirIdDeserializer;
 import lombok.Getter;
 import lombok.Setter;
 import org.hl7.fhir.instance.model.api.IBaseResource;
@@ -18,7 +20,10 @@ public abstract class AbstractResource {
 
     private String facilityId;
     private ResourceType resourceType;
+
+    @JsonDeserialize(using = FhirIdDeserializer.class)
     private String resourceId;
+
     private IBaseResource resource;
 
     @CreatedDate

--- a/Java/measureeval/src/main/java/com/lantanagroup/link/measureeval/entities/PatientReportingEvaluationStatus.java
+++ b/Java/measureeval/src/main/java/com/lantanagroup/link/measureeval/entities/PatientReportingEvaluationStatus.java
@@ -2,8 +2,10 @@ package com.lantanagroup.link.measureeval.entities;
 
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.lantanagroup.link.measureeval.models.NormalizationStatus;
 import com.lantanagroup.link.measureeval.models.QueryType;
+import com.lantanagroup.link.measureeval.serdes.FhirIdDeserializer;
 import lombok.Getter;
 import lombok.Setter;
 import org.hl7.fhir.r4.model.ResourceType;
@@ -22,7 +24,9 @@ public class PatientReportingEvaluationStatus {
     private String id;
 
     private String facilityId;
+
     private String correlationId;
+    @JsonDeserialize(using = FhirIdDeserializer.class)
     private String patientId;
 
     @JsonSetter(nulls = Nulls.AS_EMPTY)
@@ -55,7 +59,10 @@ public class PatientReportingEvaluationStatus {
     public static class Resource {
         private Boolean isPatientResource;
         private ResourceType resourceType;
+
+        @JsonDeserialize(using = FhirIdDeserializer.class)
         private String resourceId;
+
         private QueryType queryType;
         private NormalizationStatus normalizationStatus;
     }

--- a/Java/measureeval/src/main/java/com/lantanagroup/link/measureeval/entities/PatientResource.java
+++ b/Java/measureeval/src/main/java/com/lantanagroup/link/measureeval/entities/PatientResource.java
@@ -1,10 +1,13 @@
 package com.lantanagroup.link.measureeval.entities;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.lantanagroup.link.measureeval.serdes.FhirIdDeserializer;
 import lombok.Getter;
 import lombok.Setter;
 
 @Getter
 @Setter
 public class PatientResource extends AbstractResource {
+    @JsonDeserialize(using = FhirIdDeserializer.class)
     private String patientId;
 }

--- a/Java/measureeval/src/main/java/com/lantanagroup/link/measureeval/models/QueryResults.java
+++ b/Java/measureeval/src/main/java/com/lantanagroup/link/measureeval/models/QueryResults.java
@@ -2,6 +2,8 @@ package com.lantanagroup.link.measureeval.models;
 
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.lantanagroup.link.measureeval.serdes.FhirIdDeserializer;
 import lombok.Getter;
 import lombok.Setter;
 import org.hl7.fhir.r4.model.ResourceType;
@@ -12,6 +14,7 @@ import java.util.List;
 @Getter
 @Setter
 public class QueryResults {
+    @JsonDeserialize(using = FhirIdDeserializer.class)
     private String patientId;
 
     @JsonSetter(nulls = Nulls.AS_EMPTY)
@@ -21,7 +24,10 @@ public class QueryResults {
     @Setter
     public static class QueryResult {
         private ResourceType resourceType;
+
+        @JsonDeserialize(using = FhirIdDeserializer.class)
         private String resourceId;
+
         private QueryType queryType;
     }
 }

--- a/Java/measureeval/src/main/java/com/lantanagroup/link/measureeval/records/DataAcquisitionRequested.java
+++ b/Java/measureeval/src/main/java/com/lantanagroup/link/measureeval/records/DataAcquisitionRequested.java
@@ -2,7 +2,9 @@ package com.lantanagroup.link.measureeval.records;
 
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.lantanagroup.link.measureeval.models.QueryType;
+import com.lantanagroup.link.measureeval.serdes.FhirIdDeserializer;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -13,7 +15,9 @@ import java.util.List;
 @Getter
 @Setter
 public class DataAcquisitionRequested {
+    @JsonDeserialize(using = FhirIdDeserializer.class)
     private String patientId;
+
     private QueryType queryType;
 
     @JsonSetter(nulls = Nulls.AS_EMPTY)

--- a/Java/measureeval/src/main/java/com/lantanagroup/link/measureeval/records/ResourceAcquired.java
+++ b/Java/measureeval/src/main/java/com/lantanagroup/link/measureeval/records/ResourceAcquired.java
@@ -2,7 +2,9 @@ package com.lantanagroup.link.measureeval.records;
 
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.lantanagroup.link.measureeval.models.QueryType;
+import com.lantanagroup.link.measureeval.serdes.FhirIdDeserializer;
 import lombok.Getter;
 import lombok.Setter;
 import org.hl7.fhir.instance.model.api.IBaseResource;
@@ -14,7 +16,9 @@ import java.util.List;
 @Getter
 @Setter
 public class ResourceAcquired {
+    @JsonDeserialize(using = FhirIdDeserializer.class)
     private String patientId;
+
     private QueryType queryType;
     private IBaseResource resource;
 

--- a/Java/measureeval/src/main/java/com/lantanagroup/link/measureeval/records/ResourceEvaluated.java
+++ b/Java/measureeval/src/main/java/com/lantanagroup/link/measureeval/records/ResourceEvaluated.java
@@ -1,5 +1,7 @@
 package com.lantanagroup.link.measureeval.records;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.lantanagroup.link.measureeval.serdes.FhirIdDeserializer;
 import lombok.Getter;
 import lombok.Setter;
 import org.hl7.fhir.instance.model.api.IBaseResource;
@@ -9,8 +11,12 @@ import java.util.Date;
 @Getter
 @Setter
 public class ResourceEvaluated {
+    @JsonDeserialize(using = FhirIdDeserializer.class)
     private String measureReportId;
+
+    @JsonDeserialize(using = FhirIdDeserializer.class)
     private String patientId;
+
     private IBaseResource resource;
 
     @Getter

--- a/Java/measureeval/src/main/java/com/lantanagroup/link/measureeval/records/ResourceNormalized.java
+++ b/Java/measureeval/src/main/java/com/lantanagroup/link/measureeval/records/ResourceNormalized.java
@@ -2,7 +2,9 @@ package com.lantanagroup.link.measureeval.records;
 
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.lantanagroup.link.measureeval.models.QueryType;
+import com.lantanagroup.link.measureeval.serdes.FhirIdDeserializer;
 import lombok.Getter;
 import lombok.Setter;
 import org.apache.commons.lang3.StringUtils;
@@ -16,7 +18,9 @@ import java.util.List;
 @Getter
 @Setter
 public class ResourceNormalized {
+    @JsonDeserialize(using = FhirIdDeserializer.class)
     private String patientId;
+
     private QueryType queryType;
     private IBaseResource resource;
 

--- a/Java/measureeval/src/main/java/com/lantanagroup/link/measureeval/serdes/FhirIdDeserializer.java
+++ b/Java/measureeval/src/main/java/com/lantanagroup/link/measureeval/serdes/FhirIdDeserializer.java
@@ -1,0 +1,21 @@
+package com.lantanagroup.link.measureeval.serdes;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import org.hl7.fhir.r4.model.IdType;
+
+import java.io.IOException;
+
+public class FhirIdDeserializer extends StdDeserializer<String> {
+    public FhirIdDeserializer() {
+        super(String.class);
+    }
+
+    @Override
+    public String deserialize(JsonParser jsonParser, DeserializationContext deserializationContext) throws IOException {
+        String value = jsonParser.getText();
+        IdType id = new IdType(value);
+        return id.getIdPart();
+    }
+}

--- a/Java/measureeval/src/main/java/com/lantanagroup/link/measureeval/serdes/FhirModule.java
+++ b/Java/measureeval/src/main/java/com/lantanagroup/link/measureeval/serdes/FhirModule.java
@@ -15,6 +15,6 @@ public class FhirModule extends SimpleModule {
 
     private <T extends IBaseResource> void register(FhirContext fhirContext, Class<T> resourceType) {
         addDeserializer(resourceType, new FhirResourceDeserializer<>(resourceType, fhirContext));
-        addSerializer(resourceType, new FhirResourceSerializer<>(fhirContext));
+        addSerializer(resourceType, new FhirResourceSerializer<>(resourceType, fhirContext));
     }
 }

--- a/Java/measureeval/src/main/java/com/lantanagroup/link/measureeval/serdes/FhirResourceDeserializer.java
+++ b/Java/measureeval/src/main/java/com/lantanagroup/link/measureeval/serdes/FhirResourceDeserializer.java
@@ -5,17 +5,18 @@ import ca.uhn.fhir.parser.DataFormatException;
 import ca.uhn.fhir.parser.IParser;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 import com.lantanagroup.link.measureeval.exceptions.FhirParseException;
 import org.hl7.fhir.instance.model.api.IBaseResource;
 
 import java.io.IOException;
 
-public class FhirResourceDeserializer<T extends IBaseResource> extends JsonDeserializer<T> {
+public class FhirResourceDeserializer<T extends IBaseResource> extends StdDeserializer<T> {
     private final Class<T> resourceType;
     private final FhirContext fhirContext;
 
     public FhirResourceDeserializer(Class<T> resourceType, FhirContext fhirContext) {
+        super(resourceType);
         this.resourceType = resourceType;
         this.fhirContext = fhirContext;
     }

--- a/Java/measureeval/src/main/java/com/lantanagroup/link/measureeval/serdes/FhirResourceSerializer.java
+++ b/Java/measureeval/src/main/java/com/lantanagroup/link/measureeval/serdes/FhirResourceSerializer.java
@@ -2,16 +2,17 @@ package com.lantanagroup.link.measureeval.serdes;
 
 import ca.uhn.fhir.context.FhirContext;
 import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
 import org.hl7.fhir.instance.model.api.IBaseResource;
 
 import java.io.IOException;
 
-public class FhirResourceSerializer<T extends IBaseResource> extends JsonSerializer<T> {
+public class FhirResourceSerializer<T extends IBaseResource> extends StdSerializer<T> {
     private final FhirContext fhirContext;
 
-    public FhirResourceSerializer(FhirContext fhirContext) {
+    public FhirResourceSerializer(Class<T> resourceType, FhirContext fhirContext) {
+        super(resourceType);
         this.fhirContext = fhirContext;
     }
 


### PR DESCRIPTION
Support IDs with or without a `{type}/` prefix (as well as any other variant that HAPI's `IdType` understands).