### PR TITLE
LNK-3224: Submission Metrics

### DIFF
--- a/DotNet/Report/Domain/Enums/PatientSubmissionStatus.cs
+++ b/DotNet/Report/Domain/Enums/PatientSubmissionStatus.cs
@@ -1,9 +1,14 @@
-﻿namespace LantanaGroup.Link.Report.Domain.Enums;
+﻿using System.Runtime.Serialization;
+
+namespace LantanaGroup.Link.Report.Domain.Enums;
 
 public enum PatientSubmissionStatus
 {
+    [EnumMember(Value = "NotEvaluated")]
     NotEvaluated = 1,
+    [EnumMember(Value = "NotReportable")]
     NotReportable = 2,
+    [EnumMember(Value = "ReadyForSubmission")]
     ReadyForSubmission = 3
 }
 

--- a/DotNet/Report/Entities/MeasureReportSubmissionEntryModel.cs
+++ b/DotNet/Report/Entities/MeasureReportSubmissionEntryModel.cs
@@ -24,7 +24,7 @@ namespace LantanaGroup.Link.Report.Entities
         public MeasureReport? MeasureReport { get; set; }
 
         public PatientSubmissionStatus Status { get; set; } = PatientSubmissionStatus.NotEvaluated;
-        public List<ContainedResource> ContainedResources { get; set; } = new();
+        public List<ContainedResource> ContainedResources { get; private set; } = new List<ContainedResource>();
 
         public class ContainedResource
         {
@@ -42,13 +42,13 @@ namespace LantanaGroup.Link.Report.Entities
 
         public void AddMeasureReport(MeasureReport measureReport)
         {
-            MeasureReport =  measureReport;
+            MeasureReport = measureReport;
 
             foreach (var evaluatedResource in measureReport.EvaluatedResource)
             {
                 //If the resource is already in the list, skip it
                 if (ContainedResources.Any(x => x.Reference() == evaluatedResource.Reference))
-                { 
+                {
                     continue;
                 }
 

--- a/DotNet/Report/Entities/MeasureReportSubmissionEntryModel.cs
+++ b/DotNet/Report/Entities/MeasureReportSubmissionEntryModel.cs
@@ -24,7 +24,7 @@ namespace LantanaGroup.Link.Report.Entities
         public MeasureReport? MeasureReport { get; set; }
 
         public PatientSubmissionStatus Status { get; set; } = PatientSubmissionStatus.NotEvaluated;
-        public List<ContainedResource> ContainedResources { get; private set; } = new List<ContainedResource>();
+        public List<ContainedResource> ContainedResources { get; set; } = new();
 
         public class ContainedResource
         {

--- a/DotNet/Submission/Application/Interfaces/ISubmissionServiceMetrics.cs
+++ b/DotNet/Submission/Application/Interfaces/ISubmissionServiceMetrics.cs
@@ -2,6 +2,8 @@
 {
     public interface ISubmissionServiceMetrics
     {
-        void IncrementSubmissionCounter(List<KeyValuePair<string, object?>> tags);       
+        void IncrementResourcesSubmittedCounter(int resourcesSubmitted, List<KeyValuePair<string, object?>> tags);
+        void IncrementResourceTypeCounter(int resourceTypeCount, List<KeyValuePair<string, object?>> tags);
+        void IncrementMedicationCounter(int medCodeCount, List<KeyValuePair<string, object?>> tags);
     }
 }

--- a/DotNet/Submission/Application/Interfaces/ISubmissionServiceMetrics.cs
+++ b/DotNet/Submission/Application/Interfaces/ISubmissionServiceMetrics.cs
@@ -4,6 +4,6 @@
     {
         void IncrementResourcesSubmittedCounter(int resourcesSubmitted, List<KeyValuePair<string, object?>> tags);
         void IncrementResourceTypeCounter(int resourceTypeCount, List<KeyValuePair<string, object?>> tags);
-        void IncrementMedicationCounter(int medCodeCount, List<KeyValuePair<string, object?>> tags);
+        void IncrementMedicationCounter(int medicationCount, List<KeyValuePair<string, object?>> tags);
     }
 }

--- a/DotNet/Submission/Application/Services/SubmissionServiceMetrics.cs
+++ b/DotNet/Submission/Application/Services/SubmissionServiceMetrics.cs
@@ -11,13 +11,27 @@ namespace LantanaGroup.Link.Submission.Application.Services
         public SubmissionServiceMetrics(IMeterFactory meterFactory)
         {         
             Meter meter = meterFactory.Create(MeterName);
-            SubmissionCounter = meter.CreateCounter<long>("link_submission_service.submission.count");       
+            ResourcesSubmittedCounter = meter.CreateCounter<long>("link_submission_service.resources_submitted.count");
+            ResourceTypeCounter = meter.CreateCounter<long>("link_submission_service.resource_type_submitted.count");
+            MedicationCodeCounter = meter.CreateCounter<long>("link_submission_service.medication_code_submitted.count");
         }
 
-        public Counter<long> SubmissionCounter { get; private set; }
-        public void IncrementSubmissionCounter(List<KeyValuePair<string, object?>> tags)
+        public Counter<long> ResourcesSubmittedCounter { get; private set; }
+        public void IncrementResourcesSubmittedCounter(int resourcesSubmitted, List<KeyValuePair<string, object?>> tags)
         {
-            SubmissionCounter.Add(1, tags.ToArray());
+            ResourcesSubmittedCounter.Add(resourcesSubmitted, tags.ToArray());
+        }
+
+        public Counter<long> ResourceTypeCounter { get; private set; }
+        public void IncrementResourceTypeCounter(int resourceTypeCount, List<KeyValuePair<string, object?>> tags)
+        {
+            ResourceTypeCounter.Add(resourceTypeCount, tags.ToArray());
+        }
+
+        public Counter<long> MedicationCodeCounter { get; private set; }
+        public void IncrementMedicationCounter(int resourceTypeCount, List<KeyValuePair<string, object?>> tags)
+        {
+            MedicationCodeCounter.Add(resourceTypeCount, tags.ToArray());
         }
     }
 }

--- a/DotNet/Submission/Application/Services/SubmissionServiceMetrics.cs
+++ b/DotNet/Submission/Application/Services/SubmissionServiceMetrics.cs
@@ -29,9 +29,9 @@ namespace LantanaGroup.Link.Submission.Application.Services
         }
 
         public Counter<long> MedicationCodeCounter { get; private set; }
-        public void IncrementMedicationCounter(int resourceTypeCount, List<KeyValuePair<string, object?>> tags)
+        public void IncrementMedicationCounter(int medicationCount, List<KeyValuePair<string, object?>> tags)
         {
-            MedicationCodeCounter.Add(resourceTypeCount, tags.ToArray());
+            MedicationCodeCounter.Add(medicationCount, tags.ToArray());
         }
     }
 }

