### PR TITLE
LNK-3341: Add X-Report-Tracking-Id Data Acquisition

### DIFF
--- a/DotNet/DataAcquisition.Domain/Models/Frequency.cs
+++ b/DotNet/DataAcquisition.Domain/Models/Frequency.cs
@@ -13,5 +13,7 @@ public enum Frequency
     [StringValue("Weekly")]
     Weekly = 2,
     [StringValue("Monthly")]
-    Monthly = 3
+    Monthly = 3,
+    [StringValue("Adhoc")]
+    Adhoc = 4
 }

--- a/DotNet/DataAcquisition.Domain/Settings/DataAcquisitionConstants.cs
+++ b/DotNet/DataAcquisition.Domain/Settings/DataAcquisitionConstants.cs
@@ -34,6 +34,7 @@ public static class DataAcquisitionConstants
     public static class HeaderNames
     {
         public const string CorrelationId = "X-Correlation-Id";
+        public const string ReportId = "X-Report-Tracking-Id";
     }
 
     public static class ContentTypes

--- a/DotNet/DataAcquisition/Application/Factories/ReportableEventToQueryPlanTypeFactory.cs
+++ b/DotNet/DataAcquisition/Application/Factories/ReportableEventToQueryPlanTypeFactory.cs
@@ -14,6 +14,7 @@ public class ReportableEventToQueryPlanTypeFactory
             ReportableEvent.EOM => Frequency.Monthly,
             ReportableEvent.EOW => Frequency.Weekly,
             ReportableEvent.EOD => Frequency.Daily,
+            ReportableEvent.Adhoc => Frequency.Discharge,
             _ => throw new ArgumentException("Invalid reportable event type")
 
         };

--- a/DotNet/DataAcquisition/Application/Models/GetPatientDataRequest.cs
+++ b/DotNet/DataAcquisition/Application/Models/GetPatientDataRequest.cs
@@ -8,6 +8,7 @@ namespace LantanaGroup.Link.DataAcquisition.Application.Models
         public string FacilityId { get; set; }
         public ConsumeResult<string, DataAcquisitionRequested> ConsumeResult { get; set; }
         public string CorrelationId { get; set; }
+        public string ReportTrackingId { get; set; }
         public QueryPlanType QueryPlanType { get; set; }
     }
 }

--- a/DotNet/DataAcquisition/Application/Models/ReportableEvent.cs
+++ b/DotNet/DataAcquisition/Application/Models/ReportableEvent.cs
@@ -13,5 +13,7 @@ public enum ReportableEvent
     [StringValue("EOW")]
     EOW,
     [StringValue("EOD")]
-    EOD
+    EOD,
+    [StringValue("Adhoc")]
+    Adhoc
 }

--- a/DotNet/DataAcquisition/Application/Services/BundleEventService.cs
+++ b/DotNet/DataAcquisition/Application/Services/BundleEventService.cs
@@ -9,14 +9,14 @@ using LantanaGroup.Link.DataAcquisition.Application.Models;
 
 namespace LantanaGroup.Link.DataAcquisition.Application.Services;
 
-public record ResourceRequiredMessageRequest(string facilityId, string patientId, string queryType, string correlationId, ReportableEvent ReportableEvent, List<ScheduledReport> scheduledReports);
+public record ResourceAcquiredMessageGenerationRequest(string facilityId, string patientId, string queryType, string correlationId, string reportTrackingId, ReportableEvent ReportableEvent, List<ScheduledReport> scheduledReports);
 
 public interface IBundleEventService<EventKey, EventValue, EventRequest>
 {
     Task GenerateEventAsync(Bundle bundle, EventRequest request, CancellationToken cancellationToken = default);
 }
 
-public class BundleResourceAcquiredEventService : IBundleEventService<string, ResourceAcquired, ResourceRequiredMessageRequest>
+public class BundleResourceAcquiredEventService : IBundleEventService<string, ResourceAcquired, ResourceAcquiredMessageGenerationRequest>
 {
     private readonly ILogger<BundleResourceAcquiredEventService> _logger;
     private readonly IProducer<string, ResourceAcquired> _producer;
@@ -27,7 +27,7 @@ public class BundleResourceAcquiredEventService : IBundleEventService<string, Re
         _producer = producer ?? throw new ArgumentNullException(nameof(producer));
     }
 
