### PR TITLE
LNK-3398: Use Cache for Account Services

### DIFF
--- a/DotNet/Admin.BFF/Application/Commands/Integration/KafkaConsumerService.cs
+++ b/DotNet/Admin.BFF/Application/Commands/Integration/KafkaConsumerService.cs
@@ -1,9 +1,9 @@
 ﻿using Confluent.Kafka;
-using LantanaGroup.Link.LinkAdmin.BFF.Application.Interfaces.Services;
 using LantanaGroup.Link.Shared.Application.Interfaces;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using System.Text.RegularExpressions;
+using Confluent.Kafka.Admin;
 
 
 namespace LantanaGroup.Link.LinkAdmin.BFF.Application.Commands.Integration
@@ -78,6 +78,7 @@ namespace LantanaGroup.Link.LinkAdmin.BFF.Application.Commands.Integration
                             }
                         }
                         _logger.LogInformation("Consumed message '{MessageValue}' from topic {Topic}, partition {Partition}, offset {Offset}, correlation {CorrelationId}", consumeResult.Message.Value, consumeResult.Topic, consumeResult.Partition, consumeResult.Offset, correlationId);
+
                     }
                 }
                 catch (ConsumeException e)
@@ -97,6 +98,8 @@ namespace LantanaGroup.Link.LinkAdmin.BFF.Application.Commands.Integration
                 }
             }
         }
+
+     
 
         public string extractFacility(string kafkaKey)
         {

--- a/DotNet/Admin.BFF/Presentation/Endpoints/IntegrationTestingEndpoints.cs
+++ b/DotNet/Admin.BFF/Presentation/Endpoints/IntegrationTestingEndpoints.cs
@@ -8,7 +8,6 @@ using LantanaGroup.Link.LinkAdmin.BFF.Application.Models.Responses;
 using LantanaGroup.Link.LinkAdmin.BFF.Infrastructure.Logging;
 using Link.Authorization.Infrastructure;
 using Link.Authorization.Policies;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Options;
 using Microsoft.OpenApi.Models;
 using System.Security.Claims;
@@ -153,10 +152,14 @@ namespace LantanaGroup.Link.LinkAdmin.BFF.Presentation.Endpoints
             Dictionary<string, string> list  =  _kafkaConsumerManager.readAllConsumers(facility.FacilityId);
             return Results.Ok(list);
         }
-        public Task DeleteConsumersRequested(HttpContext context, Facility facility)
+        public async Task<IResult> DeleteConsumersRequested(HttpContext context, Facility facility)
         {
-            _kafkaConsumerManager.StopAllConsumers(facility.FacilityId);
-            return Task.CompletedTask;
+            // Stop consumers asynchronously
+
+            await _kafkaConsumerManager.StopAllConsumers(facility.FacilityId);
+            // Return a success response with a message
+            var response = new { message = "Consumers stopped successfully." };
+            return Results.Ok(response); // This returns a 200 OK status along with the message
         }
 
         public async Task<IResult> CreatePatientAcquired(HttpContext context, PatientAcquired model)

--- a/DotNet/Admin.BFF/Presentation/Endpoints/IntegrationTestingEndpoints.cs
+++ b/DotNet/Admin.BFF/Presentation/Endpoints/IntegrationTestingEndpoints.cs
@@ -155,11 +155,16 @@ namespace LantanaGroup.Link.LinkAdmin.BFF.Presentation.Endpoints
         public async Task<IResult> DeleteConsumersRequested(HttpContext context, Facility facility)
         {
             // Stop consumers asynchronously
-
-            await _kafkaConsumerManager.StopAllConsumers(facility.FacilityId);
-            // Return a success response with a message
-            var response = new { message = "Consumers stopped successfully." };
-            return Results.Ok(response); // This returns a 200 OK status along with the message
+            try {
+                await _kafkaConsumerManager.StopAllConsumers(facility.FacilityId);
+                var response = new { message = "Consumers stopped successfully.", facilityId = facility.FacilityId};
+                return Results.Ok(response); // This returns a 200 OK status along with the messag
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to stop consumers for facility {FacilityId}", facility.FacilityId);
+                return Results.Problem("Error stopping consumers.", statusCode: StatusCodes.Status500InternalServerError);
+            }
         }
 
         public async Task<IResult> CreatePatientAcquired(HttpContext context, PatientAcquired model)

--- a/Web/Admin.UI/src/app/components/testing/integration-test/integration-test.component.ts
+++ b/Web/Admin.UI/src/app/components/testing/integration-test/integration-test.component.ts
@@ -167,7 +167,6 @@ export class IntegrationTestComponent implements OnInit, OnDestroy {
 
   stopTest(): void {
     this.isLoading = true; // Show spinner
-    this.isTestRunning = true; // Update test state
     this.consumersDataOutput.clear();
     this.stopPollingConsumerEvents();
     this.deleteConsumers(this.facilityIdControl.value);

--- a/Web/Admin.UI/src/app/components/testing/integration-test/integration-test.component.ts
+++ b/Web/Admin.UI/src/app/components/testing/integration-test/integration-test.component.ts
@@ -148,7 +148,7 @@ export class IntegrationTestComponent implements OnInit, OnDestroy {
       this.consumersDataOutput = new Map();
       this.isLoading = false; // Hide spinner
       this.isTestRunning = false; // Update test state
-      this.stopPollingConsumerEvents();
+
     }, error => {
       console.error('Error creating consumer:', error);
       this.isTestRunning = false;
@@ -166,7 +166,10 @@ export class IntegrationTestComponent implements OnInit, OnDestroy {
   }
 
   stopTest(): void {
+    this.isLoading = true; // Show spinner
+    this.isTestRunning = true; // Update test state
     this.consumersDataOutput.clear();
+    this.stopPollingConsumerEvents();
     this.deleteConsumers(this.facilityIdControl.value);
   }
 
@@ -194,7 +197,7 @@ export class IntegrationTestComponent implements OnInit, OnDestroy {
       this.consumersData.forEach((value, key) => {
         this.consumersDataOutput.set(key, JSON.parse(value) ?? "");
       });
-      this.isLoading = false
+      this.isLoading = false;
     }, error => {
       console.error('Error creating consumer:', error);
       this.isTestRunning = false;


### PR DESCRIPTION
### 🛠️ Description of Changes

Added InMemory cache for AccountServices to run locally. Enhanced stopping dynamic consumers with deleting the associated gorups.

### 🧪 Testing Performed

Tested locally using UI interface.

### 📓 Documentation Updated

Please update any relevant sections in the project documentation that were impacted by the changes in the PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Enhanced Kafka consumer management with improved topic handling and consumer group lifecycle management.
  - Added asynchronous methods for deleting consumer groups.

- **Bug Fixes**
  - Improved error handling for Kafka consumer exceptions.
  - Updated test endpoint to return structured responses.

- **Refactor**
  - Modernized asynchronous method implementations across multiple components.
  - Refined test component logic for better state management.

- **Chores**
  - Updated method signatures to support async/await patterns.
  - Improved logging and error tracking for Kafka-related operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->