### PR TITLE
LNK-3137: Extend PR title check logic to support technical debt efforts

### DIFF
--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -19,12 +19,12 @@ jobs:
         script: |
           const payload = context.payload
           const prTitle = payload.pull_request.title
-          // The pattern for JIRA ticket format LNK-nnnn:<space><PR title>, e.g. LNK-1234: My PR title
-          const jiraPattern = /^LNK-\d+([:]\s)/g
-          if (!jiraPattern.test(prTitle)) {
-            console.log('Could not find a LNK Jira ticket in PR title! Must begin with LNK-nnnn:<space>, e.g. LNK-1234: My PR title')
-            // Fails the workflow
-            core.setFailed('Could not find a LNK Jira ticket in PR title! Must begin with LNK-nnnn:<space>, e.g. LNK-1234: My PR title')
+          const prTitleExpectedPattern = /(^LNK-\d+([:]\s))|(^TECH_DEBT+([:]\s))/g
+          const prTitleMismatchError = 'Invalid PR title! Must begin with LNK-nnnn:<space> or TECH_DEBT:<space><descr>, e.g. LNK-1234: My PR title, or TECH_DEBT: My PR title'
+          if (!prTitleExpectedPattern.test(prTitle)) {
+            // Fail the workflow
+            console.log(prTitleMismatchError)
+            core.setFailed(prTitleMismatchError)
           } else {
             console.log('PR title format is correct.')
           }

--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -13,14 +13,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Check PR title
-      uses: actions/github-script@v4
+      uses: actions/github-script@v6
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         script: |
           const payload = context.payload
           const prTitle = payload.pull_request.title
-          const prTitleExpectedPattern = /(^LNK-\d+([:]\s))|(^TECH_DEBT+([:]\s))/g
-          const prTitleMismatchError = 'Invalid PR title! Must begin with LNK-nnnn:<space> or TECH_DEBT:<space><descr>, e.g. LNK-1234: My PR title, or TECH_DEBT: My PR title'
+          const prTitleExpectedPattern = /(^LNK-\d+:\s)|(^TECH_DEBT:\s)/g
+          const prTitleMismatchError = 'Invalid PR title! Must begin with LNK-nnnn:<space> or TECH_DEBT:<space>, e.g. LNK-1234: My PR title, or TECH_DEBT: My PR title'
           if (!prTitleExpectedPattern.test(prTitle)) {
             // Fail the workflow
             console.log(prTitleMismatchError)


### PR DESCRIPTION
### 🛠 Description of Changes

Modified the regex in the PR-title-check.yml file to **additionally** accept _TECH_DEBT:_ and a description. This means technical debt work in the form of PR content does not need to have an associated Jira ticket.

### 🧪 Testing Performed

Created a draft PR and modified the title to exercise positive and negative test scenarios.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Expanded pull request title validation to include "TECH_DEBT: " format alongside the existing "LNK-nnnn: " format.
  
- **Bug Fixes**
	- Improved error messaging for pull request title formatting to provide clearer guidance.
  
- **Chores**
	- Updated the GitHub Actions workflow to use the latest version of `actions/github-script`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->