### PR TITLE
use strings for MeasureReports

### DIFF
--- a/DotNet/Account/Dockerfile
+++ b/DotNet/Account/Dockerfile
@@ -1,12 +1,5 @@
 #See https://aka.ms/containerfastmode to understand how Visual Studio uses this Dockerfile to build your images for faster debugging.
 
-# ARG ACCESS_TOKEN="mbygihet4uek5omhnuatzdxu5npiqz2rw3i6i7bgywaqwtshafaq"
-# ARG ARTIFACTS_ENDPOINT="https://pkgs.dev.azure.com/lantanagroup/nhsnlink/_packaging/Shared_BOTW_Feed/nuget/v3/index.json"
-
-# Configure the environment variables
-# ENV NUGET_CREDENTIALPROVIDER_SESSIONTOKENCACHE_ENABLED true
-# ENV VSS_NUGET_EXTERNAL_FEED_ENDPOINTS "{\"endpointCredentials\": [{\"endpoint\":\"${ARTIFACTS_ENDPOINT}\", \"password\":\"${ACCESS_TOKEN}\"}]}"
-
 FROM mcr.microsoft.com/dotnet/aspnet:8.0-jammy-amd64 AS base
 WORKDIR /app
 

--- a/DotNet/Report/Application/Models/SubmissionReportValue.cs
+++ b/DotNet/Report/Application/Models/SubmissionReportValue.cs
@@ -8,7 +8,7 @@ namespace LantanaGroup.Link.Report.Application.Models
     {
         public List<string>? PatientIds { get; internal set; }
         public Organization Organization { get; internal set; }
-        public List<MeasureReport> Aggregates { get; internal set; }
+        public List<string> Aggregates { get; internal set; }
         public string MeasureIds { get; set; }
     }
 }

--- a/DotNet/Report/Listeners/ResourceEvaluatedListener.cs
+++ b/DotNet/Report/Listeners/ResourceEvaluatedListener.cs
@@ -213,6 +213,12 @@ namespace LantanaGroup.Link.Report.Listeners
 
                                         using var prod = _kafkaProducerFactory.CreateProducer(producerConfig);
 
+                                        var serializedAggregates = new List<string>();
+                                        foreach (var agg in _aggregator.Aggregate(measureReports))
+                                        {
+                                            serializedAggregates.Add(JsonSerializer.Serialize(agg, new JsonSerializerOptions().ForFhir()));
+                                        }
+
                                         prod.Produce(nameof(KafkaTopic.SubmitReport),
                                             new Message<SubmissionReportKey, SubmissionReportValue>
                                             {
@@ -228,7 +234,7 @@ namespace LantanaGroup.Link.Report.Listeners
                                                     MeasureIds = string.Join("+",
                                                         measureReports.Select(mr => mr.Measure).Distinct()),
                                                     Organization = _bundler.CreateOrganization(schedule.FacilityId),
-                                                    Aggregates = _aggregator.Aggregate(measureReports)
+                                                    Aggregates = serializedAggregates
                                                 },
                                                 Headers = new Headers
                                                 {

--- a/DotNet/Submission/Application/Models/SubmitReportValue.cs
+++ b/DotNet/Submission/Application/Models/SubmitReportValue.cs
@@ -6,7 +6,7 @@ namespace LantanaGroup.Link.Submission.Application.Models
     {
         public List<string>? PatientIds { get; internal set; }
         public Organization Organization { get; internal set; }
-        public List<MeasureReport> Aggregates { get; internal set; }
+        public List<string> Aggregates { get; internal set; }
         public string MeasureIds { get; set; }
     }
 }

--- a/DotNet/Submission/Listeners/SubmitReportListener.cs
+++ b/DotNet/Submission/Listeners/SubmitReportListener.cs
@@ -12,6 +12,7 @@ using MediatR;
 using Microsoft.Extensions.Options;
 using Newtonsoft.Json;
 using System.Text.Json;
+using JsonSerializer = Newtonsoft.Json.JsonSerializer;
 using Task = System.Threading.Tasks.Task;
 
 namespace LantanaGroup.Link.Submission.Listeners
@@ -200,8 +201,9 @@ namespace LantanaGroup.Link.Submission.Listeners
 
                                 foreach (var aggregate in value.Aggregates)
                                 {
-                                    fileName = $"aggregate-{aggregate.Measure}.json";
-                                    contents = System.Text.Json.JsonSerializer.Serialize(aggregate, options);
+                                    var agg = System.Text.Json.JsonSerializer.Deserialize<MeasureReport>(aggregate, options);
+                                    fileName = $"aggregate-{agg.Measure}.json";
+                                    contents = aggregate;
 
                                     await File.WriteAllTextAsync(submissionDirectory + "/" + fileName, contents,
                                         cancellationToken);


### PR DESCRIPTION
use strings for MeasureReports

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced data handling for submission reports by introducing serialized aggregates.
	- Updated serialization strategy to utilize `System.Text.Json` for improved efficiency.

- **Bug Fixes**
	- Refined error handling in message consumption processes, adding specificity for exceptions.

- **Refactor**
	- Changed the data structure of the `Aggregates` property in multiple classes from a list of `MeasureReport` objects to a list of strings, improving data processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->