### PR TITLE
LNK-3212: Address security cookie dynamic scan result - Link Admin

### DIFF
--- a/DotNet/LinkAdmin.BFF/Infrastructure/Extensions/Security/InitializeSecurity.cs
+++ b/DotNet/LinkAdmin.BFF/Infrastructure/Extensions/Security/InitializeSecurity.cs
@@ -76,7 +76,6 @@ namespace LantanaGroup.Link.LinkAdmin.BFF.Infrastructure.Extensions.Security
                 options.Cookie.SecurePolicy = securityServiceOptions.Environment.IsDevelopment() ? CookieSecurePolicy.SameAsRequest : CookieSecurePolicy.Always;                
                 options.Cookie.Path = configuration.GetValue<string>("Authentication:Schemas:Cookie:Path");                
                 options.Cookie.SameSite = SameSiteMode.Strict;
-                options.ExpireTimeSpan = TimeSpan.FromMinutes(30);
                 options.LoginPath = "/api/login";
                 options.LogoutPath = "/api/logout";
 

--- a/DotNet/LinkAdmin.BFF/Program.cs
+++ b/DotNet/LinkAdmin.BFF/Program.cs
@@ -91,7 +91,7 @@ static void RegisterServices(WebApplicationBuilder builder)
     builder.Services.Configure<CacheSettings>(builder.Configuration.GetSection(ConfigurationConstants.AppSettings.Cache));
 
     // Determine if anonymous access is allowed
-    bool allowAnonymousAccess = builder.Configuration.GetValue<bool>("Authentication:EnableAnonymousAccess");
+    var allowAnonymousAccess = builder.Configuration.GetValue<bool>("Authentication:EnableAnonymousAccess");
 
     // Add kafka connection singleton
     var kafkaConnection = builder.Configuration.GetSection(KafkaConstants.SectionName).Get<KafkaConnection>();
@@ -170,7 +170,7 @@ static void RegisterServices(WebApplicationBuilder builder)
         builder.Services.AddAuthorizationBuilder()        
             .AddPolicy("AuthenticatedUser", pb =>
             {
-                pb.RequireAssertion(context => true);
+                pb.RequireAssertion(_ => true);
             });
     }
 
@@ -197,17 +197,23 @@ static void RegisterServices(WebApplicationBuilder builder)
     }
 
     // Add health checks
-    var healthCheckBuilder = builder.Services.AddHealthChecks()
-        .AddCheck<AccountServiceHealthCheck>("Account Service")
-        .AddCheck<AuditServiceHealthCheck>("Audit Service")
-        .AddCheck<CensusServiceHealthCheck>("Census Service")
-        .AddCheck<DataAcquisitionHealthCheck>("Data Acquisition Service")
-        .AddCheck<MeasureEvaluationServiceHealthCheck>("Measure Evaluation Service")
-        .AddCheck<NormalizationServiceHealthCheck>("Normalization Service")
-        .AddCheck<NotificationServiceHealthCheck>("Notification Service")
-        .AddCheck<ReportServiceHealthCheck>("Report Service")
-        .AddCheck<SubmissionServiceHealthCheck>("Submission Service")
-        .AddCheck<TenantServiceHealthCheck>("Tenant Service");
+    var monitorBackend = builder.Configuration.GetValue<bool>("MonitorBackendHealthChecks");
+    var healthCheckBuilder = builder.Services.AddHealthChecks();
+    
+    if (monitorBackend)
+    {
+        healthCheckBuilder
+            .AddCheck<AccountServiceHealthCheck>("Account Service")
+            .AddCheck<AuditServiceHealthCheck>("Audit Service")
+            .AddCheck<CensusServiceHealthCheck>("Census Service")
+            .AddCheck<DataAcquisitionHealthCheck>("Data Acquisition Service")
+            .AddCheck<MeasureEvaluationServiceHealthCheck>("Measure Evaluation Service")
+            .AddCheck<NormalizationServiceHealthCheck>("Normalization Service")
+            .AddCheck<NotificationServiceHealthCheck>("Notification Service")
+            .AddCheck<ReportServiceHealthCheck>("Report Service")
+            .AddCheck<SubmissionServiceHealthCheck>("Submission Service")
+            .AddCheck<TenantServiceHealthCheck>("Tenant Service");
+    }
 
     if (builder.Configuration.GetValue<bool>("Cache:Enabled"))
     {

--- a/DotNet/LinkAdmin.BFF/appsettings.Development.json
+++ b/DotNet/LinkAdmin.BFF/appsettings.Development.json
@@ -1,5 +1,6 @@
 {
   "EnableSwagger": true,
+  "MonitorBackendHealthChecks": false,
   "ExternalConfigurationSource": "",
   "SecretManagement": {
     "Enabled": true,

--- a/DotNet/LinkAdmin.BFF/appsettings.json
+++ b/DotNet/LinkAdmin.BFF/appsettings.json
@@ -4,6 +4,7 @@
     "Version": "0.1.1"
   },
   "EnableSwagger": false,
+  "MonitorBackendHealthChecks": false,
   "ExternalConfigurationSource": "",
   "SecretManagement": {
     "Enabled": false,


### PR DESCRIPTION
### 🛠 Description of Changes

- Removed the expiration setting for the `link_cookie` to ensure it will be a session cookie.
- Made the backend service health check configurable, disabled by default

### 🧪 Testing Performed

- Logged into link-admin
- Made a request to the Account service to ensure everything was working correctly
- Closed my browsing session
- Verified that the cookie was no longer present and received an unauthorized response when making the same request to the Account service.