### PR TITLE
LNK-3403: Measure Eval Dedup header and track them in the error queue

### DIFF
--- a/Java/measureeval/src/main/java/com/lantanagroup/link/measureeval/services/AbstractResourceConsumer.java
+++ b/Java/measureeval/src/main/java/com/lantanagroup/link/measureeval/services/AbstractResourceConsumer.java
@@ -136,7 +136,7 @@ public abstract class AbstractResourceConsumer<T extends AbstractResourceRecord>
         }
 
         // add the resource in the PatientReportingEvaluationStatus only if does not exist already
-        PatientReportingEvaluationStatus.Resource existingResource = patientStatus.getResources().stream().filter(res -> res.getResourceType() == value.getResourceType() && Objects.equals(res.getResourceId(), value.getResourceId())).findFirst().orElse(null);
+        PatientReportingEvaluationStatus.Resource existingResource = patientStatus.getResources() == null ? null : patientStatus.getResources().stream().filter(res -> res.getResourceType() == value.getResourceType() && Objects.equals(res.getResourceId(), value.getResourceId())).findFirst().orElse(null);
 
         if (existingResource == null) {
             PatientReportingEvaluationStatus.Resource statusResource = new PatientReportingEvaluationStatus.Resource();


### PR DESCRIPTION
### 🛠️ Description of Changes

Remove duplications from header but send them to the error queue for tracking

### 🧪 Testing Performed

Tested locally and acknowledge them going to error queue.

### 📓 Documentation Updated

Please update any relevant sections in the project documentation that were impacted by the changes in the PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved resource handling to prevent duplicate entries in patient reporting evaluation status
  - Added validation to detect and prevent duplicate resources during processing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->