-    public async Task GenerateEventAsync(Bundle bundle, ResourceRequiredMessageRequest request, CancellationToken cancellationToken = default)
+    public async Task GenerateEventAsync(Bundle bundle, ResourceAcquiredMessageGenerationRequest request, CancellationToken cancellationToken = default)
     {
         foreach (var e in bundle.Entry)
         {
@@ -40,7 +40,8 @@ public class BundleResourceAcquiredEventService : IBundleEventService<string, Re
                         Key = request.facilityId,
                         Headers = new Headers
                         {
-                            new Header(DataAcquisitionConstants.HeaderNames.CorrelationId, Encoding.UTF8.GetBytes(request.correlationId))
+                            new Header(DataAcquisitionConstants.HeaderNames.CorrelationId, Encoding.UTF8.GetBytes(request.correlationId)),
+                            new Header(DataAcquisitionConstants.HeaderNames.ReportId, Encoding.UTF8.GetBytes(request.reportTrackingId ?? string.Empty))
                         },
                         Value = new ResourceAcquired
                         {

--- a/DotNet/DataAcquisition/Application/Services/FhirApi/FhirApiService.cs
+++ b/DotNet/DataAcquisition/Application/Services/FhirApi/FhirApiService.cs
@@ -211,7 +211,7 @@ public class FhirApiService : IFhirApiService
                 }
             }
 
-            var resource = await ReadFhirEndpointAsync(fhirClient, config.ResourceType, resourceId, patientIdReference, correlationId, facilityId, queryType);
+            var resource = await ReadFhirEndpointAsync(fhirClient, config.ResourceType, resourceId, patientIdReference, correlationId, null, facilityId, queryType);
             bundle.AddResourceEntry(resource, resource.ResourceBase.AbsolutePath);
         }
         else
@@ -266,7 +266,7 @@ public class FhirApiService : IFhirApiService
             fhirClient.RequestHeaders.Authorization = (AuthenticationHeaderValue)authBuilderResults.authHeader;
         }
 
-        return (Patient)await ReadFhirEndpointAsync(fhirClient, nameof(Patient), patientId, patientId, correlationId, facilityId, QueryPlanType.Initial.ToString());
+        return (Patient)await ReadFhirEndpointAsync(fhirClient, nameof(Patient), patientId, patientId, correlationId, null, facilityId, QueryPlanType.Initial.ToString());
     }
 
     public async Task<List> GetPatientList(string baseUrl, string listId, AuthenticationConfiguration authConfig, CancellationToken cancellationToken = default)
@@ -288,6 +288,7 @@ public class FhirApiService : IFhirApiService
         string resourceType,
         string? patientId = default,
         string? correlationId = default,
+        string? reportTrackingId = default,
         string? facilityId = default,
         string? queryType = default,
         List<ScheduledReport>? reports = default,
