### PR TITLE
LNK-3318: Report Requested Listener

### DIFF
--- a/DotNet/Report/Entities/ReportScheduleModel.cs
+++ b/DotNet/Report/Entities/ReportScheduleModel.cs
@@ -14,6 +14,7 @@ namespace LantanaGroup.Link.Report.Entities
         public DateTime ReportEndDate { get; set; }
         public DateTime? SubmitReportDateTime { get; set; }
         public DateTime? SubmittedDate { get; set; }
+        public bool EnableSubmission { get; set; } = true;
         public bool PatientsToQueryDataRequested { get; set; } = false;
         public string[] ReportTypes { get; set; } = Array.Empty<string>();
         public string Frequency { get; internal set; } = string.Empty;

--- a/DotNet/Report/Listeners/GenerateReportListener.cs
+++ b/DotNet/Report/Listeners/GenerateReportListener.cs
@@ -55,7 +55,7 @@ namespace LantanaGroup.Link.Report.Listeners
         {
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
             _kafkaConsumerFactory = kafkaConsumerFactory ?? throw new ArgumentException(nameof(kafkaConsumerFactory));
-            _serviceScopeFactory = serviceScopeFactory;
+            _serviceScopeFactory = serviceScopeFactory ?? throw new ArgumentNullException(nameof(serviceScopeFactory));
 
             _transientExceptionHandler = transientExceptionHandler ??
                                                throw new ArgumentException(nameof(_deadLetterExceptionHandler));

--- a/DotNet/Report/Listeners/GenerateReportListener.cs
+++ b/DotNet/Report/Listeners/GenerateReportListener.cs
@@ -86,7 +86,10 @@ namespace LantanaGroup.Link.Report.Listeners
             var config = new ConsumerConfig()
             {
                 GroupId = ReportConstants.ServiceName,
-                EnableAutoCommit = false
+                EnableAutoCommit = false,
+                AutoOffsetReset = AutoOffsetReset.Earliest,
+                SessionTimeoutMs = 10000,
+                MaxPollIntervalMs = 300000
             };
 
             using var consumer = _kafkaConsumerFactory.CreateConsumer(config);

--- a/DotNet/Report/Listeners/GenerateReportListener.cs
+++ b/DotNet/Report/Listeners/GenerateReportListener.cs
@@ -283,7 +283,7 @@ namespace LantanaGroup.Link.Report.Listeners
                     }
                     catch (Exception ex)
                     {
-                        _logger.LogError(ex, "Error encountered in ReportScheduledListener");
+                        _logger.LogError(ex, "Error encountered in GenerateReportListener");
                         consumer.Commit();
                     }
                 }

