### PR TITLE
Fix duplicate error handling

### DIFF
--- a/DotNet/Normalization/Listeners/ResourceAcquiredListener.cs
+++ b/DotNet/Normalization/Listeners/ResourceAcquiredListener.cs
@@ -220,14 +220,6 @@ public class ResourceAcquiredListener : BackgroundService
                             });
                         }
                     }
-                    catch(NoEntityFoundException ex)
-                    {
-                        var errorMessage = $"An error was encountered processing Operation Commands for {messageMetaData.facilityId}";
-
-                        _logger.LogError(ex, "An error was encountered processing Operation Commands for {facilityId}", messageMetaData.facilityId);
-                        _transientExceptionHandler.HandleException(message, ex, AuditEventType.Create, messageMetaData.facilityId);
-                        kafkaConsumer.Commit(message);
-                    }
                     catch (Exception ex)
                     {
                         var errorMessage = $"An error was encountered processing Operation Commands for {messageMetaData.facilityId}";


### PR DESCRIPTION
The removed `catch` block for `NoEntityFoundException` duplicates the block for `Exception` but fails to (correctly) return early.