@@ -324,7 +325,7 @@ public class FhirApiService : IFhirApiService
             if (resultBundle != null)
             {
                 if (generateMessages)
-                    await _bundleResourceAcquiredEventService.GenerateEventAsync(resultBundle, new ResourceRequiredMessageRequest(facilityId, patientId, queryType, correlationId, reportableEvent, reports), cancellationToken);
+                    await _bundleResourceAcquiredEventService.GenerateEventAsync(resultBundle, new ResourceAcquiredMessageGenerationRequest(facilityId, patientId, queryType, correlationId, reportTrackingId, reportableEvent, reports), cancellationToken);
 
                 foreach (var entry in resultBundle.Entry)
                 {
@@ -383,7 +384,7 @@ public class FhirApiService : IFhirApiService
                             newResultBundle.Entry.AddRange(resultBundle.Entry);
                         
                         if(generateMessages)
-                            await _bundleResourceAcquiredEventService.GenerateEventAsync(resultBundle, new ResourceRequiredMessageRequest(facilityId, patientId, queryType, correlationId, reportableEvent, reports), cancellationToken);
+                            await _bundleResourceAcquiredEventService.GenerateEventAsync(resultBundle, new ResourceAcquiredMessageGenerationRequest(facilityId, patientId, queryType, correlationId, reportTrackingId, reportableEvent, reports), cancellationToken);
 
                         foreach (var entry in resultBundle.Entry)
                         {
@@ -445,6 +446,7 @@ public class FhirApiService : IFhirApiService
         string id,
         string? patientId = default,
         string? correlationId = default,
+        string? reportTrackingId = default,
         string? facilityId = default,
         string? queryType = default,
         ReportableEvent reportableEvent = default,
@@ -499,7 +501,7 @@ public class FhirApiService : IFhirApiService
         if (readResource != null)
         {
             if (generateMessages)
-                await _bundleResourceAcquiredEventService.GenerateEventAsync(new Bundle { Entry = new List<Bundle.EntryComponent> { new Bundle.EntryComponent { Resource = readResource } } }, new ResourceRequiredMessageRequest(facilityId, patientId, queryType, correlationId, reportableEvent, new List<ScheduledReport> { report }), cancellationToken);
+                await _bundleResourceAcquiredEventService.GenerateEventAsync(new Bundle { Entry = new List<Bundle.EntryComponent> { new Bundle.EntryComponent { Resource = readResource } } }, new ResourceAcquiredMessageGenerationRequest(facilityId, patientId, queryType, correlationId, reportTrackingId, reportableEvent, new List<ScheduledReport> { report }), cancellationToken);
 
             if (readResource is not OperationOutcome)
             {
@@ -657,7 +659,7 @@ public class FhirApiService : IFhirApiService
                 parameters.Add(kvPair.Key, kvPair.Value);
             }
 
-            var results = await SearchFhirEndpointAsync(parameters, fhirClient, config.ResourceType, request.ConsumeResult.Value.PatientId, request.CorrelationId, request.FacilityId, queryType, request.ConsumeResult.Value.ScheduledReports, referenceTypes, request.ConsumeResult.Value.ReportableEvent, true, false);
+            var results = await SearchFhirEndpointAsync(parameters, fhirClient, config.ResourceType, request.ConsumeResult.Value.PatientId, request.CorrelationId, request.ReportTrackingId ?? null, request.FacilityId, queryType, request.ConsumeResult.Value.ScheduledReports, referenceTypes, request.ConsumeResult.Value.ReportableEvent, true, false);
             references.AddRange(results.ResourceReference);
         }
 
@@ -705,9 +707,9 @@ public class FhirApiService : IFhirApiService
                 }
             }
 
-            var resource = await ReadFhirEndpointAsync(fhirClient, config.ResourceType, resourceId, request.ConsumeResult.Value.PatientId, request.CorrelationId, request.FacilityId, queryType, request.ConsumeResult.Value.ReportableEvent);
+            var resource = await ReadFhirEndpointAsync(fhirClient, config.ResourceType, resourceId, request.ConsumeResult.Value.PatientId, request.CorrelationId, null, request.FacilityId, queryType, request.ConsumeResult.Value.ReportableEvent);
             
-            await _bundleResourceAcquiredEventService.GenerateEventAsync(new Bundle { Entry = new List<Bundle.EntryComponent> { new Bundle.EntryComponent { Resource = resource } } }, new ResourceRequiredMessageRequest(request.FacilityId, request.ConsumeResult.Value.PatientId, queryType, request.CorrelationId, request.ConsumeResult.Value.ReportableEvent, request.ConsumeResult.Value.ScheduledReports));
+            await _bundleResourceAcquiredEventService.GenerateEventAsync(new Bundle { Entry = new List<Bundle.EntryComponent> { new Bundle.EntryComponent { Resource = resource } } }, new ResourceAcquiredMessageGenerationRequest(request.FacilityId, request.ConsumeResult.Value.PatientId, queryType, request.CorrelationId, request.ReportTrackingId, request.ConsumeResult.Value.ReportableEvent, request.ConsumeResult.Value.ScheduledReports));
 
             references.AddRange(ReferenceResourceBundleExtractor.Extract(new Bundle { Entry = new List<Bundle.EntryComponent> { new Bundle.EntryComponent { Resource = resource } } }, resourceTypes));
         }
@@ -724,7 +726,7 @@ public class FhirApiService : IFhirApiService
                 query.SearchParams.Add(kvPair.Key, kvPair.Value);
             }
 
