### PR TITLE
Remove UseHttpsRedirect middleware

### DIFF
--- a/DotNet/LinkAdmin.BFF/Program.cs
+++ b/DotNet/LinkAdmin.BFF/Program.cs
@@ -294,7 +294,7 @@ static void SetupMiddleware(WebApplication app)
     }
 
     app.UseStatusCodePages();
-    app.UseHttpsRedirection();
+    //app.UseHttpsRedirection();
 
     // Configure swagger
     if (app.Configuration.GetValue<bool>(ConfigurationConstants.AppSettings.EnableSwagger))


### PR DESCRIPTION
In the deployment environments this will not be needed as it is taken care of by network controls.