--- a/DotNet/Submission/Listeners/SubmitReportListener.cs
+++ b/DotNet/Submission/Listeners/SubmitReportListener.cs
@@ -1,6 +1,5 @@
 ﻿using Confluent.Kafka;
 using Confluent.Kafka.Extensions.Diagnostics;
-using Hl7.Fhir.ElementModel.Types;
 using Hl7.Fhir.Model;
 using Hl7.Fhir.Serialization;
 using LantanaGroup.Link.Shared.Application.Error.Exceptions;

--- a/DotNet/Submission/Listeners/SubmitReportListener.cs
+++ b/DotNet/Submission/Listeners/SubmitReportListener.cs
@@ -1,5 +1,6 @@
 ﻿using Confluent.Kafka;
 using Confluent.Kafka.Extensions.Diagnostics;
+using Hl7.Fhir.ElementModel.Types;
 using Hl7.Fhir.Model;
 using Hl7.Fhir.Serialization;
 using LantanaGroup.Link.Shared.Application.Error.Exceptions;
@@ -8,8 +9,10 @@ using LantanaGroup.Link.Shared.Application.Interfaces;
 using LantanaGroup.Link.Shared.Application.Interfaces.Services.Security.Token;
 using LantanaGroup.Link.Shared.Application.Models;
 using LantanaGroup.Link.Shared.Application.Models.Configs;
