### PR TITLE
Improved link admin service registration logging and link token setting fix

### DIFF
--- a/DotNet/LinkAdmin.BFF/Infrastructure/Extensions/Security/InitializeSecurity.cs
+++ b/DotNet/LinkAdmin.BFF/Infrastructure/Extensions/Security/InitializeSecurity.cs
@@ -66,7 +66,7 @@ namespace LantanaGroup.Link.LinkAdmin.BFF.Infrastructure.Extensions.Security
 
                 options.Cookie.Name = LinkAdminConstants.AuthenticationSchemes.Cookie;
                 options.Cookie.HttpOnly = configuration.GetValue<bool>("Authentication:Schemas:Cookie:HttpOnly");
-                options.Cookie.SecurePolicy = CookieSecurePolicy.SameAsRequest;                
+                options.Cookie.SecurePolicy = securityServiceOptions.Environment.IsDevelopment() ? CookieSecurePolicy.SameAsRequest : CookieSecurePolicy.Always;                
                 options.Cookie.Path = configuration.GetValue<string>("Authentication:Schemas:Cookie:Path");                
                 options.Cookie.SameSite = SameSiteMode.Strict;
                 options.ExpireTimeSpan = TimeSpan.FromMinutes(30);
@@ -80,20 +80,20 @@ namespace LantanaGroup.Link.LinkAdmin.BFF.Infrastructure.Extensions.Security
                     
             });
 
-            logger.Information("Set Cookie Authentication Scheme: {Scheme} with the following settings: ", LinkAdminConstants.AuthenticationSchemes.Cookie);
+            logger.Debug("Registering Cookie Authentication Scheme: {Scheme} with the following settings: ", LinkAdminConstants.AuthenticationSchemes.Cookie);
             if (!string.IsNullOrEmpty(configuration.GetValue<string>("Authentication:Schemas:Cookie:Domain")))
             {
-                logger.Information("Cookie Domain: {Domain}", configuration.GetValue<string>("Authentication:Schemas:Cookie:Domain"));
+                logger.Debug("Cookie Domain: {Domain}", configuration.GetValue<string>("Authentication:Schemas:Cookie:Domain"));
             }
-            logger.Information("Cookie Path: {Path}", configuration.GetValue<string>("Authentication:Schemas:Cookie:Path"));
-            logger.Information("Cookie HttpOnly: {HttpOnly}", configuration.GetValue<bool>("Authentication:Schemas:Cookie:HttpOnly"));
-            logger.Information("Cookie SecurePolicy: {SecurePolicy}", nameof(CookieSecurePolicy.SameAsRequest));
-            logger.Information("Cookie SameSite: {SameSite}", nameof(SameSiteMode.Strict));
+            logger.Debug("Cookie Path: {Path}", configuration.GetValue<string>("Authentication:Schemas:Cookie:Path"));
+            logger.Debug("Cookie HttpOnly: {HttpOnly}", configuration.GetValue<bool>("Authentication:Schemas:Cookie:HttpOnly"));
+            logger.Debug("Cookie SecurePolicy: {SecurePolicy}", nameof(CookieSecurePolicy.SameAsRequest));
+            logger.Debug("Cookie SameSite: {SameSite}", nameof(SameSiteMode.Strict));
 
             //Add Oauth authorization scheme if enabled
             if (configuration.GetValue<bool>("Authentication:Schemas:Oauth2:Enabled"))
             {
-                logger.Information("Registering OAuth2 authentication scheme.");
+                logger.Information("Registering OAuth2 authentication scheme: {Scheme}", LinkAdminConstants.AuthenticationSchemes.Oauth2);
                 if (!LinkAdminConstants.AuthenticationSchemes.Oauth2.Equals(defaultChallengeScheme))
                     authSchemas.Add(LinkAdminConstants.AuthenticationSchemes.Oauth2);
 
@@ -108,18 +108,18 @@ namespace LantanaGroup.Link.LinkAdmin.BFF.Infrastructure.Extensions.Security
                     options.CallbackPath = configuration.GetValue<string>("Authentication:Schemas:Oauth2:CallbackPath");                                     
                 });
 