--- a/DotNet/Report/Listeners/GenerateReportListener.cs
+++ b/DotNet/Report/Listeners/GenerateReportListener.cs
@@ -113,7 +113,7 @@ namespace LantanaGroup.Link.Report.Listeners
 
                             try
                             {
-                                var scope = _serviceScopeFactory.CreateScope();
+                                using var scope = _serviceScopeFactory.CreateScope();
                                 var measureReportScheduledManager =
                                     scope.ServiceProvider.GetRequiredService<IReportScheduledManager>();
 

--- a/DotNet/Report/Listeners/GenerateReportListener.cs
+++ b/DotNet/Report/Listeners/GenerateReportListener.cs
@@ -1,0 +1,337 @@
+﻿using Confluent.Kafka;
+using Confluent.Kafka.Extensions.Diagnostics;
+using Hl7.Fhir.Model;
+using Hl7.Fhir.Serialization;
+using LantanaGroup.Link.Report.Application.Models;
+using LantanaGroup.Link.Report.Domain.Enums;
+using LantanaGroup.Link.Report.Domain.Managers;
+using LantanaGroup.Link.Report.Entities;
+using LantanaGroup.Link.Report.Settings;
+using LantanaGroup.Link.Shared.Application.Error.Exceptions;
+using LantanaGroup.Link.Shared.Application.Error.Interfaces;
+using LantanaGroup.Link.Shared.Application.Interfaces;
+using LantanaGroup.Link.Shared.Application.Interfaces.Services.Security.Token;
+using LantanaGroup.Link.Shared.Application.Models;
+using LantanaGroup.Link.Shared.Application.Models.Configs;
+using LantanaGroup.Link.Shared.Application.Models.Kafka;
+using LantanaGroup.Link.Shared.Application.Services.Security;
+using LantanaGroup.Link.Shared.Settings;
+using Microsoft.Extensions.Options;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+using Task = System.Threading.Tasks.Task;
+
+namespace LantanaGroup.Link.Report.Listeners
+{
+    public class GenerateReportListener : BackgroundService
+    {
+
+        private readonly ILogger<GenerateReportListener> _logger;
+        private readonly IKafkaConsumerFactory<string, GenerateReportValue> _kafkaConsumerFactory;
+        private readonly ITransientExceptionHandler<string, GenerateReportValue> _transientExceptionHandler;
+        private readonly IDeadLetterExceptionHandler<string, GenerateReportValue> _deadLetterExceptionHandler;
+        private readonly ServiceRegistry _serviceRegistry;
+        private readonly IServiceScopeFactory _serviceScopeFactory;
+        
+        private readonly IHttpClientFactory _httpClientFactory;
+        private readonly IOptions<LinkTokenServiceSettings> _linkTokenServiceConfig;
+        private readonly ICreateSystemToken _createSystemToken;
+
+        private readonly IProducer<string, DataAcquisitionRequestedValue> _dataAcqProducer;
+
+        private string Name => this.GetType().Name;
+
+        public GenerateReportListener(ILogger<GenerateReportListener> logger, 
+            IKafkaConsumerFactory<string, GenerateReportValue> kafkaConsumerFactory,
+            ITransientExceptionHandler<string, GenerateReportValue> transientExceptionHandler,
+            IDeadLetterExceptionHandler<string, GenerateReportValue> deadLetterExceptionHandler,
+            IServiceScopeFactory serviceScopeFactory,
+            IHttpClientFactory httpClientFactory,
+            IOptions<LinkTokenServiceSettings> linkTokenService,
+            ICreateSystemToken createSystemToken,
+            IOptions<ServiceRegistry> serviceRegistry,
+            IProducer<string, DataAcquisitionRequestedValue> dataAcqProducer)
+        {
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+            _kafkaConsumerFactory = kafkaConsumerFactory ?? throw new ArgumentException(nameof(kafkaConsumerFactory));
+            _serviceScopeFactory = serviceScopeFactory;
+
+            _transientExceptionHandler = transientExceptionHandler ??
+                                               throw new ArgumentException(nameof(_deadLetterExceptionHandler));
+
+            _deadLetterExceptionHandler = deadLetterExceptionHandler ??
+                                               throw new ArgumentException(nameof(_deadLetterExceptionHandler));
+
+            _transientExceptionHandler.ServiceName = ReportConstants.ServiceName;
+            _transientExceptionHandler.Topic = nameof(KafkaTopic.GenerateReportRequested) + "-Retry";
+
+            _deadLetterExceptionHandler.ServiceName = ReportConstants.ServiceName;
+            _deadLetterExceptionHandler.Topic = nameof(KafkaTopic.GenerateReportRequested) + "-Error";
+            _httpClientFactory = httpClientFactory;
+            _linkTokenServiceConfig = linkTokenService;
+            _createSystemToken = createSystemToken;
+            _serviceRegistry = serviceRegistry.Value;
+            _dataAcqProducer = dataAcqProducer;
+        }
+
+        protected override Task ExecuteAsync(CancellationToken stoppingToken)
+        {
+            return Task.Run(() => StartConsumerLoop(stoppingToken), stoppingToken);
+        }
+
+
+        private async void StartConsumerLoop(CancellationToken cancellationToken)
+        {
+            var config = new ConsumerConfig()
+            {
+                GroupId = ReportConstants.ServiceName,
+                EnableAutoCommit = false
+            };
+
+            using var consumer = _kafkaConsumerFactory.CreateConsumer(config);
+            try
+            {
+                consumer.Subscribe(nameof(KafkaTopic.GenerateReportRequested));
+                _logger.LogInformation($"Started report scheduled consumer for topic '{nameof(KafkaTopic.GenerateReportRequested)}' at {DateTime.UtcNow}");
+
+                while (!cancellationToken.IsCancellationRequested)
+                {
+                    string facilityId = string.Empty;
+                    try
+                    {
+                        await consumer.ConsumeWithInstrumentation(async (result, consumeCancellationToken) =>
+                        {
+                            if (result == null)
+                            {
+                                consumer.Commit();
+                                return;
+                            }
+
+                            try
+                            {
+                                var scope = _serviceScopeFactory.CreateScope();
+                                var measureReportScheduledManager =
+                                    scope.ServiceProvider.GetRequiredService<IReportScheduledManager>();
+
+                                var key = result.Message.Key;
+                                var value = result.Message.Value;
+                                var startDate = value.StartDate;
+                                var endDate = value.EndDate;
+                                var reportTypes = value.ReportTypes?.ToArray();
+
+                                facilityId = key;
+
+
+                                if (string.IsNullOrWhiteSpace(facilityId))
+                                {
+                                    throw new DeadLetterException(
+                                        $"{Name}: FacilityId is null or empty.");
+                                }
+
+                                result.Message.Headers.TryGetLastBytes("X-Report-Tracking-Id", out var headerValue);
+                                var newReportId = System.Text.Encoding.UTF8.GetString(headerValue);
+
+                                //If we are re-running an existing report, fetch the details from the database and replace the Values retrieved from the message
+                                if (value.ReportId != null)
+                                {
+                                    var existing = await measureReportScheduledManager.SingleOrDefaultAsync(x => x.Id == value.ReportId, consumeCancellationToken);
+
+                                    if(existing == null)
+                                    {
+                                        throw new DeadLetterException("No ReportSchedule found for the provided ID: " + HtmlInputSanitizer.Sanitize(value.ReportId));
+                                    }
+
+                                    startDate = existing.ReportStartDate;
+                                    endDate = existing.ReportEndDate;
+                                    reportTypes = existing.ReportTypes;
+                                }
+                                else //Otherwise validate the values from the message
+                                {
+                                    if (reportTypes == null || reportTypes.Length == 0)
+                                    {
+                                        throw new DeadLetterException(
+                                            $"{Name}: ReportTypes is null or empty.");
+                                    }
+
+                                    if (startDate == null || endDate == null)
+                                    {
+                                        throw new DeadLetterException("Start and End dates must be provided.");
+                                    }
+                                    
+                                }
+
+                                // Create ReportSchedule for AdHoc Report
+                                var reportSchedule = new ReportScheduleModel
+                                {
+                                    Id = newReportId,
+                                    FacilityId = facilityId,
+                                    ReportStartDate = startDate.Value,
+                                    ReportEndDate = endDate.Value,
+                                    Frequency = "AdHoc",
+                                    ReportTypes = reportTypes.ToArray(),
+                                    PatientsToQueryDataRequested = true,
+                                    CreateDate = DateTime.UtcNow
+                                };
+
+                                await measureReportScheduledManager.AddAsync(reportSchedule, cancellationToken);
+
+                                // Get Patient List if none was provided or we are re-running an existing report
+                                if (value.PatientIds == null || value.PatientIds.Count == 0)
+                                {
+                                    value.PatientIds = await GetPatientList(facilityId, startDate.Value, endDate.Value);
+                                }
+
+                                foreach (var patient in value.PatientIds)
+                                {
+                                    //For each patient and report type, Create Submission Entries for each Patient and Report Type
+                                    foreach (var reportType in reportTypes)
+                                    {
+                                        var submissionEntryManager =
+                                            scope.ServiceProvider.GetRequiredService<ISubmissionEntryManager>();
+
+                                        await submissionEntryManager.AddAsync(new MeasureReportSubmissionEntryModel()
+                                        {
+                                            PatientId = patient,
+                                            Status = PatientSubmissionStatus.NotEvaluated,
+                                            ReportScheduleId = newReportId,
+                                            FacilityId = facilityId,
+                                            ReportType = reportType,
+                                        }, cancellationToken);
+                                    }
+
+                                    //Submit a Data Acquisition Request for each patient
+                                    var darValue = new DataAcquisitionRequestedValue()
+                                    {
+                                        PatientId = patient,
+                                        ReportableEvent = "AdHoc",
+                                        ScheduledReports = new List<ScheduledReport>()
+                                            {
+                                                new ()
+                                                {
+                                                    StartDate = startDate.Value,
+                                                    EndDate = endDate.Value,
+                                                    Frequency = "AdHoc",
+                                                    ReportTypes = reportTypes
+                                                }
+                                            },
+                                        QueryType = QueryType.Initial.ToString(),
+                                    };
+
+                                    _dataAcqProducer.Produce(nameof(KafkaTopic.DataAcquisitionRequested), new Message<string, DataAcquisitionRequestedValue>
+                                    {
+                                        Key = facilityId,
+                                        Value = darValue,
+                                        Headers = result.Message.Headers
+                                    });
+
+                                    _dataAcqProducer.Flush(cancellationToken);
+                                }
+                            }
+                            catch (DeadLetterException ex)
+                            {
+                                _deadLetterExceptionHandler.HandleException(result, ex, facilityId);
+                            }
+                            catch (TransientException ex)
+                            {
+                                _transientExceptionHandler.HandleException(result, ex, facilityId);
+                            }
+                            catch (TimeoutException ex)
+                            {
+                                var transientException = new TransientException(ex.Message, ex.InnerException);
+
+                                _transientExceptionHandler.HandleException(result, transientException, facilityId);
+                            }
+                            catch (Exception ex)
+                            {
+                                _transientExceptionHandler.HandleException(result, ex, facilityId);
+                            }
+                            finally
+                            {
+                                consumer.Commit(result);
+                            }
+                        }, cancellationToken);
+
+                    }
+                    catch (ConsumeException ex)
+                    {
+                        _logger.LogError(ex, "Error consuming message for topics: [{1}] at {2}", string.Join(", ", consumer.Subscription), DateTime.UtcNow);
+
+                        if (ex.Error.Code == ErrorCode.UnknownTopicOrPart)
+                        {
+                            throw new OperationCanceledException(ex.Error.Reason, ex);
+                        }
+
+                        facilityId = GetFacilityIdFromHeader(ex.ConsumerRecord.Message.Headers);
+
+                        _deadLetterExceptionHandler.HandleConsumeException(ex, facilityId);
+
+                        var offset = ex.ConsumerRecord?.TopicPartitionOffset;
+                        consumer.Commit(offset == null ? new List<TopicPartitionOffset>() : new List<TopicPartitionOffset> { offset });
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.LogError(ex, "Error encountered in ReportScheduledListener");
+                        consumer.Commit();
+                    }
+                }
+            }
+            catch (OperationCanceledException oce)
+            {
+                _logger.LogError(oce, $"Operation Canceled: {oce.Message}");
+                consumer.Close();
+                consumer.Dispose();
+            }
+        }
+
+        private async Task<List<string>> GetPatientList(string facilityId, DateTime startDate, DateTime enddate)
+        {
+            string dtFormat = "yyyy-MM-ddTHH:mm:ss.fffZ";
+            var httpClient = _httpClientFactory.CreateClient();
+
+            string censusRequestUrl = $"{_serviceRegistry.CensusServiceApiUrl}/Census/{facilityId}/history/admitted?startDate={startDate.ToString(dtFormat)}&endDate={enddate.ToString(dtFormat)}";
+
+            if (_linkTokenServiceConfig.Value.SigningKey is null)
+                throw new Exception("Link Token Service Signing Key is missing.");
+
+            //Add link token
+            var token = _createSystemToken.ExecuteAsync(_linkTokenServiceConfig.Value.SigningKey, 5).Result;
+            httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+
+            var censusResponse = await httpClient.GetAsync(censusRequestUrl, CancellationToken.None);
+            var censusContent = await censusResponse.Content.ReadAsStringAsync(CancellationToken.None);
+
+            if (!censusResponse.IsSuccessStatusCode)
+                throw new TransientException("Response from Census service is not successful: " + censusContent);
+
+            List? admittedPatients;
+            try
+            {
+                admittedPatients =
+                    System.Text.Json.JsonSerializer.Deserialize<List>(
+                        censusContent,
+                        new JsonSerializerOptions().ForFhir());
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error deserializing admitted patients from Census service response.");
+                _logger.LogDebug("Census service response: " + censusContent);
+                throw new TransientException("Error deserializing admitted patients from Census service response: " + ex.Message + Environment.NewLine + ex.StackTrace, ex.InnerException);
+            }
+
+            return admittedPatients?.Entry?.Select(p => p.Item.Reference).ToList() ?? new List<string>();
+        }
+
+        private static string GetFacilityIdFromHeader(Headers headers)
+        {
+            string facilityId = string.Empty;
+
+            if (headers.TryGetLastBytes(KafkaConstants.HeaderConstants.ExceptionFacilityId, out var facilityIdBytes))
+            {
+                facilityId = Encoding.UTF8.GetString(facilityIdBytes);
+            }
+
+            return facilityId;
+        }
+    }
+}

--- a/DotNet/Report/Listeners/GenerateReportListener.cs
+++ b/DotNet/Report/Listeners/GenerateReportListener.cs
@@ -171,6 +171,7 @@ namespace LantanaGroup.Link.Report.Listeners
                                     Frequency = "AdHoc",
                                     ReportTypes = reportTypes.ToArray(),
                                     PatientsToQueryDataRequested = true,
+                                    EnableSubmission = !value.BypassSubmission,
                                     CreateDate = DateTime.UtcNow
                                 };
 

