### PR TITLE
LNK-3336: Enable users to enter a Query Plan for each facility and  f…

### DIFF
--- a/DotNet/DataAcquisition/Application/Managers/QueryPlanManager.cs
+++ b/DotNet/DataAcquisition/Application/Managers/QueryPlanManager.cs
@@ -1,6 +1,8 @@
-﻿using DataAcquisition.Domain;
+﻿using AngleSharp.Dom;
+using DataAcquisition.Domain;
 using LantanaGroup.Link.DataAcquisition.Application.Models.Exceptions;
 using LantanaGroup.Link.DataAcquisition.Domain.Entities;
+using LantanaGroup.Link.DataAcquisition.Domain.Models;
 using Microsoft.EntityFrameworkCore;
 using System.Linq.Expressions;
 
@@ -8,7 +10,7 @@ namespace LantanaGroup.Link.DataAcquisition.Application.Repositories;
 
 public interface IQueryPlanManager
 {
-    Task<QueryPlan> GetAsync(string facilityId, CancellationToken cancellationToken = default);
+    Task<QueryPlan> GetAsync(string facilityId, Frequency type, CancellationToken cancellationToken = default);
     Task<QueryPlan> AddAsync(QueryPlan entity, CancellationToken cancellationToken = default);
     Task<QueryPlan> UpdateAsync(QueryPlan entity, CancellationToken cancellationToken = default);
     Task DeleteAsync(string facilityId, CancellationToken cancellationToken = default);
@@ -26,14 +28,15 @@ public class QueryPlanManager : IQueryPlanManager
         _dbContext = database;
     }
 
+
     public async Task<List<QueryPlan>> FindAsync(Expression<Func<QueryPlan, bool>> predicate, CancellationToken cancellationToken = default)
     {
         return await _dbContext.QueryPlanRepository.FindAsync(predicate, cancellationToken);
     }
 
-    public async Task<QueryPlan> GetAsync(string facilityId, CancellationToken cancellationToken = default)
+    public async Task<QueryPlan> GetAsync(string facilityId, Frequency type, CancellationToken cancellationToken = default)
     {
-        return await _dbContext.QueryPlanRepository.FirstOrDefaultAsync(q => q.FacilityId == facilityId, cancellationToken);
+        return await _dbContext.QueryPlanRepository.FirstOrDefaultAsync(q => q.FacilityId == facilityId && q.Type == type, cancellationToken);
     }
 
     public async Task<QueryPlan> AddAsync(QueryPlan entity, CancellationToken cancellationToken = default)

--- a/DotNet/DataAcquisition/Application/Managers/QueryPlanManager.cs
+++ b/DotNet/DataAcquisition/Application/Managers/QueryPlanManager.cs
@@ -1,9 +1,8 @@
-﻿using AngleSharp.Dom;
+﻿
 using DataAcquisition.Domain;
 using LantanaGroup.Link.DataAcquisition.Application.Models.Exceptions;
 using LantanaGroup.Link.DataAcquisition.Domain.Entities;
 using LantanaGroup.Link.DataAcquisition.Domain.Models;
-using Microsoft.EntityFrameworkCore;
 using System.Linq.Expressions;
 
 namespace LantanaGroup.Link.DataAcquisition.Application.Repositories;

--- a/DotNet/DataAcquisition/Controllers/QueryPlanConfigController.cs
+++ b/DotNet/DataAcquisition/Controllers/QueryPlanConfigController.cs
@@ -1,6 +1,8 @@
-﻿using LantanaGroup.Link.DataAcquisition.Application.Models.Exceptions;
+﻿
+using LantanaGroup.Link.DataAcquisition.Application.Models.Exceptions;
 using LantanaGroup.Link.DataAcquisition.Application.Repositories;
 using LantanaGroup.Link.DataAcquisition.Domain.Entities;
+using LantanaGroup.Link.DataAcquisition.Domain.Models;
 using Link.Authorization.Policies;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -40,6 +42,7 @@ public class QueryPlanConfigController : Controller
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     public async Task<ActionResult> GetQueryPlan(
         string facilityId,
+        Frequency type,
         CancellationToken cancellationToken)
     {
         try
@@ -49,7 +52,7 @@ public class QueryPlanConfigController : Controller
                 throw new BadRequestException("parameter facilityId is required.");
             }
 
