### PR TITLE
TECH_DEBT: Fixing health check on sql-server docker compose container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -63,7 +63,7 @@ services:
       - mssql_data:/var/opt/mssql
     restart: always
     healthcheck:
-      test: ["CMD-SHELL", "/opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P ${LINK_DB_PASS} -Q 'SELECT 1' || exit 1"]
+      test: ["CMD-SHELL", "/opt/mssql-tools18/bin/sqlcmd -C -S localhost -U sa -P ${LINK_DB_PASS} -Q 'SELECT 1' || exit 1"]
       interval: 10s
       retries: 10
       start_period: 10s


### PR DESCRIPTION
### 🛠️ Description of Changes

- Updated Docker Compose health check configuration for MSSQL service
- Modified sqlcmd tool path and added SSL connection option for service monitoring

### 🧪 Testing Performed

Ran `docker compose up` to see that the `mssql` container reports "healthy"

### 📓 Documentation Updated

None