--- a/DotNet/Report/Listeners/GenerateReportListener.cs
+++ b/DotNet/Report/Listeners/GenerateReportListener.cs
@@ -296,7 +296,7 @@ namespace LantanaGroup.Link.Report.Listeners
                 throw new Exception("Link Token Service Signing Key is missing.");
 
             //Add link token
-            var token = _createSystemToken.ExecuteAsync(_linkTokenServiceConfig.Value.SigningKey, 5).Result;
+            var token = await _createSystemToken.ExecuteAsync(_linkTokenServiceConfig.Value.SigningKey, 5);
             httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
 
             var censusResponse = await httpClient.GetAsync(censusRequestUrl, CancellationToken.None);

--- a/DotNet/Report/Listeners/GenerateReportListener.cs
+++ b/DotNet/Report/Listeners/GenerateReportListener.cs
@@ -81,7 +81,7 @@ namespace LantanaGroup.Link.Report.Listeners
         }
 
 
-        private async void StartConsumerLoop(CancellationToken cancellationToken)
+        private async Task StartConsumerLoop(CancellationToken cancellationToken)
         {
             var config = new ConsumerConfig()
             {

--- a/DotNet/Report/Listeners/GenerateReportListener.cs
+++ b/DotNet/Report/Listeners/GenerateReportListener.cs
@@ -130,6 +130,10 @@ namespace LantanaGroup.Link.Report.Listeners
                                 }
 
                                 result.Message.Headers.TryGetLastBytes("X-Report-Tracking-Id", out var headerValue);
+                                if (headerValue == null)
+                                {
+                                    throw new DeadLetterException("Header 'X-Report-Tracking-Id' not found in message headers.");
+                                }
                                 var newReportId = System.Text.Encoding.UTF8.GetString(headerValue);
 
                                 //If we are re-running an existing report, fetch the details from the database and replace the Values retrieved from the message

--- a/DotNet/Report/Listeners/GenerateReportListener.cs
+++ b/DotNet/Report/Listeners/GenerateReportListener.cs
@@ -301,7 +301,7 @@ namespace LantanaGroup.Link.Report.Listeners
             string dtFormat = "yyyy-MM-ddTHH:mm:ss.fffZ";
             var httpClient = _httpClientFactory.CreateClient();
 
-            string censusRequestUrl = $"{_serviceRegistry.CensusServiceApiUrl}/Census/{facilityId}/history/admitted?startDate={startDate.ToString(dtFormat)}&endDate={enddate.ToString(dtFormat)}";
+            string censusRequestUrl = $"{_serviceRegistry.CensusServiceApiUrl}/Census/{Uri.EscapeDataString(facilityId)}/history/admitted?startDate={Uri.EscapeDataString(startDate.ToString(dtFormat))}&endDate={Uri.EscapeDataString(enddate.ToString(dtFormat))}";
 
             if (_linkTokenServiceConfig.Value.SigningKey is null)
                 throw new Exception("Link Token Service Signing Key is missing.");

--- a/DotNet/Report/Listeners/GenerateReportListener.cs
+++ b/DotNet/Report/Listeners/GenerateReportListener.cs
@@ -165,6 +165,10 @@ namespace LantanaGroup.Link.Report.Listeners
                                     {
                                         throw new DeadLetterException("Start and End dates must be provided.");
                                     }
+                                    if (endDate <= startDate)
+                                    {
+                                        throw new DeadLetterException("End date must be after start date.");
+                                    }
                                     
                                 }
 

