### PR TITLE
LNK-3342: normalization report tracking

### DIFF
--- a/DotNet/Normalization/Application/Models/Messages/ResourceAcquiredMessage.cs
+++ b/DotNet/Normalization/Application/Models/Messages/ResourceAcquiredMessage.cs
@@ -1,6 +1,4 @@
-﻿using Hl7.Fhir.Model;
-
-namespace LantanaGroup.Link.Normalization.Application.Models.Messages;
+﻿namespace LantanaGroup.Link.Normalization.Application.Models.Messages;
 
 public class ResourceAcquiredMessage
 {

--- a/DotNet/Normalization/Application/Models/Messages/ScheduledReport.cs
+++ b/DotNet/Normalization/Application/Models/Messages/ScheduledReport.cs
@@ -2,6 +2,7 @@
 
 public class ScheduledReport
 {
+    public string ReportTrackingId { get; set; } = string.Empty;    
     public string[] ReportTypes { get; set; }
     public string StartDate { get; set; }
     public string EndDate { get; set; }


### PR DESCRIPTION
### 🛠️ Description of Changes

Added ReportTrackingId to Normalization's ScheduledReport class, which is used in ResourceAcquired events received from DataAcquisition.

### 🧪 Testing Performed

Local testing by sending manual events to the ResourceAcquiredListener.

### 📓 Documentation Updated

Please update any relevant sections in the project documentation that were impacted by the changes in the PR.
