### PR TITLE
LNK-2908: Set microservice versions to 0.1.1-dev in dev branch

### DIFF
--- a/DotNet/Account/Account.csproj
+++ b/DotNet/Account/Account.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-	<Version>1.0.0-beta</Version>
+	<Version>0.1.1-dev</Version>
 	<IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/DotNet/Audit/appsettings.json
+++ b/DotNet/Audit/appsettings.json
@@ -1,7 +1,7 @@
 {
   "ServiceInformation": {
     "Name": "Audit",
-    "Version": "1.0.0-beta"
+    "Version": "0.1.1-dev"
   },
   "ExternalConfigurationSource": "",
   "KafkaConnection": {

--- a/DotNet/Census/appsettings.json
+++ b/DotNet/Census/appsettings.json
@@ -1,7 +1,7 @@
 {
   "ServiceInformation": {
     "Name": "Link Census Service",
-    "Version": "1.1.00-dev"
+    "Version": "0.1.1-dev"
   },
   "EnableSwagger": false,
   "AllowReflection": true,

--- a/DotNet/DataAcquisition/appsettings.json
+++ b/DotNet/DataAcquisition/appsettings.json
@@ -2,7 +2,7 @@
   "ServiceInformation": {
     "Name": "Link Data Acquisition Service",
     "ServiceName": "DataAcquisition",
-    "Version": "1.1.00-dev"
+    "Version": "0.1.1-dev"
   },
   "EnableSwagger": false,
   "KafkaConnection": {

--- a/DotNet/LinkAdmin.BFF/LinkAdmin.BFF.csproj
+++ b/DotNet/LinkAdmin.BFF/LinkAdmin.BFF.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-	<Version>1.0.0-beta</Version>
+	<Version>0.1.1-dev</Version>
 	<IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/DotNet/LinkAdmin.BFF/appsettings.json
+++ b/DotNet/LinkAdmin.BFF/appsettings.json
@@ -1,7 +1,7 @@
 {
   "ServiceInformation": {
     "Name": "Link Admin BFF",
-    "Version": "1.1.00-dev"
+    "Version": "0.1.1-dev"
   },
   "EnableSwagger": false,
   "ExternalConfigurationSource": "",

--- a/DotNet/Normalization/appsettings.json
+++ b/DotNet/Normalization/appsettings.json
@@ -2,7 +2,7 @@
   "ServiceInformation": {
     "Name": "Link Normalization Service",
     "ServiceName": "Normalization",
-    "Version": "1.1.00-dev"
+    "Version": "0.1.1-dev"
   },
   "EnableSwagger": false,
   "Logging": {

--- a/DotNet/Notification/appsettings.json
+++ b/DotNet/Notification/appsettings.json
@@ -1,7 +1,7 @@
 {
   "ServiceInformation": {
     "Name": "Link Notification Service",
-    "Version": "1.1.00-dev"
+    "Version": "0.1.1-dev"
   },
   "EnableSwagger": false,
   "ExternalConfigurationSource": "",

--- a/DotNet/QueryDispatch/appsettings.json
+++ b/DotNet/QueryDispatch/appsettings.json
@@ -1,7 +1,7 @@
 {
   "ServiceInformation": {
     "Name": "Link Query Dispatch Service",
-    "Version": "1.1.00-dev"
+    "Version": "0.1.1-dev"
   },
   "EnableSwagger": false,
   "KafkaConnection": {

--- a/DotNet/Report/appsettings.json
+++ b/DotNet/Report/appsettings.json
@@ -1,7 +1,7 @@
 {
   "ServiceInformation": {
     "Name": "Link Report Service",
-    "Version": "1.1.00-dev"
+    "Version": "0.1.1-dev"
   },
   "EnableSwagger": false,
   "KafkaConnection": {

--- a/DotNet/Shared/Shared.csproj
+++ b/DotNet/Shared/Shared.csproj
@@ -13,7 +13,7 @@
 		<Company>Lantana Consulting Group</Company>
 		<Description>Shared library for Lantana Link</Description>
 		<Product>NHSN Link Shared Library</Product>
-		<VersionPrefix>2.3.3</VersionPrefix>
+		<VersionPrefix>0.1.1-dev</VersionPrefix>
 		<PackageId>com.lantanagroup.link.Shared</PackageId>
 	</PropertyGroup>
 

--- a/DotNet/Submission/appsettings.json
+++ b/DotNet/Submission/appsettings.json
@@ -2,7 +2,7 @@
   "EnableSwagger": true,
   "ServiceInformation": {
     "Name": "Link Submission Service",
-    "Version": "1.1.00-dev"
+    "Version": "0.1.1-dev"
   },
   "AllowedHosts": "*",
   "KafkaConnection": {

--- a/DotNet/Tenant/appsettings.json
+++ b/DotNet/Tenant/appsettings.json
@@ -1,7 +1,7 @@
 {
   "ServiceInformation": {
     "Name": "Link Tenant Service",
-    "Version": "1.1.00-dev"
+    "Version": "0.1.1-dev"
   },
   "EnableSwagger": false,
   "ExternalConfigurationSource": "",

--- a/Java/measureeval/pom.xml
+++ b/Java/measureeval/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.lantanagroup.link</groupId>
         <artifactId>main</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>0.1.1-dev</version>
     </parent>
 
     <artifactId>measureeval</artifactId>

--- a/Java/pom.xml
+++ b/Java/pom.xml
@@ -13,7 +13,7 @@
 
     <groupId>com.lantanagroup.link</groupId>
     <artifactId>main</artifactId>
-    <version>0.1.0-SNAPSHOT</version>
+    <version>0.1.1-dev</version>
     <packaging>pom</packaging>
 
     <name>Link Java Modules</name>

--- a/Java/shared/pom.xml
+++ b/Java/shared/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.lantanagroup.link</groupId>
         <artifactId>main</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>0.1.1-dev</version>
     </parent>
 
     <artifactId>shared</artifactId>

--- a/Java/validation/pom.xml
+++ b/Java/validation/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.lantanagroup.link</groupId>
         <artifactId>main</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>0.1.1-dev</version>
     </parent>
 
     <artifactId>validation</artifactId>


### PR DESCRIPTION
Setting all service versions to 0.1.1-dev after RC branch was created and revved.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Version Updates**
	- Updated version numbers for multiple services and projects to reflect a shift from beta or snapshot states to a development phase (e.g., changed from `1.0.0-beta` to `0.1.1-dev`).
	- This indicates ongoing development or changes in the development strategy across various services.
	- Services affected include Account, Audit, Census, Data Acquisition, and several others.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->