### PR TITLE
Using shared constants for sql server connections across all projects

### DIFF
--- a/DotNet/Account/Program.cs
+++ b/DotNet/Account/Program.cs
@@ -160,8 +160,8 @@ static void RegisterServices(WebApplicationBuilder builder)
         var dbProvider = builder.Configuration.GetValue<string>(AccountConstants.AppSettingsSectionNames.DatabaseProvider);
         switch (dbProvider)
         {
-            case "SqlServer":
-                string? connectionString = builder.Configuration.GetValue<string>(AccountConstants.AppSettingsSectionNames.DatabaseConnectionString);
+            case ConfigurationConstants.AppSettings.SqlServerDatabaseProvider:
+                string? connectionString = builder.Configuration.GetConnectionString(ConfigurationConstants.DatabaseConnections.DatabaseConnection);
 
                 if (string.IsNullOrEmpty(connectionString))
                     throw new InvalidOperationException("Database connection string is null or empty.");

--- a/DotNet/Account/Settings/AccountConstants.cs
+++ b/DotNet/Account/Settings/AccountConstants.cs
@@ -7,14 +7,8 @@
         public static class AppSettingsSectionNames
         {
             public const string ExternalConfigurationSource = "ExternalConfigurationSource";
-            public const string Kafka = "KafkaConnection";
             public const string DatabaseProvider = "DatabaseProvider";
-            public const string DatabaseConnectionString = "ConnectionStrings:DatabaseConnection";            
-            public const string Postgres = "Postgres";
-            public const string Serilog = "Serilog";
             public const string EnableSwagger = "EnableSwagger";
-            public const string SecretManagement = "SecretManagement";
-            public const string TenantApiSettings = "TenantApiSettings";
             public const string UserManagement = "UserManagement";
         }
 

--- a/DotNet/Audit/Program.cs
+++ b/DotNet/Audit/Program.cs
@@ -159,8 +159,10 @@ static void RegisterServices(WebApplicationBuilder builder)
 
         switch(builder.Configuration.GetValue<string>(AuditConstants.AppSettingsSectionNames.DatabaseProvider))
         {          
-            case "SqlServer":
-                string? connectionString = builder.Configuration.GetValue<string>(AuditConstants.AppSettingsSectionNames.DatabaseConnectionString);
+            case ConfigurationConstants.AppSettings.SqlServerDatabaseProvider:
+                string? connectionString =
+                    builder.Configuration.GetConnectionString(ConfigurationConstants.DatabaseConnections
+                        .DatabaseConnection);
                 
                 if (string.IsNullOrEmpty(connectionString))
                     throw new InvalidOperationException("Database connection string is null or empty.");

--- a/DotNet/Audit/Settings/AuditConstants.cs
+++ b/DotNet/Audit/Settings/AuditConstants.cs
@@ -8,14 +8,10 @@
         {
             public const string ExternalConfigurationSource = "ExternalConfigurationSource";
             public const string ServiceInformation = "ServiceInformation";
-            public const string Kafka = "KafkaConnection";
-            public const string DatabaseConnectionString = "ConnectionStrings:DatabaseConnection";
             public const string DatabaseProvider = "DatabaseProvider";            
             public const string IdentityProvider = "IdentityProviderConfig";
-            public const string Telemetry = "Telemetry";
             public const string Serilog = "Serilog";
             public const string EnableSwagger = "EnableSwagger";
-            public const string AllowReflection = "AllowReflection";
         }
 
         public static class AuditExceptionMessages 

--- a/DotNet/Census/Application/Settings/CensusConstants.cs
+++ b/DotNet/Census/Application/Settings/CensusConstants.cs
@@ -6,7 +6,6 @@ public static class CensusConstants
     public static class AppSettings
     {
         public const string ServiceInformation = "ServiceInformation";
-        public const string DatabaseConnection = "SqlServer";
         public const string DatabaseProvider = "DatabaseProvider";
         public const string ExternalConfigurationSource = "ExternalConfigurationSource";
     }

--- a/DotNet/Census/Program.cs
+++ b/DotNet/Census/Program.cs
@@ -97,9 +97,15 @@ static void RegisterServices(WebApplicationBuilder builder)
 
         switch (builder.Configuration.GetValue<string>(CensusConstants.AppSettings.DatabaseProvider))
         {
-            case "SqlServer":
-                options.UseSqlServer(
-                    builder.Configuration.GetConnectionString(CensusConstants.AppSettings.DatabaseConnection))
+            case ConfigurationConstants.AppSettings.SqlServerDatabaseProvider:
+                string? connectionString =
+                    builder.Configuration.GetConnectionString(ConfigurationConstants.DatabaseConnections
+                        .DatabaseConnection);
+                
+                if (string.IsNullOrEmpty(connectionString))
+                    throw new InvalidOperationException("Database connection string is null or empty.");
+                
+                options.UseSqlServer(connectionString)
                    .AddInterceptors(updateBaseEntityInterceptor);
                 break;
             default:

--- a/DotNet/DataAcquisition.Domain/Extensions/SQLServerEFExtension.cs
+++ b/DotNet/DataAcquisition.Domain/Extensions/SQLServerEFExtension.cs
@@ -1,6 +1,7 @@
 ﻿using LantanaGroup.Link.DataAcquisition.Application.Settings;
 using LantanaGroup.Link.DataAcquisition.Domain;
 using LantanaGroup.Link.Shared.Application.Repositories.Interceptors;
+using LantanaGroup.Link.Shared.Settings;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -13,14 +14,19 @@ public static class SQLServerEFExtension
     {
         builder.Services.AddDbContext<DataAcquisitionDbContext>((sp, options) =>
         {
-
             var updateBaseEntityInterceptor = sp.GetService<UpdateBaseEntityInterceptor>()!;
 
             switch (builder.Configuration.GetValue<string>(DataAcquisitionConstants.AppSettingsSectionNames.DatabaseProvider))
             {
-                case "SqlServer":
-                    options.UseSqlServer(
-                        builder.Configuration.GetConnectionString(DataAcquisitionConstants.AppSettingsSectionNames.DatabaseConnection))
+                case ConfigurationConstants.AppSettings.SqlServerDatabaseProvider:
+                    string? connectionString =
+                        builder.Configuration.GetConnectionString(ConfigurationConstants.DatabaseConnections
+                            .DatabaseConnection);
+
+                    if (string.IsNullOrEmpty(connectionString))
+                        throw new InvalidOperationException("Database connection string is null or empty.");
+                    
+                    options.UseSqlServer(connectionString)
                        .AddInterceptors(updateBaseEntityInterceptor);
                     break;
                 default:

--- a/DotNet/DataAcquisition.Domain/Settings/DataAcquisitionConstants.cs
+++ b/DotNet/DataAcquisition.Domain/Settings/DataAcquisitionConstants.cs
@@ -10,7 +10,6 @@ public static class DataAcquisitionConstants
         public const string ServiceInformation = "ServiceInformation";
         public const string ExternalConfigurationSource = "ExternalConfigurationSource";
         public const string DatabaseProvider = "DatabaseProvider";
-        public const string DatabaseConnection = "SqlServer";
         public const string Serilog = "Serilog";
     }
 

--- a/DotNet/DataAcquisition/Program.cs
+++ b/DotNet/DataAcquisition/Program.cs
@@ -99,8 +99,7 @@ static void RegisterServices(WebApplicationBuilder builder)
 
     //Add DbContext
     builder.Services.AddTransient<UpdateBaseEntityInterceptor>();
-    SQLServerEFExtension.AddSQLServerEF_DataAcq(builder);
-
+    builder.AddSQLServerEF_DataAcq();
 
     builder.Services.AddHttpClient("FhirHttpClient")
             .ConfigurePrimaryHttpMessageHandler(() => new HttpClientHandler()

--- a/DotNet/Normalization/Application/Settings/NormalizationConstants.cs
+++ b/DotNet/Normalization/Application/Settings/NormalizationConstants.cs
@@ -8,7 +8,6 @@ public static class NormalizationConstants
     public static class AppSettingsSectionNames
     {
         public const string ServiceInformation = "ServiceInformation";
-        public const string DatabaseConnectionString = "ConnectionStrings:DatabaseConnection";
         public const string DatabaseProvider = "DatabaseProvider";
         public const string ExternalConfigurationSource = "ExternalConfigurationSource";
     }

--- a/DotNet/Normalization/Program.cs
+++ b/DotNet/Normalization/Program.cs
@@ -122,8 +122,8 @@ static void RegisterServices(WebApplicationBuilder builder)
             builder.Configuration.GetValue<string>(NormalizationConstants.AppSettingsSectionNames.DatabaseProvider);
         switch (dbProvider)
         {
-            case "SqlServer":
-                string? connectionString = builder.Configuration.GetValue<string>(NormalizationConstants.AppSettingsSectionNames.DatabaseConnectionString);
+            case ConfigurationConstants.AppSettings.SqlServerDatabaseProvider:
+                string? connectionString = builder.Configuration.GetConnectionString(ConfigurationConstants.DatabaseConnections.DatabaseConnection);
 
                 if (string.IsNullOrEmpty(connectionString))
                     throw new InvalidOperationException("Database connection string is null or empty.");

--- a/DotNet/Notification/Program.cs
+++ b/DotNet/Notification/Program.cs
@@ -162,10 +162,15 @@ static void RegisterServices(WebApplicationBuilder builder)
         
         switch (builder.Configuration.GetValue<string>(NotificationConstants.AppSettingsSectionNames.DatabaseProvider))
         {
-            case "SqlServer":
-                options.UseSqlServer(
-                    builder.Configuration.GetValue<string>(NotificationConstants.AppSettingsSectionNames.DatabaseConnectionString))
-                .AddInterceptors(updateBaseEntityInterceptor);                    
+            case ConfigurationConstants.AppSettings.SqlServerDatabaseProvider:
+                string? connectionString =
+                    builder.Configuration.GetValue<string>(ConfigurationConstants.DatabaseConnections.DatabaseConnection);
+                
+                if (string.IsNullOrEmpty(connectionString))
+                    throw new InvalidOperationException("Database connection string is null or empty.");
+                
+                options.UseSqlServer(connectionString)
+                    .AddInterceptors(updateBaseEntityInterceptor);                    
                 break;
             default:
                 throw new InvalidOperationException("Database provider not supported.");

--- a/DotNet/Notification/Settings/NotificationConstants.cs
+++ b/DotNet/Notification/Settings/NotificationConstants.cs
@@ -9,15 +9,12 @@
             public const string ExternalConfigurationSource = "ExternalConfigurationSource";
             public const string ServiceInformation = "ServiceInformation";
             public const string Kafka = "KafkaConnection";
-            public const string DatabaseConnectionString = "ConnectionStrings:DatabaseConnection";
             public const string DatabaseProvider = "DatabaseProvider";
             public const string Smtp = "SmtpConnection";
             public const string Channels = "Channels";
             public const string IdentityProvider = "IdentityProviderConfig";
-            public const string Telemetry = "Telemetry";
             public const string Serilog = "Serilog";
             public const string EnableSwagger = "EnableSwagger";
-            public const string AllowReflection = "AllowReflection";
         }
 
         public static class NotificationLoggingIds

--- a/DotNet/Shared/Application/Extensions/SqlServerRegistration.cs
+++ b/DotNet/Shared/Application/Extensions/SqlServerRegistration.cs
@@ -16,15 +16,26 @@ public static class SqlServerRegistration
 
             switch (builder.Configuration.GetValue<string>(ConfigurationConstants.AppSettings.DatabaseProvider))
             {
-                case "SqlServer":
+                case ConfigurationConstants.AppSettings.SqlServerDatabaseProvider:
                     {
                         if (useUpdateBaseEntityInterceptor)
-                            options.UseSqlServer(
-                                builder.Configuration.GetConnectionString(ConfigurationConstants.DatabaseConnections.DatabaseConnection))
+                        {
+                            string? connectionString =
+                                builder.Configuration.GetConnectionString(ConfigurationConstants.DatabaseConnections
+                                    .DatabaseConnection);
+
+                            if (string.IsNullOrEmpty(connectionString))
+                                throw new InvalidOperationException("Database connection string is null or empty.");
+                            
+                            options.UseSqlServer(connectionString)
                                 .AddInterceptors(updateBaseEntityInterceptor);
+                        }
                         else
+                        {
                             options.UseSqlServer(
-                                builder.Configuration.GetConnectionString(ConfigurationConstants.DatabaseConnections.DatabaseConnection));
+                                builder.Configuration.GetConnectionString(ConfigurationConstants.DatabaseConnections
+                                    .DatabaseConnection));
+                        }
                     }
                     break;
                 default:

--- a/DotNet/Shared/Settings/ConfigurationConstants.cs
+++ b/DotNet/Shared/Settings/ConfigurationConstants.cs
@@ -1,7 +1,7 @@
 ﻿
 namespace LantanaGroup.Link.Shared.Settings
 {
-    public class ConfigurationConstants
+    public static class ConfigurationConstants
     {
         public static class AppSettings
         {
@@ -11,12 +11,12 @@ namespace LantanaGroup.Link.Shared.Settings
             public const string CORS = "CORS";
             public const string AutoMigrate = "AutoMigrate";
             public const string DatabaseProvider = "DatabaseProvider";
+            public const string SqlServerDatabaseProvider = "SqlServer";
             public const string DataProtection = "DataProtection";
         }
 
         public static class DatabaseConnections
         {
-            public const string SqlServer = "SqlServer";
             public const string DatabaseConnection = "DatabaseConnection";
         }
 

--- a/DotNet/Tenant/Config/TenantConstants.cs
+++ b/DotNet/Tenant/Config/TenantConstants.cs
@@ -12,7 +12,6 @@ namespace LantanaGroup.Link.Tenant.Config
             public const string EnableSwagger = "EnableSwagger";
             public const string Serilog = "Serilog";
             public const string DatabaseProvider = "DatabaseProvider";
-            public const string DatabaseConnectionString = "ConnectionStrings:DatabaseConnection";
         }
 
         public static class TenantLoggingIds

--- a/DotNet/Tenant/Program.cs
+++ b/DotNet/Tenant/Program.cs
@@ -113,9 +113,15 @@ namespace Tenant
 
                 switch (builder.Configuration.GetValue<string>(TenantConstants.AppSettingsSectionNames.DatabaseProvider))
                 {
-                    case "SqlServer":
-                        options.UseSqlServer(
-                            builder.Configuration.GetValue<string>(TenantConstants.AppSettingsSectionNames.DatabaseConnectionString))
+                    case ConfigurationConstants.AppSettings.SqlServerDatabaseProvider:
+                        string? connectionString =
+                            builder.Configuration.GetConnectionString(ConfigurationConstants.DatabaseConnections
+                                .DatabaseConnection);
+
+                        if (string.IsNullOrEmpty(connectionString))
+                            throw new InvalidOperationException("Database connection string is null or empty.");
+                        
+                        options.UseSqlServer(connectionString)
                            .AddInterceptors(updateBaseEntityInterceptor);
                         break;
                     default:


### PR DESCRIPTION
Census and DataAcquisition: uses "DatabaseConnection" instead of "SqlServer" now