-            var result = await SearchFhirEndpointAsync(query.SearchParams, fhirClient, config.ResourceType, request.ConsumeResult.Value.PatientId, request.CorrelationId, request.FacilityId, queryType, request.ConsumeResult.Value.ScheduledReports, resourceTypes, request.ConsumeResult.Value.ReportableEvent, true, false);
+            var result = await SearchFhirEndpointAsync(query.SearchParams, fhirClient, config.ResourceType, request.ConsumeResult.Value.PatientId, request.CorrelationId, request.ReportTrackingId, request.FacilityId, queryType, request.ConsumeResult.Value.ScheduledReports, resourceTypes, request.ConsumeResult.Value.ReportableEvent, true, false);
 
             references.AddRange(result.ResourceReference);
         }
@@ -771,7 +773,7 @@ public class FhirApiService : IFhirApiService
                 }
             }
 
-            var result = await ReadFhirEndpointAsync(fhirClient, resourceType, refId, request.ConsumeResult.Value.PatientId.SplitReference(), request.CorrelationId, request.FacilityId, queryPlanType);
+            var result = await ReadFhirEndpointAsync(fhirClient, resourceType, refId, request.ConsumeResult.Value.PatientId.SplitReference(), request.CorrelationId, null, request.FacilityId, queryPlanType);
 
             if (result.TypeName == nameof(OperationOutcome))
             {
@@ -804,7 +806,7 @@ public class FhirApiService : IFhirApiService
 
             await _bundleResourceAcquiredEventService.GenerateEventAsync(
                 new Bundle { Entry = new List<Bundle.EntryComponent> { new Bundle.EntryComponent { Resource = result } } }, 
-                new ResourceRequiredMessageRequest(request.FacilityId, request.ConsumeResult.Value.PatientId?.SplitReference(), queryPlanType, request.CorrelationId, request.ConsumeResult.Value.ReportableEvent, request.ConsumeResult.Value.ScheduledReports));
+                new ResourceAcquiredMessageGenerationRequest(request.FacilityId, request.ConsumeResult.Value.PatientId?.SplitReference(), queryPlanType, request.CorrelationId, request.ReportTrackingId, request.ConsumeResult.Value.ReportableEvent, request.ConsumeResult.Value.ScheduledReports));
         }
         else
         {
@@ -828,7 +830,7 @@ public class FhirApiService : IFhirApiService
                 searchParams.Add(kvPair.Key, kvPair.Value);
             }
 
-            await SearchFhirEndpointAsync(searchParams, fhirClient, resourceType, request.ConsumeResult.Value.PatientId?.SplitReference(), request.CorrelationId, request.FacilityId, queryPlanType, request.ConsumeResult.Value.ScheduledReports, null, request.ConsumeResult.Value.ReportableEvent, true, false, true);
+            await SearchFhirEndpointAsync(searchParams, fhirClient, resourceType, request.ConsumeResult.Value.PatientId?.SplitReference(), request.CorrelationId, request.ReportTrackingId, request.FacilityId, queryPlanType, request.ConsumeResult.Value.ScheduledReports, null, request.ConsumeResult.Value.ReportableEvent, true, false, true);
         }
     }
 }

--- a/DotNet/DataAcquisition/Application/Services/PatientDataService.cs
+++ b/DotNet/DataAcquisition/Application/Services/PatientDataService.cs
@@ -12,7 +12,6 @@ using LantanaGroup.Link.DataAcquisition.Domain.Models;
 using LantanaGroup.Link.DataAcquisition.Domain.Models.QueryConfig;
 using LantanaGroup.Link.DataAcquisition.Domain.Settings;
 using LantanaGroup.Link.Shared.Application.Models;
-using LantanaGroup.Link.Shared.Application.Utilities;
 using System.Text;
 using Task = System.Threading.Tasks.Task;
 
