### PR TITLE
LNK-2608: DEV - Add azure ad authentication compatibility to link admin bff

### DIFF
--- a/DotNet/LinkAdmin.BFF/Infrastructure/Extensions/Security/InitializeSecurity.cs
+++ b/DotNet/LinkAdmin.BFF/Infrastructure/Extensions/Security/InitializeSecurity.cs
@@ -4,6 +4,8 @@ using LantanaGroup.Link.LinkAdmin.BFF.Settings;
 using Link.Authorization.Infrastructure;
 using Link.Authorization.Infrastructure.Extensions;
 using Microsoft.AspNetCore.Authentication;
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
 
 namespace LantanaGroup.Link.LinkAdmin.BFF.Infrastructure.Extensions.Security
 {
@@ -77,7 +79,36 @@ namespace LantanaGroup.Link.LinkAdmin.BFF.Infrastructure.Extensions.Security
                 {
                     options.Cookie.Domain = configuration.GetValue<string>("Authentication:Schemas:Cookie:Domain");
                 }
-                    
+
+                options.Events.OnSigningIn = context =>
+                {
+                    //get claims principal
+                    if (context.Principal?.Identity is not ClaimsIdentity claimsIdentity)
+                    {
+                        return Task.CompletedTask;
+                    }
+                    // Define the claim types to keep
+                    var allowedClaims = new HashSet<string> {
+                        JwtRegisteredClaimNames.FamilyName,
+                        JwtRegisteredClaimNames.GivenName,
+                        LinkAuthorizationConstants.LinkSystemClaims.Email,
+                        LinkAuthorizationConstants.LinkSystemClaims.Subject,
+                        LinkAuthorizationConstants.LinkSystemClaims.Role,
+                        LinkAuthorizationConstants.LinkSystemClaims.LinkPermissions
+                    };
+                    //Define all claims that should be removed
+                    var claimsToRemove = claimsIdentity.Claims
+                        .Where(claim => !allowedClaims.Contains(claim.Type))
+                        .ToList();
+                    //remove uneeeded claims
+                    foreach (var claim in claimsToRemove)
+                    {
+                        claimsIdentity.RemoveClaim(claim);
+                    }
+                    logger.Debug("User {User} is signing in.", claimsIdentity.Name);
+                    return Task.CompletedTask;
+                };
+
             });
 
             logger.Debug("Registering Cookie Authentication Scheme: {Scheme} with the following settings: ", LinkAdminConstants.AuthenticationSchemes.Cookie);
@@ -129,6 +160,7 @@ namespace LantanaGroup.Link.LinkAdmin.BFF.Infrastructure.Extensions.Security
                     options.Authority = configuration.GetValue<string>("Authentication:Schemas:OpenIdConnect:Authority")!;
                     options.ClientId = configuration.GetValue<string>("Authentication:Schemas:OpenIdConnect:ClientId")!;
                     options.ClientSecret = configuration.GetValue<string>("Authentication:Schemas:OpenIdConnect:ClientSecret")!;
+                    options.CallbackPath = configuration.GetValue<string>("Authentication:Schemas:OpenIdConnect:CallbackPath")!;
                     options.NameClaimType = configuration.GetValue<string>("Authentication:Schemas:OpenIdConnect:NameClaimType");
                     options.RoleClaimType = configuration.GetValue<string>("Authentication:Schemas:OpenIdConnect:RoleClaimType");
                 });

--- a/DotNet/LinkAdmin.BFF/Infrastructure/Extensions/Security/OpenIdConnectSchemeExtension.cs
+++ b/DotNet/LinkAdmin.BFF/Infrastructure/Extensions/Security/OpenIdConnectSchemeExtension.cs
@@ -1,4 +1,5 @@
-﻿using LantanaGroup.Link.LinkAdmin.BFF.Settings;
+﻿using LantanaGroup.Link.LinkAdmin.BFF.Application.Interfaces.Infrastructure;
+using LantanaGroup.Link.LinkAdmin.BFF.Settings;
 using Microsoft.AspNetCore.Authentication;
 
 namespace LantanaGroup.Link.LinkAdmin.BFF.Infrastructure.Extensions.Security
@@ -26,6 +27,16 @@ namespace LantanaGroup.Link.LinkAdmin.BFF.Infrastructure.Extensions.Security
                     NameClaimType = openIdConnectOptions.NameClaimType,
                     RoleClaimType = openIdConnectOptions.RoleClaimType
                 };
+
+                options.Events.OnTokenValidated = context => {
+                    
+                    //increment login counter
+                    var metrics = context.HttpContext.RequestServices.GetRequiredService<ILinkAdminMetrics>();
+                    metrics.IncrementUserLoginCounter([
+                        new KeyValuePair<string, object?>("auth.scheme", LinkAdminConstants.AuthenticationSchemes.OpenIdConnect)
+                    ]);
+                    return Task.CompletedTask;
+                };
             });
 
             return builder;