+using LantanaGroup.Link.Shared.Application.Models.Telemetry;
 using LantanaGroup.Link.Shared.Settings;
 using LantanaGroup.Link.Submission.Application.Config;
+using LantanaGroup.Link.Submission.Application.Interfaces;
 using LantanaGroup.Link.Submission.Application.Models;
 using LantanaGroup.Link.Submission.Settings;
 using Microsoft.Extensions.Options;
@@ -37,6 +40,8 @@ namespace LantanaGroup.Link.Submission.Listeners
         private readonly IOptions<LinkTokenServiceSettings> _linkTokenServiceConfig;
         private readonly ICreateSystemToken _createSystemToken;
 
+        private readonly ISubmissionServiceMetrics _submissionServiceMetrics;
+
         private string Name => this.GetType().Name;
 
         public SubmitReportListener(ILogger<SubmitReportListener> logger,
@@ -46,7 +51,8 @@ namespace LantanaGroup.Link.Submission.Listeners
             ITransientExceptionHandler<SubmitReportKey, SubmitReportValue> transientExceptionHandler,
             IDeadLetterExceptionHandler<SubmitReportKey, SubmitReportValue> deadLetterExceptionHandler,
             IOptions<LinkTokenServiceSettings> linkTokenServiceConfig, ICreateSystemToken createSystemToken, 
-            IOptions<ServiceRegistry> serviceRegistry)
+            IOptions<ServiceRegistry> serviceRegistry,
+            ISubmissionServiceMetrics submissionServiceMetrics)
         {
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
             _kafkaConsumerFactory = kafkaConsumerFactory ?? throw new ArgumentException(nameof(kafkaConsumerFactory));
@@ -68,6 +74,8 @@ namespace LantanaGroup.Link.Submission.Listeners
             _createSystemToken = createSystemToken ?? throw new ArgumentNullException(nameof(createSystemToken));
             
             _serviceRegistry = serviceRegistry?.Value ?? throw new ArgumentNullException(nameof(serviceRegistry));
+
+            _submissionServiceMetrics = submissionServiceMetrics;
         }
 
         protected override Task ExecuteAsync(CancellationToken stoppingToken)
@@ -80,7 +88,7 @@ namespace LantanaGroup.Link.Submission.Listeners
             // If a URL, may contain |0.1.2 representing the version at the end of the URL
             // Remove it so that we're looking at the generic URL, not the URL specific to a measure version
             string measureWithoutVersion = measure.Contains("|") ?
-                measure.Substring(0, measure.LastIndexOf("|", StringComparison.Ordinal)) :
+                measure.Substring(0, measure.LastIndexOf("|", System.StringComparison.Ordinal)) :
                 measure;
 
             var urlShortName = _submissionConfig.MeasureNames.FirstOrDefault(x => x.Url == measureWithoutVersion || x.MeasureId == measureWithoutVersion)?.ShortName;