-                logger.Information("Set OAuth2 Authentication Scheme: {Scheme} with the following settings: ", LinkAdminConstants.AuthenticationSchemes.Oauth2);
-                logger.Information("Client Id: {ClientId}", configuration.GetValue<string>("Authentication:Schemas:Oauth2:ClientId"));
-                logger.Information("Authorization Endpoint: {AuthorizationEndpoint}", configuration.GetValue<string>("Authentication:Schemas:Oauth2:Endpoints:Authorization"));
-                logger.Information("Token Endpoint: {TokenEndpoint}", configuration.GetValue<string>("Authentication:Schemas:Oauth2:Endpoints:Token"));
-                logger.Information("User Information Endpoint: {UserInformationEndpoint}", configuration.GetValue<string>("Authentication:Schemas:Oauth2:Endpoints:UserInformation"));
-                logger.Information("Callback Path: {CallbackPath}", configuration.GetValue<string>("Authentication:Schemas:Oauth2:CallbackPath"));
+                logger.Debug("Set OAuth2 Authentication Scheme: {Scheme} with the following settings: ", LinkAdminConstants.AuthenticationSchemes.Oauth2);
+                logger.Debug("Client Id: {ClientId}", configuration.GetValue<string>("Authentication:Schemas:Oauth2:ClientId"));
+                logger.Debug("Authorization Endpoint: {AuthorizationEndpoint}", configuration.GetValue<string>("Authentication:Schemas:Oauth2:Endpoints:Authorization"));
+                logger.Debug("Token Endpoint: {TokenEndpoint}", configuration.GetValue<string>("Authentication:Schemas:Oauth2:Endpoints:Token"));
+                logger.Debug("User Information Endpoint: {UserInformationEndpoint}", configuration.GetValue<string>("Authentication:Schemas:Oauth2:Endpoints:UserInformation"));
+                logger.Debug("Callback Path: {CallbackPath}", configuration.GetValue<string>("Authentication:Schemas:Oauth2:CallbackPath"));
             }
 
             // Add OpenIdConnect authorization scheme if enabled
             if (configuration.GetValue<bool>("Authentication:Schemas:OpenIdConnect:Enabled"))
             {
-                logger.Information("Registering OpenIdConnect authentication scheme.");
+                logger.Debug("Registering OpenIdConnect authentication scheme: {scheme}", LinkAdminConstants.AuthenticationSchemes.OpenIdConnect);
                 if (!LinkAdminConstants.AuthenticationSchemes.OpenIdConnect.Equals(defaultChallengeScheme))
                     authSchemas.Add(LinkAdminConstants.AuthenticationSchemes.OpenIdConnect);
 
@@ -133,15 +133,15 @@ namespace LantanaGroup.Link.LinkAdmin.BFF.Infrastructure.Extensions.Security
                     options.RoleClaimType = configuration.GetValue<string>("Authentication:Schemas:OpenIdConnect:RoleClaimType");
                 });
 
-                logger.Information("Set OpenIdConnect Authentication Scheme: {Scheme} with the following settings: ", LinkAdminConstants.AuthenticationSchemes.OpenIdConnect);
-                logger.Information("Authority: {Authority}", configuration.GetValue<string>("Authentication:Schemas:OpenIdConnect:Authority"));
-                logger.Information("Client Id: {ClientId}", configuration.GetValue<string>("Authentication:Schemas:OpenIdConnect:ClientId"));
+                logger.Debug("Set OpenIdConnect Authentication Scheme: {Scheme} with the following settings: ", LinkAdminConstants.AuthenticationSchemes.OpenIdConnect);
+                logger.Debug("Authority: {Authority}", configuration.GetValue<string>("Authentication:Schemas:OpenIdConnect:Authority"));
+                logger.Debug("Client Id: {ClientId}", configuration.GetValue<string>("Authentication:Schemas:OpenIdConnect:ClientId"));
             }
 
             // Add JWT authorization scheme if enabled
             if (configuration.GetValue<bool>("Authentication:Schemas:Jwt:Enabled"))
             {
-                logger.Information("Registering JWT authentication scheme.");
+                logger.Debug("Registering JWT authentication scheme: {scheme}", LinkAdminConstants.AuthenticationSchemes.JwtBearerToken);
                 if (!LinkAdminConstants.AuthenticationSchemes.JwtBearerToken.Equals(defaultChallengeScheme))
                     authSchemas.Add(LinkAdminConstants.AuthenticationSchemes.JwtBearerToken);
 
@@ -154,9 +154,9 @@ namespace LantanaGroup.Link.LinkAdmin.BFF.Infrastructure.Extensions.Security
                     options.RoleClaimType = configuration.GetValue<string>("Authentication:Schemas:Jwt:RoleClaimType");
                 });
 
