### PR TITLE
LNK-2445: Update link bearer services authority to be configurable

### DIFF
--- a/DotNet/Account/Program.cs
+++ b/DotNet/Account/Program.cs
@@ -35,6 +35,7 @@ using Microsoft.Extensions.Configuration.AzureAppConfiguration;
 using Microsoft.OpenApi.Models;
 using Serilog;
 using Serilog.Enrichers.Span;
+using System.Configuration;
 using System.Reflection;
 using System.Text;
 using System.Text.Json.Serialization;
@@ -144,7 +145,8 @@ static void RegisterServices(WebApplicationBuilder builder)
     {
         options.Environment = builder.Environment;
         options.AllowAnonymous = allowAnonymousAccess;
-        options.ValidateToken = builder.Configuration.GetValue<bool>("Authentication:ValidateToken");
+        options.Authority = builder.Configuration.GetValue<string>("Authentication:Schemas:LinkBearer:Authority");
+        options.ValidateToken = builder.Configuration.GetValue<bool>("Authentication:Schemas:LinkBearer:ValidateToken");
         options.ProtectKey = builder.Configuration.GetValue<bool>("DataProtection:Enabled");
     });
 

--- a/DotNet/Account/appsettings.Development.json
+++ b/DotNet/Account/appsettings.Development.json
@@ -31,7 +31,12 @@
   },
   "Authentication": {
     "EnableAnonymousAccess": false,
-    "ValidateToken": false
+    "Schemas": {
+      "LinkBearer": {
+        "Authority": "https://localhost:7004",
+        "ValidateToken": true
+      }
+    }
   },
   "EnableSwagger": true,
   "Logging": {

--- a/DotNet/Account/appsettings.json
+++ b/DotNet/Account/appsettings.json
@@ -30,7 +30,12 @@
   },
   "Authentication": {
     "EnableAnonymousAccess": false,
-    "ValidateToken": true
+    "Schemas": {
+      "LinkBearer": {
+        "Authority": "",
+        "ValidateToken": true
+      }
+    }
   },
   "EnableSwagger": false,
   "CORS": {

--- a/DotNet/LinkAdmin.BFF/Application/Models/Configuration/LinkBearerServiceConfig.cs
+++ b/DotNet/LinkAdmin.BFF/Application/Models/Configuration/LinkBearerServiceConfig.cs
@@ -3,6 +3,7 @@
     public class LinkBearerServiceConfig
     {
         public bool EnableTokenGenrationEndpoint { get; set; }
+        public string Authority { get; set; } = default!;
         public string? LinkAdminEmail { get; set; }
         public int TokenLifespan { get; set; } = 10;
     }

--- a/DotNet/LinkAdmin.BFF/Infrastructure/Extensions/Security/InitializeSecurity.cs
+++ b/DotNet/LinkAdmin.BFF/Infrastructure/Extensions/Security/InitializeSecurity.cs
@@ -123,8 +123,8 @@ namespace LantanaGroup.Link.LinkAdmin.BFF.Infrastructure.Extensions.Security
             services.AddLinkBearerServiceAuthentication(options =>
             {
                 options.Environment = securityServiceOptions.Environment;
-                options.Authority = LinkAuthorizationConstants.LinkBearerService.LinkBearerIssuer;
-                options.Audience = LinkAuthorizationConstants.LinkBearerService.LinkBearerAudience;
+                options.Authority = configuration.GetValue<string>("LinkBearerService:Authority") ?? LinkAuthorizationConstants.LinkBearerService.LinkBearerIssuer;
+                options.Audience = LinkAuthorizationConstants.LinkBearerService.LinkBearerAudience;              
             });
 
             // Add Authorization

--- a/DotNet/LinkAdmin.BFF/appsettings.Development.json
+++ b/DotNet/LinkAdmin.BFF/appsettings.Development.json
@@ -26,6 +26,7 @@
   "EnableIntegrationFeature": true,
   "LinkBearerService": {
     "EnableTokenGenrationEndpoint": true,
+    "Authority": "https://localhost:7004",
     "LinkAdminEmail": "linkadmin@lantanagroup.com",
     "TokenLifespan": 10
   },

--- a/DotNet/LinkAdmin.BFF/appsettings.json
+++ b/DotNet/LinkAdmin.BFF/appsettings.json
@@ -39,6 +39,7 @@
   },
   "LinkBearerService": {
     "EnableTokenGenrationEndpoint": true,
+    "Authority": "",
     "LinkAdminEmail": "",
     "TokenLifespan": 10
   },


### PR DESCRIPTION
Made updates to allow for the configuration of the authority for the link bearer service. This change was needed to address non development environments requiring https meta data for the authority.