### PR TITLE
LNK-2610

### DIFF
--- a/DotNet/DataAcquisition/Program.cs
+++ b/DotNet/DataAcquisition/Program.cs
@@ -215,7 +215,15 @@ static void RegisterServices(WebApplicationBuilder builder)
     builder.Services.RegisterKafkaProducer<string, AuditEventMessage>(
         builder.Configuration.GetRequiredSection(KafkaConstants.SectionName).Get<KafkaConnection>(),
         new Confluent.Kafka.ProducerConfig { CompressionType = Confluent.Kafka.CompressionType.Zstd });
+    
     builder.Services.AddTransient<IKafkaProducerFactory<string, AuditEventMessage>, KafkaProducerFactory<string, AuditEventMessage>>();
+    builder.Services.AddTransient<IKafkaProducerFactory<string, object>, KafkaProducerFactory<string, object>>();
+    builder.Services.AddTransient<IKafkaProducerFactory<string, string>, KafkaProducerFactory<string, string>>();
+    builder.Services.AddTransient<IKafkaProducerFactory<string, DataAcquisitionRequested>, KafkaProducerFactory<string, DataAcquisitionRequested>>();
+    builder.Services.AddTransient<IKafkaProducerFactory<string, PatientCensusScheduled>, KafkaProducerFactory<string, PatientCensusScheduled>>();
+    builder.Services.AddTransient<IKafkaProducerFactory<string, ResourceAcquired>, KafkaProducerFactory<string, ResourceAcquired>>();
+    builder.Services.AddTransient<IKafkaProducerFactory<string, PatientIDsAcquiredMessage>, KafkaProducerFactory<string, PatientIDsAcquiredMessage>>();
+
 
     //Factories - Retry
     builder.Services.AddTransient<IRetryEntityFactory, RetryEntityFactory>();


### PR DESCRIPTION
re-add kafka producer factory registrations since deadletter and transient exception handlers rely on this. This will need to be a separate refactor to accommodate IProducer<>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced Kafka producer factory registrations to support multiple message types, improving flexibility and integration with different data models.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->