### PR TITLE
LNK-2445: Add globalization invariant environment variable 

### DIFF
--- a/DotNet/Account/Dockerfile
+++ b/DotNet/Account/Dockerfile
@@ -9,6 +9,12 @@
 
 FROM mcr.microsoft.com/dotnet/aspnet:8.0-alpine AS base
 WORKDIR /app
+
+ENV \
+    DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false \
+    LC_ALL=en_US.UTF-8 \
+    LANG=en_US.UTF-8
+
 EXPOSE 80
 EXPOSE 443
 


### PR DESCRIPTION
The switch to SQL server requires this addition due to the alpine image being used.