@@ -110,7 +118,7 @@ namespace LantanaGroup.Link.Submission.Listeners
             {
                 consumer.Subscribe(nameof(KafkaTopic.SubmitReport));
                 _logger.LogInformation(
-                    $"Started consumer for topic '{nameof(KafkaTopic.SubmitReport)}' at {DateTime.UtcNow}");
+                    $"Started consumer for topic '{nameof(KafkaTopic.SubmitReport)}' at {System.DateTime.UtcNow}");
 
                 while (!cancellationToken.IsCancellationRequested)
                 {
@@ -165,7 +173,7 @@ namespace LantanaGroup.Link.Submission.Listeners
                                 string dtFormat = "yyyy-MM-ddTHH:mm:ss.fffZ";
 
                                 #region Census Admitted Patient List
-                                string censusRequestUrl = $"{_serviceRegistry.CensusServiceApiUrl}/Census/{key.FacilityId}/history/admitted?startDate={key.StartDate.ToString(dtFormat)}&endDate={key.EndDate.ToString(dtFormat)}";
+                                string censusRequestUrl = $"http://localhost:5234/api/Census/{key.FacilityId}/history/admitted?startDate={key.StartDate.ToString(dtFormat)}&endDate={key.EndDate.ToString(dtFormat)}";
 
                                 //TODO: add method to get key that includes looking at redis for future use case
                                 if (_linkTokenServiceConfig.Value.SigningKey is null)
@@ -175,7 +183,6 @@ namespace LantanaGroup.Link.Submission.Listeners
                                 var token = _createSystemToken.ExecuteAsync(_linkTokenServiceConfig.Value.SigningKey, 5).Result;
                                 httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
 
-                                _logger.LogDebug("Requesting census from Census service: " + censusRequestUrl);
                                 var censusResponse = await httpClient.GetAsync(censusRequestUrl, consumeCancellationToken);
                                 var censusContent = await censusResponse.Content.ReadAsStringAsync(consumeCancellationToken);
 
@@ -294,6 +301,8 @@ namespace LantanaGroup.Link.Submission.Listeners
 
                                 var batchSize = _submissionConfig.PatientBundleBatchSize;
 
+                                List<string> patientFilesWritten = new List<string>();
+
                                 while (patientIds.Any())
                                 {
                                     var otherResourcesBag = new ConcurrentBag<Bundle>();
@@ -314,12 +323,13 @@ namespace LantanaGroup.Link.Submission.Listeners
                                     {
                                         tasks.Add(Task.Run(async () =>
                                         {
-                                            var otherResources = await CreatePatientBundleFiles(submissionDirectory,
+                                            var resultModel = await CreatePatientBundleFiles(submissionDirectory,
                                                 pid,
                                                 facilityId,
                                                 key.ReportScheduleId, consumeCancellationToken);
 
-                                            otherResourcesBag.Add(otherResources);
+                                            patientFilesWritten.Add(resultModel.FilePath);
+                                            otherResourcesBag.Add(resultModel.OtherResources);
                                         }));
                                     }
 
@@ -345,8 +355,10 @@ namespace LantanaGroup.Link.Submission.Listeners
                                 fileName = "other-resources.json";
                                 contents = await fhirSerializer.SerializeToStringAsync(otherResourcesBundle);
 
-                                await File.WriteAllTextAsync(submissionDirectory + "/" + fileName, contents,
-                                    consumeCancellationToken);
+                                await File.WriteAllTextAsync(submissionDirectory + "/" + fileName, contents, consumeCancellationToken);
+
+                                //Generate Metrics
+                                GenerateSubmissionMetrics(otherResourcesBundle,  patientFilesWritten, facilityId, key.StartDate, key.EndDate);
 
                                 #endregion
                             }
@@ -377,7 +389,7 @@ namespace LantanaGroup.Link.Submission.Listeners
                     }
                     catch (ConsumeException ex)
                     {
-                        _logger.LogError(ex, "Error consuming message for topics: [{1}] at {2}", string.Join(", ", consumer.Subscription), DateTime.UtcNow);
+                        _logger.LogError(ex, "Error consuming message for topics: [{1}] at {2}", string.Join(", ", consumer.Subscription), System.DateTime.UtcNow);
 
                         if (ex.Error.Code == ErrorCode.UnknownTopicOrPart)
                         {
@@ -403,6 +415,83 @@ namespace LantanaGroup.Link.Submission.Listeners
                 _logger.LogError(oce, $"Operation Canceled: {oce.Message}");
                 consumer.Close();
                 consumer.Dispose();
+            }
+        }
+
+        protected void GenerateSubmissionMetrics(Bundle? otherResourcesBundle, List<string>? patientFilesWritten, string facilityId, System.DateTime startDate, System.DateTime endDate )
+        {
+            if(otherResourcesBundle == null) { return; }    
+            if (patientFilesWritten == null || patientFilesWritten.Count == 0) { return; }
+
+            var totalResources = otherResourcesBundle.GetResources().Count();
+            var resourceTypes = new Dictionary<string, int>();
+            var medicationCodes = new Dictionary<string, int>();
+            foreach (var patientFile in patientFilesWritten)
+            {
+                string contents = File.ReadAllText(patientFile);
+                var bundle = JsonSerializer.Deserialize<Bundle>(contents, new JsonSerializerOptions().ForFhir());
+
+                var resources = bundle.GetResources();
+
+                if (resources == null)
+                    continue;
+
+                foreach (var resource in resources)
+                {
+                    totalResources += 1;
+
+                    var resType = resource.TypeName;
+
+                    if (!resourceTypes.TryAdd(resType, 1))
+                    {
+                        resourceTypes[resType] += 1;
+                    }
+
+                    if (resource is Medication)
+                    {
+                        var med = (Medication)resource;
+                        var code = med.Code?.Coding?.FirstOrDefault();
+                        if (code != null)
+                        {
+                            string val = $"{code.Display}|{code.Code}|{code.System}";
+                            if (!medicationCodes.TryAdd(val, 1))
+                            {
+                                medicationCodes[val] += 1;
+                            }
+                        }
+                    }
+                }
+            }
+
+            //Total resources submitted
+            _submissionServiceMetrics.IncrementResourcesSubmittedCounter(totalResources, new List<KeyValuePair<string, object?>>() {
+                new KeyValuePair<string, object?>(DiagnosticNames.FacilityId, facilityId),
+                new KeyValuePair<string, object?>(DiagnosticNames.PeriodStart, startDate),
+                new KeyValuePair<string, object?>(DiagnosticNames.PeriodEnd, endDate)
+            });
+
+            //ResourceTypes
+            foreach (var resType in resourceTypes)
+            {
+                _submissionServiceMetrics.IncrementResourceTypeCounter(resType.Value,
+                    new List<KeyValuePair<string, object?>>()
+                    {
+                        new KeyValuePair<string, object?>(DiagnosticNames.FacilityId, facilityId),
+                        new KeyValuePair<string, object?>(DiagnosticNames.Resource, resType.Key)
+                    });
+            }
+
+            //Medication Codes
+            foreach (var resType in resourceTypes)
+            {
+                _submissionServiceMetrics.IncrementMedicationCounter(resType.Value,
+                    new List<KeyValuePair<string, object?>>()
+                    {
+                        new KeyValuePair<string, object?>(DiagnosticNames.FacilityId, facilityId),
+                        new KeyValuePair<string, object?>(DiagnosticNames.Resource, resType.Key),
+                        new KeyValuePair<string, object?>(DiagnosticNames.PeriodStart, startDate),
+                        new KeyValuePair<string, object?>(DiagnosticNames.PeriodEnd, endDate)
+                    });
             }
         }
 
@@ -438,8 +527,10 @@ namespace LantanaGroup.Link.Submission.Listeners
         /// <param name="endDate"></param>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        private async Task<Bundle> CreatePatientBundleFiles(string submissionDirectory, string patientId, string facilityId, string reportScheduleId, CancellationToken cancellationToken)
+        private async Task<CreatePatientBundleResult> CreatePatientBundleFiles(string submissionDirectory, string patientId, string facilityId, string reportScheduleId, CancellationToken cancellationToken )
         {
+            var returnModel = new CreatePatientBundleResult();
+
             var options = new JsonSerializerOptions().ForFhir(ModelInfo.ModelInspector);
 
             var httpClient = _httpClient.CreateClient();
@@ -475,19 +566,26 @@ namespace LantanaGroup.Link.Submission.Listeners
                                         patientSubmissionBundle.OtherResources: {patientSubmissionBundle?.OtherResources == null}");
                 }
 
-                var otherResources = patientSubmissionBundle.OtherResources;
+                returnModel.OtherResources = patientSubmissionBundle.OtherResources;
 
                 string fileName = $"patient-{patientId}.json";
                 string contents = await new FhirJsonSerializer().SerializeToStringAsync(patientSubmissionBundle.PatientResources);
 
-                await File.WriteAllTextAsync(submissionDirectory + "/" + fileName, contents, cancellationToken);
+                returnModel.FilePath = submissionDirectory + "/" + fileName;
+                await File.WriteAllTextAsync(returnModel.FilePath, contents, cancellationToken);
 
-                return otherResources;
+                return returnModel;
             }
             catch (Exception ex)
             {
                 throw new TransientException(ex.Message, ex.InnerException);
             }