--- a/DotNet/Report/Listeners/GenerateReportListener.cs
+++ b/DotNet/Report/Listeners/GenerateReportListener.cs
@@ -310,8 +310,9 @@ namespace LantanaGroup.Link.Report.Listeners
             var token = _createSystemToken.ExecuteAsync(_linkTokenServiceConfig.Value.SigningKey, 5).Result;
             httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
 
-            var censusResponse = await httpClient.GetAsync(censusRequestUrl, CancellationToken.None);
-            var censusContent = await censusResponse.Content.ReadAsStringAsync(CancellationToken.None);
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+            var censusResponse = await httpClient.GetAsync(censusRequestUrl, cts.Token);
+            var censusContent = await censusResponse.Content.ReadAsStringAsync(cts.Token);
 
             if (!censusResponse.IsSuccessStatusCode)
                 throw new TransientException("Response from Census service is not successful: " + censusContent);

--- a/DotNet/Report/Listeners/GenerateReportListener.cs
+++ b/DotNet/Report/Listeners/GenerateReportListener.cs
@@ -310,7 +310,7 @@ namespace LantanaGroup.Link.Report.Listeners
             var token = await _createSystemToken.ExecuteAsync(_linkTokenServiceConfig.Value.SigningKey, 5);
             httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
 