-                logger.Information("Set JWT Authentication Scheme: {Scheme} with the following settings: ", LinkAdminConstants.AuthenticationSchemes.JwtBearerToken);
-                logger.Information("Authority: {Authority}", configuration.GetValue<string>("Authentication:Schemas:Jwt:Authority"));
-                logger.Information("Audience: {Audience}", configuration.GetValue<string>("Authentication:Schemas:Jwt:Audience"));
+                logger.Debug("Set JWT Authentication Scheme: {Scheme} with the following settings: ", LinkAdminConstants.AuthenticationSchemes.JwtBearerToken);
+                logger.Debug("Authority: {Authority}", configuration.GetValue<string>("Authentication:Schemas:Jwt:Authority"));
+                logger.Debug("Audience: {Audience}", configuration.GetValue<string>("Authentication:Schemas:Jwt:Audience"));
             }
 
             // Add Link Bearer Token authorization schema
@@ -183,7 +183,7 @@ namespace LantanaGroup.Link.LinkAdmin.BFF.Infrastructure.Extensions.Security
             var corsConfig = configuration.GetSection(LinkAdminConstants.AppSettingsSectionNames.CORS).Get<CorsConfig>();
             if (corsConfig != null)
             {
-                logger.Information("Registering CORS settings.");
+                logger.Debug("Registering CORS settings.");
                 services.AddCorsService(options =>
                 {
                     options.Environment = securityServiceOptions.Environment;

--- a/DotNet/LinkAdmin.BFF/Infrastructure/Extensions/Security/InitializeSecurity.cs
+++ b/DotNet/LinkAdmin.BFF/Infrastructure/Extensions/Security/InitializeSecurity.cs
@@ -9,7 +9,7 @@ namespace LantanaGroup.Link.LinkAdmin.BFF.Infrastructure.Extensions.Security
 {
     public static class InitializeSecurity
     {
-        public static IServiceCollection AddLinkGatewaySecurity(this IServiceCollection services, IConfiguration configuration, Action<SecurityServiceOptions>? options = null)
+        public static IServiceCollection AddLinkGatewaySecurity(this IServiceCollection services, IConfiguration configuration, Serilog.ILogger logger, Action<SecurityServiceOptions>? options = null)
         { 
             var securityServiceOptions = new SecurityServiceOptions();
             options?.Invoke(securityServiceOptions);
@@ -37,17 +37,19 @@ namespace LantanaGroup.Link.LinkAdmin.BFF.Infrastructure.Extensions.Security
             
             }                
 
-            List<string> authSchemas = [LinkAdminConstants.AuthenticationSchemes.Cookie];
+            logger.Information("Initializing authentication schemas.");
+            List<string> authSchemas = [LinkAdminConstants.AuthenticationSchemes.Cookie];            
 
             var defaultChallengeScheme = configuration.GetValue<string>("Authentication:DefaultChallengeScheme");
             services.Configure<AuthenticationSchemaConfig>(options =>
             {
-                options.DefaultScheme = LinkAdminConstants.AuthenticationSchemes.Cookie;
+                options.DefaultScheme = LinkAdminConstants.AuthenticationSchemes.Cookie;                
 
                 if (string.IsNullOrEmpty(defaultChallengeScheme))
                     throw new NullReferenceException("DefaultChallengeScheme is required.");
 
                 options.DefaultChallengeScheme = defaultChallengeScheme;
+                
             });
 
             var authBuilder = services.AddAuthentication(options => {
@@ -55,18 +57,43 @@ namespace LantanaGroup.Link.LinkAdmin.BFF.Infrastructure.Extensions.Security
                 options.DefaultChallengeScheme = defaultChallengeScheme;
             });
 
+            logger.Information("Set Default Authentication Scheme: {DefaultScheme}", LinkAdminConstants.AuthenticationSchemes.Cookie);
+            logger.Information("Set Default Authentication Challenge Scheme: {DefaultChallengeScheme}", defaultChallengeScheme);
+
             authBuilder.AddCookie(LinkAdminConstants.AuthenticationSchemes.Cookie, options =>
             {
+                logger.Information("Registering Cookie Authentication Scheme: {Scheme}", LinkAdminConstants.AuthenticationSchemes.Cookie);
+
                 options.Cookie.Name = LinkAdminConstants.AuthenticationSchemes.Cookie;
+                options.Cookie.HttpOnly = configuration.GetValue<bool>("Authentication:Schemas:Cookie:HttpOnly");
+                options.Cookie.SecurePolicy = CookieSecurePolicy.SameAsRequest;                
+                options.Cookie.Path = configuration.GetValue<string>("Authentication:Schemas:Cookie:Path");                
                 options.Cookie.SameSite = SameSiteMode.Strict;
                 options.ExpireTimeSpan = TimeSpan.FromMinutes(30);
                 options.LoginPath = "/api/login";
                 options.LogoutPath = "/api/logout";
+
+                if (!string.IsNullOrEmpty(configuration.GetValue<string>("Authentication:Schemas:Cookie:Domain")))
+                {
+                    options.Cookie.Domain = configuration.GetValue<string>("Authentication:Schemas:Cookie:Domain");
+                }
+                    
             });
+
+            logger.Information("Set Cookie Authentication Scheme: {Scheme} with the following settings: ", LinkAdminConstants.AuthenticationSchemes.Cookie);
+            if (!string.IsNullOrEmpty(configuration.GetValue<string>("Authentication:Schemas:Cookie:Domain")))
+            {
+                logger.Information("Cookie Domain: {Domain}", configuration.GetValue<string>("Authentication:Schemas:Cookie:Domain"));
+            }
+            logger.Information("Cookie Path: {Path}", configuration.GetValue<string>("Authentication:Schemas:Cookie:Path"));
+            logger.Information("Cookie HttpOnly: {HttpOnly}", configuration.GetValue<bool>("Authentication:Schemas:Cookie:HttpOnly"));
+            logger.Information("Cookie SecurePolicy: {SecurePolicy}", nameof(CookieSecurePolicy.SameAsRequest));
+            logger.Information("Cookie SameSite: {SameSite}", nameof(SameSiteMode.Strict));
 
             //Add Oauth authorization scheme if enabled
             if (configuration.GetValue<bool>("Authentication:Schemas:Oauth2:Enabled"))
             {
+                logger.Information("Registering OAuth2 authentication scheme.");
                 if (!LinkAdminConstants.AuthenticationSchemes.Oauth2.Equals(defaultChallengeScheme))
                     authSchemas.Add(LinkAdminConstants.AuthenticationSchemes.Oauth2);
 
@@ -78,13 +105,21 @@ namespace LantanaGroup.Link.LinkAdmin.BFF.Infrastructure.Extensions.Security
                     options.AuthorizationEndpoint = configuration.GetValue<string>("Authentication:Schemas:Oauth2:Endpoints:Authorization")!;
                     options.TokenEndpoint = configuration.GetValue<string>("Authentication:Schemas:Oauth2:Endpoints:Token")!;
                     options.UserInformationEndpoint = configuration.GetValue<string>("Authentication:Schemas:Oauth2:Endpoints:UserInformation")!;
-                    options.CallbackPath = configuration.GetValue<string>("Authentication:Schemas:Oauth2:CallbackPath");
+                    options.CallbackPath = configuration.GetValue<string>("Authentication:Schemas:Oauth2:CallbackPath");                                     
                 });
+
+                logger.Information("Set OAuth2 Authentication Scheme: {Scheme} with the following settings: ", LinkAdminConstants.AuthenticationSchemes.Oauth2);
+                logger.Information("Client Id: {ClientId}", configuration.GetValue<string>("Authentication:Schemas:Oauth2:ClientId"));
+                logger.Information("Authorization Endpoint: {AuthorizationEndpoint}", configuration.GetValue<string>("Authentication:Schemas:Oauth2:Endpoints:Authorization"));
+                logger.Information("Token Endpoint: {TokenEndpoint}", configuration.GetValue<string>("Authentication:Schemas:Oauth2:Endpoints:Token"));
+                logger.Information("User Information Endpoint: {UserInformationEndpoint}", configuration.GetValue<string>("Authentication:Schemas:Oauth2:Endpoints:UserInformation"));
+                logger.Information("Callback Path: {CallbackPath}", configuration.GetValue<string>("Authentication:Schemas:Oauth2:CallbackPath"));
             }
 
             // Add OpenIdConnect authorization scheme if enabled
             if (configuration.GetValue<bool>("Authentication:Schemas:OpenIdConnect:Enabled"))
             {
+                logger.Information("Registering OpenIdConnect authentication scheme.");
                 if (!LinkAdminConstants.AuthenticationSchemes.OpenIdConnect.Equals(defaultChallengeScheme))
                     authSchemas.Add(LinkAdminConstants.AuthenticationSchemes.OpenIdConnect);
 
@@ -97,11 +132,16 @@ namespace LantanaGroup.Link.LinkAdmin.BFF.Infrastructure.Extensions.Security
                     options.NameClaimType = configuration.GetValue<string>("Authentication:Schemas:OpenIdConnect:NameClaimType");
                     options.RoleClaimType = configuration.GetValue<string>("Authentication:Schemas:OpenIdConnect:RoleClaimType");
                 });
+
+                logger.Information("Set OpenIdConnect Authentication Scheme: {Scheme} with the following settings: ", LinkAdminConstants.AuthenticationSchemes.OpenIdConnect);
+                logger.Information("Authority: {Authority}", configuration.GetValue<string>("Authentication:Schemas:OpenIdConnect:Authority"));
+                logger.Information("Client Id: {ClientId}", configuration.GetValue<string>("Authentication:Schemas:OpenIdConnect:ClientId"));
             }
 
             // Add JWT authorization scheme if enabled
             if (configuration.GetValue<bool>("Authentication:Schemas:Jwt:Enabled"))
             {
+                logger.Information("Registering JWT authentication scheme.");
                 if (!LinkAdminConstants.AuthenticationSchemes.JwtBearerToken.Equals(defaultChallengeScheme))
                     authSchemas.Add(LinkAdminConstants.AuthenticationSchemes.JwtBearerToken);
 
@@ -112,8 +152,11 @@ namespace LantanaGroup.Link.LinkAdmin.BFF.Infrastructure.Extensions.Security
                     options.Audience = configuration.GetValue<string>("Authentication:Schemas:Jwt:Audience");
                     options.NameClaimType = configuration.GetValue<string>("Authentication:Schemas:Jwt:NameClaimType");
                     options.RoleClaimType = configuration.GetValue<string>("Authentication:Schemas:Jwt:RoleClaimType");
-
                 });