+        }
+
+        public class CreatePatientBundleResult
+        {
+            public Bundle OtherResources { get; set; } = new Bundle();
+            public string FilePath { get; set; } = string.Empty;
         }
     }
 }

--- a/DotNet/Submission/Listeners/SubmitReportListener.cs
+++ b/DotNet/Submission/Listeners/SubmitReportListener.cs
@@ -172,7 +172,7 @@ namespace LantanaGroup.Link.Submission.Listeners
                                 string dtFormat = "yyyy-MM-ddTHH:mm:ss.fffZ";
 
                                 #region Census Admitted Patient List
-                                string censusRequestUrl = $"http://localhost:5234/api/Census/{key.FacilityId}/history/admitted?startDate={key.StartDate.ToString(dtFormat)}&endDate={key.EndDate.ToString(dtFormat)}";
+                                string censusRequestUrl = $"{_serviceRegistry.CensusServiceApiUrl}/Census/{key.FacilityId}/history/admitted?startDate={key.StartDate.ToString(dtFormat)}&endDate={key.EndDate.ToString(dtFormat)}";
 
                                 //TODO: add method to get key that includes looking at redis for future use case
                                 if (_linkTokenServiceConfig.Value.SigningKey is null)
@@ -481,13 +481,13 @@ namespace LantanaGroup.Link.Submission.Listeners
             }
 
             //Medication Codes
