### PR TITLE
Link Admin fix yarp config issues when service registry does not contain a route

### DIFF
--- a/DotNet/Audit/Properties/launchSettings.json
+++ b/DotNet/Audit/Properties/launchSettings.json
@@ -7,13 +7,13 @@
       },
       "dotnetRunMessages": true,
       "launchBrowser": true,
-      "launchUrl": "http://localhost:7334/swagger",
-      "applicationUrl": "http://localhost:7334;https://localhost:7335"
+      "launchUrl": "http://localhost:7344/swagger",
+      "applicationUrl": "http://localhost:7344;https://localhost:7355"
     },
     "Docker": {
       "commandName": "Docker",
-      "DockerfileRunArguments": "--name=Link-Audit --network=local-link -p 7334:8080 -p 7335:8081",
-      "launchUrl": "http://localhost:7334/swagger",      
+      "DockerfileRunArguments": "--name=Link-Audit --network=local-link -p 7344:8080 -p 7355:8081",
+      "launchUrl": "http://localhost:7344/swagger",
       "launchBrowser": true,
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",

--- a/DotNet/Audit/appsettings.Development.json
+++ b/DotNet/Audit/appsettings.Development.json
@@ -29,10 +29,10 @@
   "Kestrel": {
     "Endpoints": {
       "http": {
-        "Url": "http://localhost:7334"
+        "Url": "http://localhost:7344"
       },
       "https": {
-        "Url": "https://localhost:7335"
+        "Url": "https://localhost:7355"
       }
     }
   },

--- a/DotNet/LinkAdmin.BFF/Infrastructure/Filters/YarpConfigFilter.cs
+++ b/DotNet/LinkAdmin.BFF/Infrastructure/Filters/YarpConfigFilter.cs
@@ -6,16 +6,19 @@ namespace LantanaGroup.Link.LinkAdmin.BFF.Infrastructure.Filters;
 
 public class YarpConfigFilter : IProxyConfigFilter
 {
+    private readonly ILogger<YarpConfigFilter> _logger;
     private readonly ServiceRegistry _serviceRegistry;
 
-    public YarpConfigFilter(IOptions<ServiceRegistry> serviceRegistry)
+    public YarpConfigFilter(ILogger<YarpConfigFilter> logger, IOptions<ServiceRegistry> serviceRegistry)
     {
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _serviceRegistry = serviceRegistry.Value ?? throw new ArgumentNullException(nameof(serviceRegistry));
     }
 
     public ValueTask<ClusterConfig> ConfigureClusterAsync(ClusterConfig origCluster, CancellationToken cancel)
     {
         var newDests = new Dictionary<string, DestinationConfig>(StringComparer.OrdinalIgnoreCase);
+
 
         string endpoint = origCluster.ClusterId switch
         {
@@ -29,9 +32,16 @@ public class YarpConfigFilter : IProxyConfigFilter
             "ReportService" => _serviceRegistry.ReportServiceUrl,
             "SubmissionService" => _serviceRegistry.SubmissionServiceUrl,
             "TenantService" => _serviceRegistry.SubmissionServiceUrl,
-            _ => throw new InvalidOperationException($"Unknown cluster id: {origCluster.ClusterId}")
+            _ => string.Empty
         };
-        var existingDestination = origCluster.Destinations["destination1"];
+
+        if (string.IsNullOrEmpty(endpoint))
+        {
+            _logger.LogWarning("No endpoint found in registry for cluster {cluser}", origCluster.ClusterId);
+            return ValueTask.FromResult(origCluster);
+        }
+
+        var existingDestination = origCluster.Destinations?["destination1"];
         var modifiedDest = existingDestination with { Address = endpoint };
         newDests.Add("destination1", modifiedDest);
 

--- a/DotNet/LinkAdmin.BFF/appsettings.Development.json
+++ b/DotNet/LinkAdmin.BFF/appsettings.Development.json
@@ -10,7 +10,20 @@
     "KeyRing": "Link"
   },
   "ServiceRegistry": {
-    "AccountServiceUrl": "http://localhost:7221"
+    "AccountServiceUrl": "http://localhost:7221",
+    "AuditServiceUrl": "http://localhost:7334",
+    "CensusServiceUrl": "http://localhost:5234",
+    "DataAcquisitionServiceUrl": "http://localhost:5194",
+    "MeasureServiceUrl": "http://localhost:5135",
+    "NormalizationServiceUrl": "http://localhost:5038",
+    "NotificationServiceUrl": "http://localhost:7434",
+    "ReportServiceUrl": "http://localhost:7110",
+    "SubmissionServiceUrl": "http://localhost:5264",
+    "TenantService": {
+      "TenantServiceUrl": "https://localhost:7332",
+      "CheckIfTenantExists": true,
+      "GetTenantRelativeEndpoint": "facility/"
+    }
   },
   "KafkaConnection": {
     "BootstrapServers": [ "localhost:9092/" ]
@@ -183,6 +196,13 @@
         "Match": {
           "Path": "api/facility/{**catch-all}"
         }
+      },
+      "route12": {
+        "ClusterId": "QueryDispatchService",
+        "AuthorizationPolicy": "AuthenticatedUser",
+        "Match": {
+          "Path": "api/querydispatch/{**catch-all}"
+        }
       }
     },
     "Clusters": {
@@ -253,6 +273,13 @@
         "Destinations": {
           "destination1": {
             "Address": "http://localhost:7331"
+          }
+        }
+      },
+      "QueryDispatchService": {
+        "Destinations": {
+          "destination1": {
+            "Address": "http://localhost:7334"
           }
         }
       }

--- a/DotNet/LinkAdmin.BFF/appsettings.json
+++ b/DotNet/LinkAdmin.BFF/appsettings.json
@@ -205,6 +205,13 @@
         "Match": {
           "Path": "api/facility/{**catch-all}"
         }
+      },
+      "route12": {
+        "ClusterId": "QueryDispatchService",
+        "AuthorizationPolicy": "AuthenticatedUser",
+        "Match": {
+          "Path": "api/querydispatch/{**catch-all}"
+        }
       }
     },
     "Clusters": {
@@ -272,6 +279,13 @@
         }
       },
       "TenantService": {
+        "Destinations": {
+          "destination1": {
+            "Address": ""
+          }
+        }
+      },
+      "QueryDispatchService": {
         "Destinations": {
           "destination1": {
             "Address": ""


### PR DESCRIPTION
Fixed issue with YARP filter config when there is is a route and cluster that does not exist in the service registry. Now logs that it doesn't exist in the service registry and uses the original config from `appSettings`.