### PR TITLE
LNK-3386: Add more descriptive logging for empty fhir list

### DIFF
--- a/DotNet/Census/Listeners/CensusListener.cs
+++ b/DotNet/Census/Listeners/CensusListener.cs
@@ -160,7 +160,11 @@ public class CensusListener : BackgroundService
                 {
                     _logger.LogError(ex, "Error consuming message for topics: [{1}] at {2}", string.Join(", ", kafkaConsumer.Subscription), DateTime.UtcNow);
 
-                    if (ex.Error.Code == ErrorCode.UnknownTopicOrPart)
+                    if(ex.Error.Code == ErrorCode.Local_ValueDeserialization)
+                    {
+                        _logger.LogError(ex, "Error deserializing message for topics: [{1}] at {2}. This error usually means that the FHIR List returned contained 0 elements. Message will be sent to DeadLetter queue.", string.Join(", ", kafkaConsumer.Subscription), DateTime.UtcNow);
+                    } 
+                    else if (ex.Error.Code == ErrorCode.UnknownTopicOrPart)
                     {
                         throw new OperationCanceledException(ex.Error.Reason, ex);
                     }

--- a/DotNet/Census/appsettings.json
+++ b/DotNet/Census/appsettings.json
@@ -7,7 +7,9 @@
   "AllowReflection": true,
   "KafkaConnection": {
     "BootstrapServers": [],
-    "ClientId": ""
+    "ClientId": "",
+    "SaslProtocolEnabled": true,
+    "SaslUsername": ""
   },
   "DatabaseProvider": "SqlServer",
   "ConnectionStrings": {


### PR DESCRIPTION
### 🛠️ Description of Changes

Firely Deserialization SDK fails when trying to deserialize an empty fhir list in Census. This adds more descriptive logging so that it can be properly recognized as the message is already properly going into the deadletter queue.

### 🧪 Testing Performed

Service level testing.

### 📓 Documentation Updated

n.a


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Configuration Updates**
	- Added SASL protocol support for Kafka connections
	- Enabled SASL authentication configuration

- **Error Handling Improvements**
	- Enhanced error handling for message consumption
	- Improved logging for deserialization and topic-related errors
	- Added more detailed error context for troubleshooting

<!-- end of auto-generated comment: release notes by coderabbit.ai -->