### PR TITLE
LNK-2477: Add link token generation to shared project

### DIFF
--- a/DotNet/Account/Program.cs
+++ b/DotNet/Account/Program.cs
@@ -299,7 +299,14 @@ static void SetupMiddleware(WebApplication app)
     }
 
     // Configure swagger
-    app.ConfigureSwagger();
+    if (app.Configuration.GetValue<bool>(ConfigurationConstants.AppSettings.EnableSwagger))
+    {
+        app.UseSwagger(opts => { opts.RouteTemplate = "api/account/swagger/{documentname}/swagger.json"; });
+        app.UseSwaggerUI(opts => {
+            opts.SwaggerEndpoint("/api/account/swagger/v1/swagger.json", $"{ServiceActivitySource.ServiceName} - {ServiceActivitySource.Version}");
+            opts.RoutePrefix = "api/account/swagger";
+        });
+    }
 
     app.UseRouting();
     app.UseCors(CorsSettings.DefaultCorsPolicyName);

--- a/DotNet/Account/Program.cs
+++ b/DotNet/Account/Program.cs
@@ -148,6 +148,7 @@ static void RegisterServices(WebApplicationBuilder builder)
         options.Authority = builder.Configuration.GetValue<string>("Authentication:Schemas:LinkBearer:Authority");
         options.ValidateToken = builder.Configuration.GetValue<bool>("Authentication:Schemas:LinkBearer:ValidateToken");
         options.ProtectKey = builder.Configuration.GetValue<bool>("DataProtection:Enabled");
+        options.SigningKey = builder.Configuration.GetValue<string>("LinkTokenService:SigningKey");
     });
 
     //Add persistence interceptors

--- a/DotNet/Account/appsettings.Development.json
+++ b/DotNet/Account/appsettings.Development.json
@@ -38,6 +38,11 @@
       }
     }
   },
+  "LinkTokenService": {
+    "Authority": "https://localhost:7004",
+    "LinkAdminEmail": "linkadmin@lantanagroup.com",
+    "TokenLifespan": 10
+  },
   "EnableSwagger": true,
   "Logging": {
     "LogLevel": {

--- a/DotNet/Account/appsettings.json
+++ b/DotNet/Account/appsettings.json
@@ -37,6 +37,12 @@
       }
     }
   },
