### PR TITLE
LNK-2459 - Removing PatientsToQuery retry reference

### DIFF
--- a/DotNet/Report/Listeners/RetryListener.cs
+++ b/DotNet/Report/Listeners/RetryListener.cs
@@ -72,7 +72,6 @@ namespace LantanaGroup.Link.Report.Listeners
                     KafkaTopic.ReportScheduledRetry.GetStringValue(), 
                     KafkaTopic.ResourceEvaluatedRetry.GetStringValue(), 
                     KafkaTopic.ReportSubmittedRetry.GetStringValue(), 
-                    KafkaTopic.PatientsToQueryRetry.GetStringValue(),
                     KafkaTopic.PatientIDsAcquiredRetry.GetStringValue(),
                     KafkaTopic.DataAcquisitionRequestedRetry.GetStringValue()
                 });

--- a/DotNet/Shared/Application/Models/KafkaTopic.cs
+++ b/DotNet/Shared/Application/Models/KafkaTopic.cs
@@ -46,7 +46,6 @@ public enum KafkaTopic
     ResourceEvaluated,
     ReportSubmitted,
     BundleEvalRequested,
-    PatientsToQuery,
     SubmitReport,
     [StringValue("ResourceEvaluated-Retry")]
     ResourceEvaluatedRetry,
@@ -54,8 +53,6 @@ public enum KafkaTopic
     ReportSubmittedRetry,
     [StringValue("BundleEvalRequested-Retry")]
     BundleEvalRequestedRetry,
-    [StringValue("PatientsToQuery-Retry")]
-    PatientsToQueryRetry,
     [StringValue("SubmitReport-Retry")]
     SubmitReportRetry,
     [StringValue("ReportScheduled-Retry")]


### PR DESCRIPTION
Removed PatientsToQuery from Report retry listener. Removed PatientsToQuery from shared KafkaTopic enum.