-            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(120));
             var censusResponse = await httpClient.GetAsync(censusRequestUrl, cts.Token);
             var censusContent = await censusResponse.Content.ReadAsStringAsync(cts.Token);
 

--- a/DotNet/Report/Program.cs
+++ b/DotNet/Report/Program.cs
@@ -118,6 +118,7 @@ static void RegisterServices(WebApplicationBuilder builder)
     // Add factories
     builder.Services.AddTransient<IKafkaConsumerFactory<ResourceEvaluatedKey, ResourceEvaluatedValue>, KafkaConsumerFactory<ResourceEvaluatedKey, ResourceEvaluatedValue>>();
 
+    builder.Services.AddTransient<IKafkaConsumerFactory<string, GenerateReportValue>, KafkaConsumerFactory<string, GenerateReportValue>>();
     builder.Services.AddTransient<IKafkaConsumerFactory<string, ReportScheduledValue>, KafkaConsumerFactory<string, ReportScheduledValue>>();
     builder.Services.AddTransient<IKafkaConsumerFactory<ReportSubmittedKey, ReportSubmittedValue>, KafkaConsumerFactory<ReportSubmittedKey, ReportSubmittedValue>>();
     builder.Services.AddTransient<IKafkaConsumerFactory<string, string>, KafkaConsumerFactory<string, string>>();