+  "LinkTokenService": {
+    "Authority": "https://localhost:7004",
+    "LinkAdminEmail": "linkadmin@lantanagroup.com",
+    "TokenLifespan": 10,
+    "SigningKey": ""
+  },
   "EnableSwagger": false,
   "CORS": {
     "AllowAllOrigins": false,

--- a/DotNet/LinkAdmin.BFF/Application/Commands/Security/CreateLinkBearerToken/CreateLinkBearerToken.cs
+++ b/DotNet/LinkAdmin.BFF/Application/Commands/Security/CreateLinkBearerToken/CreateLinkBearerToken.cs
@@ -1,10 +1,10 @@
 ﻿using LantanaGroup.Link.LinkAdmin.BFF.Application.Interfaces.Infrastructure;
-using LantanaGroup.Link.LinkAdmin.BFF.Application.Models.Configuration;
 using LantanaGroup.Link.LinkAdmin.BFF.Infrastructure;
 using LantanaGroup.Link.LinkAdmin.BFF.Infrastructure.Logging;
 using LantanaGroup.Link.LinkAdmin.BFF.Settings;
 using LantanaGroup.Link.Shared.Application.Interfaces.Services;
 using LantanaGroup.Link.Shared.Application.Models.Configs;
+using Link.Authorization.Infrastructure;
 using Microsoft.AspNetCore.DataProtection;
 using Microsoft.Extensions.Caching.Distributed;
 using Microsoft.Extensions.Options;
@@ -24,17 +24,17 @@ namespace LantanaGroup.Link.LinkAdmin.BFF.Application.Commands.Security
         private readonly ISecretManager _secretManager;
         private readonly IDataProtectionProvider _dataProtectionProvider;
         private readonly IOptions<DataProtectionSettings> _dataProtectionSettings;
-        private readonly IOptions<LinkBearerServiceConfig> _linkBearerServiceConfig;
+        private readonly IOptions<LinkTokenServiceSettings> _linkTokenServiceConfig;
         private readonly ILinkAdminMetrics _metrics;
 
-        public CreateLinkBearerToken(ILogger<CreateLinkBearerToken> logger, IDistributedCache cache, ISecretManager secretManager, IDataProtectionProvider dataProtectionProvider, IOptions<DataProtectionSettings> dataProtectionSettings, IOptions<LinkBearerServiceConfig> linkBearerServiceConfig, ILinkAdminMetrics metrics)
+        public CreateLinkBearerToken(ILogger<CreateLinkBearerToken> logger, IDistributedCache cache, ISecretManager secretManager, IDataProtectionProvider dataProtectionProvider, IOptions<DataProtectionSettings> dataProtectionSettings, IOptions<LinkTokenServiceSettings> linkBearerServiceConfig, ILinkAdminMetrics metrics)
         {
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
             _cache = cache ?? throw new ArgumentNullException(nameof(cache));
             _secretManager = secretManager ?? throw new ArgumentNullException(nameof(secretManager));
             _dataProtectionProvider = dataProtectionProvider ?? throw new ArgumentNullException(nameof(dataProtectionProvider));
             _dataProtectionSettings = dataProtectionSettings ?? throw new ArgumentNullException(nameof(dataProtectionSettings));
-            _linkBearerServiceConfig = linkBearerServiceConfig ?? throw new ArgumentNullException(nameof(linkBearerServiceConfig));
+            _linkTokenServiceConfig = linkBearerServiceConfig ?? throw new ArgumentNullException(nameof(linkBearerServiceConfig));
             _metrics = metrics ?? throw new ArgumentNullException(nameof(metrics));            
         }
 
@@ -42,9 +42,9 @@ namespace LantanaGroup.Link.LinkAdmin.BFF.Application.Commands.Security
         {
             using Activity? activity = ServiceActivitySource.Instance.StartActivity("Generate Link Admin JWT");
 
-            if(string.IsNullOrEmpty(_linkBearerServiceConfig.Value.Authority))
+            if(string.IsNullOrEmpty(_linkTokenServiceConfig.Value.Authority))
             {
-                   throw new ArgumentNullException(nameof(_linkBearerServiceConfig.Value.Authority));
+                   throw new ArgumentNullException(nameof(_linkTokenServiceConfig.Value.Authority));
             }
             
             try
@@ -81,8 +81,8 @@ namespace LantanaGroup.Link.LinkAdmin.BFF.Application.Commands.Security
                 
 
                 var token = new JwtSecurityToken(                                    
-                                    issuer: _linkBearerServiceConfig.Value.Authority,
-                                    audience: LinkAdminConstants.LinkBearerService.LinkBearerAudience,
+                                    issuer: _linkTokenServiceConfig.Value.Authority,
+                                    audience: LinkAuthorizationConstants.LinkBearerService.LinkBearerAudience,
                                     claims: user.Claims,
                                     expires: DateTime.Now.AddMinutes(timespan),
                                     signingCredentials: credentials

--- a/DotNet/LinkAdmin.BFF/Application/Commands/Security/GetLinkAccount/GetLinkAccount.cs
+++ b/DotNet/LinkAdmin.BFF/Application/Commands/Security/GetLinkAccount/GetLinkAccount.cs
@@ -5,7 +5,6 @@ using System.Security.Claims;
 using LantanaGroup.Link.LinkAdmin.BFF.Infrastructure;
 using System.Diagnostics;
 using Link.Authorization.Infrastructure;
-using LantanaGroup.Link.LinkAdmin.BFF.Application.Models.Configuration;
 using LantanaGroup.Link.LinkAdmin.BFF.Infrastructure.Logging;
 using LantanaGroup.Link.Shared.Application.Models.Configs;
 using Link.Authorization.Permissions;
@@ -17,15 +16,15 @@ namespace LantanaGroup.Link.LinkAdmin.BFF.Application.Commands.Security
         private readonly ILogger<GetLinkAccount> _logger;
         private readonly IHttpClientFactory _httpClientFactory;
         private readonly IOptions<ServiceRegistry> _serviceRegistry;
-        private readonly IOptions<LinkBearerServiceConfig> _bearerServiceConfig;
+        private readonly IOptions<LinkTokenServiceSettings> _tokenServiceConfig;
         private readonly ICreateLinkBearerToken _createLinkBearerToken;
 
-        public GetLinkAccount(ILogger<GetLinkAccount> logger, IHttpClientFactory httpClientFactory, IOptions<ServiceRegistry> serviceRegistry, IOptions<LinkBearerServiceConfig> bearerServiceConfig, ICreateLinkBearerToken createLinkBearerToken)
+        public GetLinkAccount(ILogger<GetLinkAccount> logger, IHttpClientFactory httpClientFactory, IOptions<ServiceRegistry> serviceRegistry, IOptions<LinkTokenServiceSettings> tokenServiceConfig, ICreateLinkBearerToken createLinkBearerToken)
         {
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
             _httpClientFactory = httpClientFactory ?? throw new ArgumentNullException(nameof(httpClientFactory));
             _serviceRegistry = serviceRegistry ?? throw new ArgumentNullException(nameof(serviceRegistry));
-            _bearerServiceConfig = bearerServiceConfig ?? throw new ArgumentNullException(nameof(bearerServiceConfig));
+            _tokenServiceConfig = tokenServiceConfig ?? throw new ArgumentNullException(nameof(tokenServiceConfig));
             _createLinkBearerToken = createLinkBearerToken ?? throw new ArgumentNullException(nameof(createLinkBearerToken));            
         }
 
@@ -56,7 +55,7 @@ namespace LantanaGroup.Link.LinkAdmin.BFF.Application.Commands.Security
             //create a system account principal
             var claims = new List<Claim>
             {
-                new(LinkAuthorizationConstants.LinkSystemClaims.Email, _bearerServiceConfig.Value.LinkAdminEmail ?? string.Empty),
+                new(LinkAuthorizationConstants.LinkSystemClaims.Email, _tokenServiceConfig.Value.LinkAdminEmail ?? string.Empty),
                 new(LinkAuthorizationConstants.LinkSystemClaims.Subject, LinkAuthorizationConstants.LinkUserClaims.LinkSystemAccount),
                 new(LinkAuthorizationConstants.LinkSystemClaims.Role, LinkAuthorizationConstants.LinkUserClaims.LinkAdministartor),
                 new(LinkAuthorizationConstants.LinkSystemClaims.LinkPermissions, nameof(LinkSystemPermissions.IsLinkAdmin))

--- a/DotNet/LinkAdmin.BFF/Presentation/Endpoints/BearerServiceEndpoints.cs
+++ b/DotNet/LinkAdmin.BFF/Presentation/Endpoints/BearerServiceEndpoints.cs
@@ -1,9 +1,8 @@
-﻿using Hl7.FhirPath.Sprache;
-using LantanaGroup.Link.LinkAdmin.BFF.Application.Commands.Security;
+﻿using LantanaGroup.Link.LinkAdmin.BFF.Application.Commands.Security;
 using LantanaGroup.Link.LinkAdmin.BFF.Application.Interfaces.Services;
-using LantanaGroup.Link.LinkAdmin.BFF.Application.Models.Configuration;
 using LantanaGroup.Link.LinkAdmin.BFF.Application.Models.Responses;
 using LantanaGroup.Link.LinkAdmin.BFF.Infrastructure.Logging;
+using LantanaGroup.Link.Shared.Application.Models.Configs;
 using Microsoft.Extensions.Options;
 using Microsoft.OpenApi.Models;
 using OpenTelemetry.Trace;
@@ -14,11 +13,11 @@ namespace LantanaGroup.Link.LinkAdmin.BFF.Presentation.Endpoints
     public class BearerServiceEndpoints : IApi
     {
         private readonly ILogger<BearerServiceEndpoints> _logger;
-        private readonly IOptions<LinkBearerServiceConfig> _tokenServiceconfig;
+        private readonly IOptions<LinkTokenServiceSettings> _tokenServiceconfig;
         private readonly ICreateLinkBearerToken _createLinkBearerToken;
         private readonly IRefreshSigningKey _refreshSigningKey;
 
-        public BearerServiceEndpoints(ILogger<BearerServiceEndpoints> logger, IOptions<LinkBearerServiceConfig> tokenServiceconfig, ICreateLinkBearerToken createLinkBearerToken, IRefreshSigningKey refreshSigningKey)
+        public BearerServiceEndpoints(ILogger<BearerServiceEndpoints> logger, IOptions<LinkTokenServiceSettings> tokenServiceconfig, ICreateLinkBearerToken createLinkBearerToken, IRefreshSigningKey refreshSigningKey)
         {
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
             _tokenServiceconfig = tokenServiceconfig ?? throw new ArgumentNullException(nameof(tokenServiceconfig));

--- a/DotNet/LinkAdmin.BFF/Program.cs
+++ b/DotNet/LinkAdmin.BFF/Program.cs
@@ -294,13 +294,17 @@ static void SetupMiddleware(WebApplication app)
     }
 
     app.UseStatusCodePages();
-    //app.UseHttpsRedirection();
+    app.UseHttpsRedirection();
 
     // Configure swagger
-    app.ConfigureSwagger(opts =>
+    if (app.Configuration.GetValue<bool>(ConfigurationConstants.AppSettings.EnableSwagger))
     {
-        opts.RouteTemplate = "api/swagger/{documentname}/swagger.json";
-    });
+        app.UseSwagger(opts => { opts.RouteTemplate = "api/swagger/{documentname}/swagger.json"; });
+        app.UseSwaggerUI(opts => {
+            opts.SwaggerEndpoint("/api/swagger/v1/swagger.json", $"{ServiceActivitySource.ServiceName} - {ServiceActivitySource.Version}");
+            opts.RoutePrefix = "api/swagger";
+        });
+    }
 
     app.UseRouting();
     var corsConfig = app.Configuration.GetSection(ConfigurationConstants.AppSettings.CORS).Get<CorsSettings>();

--- a/DotNet/LinkAdmin.BFF/Program.cs
+++ b/DotNet/LinkAdmin.BFF/Program.cs
@@ -72,10 +72,10 @@ static void RegisterServices(WebApplicationBuilder builder)
 
     // Add IOptions
     builder.Services.Configure<KafkaConnection>(builder.Configuration.GetSection(KafkaConstants.SectionName));
-    builder.Services.Configure<SecretManagerSettings>(builder.Configuration.GetSection(LinkAdminConstants.AppSettingsSectionNames.SecretManagement));
+    builder.Services.Configure<SecretManagerSettings>(builder.Configuration.GetSection(ConfigurationConstants.AppSettings.SecretManagement));
     builder.Services.Configure<DataProtectionSettings>(builder.Configuration.GetSection(ConfigurationConstants.AppSettings.DataProtection));
     builder.Services.Configure<ServiceRegistry>(builder.Configuration.GetSection(ServiceRegistry.ConfigSectionName));
-    builder.Services.Configure<LinkBearerServiceConfig>(builder.Configuration.GetSection(LinkAdminConstants.AppSettingsSectionNames.LinkBearerService));
+    builder.Services.Configure<LinkTokenServiceSettings>(builder.Configuration.GetSection(ConfigurationConstants.AppSettings.LinkTokenService));
 
     // Add Kafka Producer Factories
     builder.Services.AddSingleton<IKafkaProducerFactory<string, object>, KafkaProducerFactory<string, object>>();

--- a/DotNet/LinkAdmin.BFF/Settings/LinkAdminConstants.cs
+++ b/DotNet/LinkAdmin.BFF/Settings/LinkAdminConstants.cs
@@ -12,8 +12,7 @@
             public const string CORS = "CORS";
             public const string Telemetry = "Telemetry";
             public const string Serilog = "Serilog";
-            public const string SecretManagement = "SecretManagement";
-            public const string LinkBearerService = "LinkBearerService";
+                        
         }
 
         public static class AuthenticationSchemes

--- a/DotNet/LinkAdmin.BFF/appsettings.Development.json
+++ b/DotNet/LinkAdmin.BFF/appsettings.Development.json
@@ -24,7 +24,7 @@
     "MaxAge": 600
   },
   "EnableIntegrationFeature": true,
-  "LinkBearerService": {
+  "LinkTokenService": {
     "EnableTokenGenrationEndpoint": true,
     "Authority": "https://localhost:7004",
     "LinkAdminEmail": "linkadmin@lantanagroup.com",

--- a/DotNet/LinkAdmin.BFF/appsettings.json
+++ b/DotNet/LinkAdmin.BFF/appsettings.json
@@ -37,7 +37,7 @@
   "ProblemDetails": {
     "IncludeExceptionDetails": false
   },
-  "LinkBearerService": {
+  "LinkTokenService": {
     "EnableTokenGenrationEndpoint": true,
     "Authority": "",
     "LinkAdminEmail": "",

--- a/DotNet/Shared/Application/Interfaces/Services/Security/Token/ICreateSystemToken.cs
+++ b/DotNet/Shared/Application/Interfaces/Services/Security/Token/ICreateSystemToken.cs
@@ -1,0 +1,7 @@
+﻿namespace LantanaGroup.Link.Shared.Application.Interfaces.Services.Security.Token
+{
+    internal interface ICreateSystemToken
+    {
+        Task<string> ExecuteAsync(string key, int timespan);
+    }
+}

--- a/DotNet/Shared/Application/Interfaces/Services/Security/Token/ICreateUserToken.cs
+++ b/DotNet/Shared/Application/Interfaces/Services/Security/Token/ICreateUserToken.cs
@@ -1,0 +1,9 @@
+﻿using System.Security.Claims;
+
+namespace LantanaGroup.Link.Shared.Application.Interfaces.Services.Security.Token
+{
+    internal interface ICreateUserToken
+    {
+        Task<string> ExecuteAsync(ClaimsPrincipal user, string key, int timespan);
+    }
+}

--- a/DotNet/Shared/Application/Models/Configs/LinkTokenServiceSettings.cs
+++ b/DotNet/Shared/Application/Models/Configs/LinkTokenServiceSettings.cs
@@ -6,5 +6,6 @@
         public string Authority { get; set; } = default!;
         public string? LinkAdminEmail { get; set; }
         public int TokenLifespan { get; set; } = 10;
+        public string? SigningKey { get; set; }
     }
 }

--- a/DotNet/Shared/Application/Models/Configs/LinkTokenServiceSettings.cs
+++ b/DotNet/Shared/Application/Models/Configs/LinkTokenServiceSettings.cs
@@ -1,6 +1,6 @@
-﻿namespace LantanaGroup.Link.LinkAdmin.BFF.Application.Models.Configuration
+﻿namespace LantanaGroup.Link.Shared.Application.Models.Configs
 {
-    public class LinkBearerServiceConfig
+    public class LinkTokenServiceSettings
     {
         public bool EnableTokenGenrationEndpoint { get; set; }
         public string Authority { get; set; } = default!;

--- a/DotNet/Shared/Application/Services/Security/Token/CreateSystemToken.cs
+++ b/DotNet/Shared/Application/Services/Security/Token/CreateSystemToken.cs
@@ -1,0 +1,65 @@
+﻿using LantanaGroup.Link.Shared.Application.Interfaces.Services.Security.Token;
+using LantanaGroup.Link.Shared.Application.Models.Configs;
+using Link.Authorization.Infrastructure;
+using Link.Authorization.Permissions;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Microsoft.IdentityModel.Tokens;
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using System.Text;
+
+namespace LantanaGroup.Link.Shared.Application.Services.Security.Token
+{
+    public class CreateSystemToken : ICreateSystemToken
+    {
+        private readonly ILogger<CreateSystemToken> _logger;
+        private readonly IOptions<LinkTokenServiceSettings> _linkTokenServiceConfig;
+
+        public CreateSystemToken(ILogger<CreateSystemToken> logger, IOptions<LinkTokenServiceSettings> linkBearerServiceConfig)
+        {
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+            _linkTokenServiceConfig = linkBearerServiceConfig ?? throw new ArgumentNullException(nameof(linkBearerServiceConfig));
+        }
+
+        public Task<string> ExecuteAsync(string key, int timespan)
+        {
+            if (string.IsNullOrEmpty(_linkTokenServiceConfig.Value.Authority))
+            {
+                throw new ArgumentNullException(nameof(_linkTokenServiceConfig.Value.Authority));
+            }
+
+            try
+            {
+                //create a system account principal
+                var claims = new List<Claim>
+                {
+                    new(LinkAuthorizationConstants.LinkSystemClaims.Email, _linkTokenServiceConfig.Value.LinkAdminEmail ?? string.Empty),
+                    new(LinkAuthorizationConstants.LinkSystemClaims.Subject, LinkAuthorizationConstants.LinkUserClaims.LinkSystemAccount),
+                    new(LinkAuthorizationConstants.LinkSystemClaims.Role, LinkAuthorizationConstants.LinkUserClaims.LinkAdministartor),
+                    new(LinkAuthorizationConstants.LinkSystemClaims.LinkPermissions, nameof(LinkSystemPermissions.IsLinkAdmin))
+                };               
+
+                var credentials = new SigningCredentials(new SymmetricSecurityKey(Encoding.UTF8.GetBytes(key)), SecurityAlgorithms.HmacSha512);
+                var token = new JwtSecurityToken(
+                                    issuer: _linkTokenServiceConfig.Value.Authority,
+                                    audience: LinkAuthorizationConstants.LinkBearerService.LinkBearerAudience,
+                                    claims: claims,
+                                    expires: DateTime.Now.AddMinutes(timespan),
+                                    signingCredentials: credentials
+                                );
+
+                var jwt = new JwtSecurityTokenHandler().WriteToken(token);
+
+                _logger.LogInformation("Link token created for a system request.");
+
+                return Task.FromResult(jwt);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error creating system token: {message}", ex.Message);
+                throw;
+            }
+        }
+    }
+}

--- a/DotNet/Shared/Application/Services/Security/Token/CreateUserToken.cs
+++ b/DotNet/Shared/Application/Services/Security/Token/CreateUserToken.cs
@@ -1,0 +1,55 @@
+﻿using LantanaGroup.Link.Shared.Application.Interfaces.Services.Security.Token;
+using LantanaGroup.Link.Shared.Application.Models.Configs;
+using Link.Authorization.Infrastructure;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Microsoft.IdentityModel.Tokens;
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using System.Text;
+
+namespace LantanaGroup.Link.Shared.Application.Services.Security.Token
+{
+    public class CreateUserToken : ICreateUserToken
+    {
+        private readonly ILogger<CreateUserToken> _logger;
+        private readonly IOptions<LinkTokenServiceSettings> _linkTokenServiceConfig;
+
+        public CreateUserToken(ILogger<CreateUserToken> logger, IOptions<LinkTokenServiceSettings> linkBearerServiceConfig)
+        {
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+            _linkTokenServiceConfig = linkBearerServiceConfig ?? throw new ArgumentNullException(nameof(linkBearerServiceConfig));
+        }
+
+        public Task<string> ExecuteAsync(ClaimsPrincipal user, string key, int timespan)
+        {
+            if (string.IsNullOrEmpty(_linkTokenServiceConfig.Value.Authority))
+            {
+                throw new ArgumentNullException(nameof(_linkTokenServiceConfig.Value.Authority));
+            }
+
+            try
+            {
+                var credentials = new SigningCredentials(new SymmetricSecurityKey(Encoding.UTF8.GetBytes(key)), SecurityAlgorithms.HmacSha512);
+                var token = new JwtSecurityToken(
+                                    issuer: _linkTokenServiceConfig.Value.Authority,
+                                    audience: LinkAuthorizationConstants.LinkBearerService.LinkBearerAudience,
+                                    claims: user.Claims,
+                                    expires: DateTime.Now.AddMinutes(timespan),
+                                    signingCredentials: credentials
+                                );
+
+                var jwt = new JwtSecurityTokenHandler().WriteToken(token);
+
+                _logger.LogInformation("Link token created for user {user}", user.Claims.First(c => c.Type == "sub").Value);
+
+                return Task.FromResult(jwt);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error creating user token: {message}", ex.Message);
+                throw;
+            }
+        }
+    }
+}

--- a/DotNet/Shared/Settings/ConfigurationConstants.cs
+++ b/DotNet/Shared/Settings/ConfigurationConstants.cs
@@ -13,6 +13,8 @@ namespace LantanaGroup.Link.Shared.Settings
             public const string DatabaseProvider = "DatabaseProvider";
             public const string SqlServerDatabaseProvider = "SqlServer";
             public const string DataProtection = "DataProtection";
+            public const string LinkTokenService = "LinkTokenService";
+            public const string SecretManagement = "SecretManagement";
         }
 
         public static class DatabaseConnections


### PR DESCRIPTION
- Added token generation methods and configuration to the shared project
- Fixed swagger in link admin and account services
- Added ability to set symmetric signing key in configuration until long term support for shared encryption across .NET/Java services are enabled