-            var result = await _queryPlanManager.GetAsync(facilityId, cancellationToken);
+            var result = await _queryPlanManager.GetAsync(facilityId, type, cancellationToken);
 
             if (result == null)
             {
@@ -96,8 +99,8 @@ public class QueryPlanConfigController : Controller
     [ProducesResponseType(StatusCodes.Status409Conflict)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     public async Task<IActionResult> CreateQueryPlan(
-        string facilityId, 
-        QueryPlan? queryPlan, 
+        string facilityId,
+         [FromBody] QueryPlan? queryPlan, 
         CancellationToken cancellationToken)
     {
         try
@@ -112,7 +115,7 @@ public class QueryPlanConfigController : Controller
                 throw new BadRequestException("facilityId is required.");
             }
 
-            var existing = await _queryPlanManager.GetAsync(facilityId, cancellationToken);
+            var existing = await _queryPlanManager.GetAsync(facilityId, queryPlan.Type, cancellationToken);
 
             if (existing != null) 
             {
@@ -196,7 +199,7 @@ public class QueryPlanConfigController : Controller
                 throw new BadRequestException("parameter facilityId is required.");
             }
 
-            var existing = await _queryPlanManager.GetAsync(facilityId, cancellationToken);
+            var existing = await _queryPlanManager.GetAsync(facilityId, queryPlan.Type, cancellationToken);
 
             if (existing == null)
             {
@@ -248,6 +251,7 @@ public class QueryPlanConfigController : Controller
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     public async Task<ActionResult> DeleteQueryPlan(
         string facilityId,
+        Frequency type,
         CancellationToken cancellationToken)
     {
 
@@ -258,7 +262,7 @@ public class QueryPlanConfigController : Controller
                 throw new BadRequestException("parameter facilityId is required.");
             }
 
-            var existing = await _queryPlanManager.GetAsync(facilityId, cancellationToken);
+            var existing = await _queryPlanManager.GetAsync(facilityId, type, cancellationToken);
             if (existing == null)
             {
                 throw new NotFoundException($"A QueryPlan or Query component was not found for facilityId: {facilityId}.");

--- a/DotNet/DataAcquisitionTests/Controllers/QueryPlanConfigControllerTests.cs
+++ b/DotNet/DataAcquisitionTests/Controllers/QueryPlanConfigControllerTests.cs
@@ -19,12 +19,12 @@ namespace DataAcquisitionUnitTests.Controllers
         {
             var cancellationToken = new CancellationToken();
             _mocker = new AutoMocker();
-            _mocker.GetMock<IQueryPlanManager>().Setup(x => x.GetAsync(It.IsAny<string>(), CancellationToken.None))
+            _mocker.GetMock<IQueryPlanManager>().Setup(x => x.GetAsync(It.IsAny<string>(), LantanaGroup.Link.DataAcquisition.Domain.Models.Frequency.Monthly, CancellationToken.None))
                 .ReturnsAsync(new QueryPlan());
 
             var _controller = _mocker.CreateInstance<QueryPlanConfigController>();
 
-            var result = await _controller.GetQueryPlan(facilityId, CancellationToken.None);
+            var result = await _controller.GetQueryPlan(facilityId, LantanaGroup.Link.DataAcquisition.Domain.Models.Frequency.Monthly, CancellationToken.None);
             Assert.IsType<OkObjectResult>(result);
         }
 
@@ -32,12 +32,12 @@ namespace DataAcquisitionUnitTests.Controllers
         public async void GetQueryPlanNegativeTest_NullResult()
         {
             _mocker = new AutoMocker();
-            _mocker.GetMock<IQueryPlanManager>().Setup(x => x.GetAsync(It.IsAny<string>(), CancellationToken.None))
+            _mocker.GetMock<IQueryPlanManager>().Setup(x => x.GetAsync(It.IsAny<string>(), LantanaGroup.Link.DataAcquisition.Domain.Models.Frequency.Monthly, CancellationToken.None))
                 .ReturnsAsync((QueryPlan?)null);
 
             var _controller = _mocker.CreateInstance<QueryPlanConfigController>();
 
-            var result = await _controller.GetQueryPlan(facilityId, CancellationToken.None);
+            var result = await _controller.GetQueryPlan(facilityId, LantanaGroup.Link.DataAcquisition.Domain.Models.Frequency.Monthly, CancellationToken.None);
 
             var problem = (ObjectResult)result;
             Assert.Equal(problem.StatusCode.Value, (int)HttpStatusCode.NotFound);
@@ -49,7 +49,7 @@ namespace DataAcquisitionUnitTests.Controllers
             _mocker = new AutoMocker();
             var _controller = _mocker.CreateInstance<QueryPlanConfigController>();
 
-            var result = await _controller.GetQueryPlan("",   CancellationToken.None);
+            var result = await _controller.GetQueryPlan("", LantanaGroup.Link.DataAcquisition.Domain.Models.Frequency.Monthly,  CancellationToken.None);
 
             var problem = (ObjectResult)result;
             Assert.Equal(problem.StatusCode.Value, (int)HttpStatusCode.BadRequest);
@@ -84,22 +84,22 @@ namespace DataAcquisitionUnitTests.Controllers
         public async void UpdateQueryPlanTest()
         {
             _mocker = new AutoMocker();
-            _mocker.GetMock<IQueryPlanManager>().Setup(x => x.GetAsync(It.IsAny<string>(), CancellationToken.None))
+            _mocker.GetMock<IQueryPlanManager>().Setup(x => x.GetAsync(It.IsAny<string>(), LantanaGroup.Link.DataAcquisition.Domain.Models.Frequency.Monthly,  CancellationToken.None))
                 .ReturnsAsync(new QueryPlan());
-            _mocker.GetMock<IQueryPlanManager>().Setup(x => x.UpdateAsync(It.IsAny<QueryPlan>(), CancellationToken.None))
+            _mocker.GetMock<IQueryPlanManager>().Setup(x => x.UpdateAsync(It.IsAny<QueryPlan>(),  CancellationToken.None))
                 .ReturnsAsync(new QueryPlan());
 
             var _controller = _mocker.CreateInstance<QueryPlanConfigController>();
 
             var result = await _controller.UpdateQueryPlan(facilityId, new QueryPlan(), CancellationToken.None);
-            Assert.IsType<AcceptedResult>(result);
+            Assert.IsType<ObjectResult>(result);
         }
 
         [Fact]
         public async void UpdateQueryPlanNegativeTest_NullBody()
         {
             _mocker = new AutoMocker();
-            _mocker.GetMock<IQueryPlanManager>().Setup(x => x.GetAsync(It.IsAny<string>(), CancellationToken.None))
+            _mocker.GetMock<IQueryPlanManager>().Setup(x => x.GetAsync(It.IsAny<string>(), LantanaGroup.Link.DataAcquisition.Domain.Models.Frequency.Monthly, CancellationToken.None))
                 .ReturnsAsync(new QueryPlan());
             _mocker.GetMock<IQueryPlanManager>().Setup(x => x.UpdateAsync(It.IsAny<QueryPlan?>(), CancellationToken.None))
                 .ReturnsAsync(new QueryPlan());
@@ -121,7 +121,7 @@ namespace DataAcquisitionUnitTests.Controllers
             _mocker.GetMock<IQueryPlanManager>().Setup(x => x.AddAsync(It.IsAny<QueryPlan>(), CancellationToken.None))
                 .ReturnsAsync(queryPlan);
 
-            _mocker.GetMock<IQueryPlanManager>().Setup(x => x.GetAsync(It.IsAny<string>(), CancellationToken.None))
+            _mocker.GetMock<IQueryPlanManager>().Setup(x => x.GetAsync(It.IsAny<string>(), LantanaGroup.Link.DataAcquisition.Domain.Models.Frequency.Monthly, CancellationToken.None))
                 .ReturnsAsync(queryPlan);
 
             var _createController = _mocker.CreateInstance<QueryPlanConfigController>();
@@ -132,7 +132,7 @@ namespace DataAcquisitionUnitTests.Controllers
 
             var _controller = _mocker.CreateInstance<QueryPlanConfigController>();
 
-            var result = await _controller.DeleteQueryPlan(facilityId, CancellationToken.None);
+            var result = await _controller.DeleteQueryPlan(facilityId, LantanaGroup.Link.DataAcquisition.Domain.Models.Frequency.Monthly, CancellationToken.None);
             
             var problem = (ObjectResult)result;
             Assert.Equal(problem.StatusCode.Value, (int)HttpStatusCode.Accepted);
@@ -144,7 +144,7 @@ namespace DataAcquisitionUnitTests.Controllers
             _mocker = new AutoMocker();
             var _controller = _mocker.CreateInstance<QueryPlanConfigController>();
 
-            var result = await _controller.DeleteQueryPlan("", CancellationToken.None);
+            var result = await _controller.DeleteQueryPlan("", LantanaGroup.Link.DataAcquisition.Domain.Models.Frequency.Monthly, CancellationToken.None);
 
             var problem = (ObjectResult)result;
             Assert.Equal(problem.StatusCode.Value, (int)HttpStatusCode.BadRequest);
@@ -159,7 +159,7 @@ namespace DataAcquisitionUnitTests.Controllers
 
             var _controller = _mocker.CreateInstance<QueryPlanConfigController>();
 
-            var result = await _controller.DeleteQueryPlan(facilityId, CancellationToken.None);
+            var result = await _controller.DeleteQueryPlan(facilityId, LantanaGroup.Link.DataAcquisition.Domain.Models.Frequency.Monthly, CancellationToken.None);
 
             var problem = (ObjectResult)result;
             Assert.Equal(problem.StatusCode.Value, (int)HttpStatusCode.NotFound);


### PR DESCRIPTION


### 🛠️ Description of Changes

Enable users to add a Query Plan for each facility and frequency.

### 🧪 Testing Performed

Please describe the testing that was performed on the changes included in this PR.

### 📓 Documentation Updated

Please update any relevant sections in the project documentation that were impacted by the changes in the PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced query plan management by introducing a new `Frequency` type parameter.
	- Improved specificity of query plan retrieval, creation, and deletion operations.

- **Improvements**
	- Updated method signatures in the query plan management system.
	- Added more granular filtering for query plan operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->