### PR TITLE
LNK-2781 Data Acq Census Scheduled Errors

### DIFF
--- a/DotNet/DataAcquisition/Listeners/PatientCensusScheduledListener.cs
+++ b/DotNet/DataAcquisition/Listeners/PatientCensusScheduledListener.cs
@@ -30,7 +30,6 @@ public class PatientCensusScheduledListener : BaseListener<PatientCensusSchedule
 
     protected override async Task ExecuteListenerAsync(ConsumeResult<string, PatientCensusScheduled> consumeResult, CancellationToken cancellationToken)
     {
-        string correlationId;
         string facilityId;
 
         try


### PR DESCRIPTION
- Remove correlation id check in PatientCensusScheduledListener as it's not needed since correlation id does not begin at this point in process.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced patient census listener functionality to produce messages related to patient IDs through Kafka integration.

- **Bug Fixes**
  - Improved error handling strategy for message production, ensuring robust initialization of dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->