@@ -163,7 +162,8 @@ public class PatientDataService : IPatientDataService
                     Key = request.FacilityId,
                     Headers = new Headers
                     {
-                            new Header(DataAcquisitionConstants.HeaderNames.CorrelationId, Encoding.UTF8.GetBytes(request.CorrelationId))
+                            new Header(DataAcquisitionConstants.HeaderNames.CorrelationId, Encoding.UTF8.GetBytes(request.CorrelationId)),
+                            new Header(DataAcquisitionConstants.HeaderNames.ReportId, Encoding.UTF8.GetBytes(request.ReportTrackingId))
                     },
                     Value = new ResourceAcquired
                     {
@@ -203,7 +203,7 @@ public class PatientDataService : IPatientDataService
                 catch (Exception ex)
                 {
                     //produce tailing message
-                    await ProduceTailingMessage(request.FacilityId, request.CorrelationId, patientId, dataAcqRequested.QueryType, dataAcqRequested.ScheduledReports, cancellationToken);
+                    await ProduceTailingMessage(request.FacilityId, request.CorrelationId, request.ReportTrackingId, patientId, dataAcqRequested.QueryType, dataAcqRequested.ScheduledReports, cancellationToken);
 
                     var message =
                         $"Error retrieving data from EHR for facility: {request.FacilityId}\n{ex.Message}\n{ex.InnerException}";
@@ -214,10 +214,10 @@ public class PatientDataService : IPatientDataService
         //}
 
         //produce tailing message to indicate acquisition is complete
-        await ProduceTailingMessage(request.FacilityId, request.CorrelationId, patientId, dataAcqRequested.QueryType, dataAcqRequested.ScheduledReports, cancellationToken);
+        await ProduceTailingMessage(request.FacilityId, request.CorrelationId, request.ReportTrackingId, patientId, dataAcqRequested.QueryType, dataAcqRequested.ScheduledReports, cancellationToken);
     }
 
-    private async Task ProduceTailingMessage(string facilityId, string correlationId, string patientId, string queryType, List<ScheduledReport> scheduledReports, CancellationToken cancellationToken)
+    private async Task ProduceTailingMessage(string facilityId, string correlationId, string reportTrackingId, string patientId, string queryType, List<ScheduledReport> scheduledReports, CancellationToken cancellationToken)
     {
         await _kafkaProducer.ProduceAsync(
             KafkaTopic.ResourceAcquired.ToString(),
@@ -226,7 +226,8 @@ public class PatientDataService : IPatientDataService
                 Key = facilityId,
                 Headers = new Headers
                 {
-                        new Header(DataAcquisitionConstants.HeaderNames.CorrelationId, Encoding.UTF8.GetBytes(correlationId))
+                        new Header(DataAcquisitionConstants.HeaderNames.CorrelationId, Encoding.UTF8.GetBytes(correlationId)),
+                        new Header(DataAcquisitionConstants.HeaderNames.ReportId, Encoding.UTF8.GetBytes(reportTrackingId))
                 },
                 Value = new ResourceAcquired
                 {

--- a/DotNet/DataAcquisition/Listeners/DataAcquisitionRequestedListener.cs
+++ b/DotNet/DataAcquisition/Listeners/DataAcquisitionRequestedListener.cs
@@ -32,6 +32,7 @@ public class DataAcquisitionRequestedListener : BaseListener<DataAcquisitionRequ
     {
         string facilityId;
         string correlationId;
+        string reportTrackingId;
 
         try
         {
@@ -41,6 +42,16 @@ public class DataAcquisitionRequestedListener : BaseListener<DataAcquisitionRequ
         {
             Logger.LogError(ex, "CorrelationId is missing from the message headers.");
             throw new DeadLetterException("CorrelationId is missing from the message headers.", ex);
+        }
+
+        try
+        {
+            reportTrackingId = ExtractReportId(consumeResult);
+        }
+        catch (ArgumentNullException ex)
+        {
+            Logger.LogError(ex, "ReportTrackingId is missing from the message headers (X-Report-Tracking-Id).");
+            throw new DeadLetterException("ReportTrackingId is missing from the message headers.", ex);
         }
 
         try
@@ -65,6 +76,7 @@ public class DataAcquisitionRequestedListener : BaseListener<DataAcquisitionRequ
             ConsumeResult = consumeResult,
             FacilityId = facilityId,
             CorrelationId = correlationId,
+            ReportTrackingId = reportTrackingId
         }, cancellationToken);
     }
 
@@ -85,6 +97,7 @@ public class DataAcquisitionRequestedListener : BaseListener<DataAcquisitionRequ
         return facilityId;
     }
 
+    
     protected override string ExtractCorrelationId(ConsumeResult<string, DataAcquisitionRequested> consumeResult)
     {
         var cIBytes = consumeResult.Headers
@@ -97,6 +110,20 @@ public class DataAcquisitionRequestedListener : BaseListener<DataAcquisitionRequ
 
         var correlationId = Encoding.UTF8.GetString(cIBytes);
         return correlationId;
+    }
+
+    private string ExtractReportId(ConsumeResult<string, DataAcquisitionRequested> consumeResult)
+    {
+        var cIBytes = consumeResult.Headers
+            .FirstOrDefault(x => x.Key.ToLower() == DataAcquisitionConstants.HeaderNames.ReportId.ToLower())
+            ?.GetValueBytes();
+
+        if (cIBytes == null || cIBytes.Length == 0)
+            throw new ArgumentNullException("Report ID is missing from the message headers.");
+
+
+        var reportId = Encoding.UTF8.GetString(cIBytes);
+        return reportId;
     }
 
 }

--- a/DotNet/DataAcquisition/Listeners/DataAcquisitionRequestedListener.cs
+++ b/DotNet/DataAcquisition/Listeners/DataAcquisitionRequestedListener.cs
@@ -46,7 +46,7 @@ public class DataAcquisitionRequestedListener : BaseListener<DataAcquisitionRequ
 
         try
         {
-            reportTrackingId = ExtractReportId(consumeResult);
+            reportTrackingId = ExtractReportTrackingId(consumeResult);
         }
         catch (ArgumentNullException ex)
         {
@@ -112,7 +112,7 @@ public class DataAcquisitionRequestedListener : BaseListener<DataAcquisitionRequ
         return correlationId;
     }
 
-    private string ExtractReportId(ConsumeResult<string, DataAcquisitionRequested> consumeResult)
+    protected override string ExtractReportTrackingId(ConsumeResult<string, DataAcquisitionRequested> consumeResult)
     {
         var cIBytes = consumeResult.Headers
             .FirstOrDefault(x => x.Key.ToLower() == DataAcquisitionConstants.HeaderNames.ReportId.ToLower())

--- a/DotNet/DataAcquisition/Listeners/PatientCensusScheduledListener.cs
+++ b/DotNet/DataAcquisition/Listeners/PatientCensusScheduledListener.cs
@@ -107,5 +107,7 @@ public class PatientCensusScheduledListener : BaseListener<PatientCensusSchedule
         var correlationId = Encoding.UTF8.GetString(cIBytes);
         return correlationId;
     }
+
+    protected override string ExtractReportTrackingId(ConsumeResult<string, PatientCensusScheduled> consumeResult) => string.Empty;
 }
 