@@ -134,6 +135,7 @@ static void RegisterServices(WebApplicationBuilder builder)
     builder.Services.AddTransient<IKafkaProducerFactory<string, ReportScheduledValue>, KafkaProducerFactory<string, ReportScheduledValue>>();
     builder.Services.AddTransient<IKafkaProducerFactory<ResourceEvaluatedKey, ResourceEvaluatedValue>, KafkaProducerFactory<ResourceEvaluatedKey, ResourceEvaluatedValue>>();
     builder.Services.AddTransient<IKafkaProducerFactory<string, PatientIdsAcquiredValue>, KafkaProducerFactory<string, PatientIdsAcquiredValue>>();
+    builder.Services.AddTransient<IKafkaProducerFactory<string, GenerateReportValue>, KafkaProducerFactory<string, GenerateReportValue>>();
 
     // Add repositories
     builder.Services.AddTransient<IEntityRepository<ReportScheduleModel>, MongoEntityRepository<ReportScheduleModel>>();
@@ -225,6 +227,7 @@ static void RegisterServices(WebApplicationBuilder builder)
     builder.Services.AddSingleton<GenerateDataAcquisitionRequestsForPatientsToQuery>();
 
     // Add hosted services
+    builder.Services.AddHostedService<GenerateReportListener>();
     builder.Services.AddHostedService<ResourceEvaluatedListener>();
     builder.Services.AddHostedService<ReportScheduledListener>();
     builder.Services.AddHostedService<PatientIdsAcquiredListener>();