+
+                logger.Information("Set JWT Authentication Scheme: {Scheme} with the following settings: ", LinkAdminConstants.AuthenticationSchemes.JwtBearerToken);
+                logger.Information("Authority: {Authority}", configuration.GetValue<string>("Authentication:Schemas:Jwt:Authority"));
+                logger.Information("Audience: {Audience}", configuration.GetValue<string>("Authentication:Schemas:Jwt:Audience"));
             }
 
             // Add Link Bearer Token authorization schema
@@ -123,7 +166,7 @@ namespace LantanaGroup.Link.LinkAdmin.BFF.Infrastructure.Extensions.Security
             services.AddLinkBearerServiceAuthentication(options =>
             {
                 options.Environment = securityServiceOptions.Environment;
-                options.Authority = configuration.GetValue<string>("LinkBearerService:Authority") ?? LinkAuthorizationConstants.LinkBearerService.LinkBearerIssuer;
+                options.Authority = configuration.GetValue<string>("LinkTokenService:Authority") ?? LinkAuthorizationConstants.LinkBearerService.LinkBearerIssuer;
                 options.Audience = LinkAuthorizationConstants.LinkBearerService.LinkBearerAudience;              
             });
 
@@ -140,6 +183,7 @@ namespace LantanaGroup.Link.LinkAdmin.BFF.Infrastructure.Extensions.Security
             var corsConfig = configuration.GetSection(LinkAdminConstants.AppSettingsSectionNames.CORS).Get<CorsConfig>();
             if (corsConfig != null)
             {
+                logger.Information("Registering CORS settings.");
                 services.AddCorsService(options =>
                 {
                     options.Environment = securityServiceOptions.Environment;

--- a/DotNet/LinkAdmin.BFF/Infrastructure/Extensions/Security/OAuthSchemeExtension.cs
+++ b/DotNet/LinkAdmin.BFF/Infrastructure/Extensions/Security/OAuthSchemeExtension.cs
@@ -1,6 +1,5 @@
 ﻿using LantanaGroup.Link.LinkAdmin.BFF.Application.Interfaces.Infrastructure;
 using LantanaGroup.Link.LinkAdmin.BFF.Settings;
-using Link.Authorization.Infrastructure;
 using Microsoft.AspNetCore.Authentication;
 using System.Net.Http.Headers;
 using System.Text.Json;

--- a/DotNet/LinkAdmin.BFF/Program.cs
+++ b/DotNet/LinkAdmin.BFF/Program.cs
@@ -57,6 +57,8 @@ static void RegisterServices(WebApplicationBuilder builder)
                     .Enrich.With<ActivityEnricher>()
                     .CreateLogger();
 
+    //Serilog.Debugging.SelfLog.Enable(Console.Error);
+
     //Initialize activity source
     var version = Assembly.GetExecutingAssembly().GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion ?? string.Empty;
     ServiceActivitySource.Initialize(version);
@@ -268,9 +270,7 @@ static void RegisterServices(WebApplicationBuilder builder)
 
     // Add YARP (reverse proxy)
     Log.Logger.Information("Registering YARP for the Link Admin API.");
-    builder.Services.AddYarpProxy(builder.Configuration, Log.Logger, options => options.Environment = builder.Environment);
-
-    //Serilog.Debugging.SelfLog.Enable(Console.Error); 
+    builder.Services.AddYarpProxy(builder.Configuration, Log.Logger, options => options.Environment = builder.Environment); 
 
     //Add telemetry if enabled
     Log.Logger.Information("Registering Open Telemetry for the Link Admin API.");

--- a/DotNet/LinkAdmin.BFF/appsettings.Development.json
+++ b/DotNet/LinkAdmin.BFF/appsettings.Development.json
@@ -35,6 +35,10 @@
     "DefaultScheme": "link_cookie",
     "DefaultChallengeScheme": "link_oauth2",
     "Schemas": {
+      "Cookie": {
+        "HttpOnly": true,
+        "Path":  "/"
+      },
       "Jwt": {
         "Enabled": true,
         "Authority": "",
@@ -45,7 +49,7 @@
       },
       "Oauth2": {
         "Enabled": true,
-        "CallbackPath": "/signin-oauth2"
+        "CallbackPath": "/api/signin-oauth2"
       },
       "OpenIdConnect": {
         "Enabled": false,

--- a/DotNet/LinkAdmin.BFF/appsettings.json
+++ b/DotNet/LinkAdmin.BFF/appsettings.json
@@ -48,6 +48,11 @@
     "DefaultScheme": "link_cookie",
     "DefaultChallengeScheme": "link_oauth2",
     "Schemas": {
+      "Cookie": {
+        "HttpOnly": true,
+        "Domain": "",
+        "Path": "/"
+      },
       "Jwt": {
         "Enabled": false,
         "Authority": "",
@@ -60,17 +65,19 @@
         "Enabled": true,
         "ClientId": "",
         "ClientSecret": "",
-        "Authorization": "",
-        "Token": "",
-        "UserInformation": "",
-        "CallbackPath": "/signin-oauth2"
+        "Endpoints": {
+          "Authorization": "",
+          "Token": "",
+          "UserInformation": ""
+        },
+        "CallbackPath": "/api/signin-oauth2"
       },
       "OpenIdConnect": {
         "Enabled": false,
         "ClientId": "",
         "ClientSecret": "",
         "Authority": "",
-        "CallbackPath": "/signin-oidc",
+        "CallbackPath": "/api/signin-oidc",
         "NameClaimType": "email",
         "RoleClaimType": "roles"
       }

--- a/DotNet/Shared/Application/Extensions/Telemetry/TelemetryServiceExtension.cs
+++ b/DotNet/Shared/Application/Extensions/Telemetry/TelemetryServiceExtension.cs
@@ -150,11 +150,7 @@ namespace LantanaGroup.Link.Shared.Application.Extensions
                 }
 
                 if (telemetryServiceOptions.Environment.IsDevelopment())
-                {
-                    otel.WithMetrics(tracerProviderBuilder =>
-                        tracerProviderBuilder
-                         .AddConsoleExporter());
-
+                {                  
                     //metrics are very verbose, only enable console exporter if you really want to see metric details
                     //otel.WithMetrics(metricsProviderBuilder =>
                     //    metricsProviderBuilder


### PR DESCRIPTION
- Added additional registration logging
- Fixed bug where the link bearer service was not pulling configuration from the updated section name for authority