### PR TITLE
LNK-2819: Validation endpoint allows for export of validation categories and rulesets

### DIFF
--- a/Java/validation/src/main/java/com/lantanagroup/link/validation/controllers/CategoryController.java
+++ b/Java/validation/src/main/java/com/lantanagroup/link/validation/controllers/CategoryController.java
@@ -88,10 +88,10 @@ public class CategoryController {
         }
     }
 
-    @Operation(summary = "Creates or updates categories and rules")
-    @PostMapping("/$bulk-save")
+    @Operation(summary = "Imports categories and rules")
+    @PostMapping("/$bulk-import")
     @Transactional
-    public void bulkSaveCategories(@RequestBody List<CategorySnapshot> categorySnapshots) {
+    public void bulkImportCategories(@RequestBody List<CategorySnapshot> categorySnapshots) {
         if (CollectionUtils.isEmpty(categorySnapshots)) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "No categories provided");
         }
@@ -112,6 +112,14 @@ public class CategoryController {
         for (CategorySnapshot categorySnapshot : categorySnapshots) {
             categorizationService.saveCategorySnapshot(categorySnapshot);
         }
+    }
+
+    @Operation(summary = "Exports categories and rules")
+    @GetMapping("/$bulk-export")
+    public List<CategorySnapshot> bulkExportCategories() {
+        return categoryRepository.findAll().stream()
+                .map(CategorySnapshot::new)
+                .toList();
     }
 
     @Operation(summary = "Gets all categories")

--- a/Java/validation/src/main/java/com/lantanagroup/link/validation/entities/CategorySnapshot.java
+++ b/Java/validation/src/main/java/com/lantanagroup/link/validation/entities/CategorySnapshot.java
@@ -14,6 +14,21 @@ public class CategorySnapshot {
     private String guidance;
     private Matcher matcher;
 
+    public CategorySnapshot() {
+    }
+
+    public CategorySnapshot(Category category) {
+        id = category.getId();
+        title = category.getTitle();
+        severity = category.getSeverity();
+        acceptable = category.isAcceptable();
+        guidance = category.getGuidance();
+        CategoryRule latestRule = category.getLatestRule();
+        if (latestRule != null) {
+            matcher = latestRule.getMatcher();
+        }
+    }
+
     public Category toCategory() {
         return toCategory(new Category());
     }


### PR DESCRIPTION
### 🛠️ Description of Changes

Added a `GET /api/category/$bulk-export` endpoint to complement the existing `POST /api/category/$bulk-import` (renamed from `$bulk-save`).

### 🧪 Testing Performed

Verified that the output of `$bulk-export` matches the input of a preceding `$bulk-import` (ignoring JSON formatting differences, etc.).

### 📓 Documentation Updated

Added inline OpenAPI annotations for the new endpoint.