### PR TITLE
LNK-2477: Fixed a bug with the bearer token endpiont not registering

### DIFF
--- a/DotNet/LinkAdmin.BFF/Program.cs
+++ b/DotNet/LinkAdmin.BFF/Program.cs
@@ -145,7 +145,7 @@ static void RegisterServices(WebApplicationBuilder builder)
     {
         builder.Services.AddTransient<IApi, AuthEndpoints>();
 
-        if (builder.Configuration.GetValue<bool>("LinkBearerService:EnableTokenGenrationEndpoint"))
+        if (builder.Configuration.GetValue<bool>("LinkTokenService:EnableTokenGenrationEndpoint"))
         {
             builder.Services.AddTransient<IApi, BearerServiceEndpoints>();
         }


### PR DESCRIPTION
The bearer token endpoints in link admin were not registering after changes to the config settings to align with updates in the shared project around the link token.