@@ -243,6 +246,10 @@ static void RegisterServices(WebApplicationBuilder builder)
     builder.Services.AddSingleton<UpdateBaseEntityInterceptor>();
 
     #region Exception Handling
+    //Generate Report Listener
+    builder.Services.AddTransient<IDeadLetterExceptionHandler<string, GenerateReportValue>, DeadLetterExceptionHandler<string, GenerateReportValue>>();
+    builder.Services.AddTransient<ITransientExceptionHandler<string, GenerateReportValue>, TransientExceptionHandler<string, GenerateReportValue>>();
+
     //Report Scheduled Listener
     builder.Services.AddTransient<IDeadLetterExceptionHandler<string, ReportScheduledValue>, DeadLetterExceptionHandler<string, ReportScheduledValue>>();
     builder.Services.AddTransient<ITransientExceptionHandler<string, ReportScheduledValue>, TransientExceptionHandler<string, ReportScheduledValue>>();

--- a/DotNet/Shared/Application/Repositories/Implementations/EntityRepository.cs
+++ b/DotNet/Shared/Application/Repositories/Implementations/EntityRepository.cs
@@ -24,7 +24,7 @@ public class EntityRepository<T> : IEntityRepository<T> where T : BaseEntity
 
     public virtual async Task<T> AddAsync(T entity, CancellationToken cancellationToken = default)
     {
-        entity.Id = Guid.NewGuid().ToString();
+        entity.Id ??= Guid.NewGuid().ToString();
 
         var result = (await _dbContext.Set<T>().AddAsync(entity, cancellationToken)).Entity;
 

--- a/DotNet/Shared/Application/Repositories/Implementations/MongoEntityRepository.cs
+++ b/DotNet/Shared/Application/Repositories/Implementations/MongoEntityRepository.cs
@@ -47,7 +47,7 @@ public class MongoEntityRepository<T> : IEntityRepository<T> where T : BaseEntit
 
     public virtual T Add(T entity)
     {
-        entity.Id = Guid.NewGuid().ToString();
+        entity.Id ??= Guid.NewGuid().ToString();
 
         try
         {


### PR DESCRIPTION
### 🛠️ Description of Changes

Added a GenerateReportListener to process those kafka events

### 🧪 Testing Performed

Ran Report/Census locally and generated kafka messages to be processed by the new listener.

### 📓 Documentation Updated

Please update any relevant sections in the project documentation that were impacted by the changes in the PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

Based on the comprehensive changes, here are the updated release notes:

- **New Features**
  - Added ability to generate ad-hoc and regenerate reports for facilities
  - Introduced new report scheduling and generation capabilities
  - Enhanced report request handling with Kafka message processing
  - Added support for input validation in report scheduling

- **Improvements**
  - Improved error handling for report generation
  - Added validation for report requests
  - Expanded facility configuration service functionality
  - Introduced a new property to control report submission behavior

- **Technical Enhancements**
  - Implemented new Kafka message handling for report generation
  - Updated repository entity management to preserve existing IDs
  - Refined service registration and dependency injection

- **Models**
  - Added new models for report requests and report schedule summaries

These changes expand the system's reporting capabilities with more flexible and robust report generation mechanisms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->