### PR TITLE
LNK-2904: Set microservice version numbers to 0.1.1

### DIFF
--- a/DotNet/Account/Account.csproj
+++ b/DotNet/Account/Account.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-	<Version>1.0.0-beta</Version>
+	<Version>0.1.1</Version>
 	<IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/DotNet/Audit/appsettings.json
+++ b/DotNet/Audit/appsettings.json
@@ -1,7 +1,7 @@
 {
   "ServiceInformation": {
     "Name": "Audit",
-    "Version": "1.0.0-beta"
+    "Version": "0.1.1"
   },
   "ExternalConfigurationSource": "",
   "KafkaConnection": {

--- a/DotNet/Census/appsettings.json
+++ b/DotNet/Census/appsettings.json
@@ -1,7 +1,7 @@
 {
   "ServiceInformation": {
     "Name": "Link Census Service",
-    "Version": "1.1.00-dev"
+    "Version": "0.1.1"
   },
   "EnableSwagger": false,
   "AllowReflection": true,

--- a/DotNet/DataAcquisition/appsettings.json
+++ b/DotNet/DataAcquisition/appsettings.json
@@ -2,7 +2,7 @@
   "ServiceInformation": {
     "Name": "Link Data Acquisition Service",
     "ServiceName": "DataAcquisition",
-    "Version": "1.1.00-dev"
+    "Version": "0.1.1"
   },
   "EnableSwagger": false,
   "KafkaConnection": {

--- a/DotNet/LinkAdmin.BFF/LinkAdmin.BFF.csproj
+++ b/DotNet/LinkAdmin.BFF/LinkAdmin.BFF.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-	<Version>1.0.0-beta</Version>
+	<Version>0.1.1</Version>
 	<IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/DotNet/LinkAdmin.BFF/appsettings.json
+++ b/DotNet/LinkAdmin.BFF/appsettings.json
@@ -1,7 +1,7 @@
 {
   "ServiceInformation": {
     "Name": "Link Admin BFF",
-    "Version": "1.1.00-dev"
+    "Version": "0.1.1"
   },
   "EnableSwagger": false,
   "ExternalConfigurationSource": "",

--- a/DotNet/Normalization/appsettings.json
+++ b/DotNet/Normalization/appsettings.json
@@ -2,7 +2,7 @@
   "ServiceInformation": {
     "Name": "Link Normalization Service",
     "ServiceName": "Normalization",
-    "Version": "1.1.00-dev"
+    "Version": "0.1.1"
   },
   "EnableSwagger": false,
   "Logging": {

--- a/DotNet/Notification/appsettings.json
+++ b/DotNet/Notification/appsettings.json
@@ -1,7 +1,7 @@
 {
   "ServiceInformation": {
     "Name": "Link Notification Service",
-    "Version": "1.1.00-dev"
+    "Version": "0.1.1"
   },
   "EnableSwagger": false,
   "ExternalConfigurationSource": "",

--- a/DotNet/QueryDispatch/appsettings.json
+++ b/DotNet/QueryDispatch/appsettings.json
@@ -1,7 +1,7 @@
 {
   "ServiceInformation": {
     "Name": "Link Query Dispatch Service",
-    "Version": "1.1.00-dev"
+    "Version": "0.1.1"
   },
   "EnableSwagger": false,
   "KafkaConnection": {

--- a/DotNet/Report/appsettings.json
+++ b/DotNet/Report/appsettings.json
@@ -1,7 +1,7 @@
 {
   "ServiceInformation": {
     "Name": "Link Report Service",
-    "Version": "1.1.00-dev"
+    "Version": "0.1.1"
   },
   "EnableSwagger": false,
   "KafkaConnection": {

--- a/DotNet/Shared/Shared.csproj
+++ b/DotNet/Shared/Shared.csproj
@@ -13,7 +13,7 @@
 		<Company>Lantana Consulting Group</Company>
 		<Description>Shared library for Lantana Link</Description>
 		<Product>NHSN Link Shared Library</Product>
-		<VersionPrefix>2.3.3</VersionPrefix>
+		<VersionPrefix>0.1.1</VersionPrefix>
 		<PackageId>com.lantanagroup.link.Shared</PackageId>
 	</PropertyGroup>
 

--- a/DotNet/Submission/appsettings.json
+++ b/DotNet/Submission/appsettings.json
@@ -2,7 +2,7 @@
   "EnableSwagger": true,
   "ServiceInformation": {
     "Name": "Link Submission Service",
-    "Version": "1.1.00-dev"
+    "Version": "0.1.1"
   },
   "AllowedHosts": "*",
   "KafkaConnection": {

--- a/DotNet/Tenant/appsettings.json
+++ b/DotNet/Tenant/appsettings.json
@@ -1,7 +1,7 @@
 {
   "ServiceInformation": {
     "Name": "Link Tenant Service",
-    "Version": "1.1.00-dev"
+    "Version": "0.1.1"
   },
   "EnableSwagger": false,
   "ExternalConfigurationSource": "",

--- a/Java/measureeval/pom.xml
+++ b/Java/measureeval/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.lantanagroup.link</groupId>
         <artifactId>main</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>0.1.1</version>
     </parent>
 
     <artifactId>measureeval</artifactId>

--- a/Java/pom.xml
+++ b/Java/pom.xml
@@ -13,7 +13,7 @@
 
     <groupId>com.lantanagroup.link</groupId>
     <artifactId>main</artifactId>
-    <version>0.1.0-SNAPSHOT</version>
+    <version>0.1.1</version>
     <packaging>pom</packaging>
 
     <name>Link Java Modules</name>

--- a/Java/shared/pom.xml
+++ b/Java/shared/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.lantanagroup.link</groupId>
         <artifactId>main</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>0.1.1</version>
     </parent>
 
     <artifactId>shared</artifactId>

--- a/Java/validation/pom.xml
+++ b/Java/validation/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.lantanagroup.link</groupId>
         <artifactId>main</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>0.1.1</version>
     </parent>
 
     <artifactId>validation</artifactId>


### PR DESCRIPTION
Couple of things to address in the review:

1. In shared.csproj, I changed line 16 
       from:
       `<VersionPrefix>2.3.3</VersionPrefix>`
       to:
       `<VersionPrefix>0.1.1</VersionPrefix>`
       I am _not_ confident about this version change, as it seemed different than the other versioning conventions. I made this exact same change in the previous RC branch, but wanted to call it out here in case it is an issue.
2. Not introduced by me, but Visual Studio Code complained about the presence of a comment in DotNet\LinkAdmin.BFF\appsettings.json (line 136)