--- a/DotNet/Shared/Application/BaseListener.cs
+++ b/DotNet/Shared/Application/BaseListener.cs
@@ -150,5 +150,6 @@ public abstract class BaseListener<MessageType, ConsumeKeyType, ConsumeValueType
     protected abstract ConsumerConfig CreateConsumerConfig();
     protected abstract string ExtractFacilityId(ConsumeResult<ConsumeKeyType, ConsumeValueType> consumeResult);
     protected abstract string ExtractCorrelationId(ConsumeResult<ConsumeKeyType, ConsumeValueType> consumeResult);
+    protected abstract string ExtractReportTrackingId(ConsumeResult<ConsumeKeyType, ConsumeValueType> consumeResult);
     protected abstract Task ExecuteListenerAsync(ConsumeResult<ConsumeKeyType, ConsumeValueType> consumeResult, CancellationToken cancellationToken = default);
 }


### PR DESCRIPTION
### 🛠️ Description of Changes

- Consume `X-Report-Tracking-Id` header from `DataAcquisitionRequested` message.
- Produce `X-Report-Tracking-Id` in the `ResourceAcquired `header.
- Add `reportTrackingId` parameter to methods within `FhirApiService`.
- Add abstract method `ExtractReportTrackingId `to `BaseListener`
- name fixes

### 🧪 Testing Performed

Local Testing: consumed `DataAcquisitionRequested` message and produced `ResourceAcquired` message.

### 📓 Documentation Updated

updated: https://lantana.atlassian.net/wiki/spaces/LSD/pages/214597642/Data+Acquisition+Service+V2
