### PR TITLE
LNK-3386: add distinctby to ref sort to prevent duplicates DEV ENV

### DIFF
--- a/DotNet/DataAcquisition/Application/Services/ReferenceResourceService.cs
+++ b/DotNet/DataAcquisition/Application/Services/ReferenceResourceService.cs
@@ -119,6 +119,7 @@ public class ReferenceResourceService : IReferenceResourceService
             referenceQueryFactoryResult
             ?.ReferenceIds
             ?.Where(x => x.TypeName == referenceQueryConfig.ResourceType || x.Reference.StartsWith(referenceQueryConfig.ResourceType, StringComparison.InvariantCultureIgnoreCase))
+            .DistinctBy(x => x.Url.ToString())
             .ToList();
 
         var existingReferenceResources =

--- a/DotNet/Normalization/Listeners/ResourceAcquiredListener.cs
+++ b/DotNet/Normalization/Listeners/ResourceAcquiredListener.cs
@@ -374,7 +374,7 @@ public class ResourceAcquiredListener : BackgroundService
             {
                 if (ex.Error.Code == ErrorCode.UnknownTopicOrPart)
                 {
-                    new OperationCanceledException(ex.Error.Reason, ex);
+                    throw new OperationCanceledException(ex.Error.Reason, ex);
                 }
 
                 string facilityId = Encoding.UTF8.GetString(ex.ConsumerRecord?.Message?.Key ?? []);

--- a/DotNet/Shared/Application/BaseListener.cs
+++ b/DotNet/Shared/Application/BaseListener.cs
@@ -108,6 +108,11 @@ public abstract class BaseListener<MessageType, ConsumeKeyType, ConsumeValueType
                         throw new OperationCanceledException(e.Error.Reason, e);
                     }
 
+                    if (consumeResult is null)
+                    {
+                        throw new OperationCanceledException(e.Error.Reason, e);
+                    }
+
                     var facilityId = ExtractFacilityId(consumeResult);
 
                     DeadLetterConsumerHandler.HandleConsumeException(e, facilityId);


### PR DESCRIPTION
🛠️ Description of Changes
A bug was found when processing patients with a large volume of associated fhir resources. A DistinctBy expression was inserted into the Linq statement that sorts and identifies valid reference resources to process.

🧪 Testing Performed
Tests were ran against a test patient with a verified large volume of associated fhir resources and observed for duplicates locally.

📓 Documentation Updated
n.a


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced error handling in resource processing to ensure unique entries based on URL.
  - Improved error handling in consumer operations to prevent potential null reference issues. 
  - Refined error handling for specific exceptions in resource acquisition.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->