### PR TITLE
LNK-2787: Add additional context to resource metrics

### DIFF
--- a/DotNet/Census/Application/Commands/ConsumePatientIdsAcquiredEventCommand.cs
+++ b/DotNet/Census/Application/Commands/ConsumePatientIdsAcquiredEventCommand.cs
@@ -112,9 +112,10 @@ public class ConsumePaitentIdsAcquiredEventHandler : IRequestHandler<ConsumePati
             await _patientListRepository.UpdateAsync(patient, cancellationToken);
             if (patient.IsDischarged)
             {
+                var correlationId = Guid.NewGuid().ToString();
                 eventList.Add(new PatientEventResponse
                 {
-                    CorrelationId = Guid.NewGuid().ToString(),
+                    CorrelationId = correlationId,
                     FacilityId = request.FacilityId,
                     PatientEvent = new PatientEvent
                     {
@@ -127,7 +128,8 @@ public class ConsumePaitentIdsAcquiredEventHandler : IRequestHandler<ConsumePati
                 _metrics.IncrementPatientDischargedCounter([
                     new KeyValuePair<string, object?>(DiagnosticNames.FacilityId, request.FacilityId),
                     new KeyValuePair<string, object?>(DiagnosticNames.PatientId, patient.PatientId),
-                    new KeyValuePair<string, object?>(DiagnosticNames.PatientEvent, PatientEvents.Discharge.ToString())
+                    new KeyValuePair<string, object?>(DiagnosticNames.PatientEvent, PatientEvents.Discharge.ToString()),
+                    new KeyValuePair<string, object?>(DiagnosticNames.CorrelationId, correlationId)
                 ]);
             }
         }

--- a/DotNet/DataAcquisition/Application/Services/FhirApi/FhirApiService.cs
+++ b/DotNet/DataAcquisition/Application/Services/FhirApi/FhirApiService.cs
@@ -199,8 +199,7 @@ public class FhirApiService : IFhirApiService
             {
                 if (!(x.Resource.TypeName == nameof(OperationOutcome)))
                 {
-                    bundle.AddResourceEntry(x.Resource, x.FullUrl);
-                    IncrementResourceAcquiredMetric(correlationId, patientIdReference, facilityId, queryType, x.Resource.TypeName, x.Resource.Id);
+                    bundle.AddResourceEntry(x.Resource, x.FullUrl);                    
                 }
             });
         }
@@ -288,6 +287,8 @@ public class FhirApiService : IFhirApiService
                         CreateDate = DateTime.UtcNow,
                         ModifyDate = DateTime.UtcNow
                     }, cancellationToken);
+
+                    IncrementResourceAcquiredMetric(correlationId, patientId, facilityId, queryType, resourceType, entry.Resource.Id);
                 }
             }
 

--- a/DotNet/DataAcquisition/Application/Services/FhirApi/FhirApiService.cs
+++ b/DotNet/DataAcquisition/Application/Services/FhirApi/FhirApiService.cs
@@ -200,7 +200,7 @@ public class FhirApiService : IFhirApiService
                 if (!(x.Resource.TypeName == nameof(OperationOutcome)))
                 {
                     bundle.AddResourceEntry(x.Resource, x.FullUrl);
-                    IncrementResourceAcquiredMetric(patientIdReference, facilityId, queryType, x.Resource.TypeName);
+                    IncrementResourceAcquiredMetric(correlationId, patientIdReference, facilityId, queryType, x.Resource.TypeName, x.Resource.Id);
                 }
             });
         }
@@ -219,7 +219,9 @@ public class FhirApiService : IFhirApiService
         using var _ = _metrics.MeasureDataRequestDuration([
             new KeyValuePair<string, object?>(DiagnosticNames.FacilityId, facilityId),
             new KeyValuePair<string, object?>(DiagnosticNames.PatientId, patientId),
-            new KeyValuePair<string, object?>(DiagnosticNames.Resource, "Patient")
+            new KeyValuePair<string, object?>(DiagnosticNames.Resource, "Patient"),
+            new KeyValuePair<string, object?>(DiagnosticNames.CorrelationId, correlationId),
+            new KeyValuePair<string, object?>(DiagnosticNames.QueryType, QueryPlanType.Initial.ToString())
         ]);
 
         patientId = patientId.Contains("Patient/", StringComparison.InvariantCultureIgnoreCase) ? patientId : $"Patient/{patientId}";
