### PR TITLE
LNK-3055: Update measure eval to use 3.12 CQFramework libraries

### DIFF
--- a/Java/measureeval/pom.xml
+++ b/Java/measureeval/pom.xml
@@ -75,6 +75,11 @@
         </dependency>
 
         <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-collections4</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>ca.uhn.hapi.fhir</groupId>
             <artifactId>hapi-fhir-base</artifactId>
         </dependency>

--- a/Java/measureeval/src/main/java/com/lantanagroup/link/measureeval/controllers/ExceptionHandlers.java
+++ b/Java/measureeval/src/main/java/com/lantanagroup/link/measureeval/controllers/ExceptionHandlers.java
@@ -4,7 +4,7 @@ import com.lantanagroup.link.measureeval.exceptions.FhirParseException;
 import com.lantanagroup.link.measureeval.exceptions.ValidationException;
 import io.jsonwebtoken.security.SignatureException;
 import jakarta.servlet.http.HttpServletRequest;
-import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections4.CollectionUtils;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;

--- a/Java/pom.xml
+++ b/Java/pom.xml
@@ -20,8 +20,8 @@
     <description>Project/folder of Java modules/services for Link</description>
 
     <properties>
-        <cqf-fhir.version>3.0.0</cqf-fhir.version>
-        <hapi-fhir.version>7.0.0</hapi-fhir.version>
+        <cqf-fhir.version>3.12.0</cqf-fhir.version>
+        <hapi-fhir.version>7.4.0</hapi-fhir.version>
         <janino.version>2.6.1</janino.version>
     </properties>
 
@@ -109,6 +109,12 @@
                 <groupId>com.github.loki4j</groupId>
                 <artifactId>loki-logback-appender</artifactId>
                 <version>1.4.1</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-collections4</artifactId>
+                <version>4.4</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
### 🛠 Description of Changes

- Updated dependency for clinical-reasoning to 3.12
- Updated dependency for HAPI FHIR to 7.4 (required by v3.12 of clinical-reasoning)

These updates are needed to enable debug logging within the CQL Engine.

### 🧪 Testing Performed

Tested locally with unit tests developed on another branch. Please conduct local tests to ensure functionality.

NOTE: the logging level must be set to DEBUG in order to see the log messages. This can easily be achieved through the addition of a `logback.xml` in the `resources` directory.

Here is an example `logback.xml`:
```
<configuration>

  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
    <!-- encoders are assigned the type
         ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
    <encoder>
      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} -%kvp- %msg%n</pattern>
    </encoder>
  </appender>

  <root level="debug">
    <appender-ref ref="STDOUT" />
  </root>
</configuration>
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added support for the Apache Commons Collections library, enhancing data structure capabilities.
  
- **Updates**
	- Upgraded `cqf-fhir` library version from `3.0.0` to `3.12.0`.
	- Upgraded `hapi-fhir` library version from `7.0.0` to `7.4.0`.

- **Bug Fixes**
	- Updated exception handling to utilize the latest version of `CollectionUtils`, ensuring improved functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->