-            foreach (var resType in resourceTypes)
+            foreach (var medication in medicationCodes)
             {
-                _submissionServiceMetrics.IncrementMedicationCounter(resType.Value,
+                _submissionServiceMetrics.IncrementMedicationCounter(medication.Value,
                     new List<KeyValuePair<string, object?>>()
                     {
                         new KeyValuePair<string, object?>(DiagnosticNames.FacilityId, facilityId),
-                        new KeyValuePair<string, object?>(DiagnosticNames.Resource, resType.Key),
+                        new KeyValuePair<string, object?>(DiagnosticNames.Resource, medication.Key),
                         new KeyValuePair<string, object?>(DiagnosticNames.PeriodStart, startDate),
                         new KeyValuePair<string, object?>(DiagnosticNames.PeriodEnd, endDate)
                     });
@@ -542,7 +542,7 @@ namespace LantanaGroup.Link.Submission.Listeners
             var token = _createSystemToken.ExecuteAsync(_linkTokenServiceConfig.Value.SigningKey, 2).Result;
             httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
 
-            string requestUrl = $"{_serviceRegistry.ReportServiceApiUrl.Trim('/')}/Report/Bundle/Patient?FacilityId={facilityId}&PatientId={patientId}&reportScheduleId={reportScheduleId}";
+            string requestUrl = $"{_serviceRegistry.ReportServiceApiUrl.Trim('/')}/Report/Bundle/Patient?FacilityId={facilityId}&PatientId={patientId}&reportScheduleId={reportScheduleId}"; st:5110/api/Report/Bundle/Patient?FacilityId={facilityId}&PatientId={patientId}&reportScheduleId={reportScheduleId}";
 
             try
             {

--- a/DotNet/Submission/Listeners/SubmitReportListener.cs
+++ b/DotNet/Submission/Listeners/SubmitReportListener.cs
@@ -300,7 +300,7 @@ namespace LantanaGroup.Link.Submission.Listeners
 
                                 var batchSize = _submissionConfig.PatientBundleBatchSize;
 
-                                List<string> patientFilesWritten = new List<string>();
+                                ConcurrentBag<string> patientFilesWritten = new ConcurrentBag<string>();
 
                                 while (patientIds.Any())
                                 {
@@ -357,7 +357,7 @@ namespace LantanaGroup.Link.Submission.Listeners
                                 await File.WriteAllTextAsync(submissionDirectory + "/" + fileName, contents, consumeCancellationToken);
 
                                 //Generate Metrics
-                                GenerateSubmissionMetrics(otherResourcesBundle,  patientFilesWritten, facilityId, key.StartDate, key.EndDate);
+                                GenerateSubmissionMetrics(otherResourcesBundle,  patientFilesWritten.ToList(), facilityId, key.StartDate, key.EndDate);
 
                                 #endregion
                             }
@@ -417,7 +417,7 @@ namespace LantanaGroup.Link.Submission.Listeners
             }
         }
 
-        protected void GenerateSubmissionMetrics(Bundle? otherResourcesBundle, List<string>? patientFilesWritten, string facilityId, System.DateTime startDate, System.DateTime endDate )
+        protected void GenerateSubmissionMetrics(Bundle? otherResourcesBundle, List<string>? patientFilesWritten, string facilityId, DateTime startDate, DateTime endDate )
         {
             if(otherResourcesBundle == null) { return; }    
             if (patientFilesWritten == null || patientFilesWritten.Count == 0) { return; }
@@ -542,7 +542,7 @@ namespace LantanaGroup.Link.Submission.Listeners
             var token = _createSystemToken.ExecuteAsync(_linkTokenServiceConfig.Value.SigningKey, 2).Result;
             httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
 
-            string requestUrl = $"{_serviceRegistry.ReportServiceApiUrl.Trim('/')}/Report/Bundle/Patient?FacilityId={facilityId}&PatientId={patientId}&reportScheduleId={reportScheduleId}"; st:5110/api/Report/Bundle/Patient?FacilityId={facilityId}&PatientId={patientId}&reportScheduleId={reportScheduleId}";
+            string requestUrl = $"{_serviceRegistry.ReportServiceApiUrl.Trim('/')}/Report/Bundle/Patient?FacilityId={facilityId}&PatientId={patientId}&reportScheduleId={reportScheduleId}";
 
             try
             {

--- a/DotNet/Submission/Listeners/SubmitReportListener.cs
+++ b/DotNet/Submission/Listeners/SubmitReportListener.cs
@@ -340,7 +340,7 @@ namespace LantanaGroup.Link.Submission.Listeners
                                     {
                                         foreach (var resource in bundle.GetResources())
                                         {
-                                            if (!otherResourcesBundle.GetResources().Any(r => r.Id == resource.Id))
+                                            if (otherResourcesBundle.GetResources().All(r => r.Id != resource.Id))
                                             {
                                                 otherResourcesBundle.AddResourceEntry(resource, GetFullUrl(resource));
                                             }

--- a/DotNet/Submission/Program.cs
+++ b/DotNet/Submission/Program.cs
@@ -26,11 +26,9 @@ using LantanaGroup.Link.Submission.Application.Models;
 using LantanaGroup.Link.Submission.Application.Services;
 using LantanaGroup.Link.Submission.Listeners;
 using LantanaGroup.Link.Submission.Settings;
-using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Diagnostics.HealthChecks;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration.AzureAppConfiguration;
-using Microsoft.OpenApi.Models;
 using Quartz;
 using Quartz.Impl;
 using Quartz.Spi;
@@ -38,7 +36,6 @@ using Serilog;
 using Serilog.Enrichers.Span;
 using Serilog.Exceptions;
 using Serilog.Settings.Configuration;
-using System.Reflection;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -118,9 +115,6 @@ static void RegisterServices(WebApplicationBuilder builder)
         options.ProtectKey = builder.Configuration.GetValue<bool>("DataProtection:Enabled");
         options.SigningKey = builder.Configuration.GetValue<string>("LinkTokenService:SigningKey");
     });
-
-    // Add Controllers
-    builder.Services.AddControllers();
 
     // Add hosted services
     builder.Services.AddHostedService<SubmitReportListener>();


### PR DESCRIPTION
### 🛠️ Description of Changes

After writing submission files, begin a process of reading each file sequentially and aggregating metrics. Then write out the metrics to OpenTelemetry.

### 🧪 Testing Performed

Ran locally and generated metrics.

### 📓 Documentation Updated

Please update any relevant sections in the project documentation that were impacted by the changes in the PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Enhanced submission metrics tracking with more granular counters for resources, resource types, and medications.
  - Improved patient bundle file creation process with a new return structure.

- **Changes**
  - Updated submission service metrics to provide more detailed tracking.
  - Modified submission report listener to support new metrics generation.
  - Adjusted patient bundle file creation to return more comprehensive results.
  - Updated enum serialization for patient submission statuses.

- **Technical Updates**
  - Refactored metrics tracking interface and implementation.
  - Removed generic submission counter in favor of specific resource counters.
  - Cleaned up unused directives and removed MVC controller registration.
  - Adjusted property accessibility for contained resources in the report submission model.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->