### PR TITLE
LNK-2975: PR workflow improvements (template and title check)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,7 @@
+### 🛠 Description of Changes
+
+Please provide a high-level overview of the changes included in this PR.
+
+### 🧪 Testing Performed
+
+Please describe the testing that was performed on the changes included in this PR.

--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -2,7 +2,11 @@
 name: "PR Title Check"
 on:
   pull_request:
-    branches: [ dev, LNK-2726-Enforce-Jira-key-in-PR-message ]
+    branches: 
+      - dev
+      - main
+      - 'release/**'
+      - 'hotfix/**'
     types: [opened, edited, synchronize]
 jobs:
   check-title:
@@ -15,12 +19,12 @@ jobs:
         script: |
           const payload = context.payload
           const prTitle = payload.pull_request.title
-          // The pattern for JIRA ticket format
-          const jiraPattern = /^LNK-\d+([:-]|\s)/g
+          // The pattern for JIRA ticket format LNK-nnnn:<space><PR title>, e.g. LNK-1234: My PR title
+          const jiraPattern = /^LNK-\d+([:]\s)/g
           if (!jiraPattern.test(prTitle)) {
-            console.log('Could not find a LNK Jira ticket in PR title! Must begin with LNK-nnnn: or LNK-nnnn- or LNK-nnnn(space)')
+            console.log('Could not find a LNK Jira ticket in PR title! Must begin with LNK-nnnn:<space>, e.g. LNK-1234: My PR title')
             // Fails the workflow
-            core.setFailed('Could not find a LNK Jira ticket in PR title! Must begin with LNK-nnnn: or LNK-nnnn- or LNK-nnnn(space)')
+            core.setFailed('Could not find a LNK Jira ticket in PR title! Must begin with LNK-nnnn:<space>, e.g. LNK-1234: My PR title')
           } else {
             console.log('PR title format is correct.')
           }


### PR DESCRIPTION
Include simple PR template for review and include more branches in the PR title check GitHub action. 

1. The PR template is included to help ensure PRs contain enough information about the change and how it was tested.
2. The PR title check is extended to include main, release and hotfix branches, as well as a modification to the desired PR title format itself. It will now ask for this format: `LNK-nnnn:<sp><PR title>` for extra clarity.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a structured pull request template to enhance clarity and communication among contributors.
  
- **Improvements**
	- Updated PR title validation logic to enforce stricter formatting rules and expanded the branches monitored for PR title checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->