@@ -264,6 +266,7 @@ public class FhirApiService : IFhirApiService
                 new KeyValuePair<string, object?>(DiagnosticNames.FacilityId, facilityId),
                 new KeyValuePair<string, object?>(DiagnosticNames.PatientId, patientId),
                 new KeyValuePair<string, object?>(DiagnosticNames.QueryType, queryType),
+                new KeyValuePair<string, object?>(DiagnosticNames.CorrelationId, correlationId),
                 new KeyValuePair<string, object?>(DiagnosticNames.Resource, resourceType)
             ]);
 
@@ -311,7 +314,9 @@ public class FhirApiService : IFhirApiService
             new KeyValuePair<string, object?>(DiagnosticNames.FacilityId, facilityId),
             new KeyValuePair<string, object?>(DiagnosticNames.PatientId, patientId),
             new KeyValuePair<string, object?>(DiagnosticNames.QueryType, queryType),
-            new KeyValuePair<string, object?>(DiagnosticNames.Resource, resourceType)
+            new KeyValuePair<string, object?>(DiagnosticNames.CorrelationId, correlationId),
+            new KeyValuePair<string, object?>(DiagnosticNames.Resource, resourceType),
+            new KeyValuePair<string, object?>(DiagnosticNames.ResourceId, id)
         ]);
 
         DomainResource? readResource = null;
@@ -359,7 +364,7 @@ public class FhirApiService : IFhirApiService
 
             if (readResource is not OperationOutcome)
             {
-                IncrementResourceAcquiredMetric(patientId, facilityId, queryType, resourceType);
+                IncrementResourceAcquiredMetric(correlationId, patientId, facilityId, queryType, resourceType, id);
             }
         }
 
@@ -553,13 +558,15 @@ public class FhirApiService : IFhirApiService
         };
     }
 
-    private void IncrementResourceAcquiredMetric(string? patientIdReference, string? facilityId, string? queryType, string resourceType)
+    private void IncrementResourceAcquiredMetric(string? correlationId, string? patientIdReference, string? facilityId, string? queryType, string resourceType, string resourceId)
     {
         _metrics.IncrementResourceAcquiredCounter([
+            new KeyValuePair<string, object?>(DiagnosticNames.CorrelationId, correlationId),
             new KeyValuePair<string, object?>(DiagnosticNames.FacilityId, facilityId),
             new KeyValuePair<string, object?>(DiagnosticNames.PatientId, patientIdReference), //TODO: Can we keep this?
             new KeyValuePair<string, object?>(DiagnosticNames.QueryType, queryType),
-            new KeyValuePair<string, object?>(DiagnosticNames.Resource, resourceType)
+            new KeyValuePair<string, object?>(DiagnosticNames.Resource, resourceType),
+            new KeyValuePair<string, object?>(DiagnosticNames.ResourceId, resourceId)
         ]);
     }
 }

--- a/DotNet/Shared/Application/Models/Telemetry/DiagnosticNames.cs
+++ b/DotNet/Shared/Application/Models/Telemetry/DiagnosticNames.cs
@@ -10,6 +10,7 @@
         public const string PatientEvent = "patient.event";
         public const string QueryType = "query.type";
         public const string Resource = "resource";
+        public const string ResourceId = "resource.id";
         public const string NormalizationOperation = "normalization.operation";
         public const string AuditId = "audit.id";
         public const string AuditLogAction = "audit.log.action";


### PR DESCRIPTION
Added correlation id and resource id to census and data acquisition meters.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced a correlation ID for enhanced traceability in patient discharge event processing.
	- Updated metrics logging to include resource IDs and correlation IDs for improved tracking of API interactions.
	- Added a new diagnostic constant for resource identification to enhance telemetry and logging capabilities.

- **Bug Fixes**
	- Improved consistency in metrics logging related to patient events and resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->