@@ -40,7 +51,7 @@ namespace LantanaGroup.Link.LinkAdmin.BFF.Infrastructure.Extensions.Security
             public string ClientSecret { get; set; } = null!;
             public string? NameClaimType { get; set; } = null!;
             public string? RoleClaimType { get; set; } = null!;
-            public string CallbackPath { get; set; } = "/signin-oidc";
+            public string CallbackPath { get; set; } = "/api/signin-oidc";
 
 
         }

--- a/DotNet/LinkAdmin.BFF/Infrastructure/Extensions/Security/OpenIdConnectSchemeExtension.cs
+++ b/DotNet/LinkAdmin.BFF/Infrastructure/Extensions/Security/OpenIdConnectSchemeExtension.cs
@@ -21,6 +21,7 @@ namespace LantanaGroup.Link.LinkAdmin.BFF.Infrastructure.Extensions.Security
                 options.SaveTokens = false;
                 options.ResponseType = "code";
                 options.CallbackPath = openIdConnectOptions.CallbackPath;
+                options.MapInboundClaims = false;
 
                 options.TokenValidationParameters = new()
                 {

--- a/DotNet/LinkAdmin.BFF/Presentation/Endpoints/AuthEndpoints.cs
+++ b/DotNet/LinkAdmin.BFF/Presentation/Endpoints/AuthEndpoints.cs
@@ -6,6 +6,8 @@ using Link.Authorization.Infrastructure;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.Extensions.Options;
 using Microsoft.OpenApi.Models;
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
 
 namespace LantanaGroup.Link.LinkAdmin.BFF.Presentation.Endpoints
 {
@@ -87,8 +89,34 @@ namespace LantanaGroup.Link.LinkAdmin.BFF.Presentation.Endpoints
 
         public IResult GetUser(HttpContext context)
         {
-            var user = context.User;
-            return Results.Ok(user.Claims.Select(x => new { x.Type, x.Value }).ToList());
+            //get claims principal
+            if (context.User.Identity is not ClaimsIdentity claimsIdentity)
+            {
+                return Results.Problem("No claims found in the current user identity", statusCode: StatusCodes.Status500InternalServerError);
+            }
+
+            // Define the claim types to keep
+            var allowedClaims = new HashSet<string> {
+                    JwtRegisteredClaimNames.FamilyName,
+                    JwtRegisteredClaimNames.GivenName,
+                    LinkAuthorizationConstants.LinkSystemClaims.Email,
+                    LinkAuthorizationConstants.LinkSystemClaims.Subject,
+                    LinkAuthorizationConstants.LinkSystemClaims.Role,
+                    LinkAuthorizationConstants.LinkSystemClaims.LinkPermissions
+                };
+
+            //Define all claims that should be removed
+            var claimsToRemove = claimsIdentity.Claims
+                .Where(claim => !allowedClaims.Contains(claim.Type))
+                .ToList();
+
+            //remove uneeeded claims
+            foreach (var claim in claimsToRemove)
+            {
+                claimsIdentity.RemoveClaim(claim);
+            }
+
+            return Results.Ok(claimsIdentity.Claims.Select(x => new { x.Type, x.Value }).ToList());
         }
 
         public IResult Logout(HttpContext context)

--- a/DotNet/LinkAdmin.BFF/appsettings.Development.json
+++ b/DotNet/LinkAdmin.BFF/appsettings.Development.json
@@ -47,11 +47,11 @@
   "Authentication": {
     "EnableAnonymousAccess": false,
     "DefaultScheme": "link_cookie",
-    "DefaultChallengeScheme": "link_oauth2",
+    "DefaultChallengeScheme": "link_openid_connect",
     "Schemas": {
       "Cookie": {
         "HttpOnly": true,
-        "Path":  "/"
+        "Path": "/"
       },
       "Jwt": {
         "Enabled": true,
@@ -63,13 +63,13 @@
         "ValidTypes": [ "at+jwt", "JWT" ]
       },
       "Oauth2": {
-        "Enabled": true,
+        "Enabled": false,
         "CallbackPath": "/api/signin-oauth2"
       },
       "OpenIdConnect": {
-        "Enabled": false,
+        "Enabled": true,
         "Authority": "",
-        "CallbackPath": "/signin-oidc",
+        "CallbackPath": "/api/signin-oidc",
         "NameClaimType": "email",
         "RoleClaimType": "roles"
       }


### PR DESCRIPTION
Added Azure Entra ID compatibility in the dev branch

- App registration was created and configured in Azure Entra ID
- Updated the OpenIdConnect auth schema to support Azure Entra Id
- Updated the Cookie auth schema to remove unneeded claims that could cause bloat in the cookie