### PR TITLE
LNK-3344: new listener measureeval

### DIFF
--- a/Java/measureeval/pom.xml
+++ b/Java/measureeval/pom.xml
@@ -158,11 +158,6 @@
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
     <build>

--- a/Java/measureeval/pom.xml
+++ b/Java/measureeval/pom.xml
@@ -147,6 +147,22 @@
             <scope>test</scope>
         </dependency>
 
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/Java/measureeval/src/main/java/com/lantanagroup/link/measureeval/kafka/Headers.java
+++ b/Java/measureeval/src/main/java/com/lantanagroup/link/measureeval/kafka/Headers.java
@@ -11,6 +11,7 @@ public class Headers {
     public static final String EXCEPTION_MESSAGE = "X-Exception-Message";
     public static final String EXCEPTION_SERVICE = "X-Exception-Service";
     public static final String RETRY_COUNT = "X-Retry-Count";
+    public static final String REPORT_TRACKING_ID = "X-Report-Tracking-Id";
 
     public static String getString(byte[] bytes) {
         return new String(bytes, CHARSET);

--- a/Java/measureeval/src/main/java/com/lantanagroup/link/measureeval/kafka/Topics.java
+++ b/Java/measureeval/src/main/java/com/lantanagroup/link/measureeval/kafka/Topics.java
@@ -7,4 +7,7 @@ public class Topics {
     public static final String RESOURCE_NORMALIZED = "ResourceNormalized";
     public static final String RESOURCE_NORMALIZED_ERROR = "ResourceNormalized-Error";
     public static final String RESOURCE_NORMALIZED_RETRY = "ResourceNormalized-Retry";
+    public static final String EVALUATION_REQUESTED = "EvaluationRequested";
+    public static final String EVALUATION_REQUESTED_ERROR = "EvaluationRequested-Error";
+    public static final String EVALUATION_REQUESTED_RETRY = "EvaluationRequested-Retry";
 }

--- a/Java/measureeval/src/main/java/com/lantanagroup/link/measureeval/models/ReportableEvent.java
+++ b/Java/measureeval/src/main/java/com/lantanagroup/link/measureeval/models/ReportableEvent.java
@@ -4,6 +4,7 @@ public enum ReportableEvent {
   DISCHARGE,
   EOM,
   EOW,
-  EOD
+  EOD,
+  ADHOC
 
 }

--- a/Java/measureeval/src/main/java/com/lantanagroup/link/measureeval/records/EvaluationRequested.java
+++ b/Java/measureeval/src/main/java/com/lantanagroup/link/measureeval/records/EvaluationRequested.java
@@ -1,0 +1,10 @@
+package com.lantanagroup.link.measureeval.records;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class EvaluationRequested {
+    private String reportId;
+}

--- a/Java/measureeval/src/main/java/com/lantanagroup/link/measureeval/records/EvaluationRequested.java
+++ b/Java/measureeval/src/main/java/com/lantanagroup/link/measureeval/records/EvaluationRequested.java
@@ -6,5 +6,6 @@ import lombok.Setter;
 @Getter
 @Setter
 public class EvaluationRequested {
-    private String reportId;
+    private String PreviousReportId;
+    private String PatientId;
 }

--- a/Java/measureeval/src/main/java/com/lantanagroup/link/measureeval/repositories/PatientReportingEvaluationStatusRepository.java
+++ b/Java/measureeval/src/main/java/com/lantanagroup/link/measureeval/repositories/PatientReportingEvaluationStatusRepository.java
@@ -21,13 +21,16 @@ public interface PatientReportingEvaluationStatusRepository
         return findOne(Example.of(probe));
     }
 
-    default List<PatientReportingEvaluationStatus> findByFacilityIdAndReportTrackingId(String facilityId, String reportTrackingID) {
+    default Optional<PatientReportingEvaluationStatus> findOne(String facilityId, String patientId, String reportTrackingID) {
         PatientReportingEvaluationStatus probe = new PatientReportingEvaluationStatus();
         probe.setFacilityId(facilityId);
+        probe.setPatientId(patientId);
         PatientReportingEvaluationStatus.Report reportProbe = new PatientReportingEvaluationStatus.Report();
         reportProbe.setReportTrackingId(reportTrackingID);
         probe.setReports(List.of(reportProbe));
+        probe.setResources(null);
+        probe.setCorrelationId(null);
 
-        return findAll(Example.of(probe));
+        return findOne(Example.of(probe));
     }
 }

--- a/Java/measureeval/src/main/java/com/lantanagroup/link/measureeval/repositories/PatientReportingEvaluationStatusRepository.java
+++ b/Java/measureeval/src/main/java/com/lantanagroup/link/measureeval/repositories/PatientReportingEvaluationStatusRepository.java
@@ -5,6 +5,7 @@ import org.springframework.data.domain.Example;
 import org.springframework.data.mongodb.repository.MongoRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -18,5 +19,15 @@ public interface PatientReportingEvaluationStatusRepository
         probe.setResources(null);
 
         return findOne(Example.of(probe));
+    }
+
+    default List<PatientReportingEvaluationStatus> findByFacilityIdAndReportTrackingId(String facilityId, String reportTrackingID) {
+        PatientReportingEvaluationStatus probe = new PatientReportingEvaluationStatus();
+        probe.setFacilityId(facilityId);
+        PatientReportingEvaluationStatus.Report reportProbe = new PatientReportingEvaluationStatus.Report();
+        reportProbe.setReportTrackingId(reportTrackingID);
+        probe.setReports(List.of(reportProbe));
+
+        return findAll(Example.of(probe));
     }
 }

--- a/Java/measureeval/src/main/java/com/lantanagroup/link/measureeval/repositories/PatientReportingEvaluationStatusRepository.java
+++ b/Java/measureeval/src/main/java/com/lantanagroup/link/measureeval/repositories/PatientReportingEvaluationStatusRepository.java
@@ -2,7 +2,12 @@ package com.lantanagroup.link.measureeval.repositories;
 
 import com.lantanagroup.link.measureeval.entities.PatientReportingEvaluationStatus;
 import org.springframework.data.domain.Example;
+import org.springframework.data.domain.ExampleMatcher;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Criteria;
+//import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.data.mongodb.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -11,25 +16,13 @@ import java.util.Optional;
 @Repository
 public interface PatientReportingEvaluationStatusRepository
         extends MongoRepository<PatientReportingEvaluationStatus, String> {
+
     default Optional<PatientReportingEvaluationStatus> findOne(String facilityId, String correlationId) {
         PatientReportingEvaluationStatus probe = new PatientReportingEvaluationStatus();
         probe.setFacilityId(facilityId);
         probe.setCorrelationId(correlationId);
         probe.setReports(null);
         probe.setResources(null);
-
-        return findOne(Example.of(probe));
-    }
-
-    default Optional<PatientReportingEvaluationStatus> findOne(String facilityId, String patientId, String reportTrackingID) {
-        PatientReportingEvaluationStatus probe = new PatientReportingEvaluationStatus();
-        probe.setFacilityId(facilityId);
-        probe.setPatientId(patientId);
-        PatientReportingEvaluationStatus.Report reportProbe = new PatientReportingEvaluationStatus.Report();
-        reportProbe.setReportTrackingId(reportTrackingID);
-        probe.setReports(List.of(reportProbe));
-        probe.setResources(null);
-        probe.setCorrelationId(null);
 
         return findOne(Example.of(probe));
     }

--- a/Java/measureeval/src/main/java/com/lantanagroup/link/measureeval/repositories/PatientReportingEvaluationStatusTemplateRepository.java
+++ b/Java/measureeval/src/main/java/com/lantanagroup/link/measureeval/repositories/PatientReportingEvaluationStatusTemplateRepository.java
@@ -1,0 +1,25 @@
+package com.lantanagroup.link.measureeval.repositories;
+
+import com.lantanagroup.link.measureeval.entities.PatientReportingEvaluationStatus;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.stereotype.Service;
+
+@Service
+public class PatientReportingEvaluationStatusTemplateRepository {
+
+    private final MongoTemplate mongoTemplate;
+
+    public PatientReportingEvaluationStatusTemplateRepository(MongoTemplate mongoTemplate) {
+        this.mongoTemplate = mongoTemplate;
+    }
+
+    public PatientReportingEvaluationStatus getFirstByFacilityIdAndPatientIdAndReports_ReportTrackingId(String facilityId, String patientId, String reportTrackingId) {
+        Query query = new Query();
+        query.addCriteria(Criteria.where("reports.reportTrackingId").is(reportTrackingId));
+        query.addCriteria(Criteria.where("facilityId").is(facilityId));
+        query.addCriteria(Criteria.where("patientId").is(patientId));
+        return mongoTemplate.find(query, PatientReportingEvaluationStatus.class).stream().findFirst().orElse(null);
+    }
+}

--- a/Java/measureeval/src/main/java/com/lantanagroup/link/measureeval/services/AbstractResourceConsumer.java
+++ b/Java/measureeval/src/main/java/com/lantanagroup/link/measureeval/services/AbstractResourceConsumer.java
@@ -39,34 +39,40 @@ public abstract class AbstractResourceConsumer<T extends AbstractResourceRecord>
     private static final Logger logger = LoggerFactory.getLogger(AbstractResourceConsumer.class);
     private final AbstractResourceRepository resourceRepository;
     private final PatientReportingEvaluationStatusRepository patientStatusRepository;
-    private final MeasureEvaluatorCache measureEvaluatorCache;
     private final MeasureReportNormalizer measureReportNormalizer;
     private final Predicate<MeasureReport> reportabilityPredicate;
     private final MeasureEvalMetrics measureEvalMetrics;
     private final KafkaTemplate<String, DataAcquisitionRequested> dataAcquisitionRequestedTemplate;
     @Qualifier("compressedKafkaTemplate")
     private final KafkaTemplate<ResourceEvaluated.Key, ResourceEvaluated> resourceEvaluatedTemplate;
+    private final EvaluateMeasureService evaluateMeasureService;
+    private final PatientStatusBundler patientStatusBundler;
+    private final ResourceEvaluatedProducer resourceEvaluatedProducer;
 
     protected abstract NormalizationStatus getNormalizationStatus ();
 
     public AbstractResourceConsumer (
             AbstractResourceRepository resourceRepository,
             PatientReportingEvaluationStatusRepository patientStatusRepository,
-            MeasureEvaluatorCache measureEvaluatorCache,
             MeasureReportNormalizer measureReportNormalizer,
             Predicate<MeasureReport> reportabilityPredicate,
             KafkaTemplate<String, DataAcquisitionRequested> dataAcquisitionRequestedTemplate,
             @Qualifier("compressedKafkaTemplate")
             KafkaTemplate<ResourceEvaluated.Key, ResourceEvaluated> resourceEvaluatedTemplate,
-            MeasureEvalMetrics measureEvalMetrics) {
+            MeasureEvalMetrics measureEvalMetrics,
+            EvaluateMeasureService evaluateMeasureService,
+            PatientStatusBundler patientStatusBundler,
+            ResourceEvaluatedProducer resourceEvaluatedProducer) {
         this.resourceRepository = resourceRepository;
         this.patientStatusRepository = patientStatusRepository;
-        this.measureEvaluatorCache = measureEvaluatorCache;
         this.measureReportNormalizer = measureReportNormalizer;
         this.reportabilityPredicate = reportabilityPredicate;
         this.dataAcquisitionRequestedTemplate = dataAcquisitionRequestedTemplate;
         this.resourceEvaluatedTemplate = resourceEvaluatedTemplate;
         this.measureEvalMetrics = measureEvalMetrics;
+        this.evaluateMeasureService = evaluateMeasureService;
+        this.patientStatusBundler = patientStatusBundler;
+        this.resourceEvaluatedProducer = resourceEvaluatedProducer;
     }
 
     protected void doConsume (String correlationId, ConsumerRecord<String, T> record) {
@@ -109,7 +115,7 @@ public abstract class AbstractResourceConsumer<T extends AbstractResourceRecord>
                 logger.info("Consuming record: RECORD=[{}] FACILITY=[{}] CORRELATION=[{}] ACQUISITION COMPLETE=[{}]", KafkaUtils.format(record), facilityId, correlationId, value.isAcquisitionComplete());
             }
             PatientReportingEvaluationStatus patientStatus = Objects.requireNonNullElseGet(retrievePatientStatus(facilityId, correlationId), () -> createPatientStatus(facilityId, correlationId, value));
-            Bundle bundle = createBundle(patientStatus);
+            Bundle bundle = patientStatusBundler.createBundle(patientStatus);
             evaluateMeasures(value, patientStatus, bundle);
             return;
         }
@@ -202,52 +208,18 @@ public abstract class AbstractResourceConsumer<T extends AbstractResourceRecord>
         return patientStatus;
     }
 
-    private Bundle createBundle (PatientReportingEvaluationStatus patientStatus) {
-        if (logger.isDebugEnabled()) {
-            logger.debug("Creating bundle");
-        }
-        Bundle bundle = new Bundle();
-        bundle.setType(Bundle.BundleType.COLLECTION);
-        retrieveResources(patientStatus).stream()
-                .map(AbstractResourceEntity::getResource)
-                .map(Resource.class::cast)
-                .forEachOrdered(resource -> bundle.addEntry().setResource(resource));
-        return bundle;
-    }
-
-    private List<AbstractResourceEntity> retrieveResources (PatientReportingEvaluationStatus patientStatus) {
-        if (logger.isDebugEnabled()) {
-            logger.debug("Retrieving resources");
-        }
-
-        Set<Map.Entry<String, String>> singles = new HashSet<>();
-
-        return patientStatus.getResources().stream()
-                .filter(resource -> resource.getNormalizationStatus() == NormalizationStatus.NORMALIZED)
-                .filter(resource -> singles.add(new AbstractMap.SimpleEntry<>(resource.getResourceType().toString(), resource.getResourceId())))
-                .map(resource -> retrieveResource(patientStatus.getFacilityId(), resource))
-                .toList();
-    }
-
-    private AbstractResourceEntity retrieveResource (
-            String facilityId,
-            PatientReportingEvaluationStatus.Resource resource) {
-        logger.trace("Retrieving resource: {}/{}", resource.getResourceType(), resource.getResourceId());
-        return resourceRepository.findOne(facilityId, resource);
-    }
-
     private void evaluateMeasures (T value, PatientReportingEvaluationStatus patientStatus, Bundle bundle) {
         if (logger.isDebugEnabled()) {
             logger.debug("Evaluating measures");
         }
         for (PatientReportingEvaluationStatus.Report report : patientStatus.getReports()) {
-            MeasureReport measureReport = evaluateMeasure(value.getQueryType().toString(), patientStatus, report, bundle);
+            MeasureReport measureReport = evaluateMeasureService.evaluateMeasure(value.getQueryType().toString(), patientStatus, report, bundle);
             switch (value.getQueryType()) {
                 case INITIAL -> {
                     updateReportability(patientStatus, report, measureReport);
-                    produceResourceEvaluatedRecords(value.getQueryType(), patientStatus, report, measureReport);
+                    resourceEvaluatedProducer.produceResourceEvaluatedRecords(value.getQueryType(), patientStatus, report, measureReport);
                 }
-                case SUPPLEMENTAL -> produceResourceEvaluatedRecords(value.getQueryType(), patientStatus, report, measureReport);
+                case SUPPLEMENTAL -> resourceEvaluatedProducer.produceResourceEvaluatedRecords(value.getQueryType(), patientStatus, report, measureReport);
                 default -> throw new IllegalStateException(String.format("Unexpected query type: %s", value.getQueryType()));
             }
         }
@@ -276,56 +248,6 @@ public abstract class AbstractResourceConsumer<T extends AbstractResourceRecord>
         }
     }
 
-    private MeasureReport evaluateMeasure (
-            String queryType,
-            PatientReportingEvaluationStatus patientStatus,
-            PatientReportingEvaluationStatus.Report report,
-            Bundle bundle) {
-
-        long start = System.currentTimeMillis();
-
-        String measureId = report.getReportType();
-        if (logger.isDebugEnabled()) {
-            logger.debug("Evaluating measure: {}", measureId);
-        }
-        MeasureEvaluator measureEvaluator = measureEvaluatorCache.get(measureId);
-        if (measureEvaluator == null) {
-            throw new IllegalStateException(String.format("Unknown measure: %s", measureId));
-        }
-        MeasureReport measureReport = measureEvaluator.evaluate(
-                report.getStartDate(),
-                report.getEndDate(),
-                patientStatus.getPatientId(),
-                bundle);
-        if (logger.isDebugEnabled()) {
-            logger.debug("Population counts: {}", measureReport.getGroup().stream()
-                    .flatMap(group -> group.getPopulation().stream())
-                    .map(population -> String.format(
-                            "%s=[%d]",
-                            population.getCode().getCodingFirstRep().getCode(),
-                            population.getCount()))
-                    .collect(Collectors.joining(" ")));
-        }
-
-        long timeElapsed = System.currentTimeMillis() - start;
-        Attributes attributes = Attributes.builder().put(stringKey("facilityId"), patientStatus.getFacilityId()).
-                put(stringKey("patientId"), patientStatus.getPatientId()).
-                put(stringKey("reportTypes"), report.getReportType()).
-                put(stringKey("frequency"), report.getFrequency()).
-                put(stringKey("startDate"), report.getStartDate().toString()).
-                put(stringKey("endDate"), report.getEndDate().toString()).
-                put(stringKey("queryType"), queryType).
-                put(stringKey("correlationId"), patientStatus.getCorrelationId()).build();
-        if (logger.isInfoEnabled()) {
-            logger.info("Measure evaluation duration for Patient {} on {} query: {}", patientStatus.getPatientId(), queryType, timeElapsed + " milliseconds");
-        }
-
-        // Record the duration of the evaluation
-        measureEvalMetrics.MeasureEvalDuration(timeElapsed, attributes);
-
-        return measureReport;
-    }
-
     private void updateReportability (
             PatientReportingEvaluationStatus patientStatus,
             PatientReportingEvaluationStatus.Report report,
@@ -334,63 +256,7 @@ public abstract class AbstractResourceConsumer<T extends AbstractResourceRecord>
         patientStatusRepository.save(patientStatus);
     }
 
-    private void produceResourceEvaluatedRecords (
-            QueryType phase,
-            PatientReportingEvaluationStatus patientStatus,
-            PatientReportingEvaluationStatus.Report report,
-            MeasureReport measureReport) {
 
-        if (logger.isDebugEnabled()) {
-            logger.debug("Producing {} records", Topics.RESOURCE_EVALUATED);
-        }
-
-        var list = measureReportNormalizer.normalize(measureReport);
-
-        if (phase == QueryType.INITIAL && !report.getReportable()) { // produce Evaluated Resource the Initial phase only if the measure is not reportable
-            list.stream().filter(resource -> resource instanceof MeasureReport).findFirst().ifPresent(measure -> produceResourceEvaluatedRecord(patientStatus, report, measure.getIdPart(), measure));
-        }  else if (phase == QueryType.SUPPLEMENTAL && report.getReportable())  { //produce Evaluated Resource only on the Supplemental phase if the measure is reportable
-            for (Resource resource : list) {
-                produceResourceEvaluatedRecord(patientStatus, report, measureReport.getIdPart(), resource);
-            }
-        }
-
-
-    }
-
-    private void produceResourceEvaluatedRecord (
-            PatientReportingEvaluationStatus patientStatus,
-            PatientReportingEvaluationStatus.Report report,
-            String measureReportId,
-            Resource resource) {
-
-        if (logger.isTraceEnabled()) {
-            logger.trace(
-                    "Producing {} record: {}/{}",
-                    Topics.RESOURCE_EVALUATED, resource.getResourceType(), resource.getIdPart());
-        }
-        ResourceEvaluated.Key key = new ResourceEvaluated.Key();
-        key.setFacilityId(patientStatus.getFacilityId());
-        key.setStartDate(report.getStartDate());
-        key.setEndDate(report.getEndDate());
-        key.setFrequency(report.getFrequency());
-        ResourceEvaluated value = new ResourceEvaluated();
-        value.setMeasureReportId(measureReportId);
-        value.setPatientId(patientStatus.getPatientId());
-        value.setResource(resource);
-        value.setReportType(report.getReportType());
-        value.setIsReportable(report.getReportable());
-        value.setReportTrackingId(report.getReportTrackingId());
-
-        org.apache.kafka.common.header.Headers headers = new RecordHeaders()
-                .add(Headers.CORRELATION_ID, Headers.getBytes(patientStatus.getCorrelationId()));
-
-        resourceEvaluatedTemplate.send(new ProducerRecord<>(
-                Topics.RESOURCE_EVALUATED,
-                null,
-                key,
-                value,
-                headers));
-    }
 
     private void produceDataAcquisitionRequestedRecord (T value, PatientReportingEvaluationStatus patientStatus) {
         if (logger.isDebugEnabled()) {

--- a/Java/measureeval/src/main/java/com/lantanagroup/link/measureeval/services/EvaluateMeasureService.java
+++ b/Java/measureeval/src/main/java/com/lantanagroup/link/measureeval/services/EvaluateMeasureService.java
@@ -1,0 +1,119 @@
+package com.lantanagroup.link.measureeval.services;
+
+import com.lantanagroup.link.measureeval.entities.PatientReportingEvaluationStatus;
+import io.opentelemetry.api.common.Attributes;
+import org.hl7.fhir.r4.model.Bundle;
+import org.hl7.fhir.r4.model.MeasureReport;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import java.util.stream.Collectors;
+
+import static io.opentelemetry.api.common.AttributeKey.stringKey;
+
+@Service
+public class EvaluateMeasureService {
+
+    private static final Logger logger = LoggerFactory.getLogger(EvaluateMeasureService.class);
+    private final MeasureEvaluatorCache measureEvaluatorCache;
+    private final MeasureEvalMetrics measureEvalMetrics;
+
+    public EvaluateMeasureService(MeasureEvaluatorCache measureEvaluatorCache, MeasureEvalMetrics measureEvalMetrics) {
+        this.measureEvaluatorCache = measureEvaluatorCache;
+        this.measureEvalMetrics = measureEvalMetrics;
+    }
+
+    public MeasureReport evaluateMeasure (
+            PatientReportingEvaluationStatus patientStatus,
+            PatientReportingEvaluationStatus.Report report,
+            Bundle bundle) {
+
+        long start = System.currentTimeMillis();
+
+        MeasureReport measureReport = doReportGeneration(patientStatus, report, bundle);
+
+        if (logger.isDebugEnabled()) {
+            logger.debug("Population counts: {}", measureReport.getGroup().stream()
+                    .flatMap(group -> group.getPopulation().stream())
+                    .map(population -> String.format(
+                            "%s=[%d]",
+                            population.getCode().getCodingFirstRep().getCode(),
+                            population.getCount()))
+                    .collect(Collectors.joining(" ")));
+        }
+
+        long timeElapsed = System.currentTimeMillis() - start;
+        Attributes attributes = Attributes.builder().put(stringKey("facilityId"), patientStatus.getFacilityId()).
+                put(stringKey("patientId"), patientStatus.getPatientId()).
+                put(stringKey("reportTypes"), report.getReportType()).
+                put(stringKey("frequency"), report.getFrequency()).
+                put(stringKey("startDate"), report.getStartDate().toString()).
+                put(stringKey("endDate"), report.getEndDate().toString()).
+                put(stringKey("correlationId"), patientStatus.getCorrelationId()).build();
+        if (logger.isInfoEnabled()) {
+            logger.info("Measure evaluation duration for Patient {} : {}", patientStatus.getPatientId(), timeElapsed + " milliseconds");
+        }
+
+        // Record the duration of the evaluation
+        measureEvalMetrics.MeasureEvalDuration(timeElapsed, attributes);
+
+        return measureReport;
+    }
+
+    public MeasureReport evaluateMeasure (
+            String queryType,
+            PatientReportingEvaluationStatus patientStatus,
+            PatientReportingEvaluationStatus.Report report,
+            Bundle bundle) {
+        long start = System.currentTimeMillis();
+
+        MeasureReport measureReport = doReportGeneration(patientStatus, report, bundle);
+
+        if (logger.isDebugEnabled()) {
+            logger.debug("Population counts: {}", measureReport.getGroup().stream()
+                    .flatMap(group -> group.getPopulation().stream())
+                    .map(population -> String.format(
+                            "%s=[%d]",
+                            population.getCode().getCodingFirstRep().getCode(),
+                            population.getCount()))
+                    .collect(Collectors.joining(" ")));
+        }
+
+        long timeElapsed = System.currentTimeMillis() - start;
+        Attributes attributes = Attributes.builder().put(stringKey("facilityId"), patientStatus.getFacilityId()).
+                put(stringKey("patientId"), patientStatus.getPatientId()).
+                put(stringKey("reportTypes"), report.getReportType()).
+                put(stringKey("frequency"), report.getFrequency()).
+                put(stringKey("startDate"), report.getStartDate().toString()).
+                put(stringKey("endDate"), report.getEndDate().toString()).
+                put(stringKey("queryType"), queryType).
+                put(stringKey("correlationId"), patientStatus.getCorrelationId()).build();
+        if (logger.isInfoEnabled()) {
+            logger.info("Measure evaluation duration for Patient {} on {} query: {}", patientStatus.getPatientId(), queryType, timeElapsed + " milliseconds");
+        }
+
+        // Record the duration of the evaluation
+        measureEvalMetrics.MeasureEvalDuration(timeElapsed, attributes);
+
+        return measureReport;
+    }
+
+    private MeasureReport doReportGeneration(PatientReportingEvaluationStatus patientStatus,
+                                             PatientReportingEvaluationStatus.Report report,
+                                             Bundle bundle){
+        String measureId = report.getReportType();
+        if (logger.isDebugEnabled()) {
+            logger.debug("Evaluating measure: {}", measureId);
+        }
+        MeasureEvaluator measureEvaluator = measureEvaluatorCache.get(measureId);
+        if (measureEvaluator == null) {
+            throw new IllegalStateException(String.format("Unknown measure: %s", measureId));
+        }
+        return measureEvaluator.evaluate(
+                report.getStartDate(),
+                report.getEndDate(),
+                patientStatus.getPatientId(),
+                bundle);
+    }
+}

--- a/Java/measureeval/src/main/java/com/lantanagroup/link/measureeval/services/EvaluationRequestedConsumer.java
+++ b/Java/measureeval/src/main/java/com/lantanagroup/link/measureeval/services/EvaluationRequestedConsumer.java
@@ -1,0 +1,151 @@
+package com.lantanagroup.link.measureeval.services;
+
+import com.lantanagroup.link.measureeval.entities.PatientReportingEvaluationStatus;
+import com.lantanagroup.link.measureeval.kafka.Headers;
+import com.lantanagroup.link.measureeval.kafka.Topics;
+import com.lantanagroup.link.measureeval.records.DataAcquisitionRequested;
+import com.lantanagroup.link.measureeval.records.EvaluationRequested;
+import com.lantanagroup.link.measureeval.records.ResourceEvaluated;
+import com.lantanagroup.link.measureeval.repositories.AbstractResourceRepository;
+import com.lantanagroup.link.measureeval.repositories.PatientReportingEvaluationStatusRepository;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.trace.Span;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.hl7.fhir.r4.model.Bundle;
+import org.hl7.fhir.r4.model.MeasureReport;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.messaging.handler.annotation.Header;
+import org.springframework.stereotype.Service;
+
+import java.util.Objects;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+import static io.opentelemetry.api.common.AttributeKey.stringKey;
+
+@Service
+public class EvaluationRequestedConsumer {
+
+    private static final Logger logger = LoggerFactory.getLogger(EvaluationRequestedConsumer.class);
+    private final PatientReportingEvaluationStatusRepository patientStatusRepository;
+    private final MeasureEvaluatorCache measureEvaluatorCache;
+    private final MeasureEvalMetrics measureEvalMetrics;
+    private final PatientStatusBundler patientStatusBundler;
+    private final ResourceEvaluatedProducer resourceEvaluatedProducer;
+
+    EvaluationRequestedConsumer(AbstractResourceRepository resourceRepository,
+                                PatientReportingEvaluationStatusRepository patientStatusRepository,
+                                MeasureEvaluatorCache measureEvaluatorCache,
+                                MeasureReportNormalizer measureReportNormalizer,
+                                Predicate<MeasureReport> reportabilityPredicate,
+                                KafkaTemplate<String, DataAcquisitionRequested> dataAcquisitionRequestedTemplate,
+                                @Qualifier("compressedKafkaTemplate")
+                                KafkaTemplate<ResourceEvaluated.Key, ResourceEvaluated> resourceEvaluatedTemplate,
+                                MeasureEvalMetrics measureEvalMetrics, PatientStatusBundler patientStatusBundler, ResourceEvaluatedProducer resourceEvaluatedProducer) {
+        this.patientStatusRepository = patientStatusRepository;
+        this.measureEvaluatorCache = measureEvaluatorCache;
+        this.measureEvalMetrics = measureEvalMetrics;
+        this.patientStatusBundler = patientStatusBundler;
+        this.resourceEvaluatedProducer = resourceEvaluatedProducer;
+    }
+
+    @KafkaListener(topics = Topics.EVALUATION_REQUESTED)
+    public void consume(@Header(Headers.REPORT_TRACKING_ID) String reportTrackingID,
+                        ConsumerRecord<String, EvaluationRequested> record) {
+
+        Span currentSpan = Span.current();
+        MDC.put("traceId", currentSpan.getSpanContext().getTraceId());
+        MDC.put("spanId", currentSpan.getSpanContext().getSpanId());
+
+        Attributes attributes = Attributes.builder().put(stringKey("reportTrackingID"), reportTrackingID).build();
+        measureEvalMetrics.IncrementRecordsReceivedCounter(attributes);
+
+        String facilityId = record.key();
+        var patientReportStatuses = patientStatusRepository.findByFacilityIdAndReportTrackingId(facilityId, reportTrackingID);
+
+        for (PatientReportingEvaluationStatus status: patientReportStatuses) {
+            var bundle = patientStatusBundler.createBundle(status);
+            evaluateMeasures(record.value(), status, bundle);
+        }
+    }
+
+    private void evaluateMeasures (EvaluationRequested value, PatientReportingEvaluationStatus patientStatus, Bundle bundle) {
+        if (logger.isDebugEnabled()) {
+            logger.debug("Evaluating measures");
+        }
+        for (PatientReportingEvaluationStatus.Report report : patientStatus.getReports().stream().filter(r -> Objects.equals(r.getReportTrackingId(), value.getReportId())).toList()) {
+            MeasureReport measureReport = evaluateMeasure(patientStatus, report, bundle);
+//            produceResourceEvaluatedRecords(value.getQueryType(), patientStatus, report, measureReport);
+            this.resourceEvaluatedProducer.produceResourceEvaluatedRecords(patientStatus, report, measureReport);
+        }
+
+        boolean reportablePatient = patientStatus.getReports().stream().anyMatch(PatientReportingEvaluationStatus.Report::getReportable);
+        // if at least one reportable measure, increment the reportable patient counter otherwise increment the non-reportable patient counter
+        //updatePatientMetrics(value, patientStatus, reportablePatient);
+    }
+
+//    private void updatePatientMetrics (EvaluationRequested value, PatientReportingEvaluationStatus patientStatus, boolean reportablePatient) {
+//        Attributes attributes = Attributes.builder().put(stringKey("facilityId"), patientStatus.getFacilityId()).
+//                    put(stringKey("patientId"), patientStatus.getPatientId()).
+//                    put(stringKey("correlationId"), patientStatus.getCorrelationId()).build();
+//            if (reportablePatient) {
+//                measureEvalMetrics.IncrementPatientReportableCounter(attributes);
+//            } else {
+//                measureEvalMetrics.IncrementPatientNonReportableCounter(attributes);
+//            }
+//
+//    }
+
+    private MeasureReport evaluateMeasure (
+            PatientReportingEvaluationStatus patientStatus,
+            PatientReportingEvaluationStatus.Report report,
+            Bundle bundle) {
+
+        long start = System.currentTimeMillis();
+
+        String measureId = report.getReportType();
+        if (logger.isDebugEnabled()) {
+            logger.debug("Evaluating measure: {}", measureId);
+        }
+        MeasureEvaluator measureEvaluator = measureEvaluatorCache.get(measureId);
+        if (measureEvaluator == null) {
+            throw new IllegalStateException(String.format("Unknown measure: %s", measureId));
+        }
+        MeasureReport measureReport = measureEvaluator.evaluate(
+                report.getStartDate(),
+                report.getEndDate(),
+                patientStatus.getPatientId(),
+                bundle);
+        if (logger.isDebugEnabled()) {
+            logger.debug("Population counts: {}", measureReport.getGroup().stream()
+                    .flatMap(group -> group.getPopulation().stream())
+                    .map(population -> String.format(
+                            "%s=[%d]",
+                            population.getCode().getCodingFirstRep().getCode(),
+                            population.getCount()))
+                    .collect(Collectors.joining(" ")));
+        }
+
+        long timeElapsed = System.currentTimeMillis() - start;
+        Attributes attributes = Attributes.builder().put(stringKey("facilityId"), patientStatus.getFacilityId()).
+                put(stringKey("patientId"), patientStatus.getPatientId()).
+                put(stringKey("reportTypes"), report.getReportType()).
+                put(stringKey("frequency"), report.getFrequency()).
+                put(stringKey("startDate"), report.getStartDate().toString()).
+                put(stringKey("endDate"), report.getEndDate().toString()).
+                put(stringKey("correlationId"), patientStatus.getCorrelationId()).build();
+        if (logger.isInfoEnabled()) {
+            logger.info("Measure evaluation duration for Patient {} : {}", patientStatus.getPatientId(), timeElapsed + " milliseconds");
+        }
+
+        // Record the duration of the evaluation
+        measureEvalMetrics.MeasureEvalDuration(timeElapsed, attributes);
+
+        return measureReport;
+    }
+}

--- a/Java/measureeval/src/main/java/com/lantanagroup/link/measureeval/services/EvaluationRequestedConsumer.java
+++ b/Java/measureeval/src/main/java/com/lantanagroup/link/measureeval/services/EvaluationRequestedConsumer.java
@@ -1,6 +1,7 @@
 package com.lantanagroup.link.measureeval.services;
 
 import com.lantanagroup.link.measureeval.entities.PatientReportingEvaluationStatus;
+import com.lantanagroup.link.measureeval.exceptions.ValidationException;
 import com.lantanagroup.link.measureeval.kafka.Headers;
 import com.lantanagroup.link.measureeval.kafka.Topics;
 import com.lantanagroup.link.measureeval.models.ReportableEvent;
@@ -24,9 +25,7 @@ import org.springframework.messaging.handler.annotation.Header;
 import org.springframework.stereotype.Service;
 
 import java.util.Objects;
-import java.util.UUID;
 import java.util.function.Predicate;
-import java.util.stream.Collectors;
 
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
 
@@ -57,6 +56,7 @@ public class EvaluationRequestedConsumer {
 
     @KafkaListener(topics = Topics.EVALUATION_REQUESTED)
     public void consume(@Header(Headers.REPORT_TRACKING_ID) String reportTrackingID,
+                        @Header(Headers.CORRELATION_ID) String correlationId,
                         ConsumerRecord<String, EvaluationRequested> record) {
 
         Span currentSpan = Span.current();
@@ -67,38 +67,45 @@ public class EvaluationRequestedConsumer {
         measureEvalMetrics.IncrementRecordsReceivedCounter(attributes);
 
         String facilityId = record.key();
-        var patientReportStatuses = patientStatusRepository.findByFacilityIdAndReportTrackingId(facilityId, record.value().getReportId());
+        var patientReportStatus = patientStatusRepository.findOne(facilityId, record.value().getPatientId(), record.value().getPreviousReportId());
 
-        for (PatientReportingEvaluationStatus status: patientReportStatuses) {
-            var bundle = patientStatusBundler.createBundle(status);
-            evaluateMeasures(reportTrackingID, record.value(), status, bundle);
+        if (patientReportStatus.isPresent()) {
+            var bundle = patientStatusBundler.createBundle(patientReportStatus.get());
+            evaluateMeasures(reportTrackingID, correlationId, record.value(), patientReportStatus.get(), bundle);
+        } else {
+            logger.warn("Patient status not found for facilityId: {}, patientId: {}, reportTrackingId: {}. EvaluationRequested event not fully processed.", facilityId, record.value().getPatientId(), record.value().getPreviousReportId());
         }
     }
 
-    private void evaluateMeasures (String reportTrackingId, EvaluationRequested value, PatientReportingEvaluationStatus patientStatus, Bundle bundle) {
+    private void evaluateMeasures (String reportTrackingId, String correlationId, EvaluationRequested value, PatientReportingEvaluationStatus patientStatus, Bundle bundle) {
         if (logger.isDebugEnabled()) {
             logger.debug("Evaluating measures");
         }
-        for (PatientReportingEvaluationStatus.Report report : patientStatus.getReports().stream().filter(r -> Objects.equals(r.getReportTrackingId(), value.getReportId())).toList()) {
 
-            //create new PatientReportingEvaluationStatus and save it
-            var newPatientStatus = new PatientReportingEvaluationStatus();
-            newPatientStatus.setFacilityId(patientStatus.getFacilityId());
-            newPatientStatus.setPatientId(patientStatus.getPatientId());
-            newPatientStatus.setCorrelationId(UUID.randomUUID().toString());
-            newPatientStatus.setReportableEvent(ReportableEvent.ADHOC.name());
-            report.setReportTrackingId(reportTrackingId);
-            var reports = patientStatus.getReports();
-            reports.clear();
-            reports.add(report);
-            newPatientStatus.setReports(reports);
-            newPatientStatus.setResources(patientStatus.getResources());
+        //get valid report in array
+        var reports = patientStatus.getReports().stream().filter(r -> Objects.equals(r.getReportTrackingId(), value.getPreviousReportId())).toList();
 
-            patientStatusRepository.save(patientStatus);
-
-            MeasureReport measureReport = evaluateMeasureService.evaluateMeasure(patientStatus, report, bundle);
-            this.resourceEvaluatedProducer.produceResourceEvaluatedRecords(patientStatus, report, measureReport);
+        if(reports.size() > 1){
+            var message = String.format("Multiple reports found with the same reportTrackingId: %s", value.getPreviousReportId());
+            throw new ValidationException(message);
         }
+
+        //create new PatientReportingEvaluationStatus and save it
+        reports.forEach(r -> r.setReportTrackingId(reportTrackingId));
+        var newPatientStatus = new PatientReportingEvaluationStatus();
+        newPatientStatus.setFacilityId(patientStatus.getFacilityId());
+        newPatientStatus.setPatientId(patientStatus.getPatientId());
+        newPatientStatus.setCorrelationId(correlationId);
+        newPatientStatus.setReportableEvent(ReportableEvent.ADHOC.name());
+        newPatientStatus.setReports(reports);
+        newPatientStatus.setResources(patientStatus.getResources());
+
+        patientStatusRepository.save(patientStatus);
+
+        reports.forEach(r -> {
+            MeasureReport measureReport = evaluateMeasureService.evaluateMeasure(patientStatus, r, bundle);
+            this.resourceEvaluatedProducer.produceResourceEvaluatedRecords(patientStatus, r, measureReport);
+        });
 
         boolean reportablePatient = patientStatus.getReports().stream().anyMatch(PatientReportingEvaluationStatus.Report::getReportable);
         // if at least one reportable measure, increment the reportable patient counter otherwise increment the non-reportable patient counter

--- a/Java/measureeval/src/main/java/com/lantanagroup/link/measureeval/services/EvaluationRequestedConsumer.java
+++ b/Java/measureeval/src/main/java/com/lantanagroup/link/measureeval/services/EvaluationRequestedConsumer.java
@@ -3,6 +3,7 @@ package com.lantanagroup.link.measureeval.services;
 import com.lantanagroup.link.measureeval.entities.PatientReportingEvaluationStatus;
 import com.lantanagroup.link.measureeval.kafka.Headers;
 import com.lantanagroup.link.measureeval.kafka.Topics;
+import com.lantanagroup.link.measureeval.models.ReportableEvent;
 import com.lantanagroup.link.measureeval.records.DataAcquisitionRequested;
 import com.lantanagroup.link.measureeval.records.EvaluationRequested;
 import com.lantanagroup.link.measureeval.records.ResourceEvaluated;
@@ -23,6 +24,7 @@ import org.springframework.messaging.handler.annotation.Header;
 import org.springframework.stereotype.Service;
 
 import java.util.Objects;
+import java.util.UUID;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
@@ -33,25 +35,24 @@ public class EvaluationRequestedConsumer {
 
     private static final Logger logger = LoggerFactory.getLogger(EvaluationRequestedConsumer.class);
     private final PatientReportingEvaluationStatusRepository patientStatusRepository;
-    private final MeasureEvaluatorCache measureEvaluatorCache;
     private final MeasureEvalMetrics measureEvalMetrics;
     private final PatientStatusBundler patientStatusBundler;
     private final ResourceEvaluatedProducer resourceEvaluatedProducer;
+    private final EvaluateMeasureService evaluateMeasureService;
 
     EvaluationRequestedConsumer(AbstractResourceRepository resourceRepository,
                                 PatientReportingEvaluationStatusRepository patientStatusRepository,
-                                MeasureEvaluatorCache measureEvaluatorCache,
                                 MeasureReportNormalizer measureReportNormalizer,
                                 Predicate<MeasureReport> reportabilityPredicate,
                                 KafkaTemplate<String, DataAcquisitionRequested> dataAcquisitionRequestedTemplate,
                                 @Qualifier("compressedKafkaTemplate")
                                 KafkaTemplate<ResourceEvaluated.Key, ResourceEvaluated> resourceEvaluatedTemplate,
-                                MeasureEvalMetrics measureEvalMetrics, PatientStatusBundler patientStatusBundler, ResourceEvaluatedProducer resourceEvaluatedProducer) {
+                                MeasureEvalMetrics measureEvalMetrics, PatientStatusBundler patientStatusBundler, ResourceEvaluatedProducer resourceEvaluatedProducer, EvaluateMeasureService evaluateMeasureService) {
         this.patientStatusRepository = patientStatusRepository;
-        this.measureEvaluatorCache = measureEvaluatorCache;
         this.measureEvalMetrics = measureEvalMetrics;
         this.patientStatusBundler = patientStatusBundler;
         this.resourceEvaluatedProducer = resourceEvaluatedProducer;
+        this.evaluateMeasureService = evaluateMeasureService;
     }
 
     @KafkaListener(topics = Topics.EVALUATION_REQUESTED)
@@ -66,86 +67,53 @@ public class EvaluationRequestedConsumer {
         measureEvalMetrics.IncrementRecordsReceivedCounter(attributes);
 
         String facilityId = record.key();
-        var patientReportStatuses = patientStatusRepository.findByFacilityIdAndReportTrackingId(facilityId, reportTrackingID);
+        var patientReportStatuses = patientStatusRepository.findByFacilityIdAndReportTrackingId(facilityId, record.value().getReportId());
 
         for (PatientReportingEvaluationStatus status: patientReportStatuses) {
             var bundle = patientStatusBundler.createBundle(status);
-            evaluateMeasures(record.value(), status, bundle);
+            evaluateMeasures(reportTrackingID, record.value(), status, bundle);
         }
     }
 
-    private void evaluateMeasures (EvaluationRequested value, PatientReportingEvaluationStatus patientStatus, Bundle bundle) {
+    private void evaluateMeasures (String reportTrackingId, EvaluationRequested value, PatientReportingEvaluationStatus patientStatus, Bundle bundle) {
         if (logger.isDebugEnabled()) {
             logger.debug("Evaluating measures");
         }
         for (PatientReportingEvaluationStatus.Report report : patientStatus.getReports().stream().filter(r -> Objects.equals(r.getReportTrackingId(), value.getReportId())).toList()) {
-            MeasureReport measureReport = evaluateMeasure(patientStatus, report, bundle);
-//            produceResourceEvaluatedRecords(value.getQueryType(), patientStatus, report, measureReport);
+
+            //create new PatientReportingEvaluationStatus and save it
+            var newPatientStatus = new PatientReportingEvaluationStatus();
+            newPatientStatus.setFacilityId(patientStatus.getFacilityId());
+            newPatientStatus.setPatientId(patientStatus.getPatientId());
+            newPatientStatus.setCorrelationId(UUID.randomUUID().toString());
+            newPatientStatus.setReportableEvent(ReportableEvent.ADHOC.name());
+            report.setReportTrackingId(reportTrackingId);
+            var reports = patientStatus.getReports();
+            reports.clear();
+            reports.add(report);
+            newPatientStatus.setReports(reports);
+            newPatientStatus.setResources(patientStatus.getResources());
+
+            patientStatusRepository.save(patientStatus);
+
+            MeasureReport measureReport = evaluateMeasureService.evaluateMeasure(patientStatus, report, bundle);
             this.resourceEvaluatedProducer.produceResourceEvaluatedRecords(patientStatus, report, measureReport);
         }
 
         boolean reportablePatient = patientStatus.getReports().stream().anyMatch(PatientReportingEvaluationStatus.Report::getReportable);
         // if at least one reportable measure, increment the reportable patient counter otherwise increment the non-reportable patient counter
-        //updatePatientMetrics(value, patientStatus, reportablePatient);
+        updatePatientMetrics(value, patientStatus, reportablePatient);
     }
 
-//    private void updatePatientMetrics (EvaluationRequested value, PatientReportingEvaluationStatus patientStatus, boolean reportablePatient) {
-//        Attributes attributes = Attributes.builder().put(stringKey("facilityId"), patientStatus.getFacilityId()).
-//                    put(stringKey("patientId"), patientStatus.getPatientId()).
-//                    put(stringKey("correlationId"), patientStatus.getCorrelationId()).build();
-//            if (reportablePatient) {
-//                measureEvalMetrics.IncrementPatientReportableCounter(attributes);
-//            } else {
-//                measureEvalMetrics.IncrementPatientNonReportableCounter(attributes);
-//            }
-//
-//    }
-
-    private MeasureReport evaluateMeasure (
-            PatientReportingEvaluationStatus patientStatus,
-            PatientReportingEvaluationStatus.Report report,
-            Bundle bundle) {
-
-        long start = System.currentTimeMillis();
-
-        String measureId = report.getReportType();
-        if (logger.isDebugEnabled()) {
-            logger.debug("Evaluating measure: {}", measureId);
-        }
-        MeasureEvaluator measureEvaluator = measureEvaluatorCache.get(measureId);
-        if (measureEvaluator == null) {
-            throw new IllegalStateException(String.format("Unknown measure: %s", measureId));
-        }
-        MeasureReport measureReport = measureEvaluator.evaluate(
-                report.getStartDate(),
-                report.getEndDate(),
-                patientStatus.getPatientId(),
-                bundle);
-        if (logger.isDebugEnabled()) {
-            logger.debug("Population counts: {}", measureReport.getGroup().stream()
-                    .flatMap(group -> group.getPopulation().stream())
-                    .map(population -> String.format(
-                            "%s=[%d]",
-                            population.getCode().getCodingFirstRep().getCode(),
-                            population.getCount()))
-                    .collect(Collectors.joining(" ")));
-        }
-
-        long timeElapsed = System.currentTimeMillis() - start;
+    private void updatePatientMetrics (EvaluationRequested value, PatientReportingEvaluationStatus patientStatus, boolean reportablePatient) {
         Attributes attributes = Attributes.builder().put(stringKey("facilityId"), patientStatus.getFacilityId()).
-                put(stringKey("patientId"), patientStatus.getPatientId()).
-                put(stringKey("reportTypes"), report.getReportType()).
-                put(stringKey("frequency"), report.getFrequency()).
-                put(stringKey("startDate"), report.getStartDate().toString()).
-                put(stringKey("endDate"), report.getEndDate().toString()).
-                put(stringKey("correlationId"), patientStatus.getCorrelationId()).build();
-        if (logger.isInfoEnabled()) {
-            logger.info("Measure evaluation duration for Patient {} : {}", patientStatus.getPatientId(), timeElapsed + " milliseconds");
-        }
+                    put(stringKey("patientId"), patientStatus.getPatientId()).
+                    put(stringKey("correlationId"), patientStatus.getCorrelationId()).build();
+            if (reportablePatient) {
+                measureEvalMetrics.IncrementPatientReportableCounter(attributes);
+            } else {
+                measureEvalMetrics.IncrementPatientNonReportableCounter(attributes);
+            }
 
-        // Record the duration of the evaluation
-        measureEvalMetrics.MeasureEvalDuration(timeElapsed, attributes);
-
-        return measureReport;
     }
 }

--- a/Java/measureeval/src/main/java/com/lantanagroup/link/measureeval/services/EvaluationRequestedConsumer.java
+++ b/Java/measureeval/src/main/java/com/lantanagroup/link/measureeval/services/EvaluationRequestedConsumer.java
@@ -10,6 +10,7 @@ import com.lantanagroup.link.measureeval.records.EvaluationRequested;
 import com.lantanagroup.link.measureeval.records.ResourceEvaluated;
 import com.lantanagroup.link.measureeval.repositories.AbstractResourceRepository;
 import com.lantanagroup.link.measureeval.repositories.PatientReportingEvaluationStatusRepository;
+import com.lantanagroup.link.measureeval.repositories.PatientReportingEvaluationStatusTemplateRepository;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.trace.Span;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
@@ -38,6 +39,7 @@ public class EvaluationRequestedConsumer {
     private final PatientStatusBundler patientStatusBundler;
     private final ResourceEvaluatedProducer resourceEvaluatedProducer;
     private final EvaluateMeasureService evaluateMeasureService;
+    private final PatientReportingEvaluationStatusTemplateRepository patientReportingEvaluationStatusTemplateRepository;
 
     EvaluationRequestedConsumer(AbstractResourceRepository resourceRepository,
                                 PatientReportingEvaluationStatusRepository patientStatusRepository,
@@ -46,12 +48,17 @@ public class EvaluationRequestedConsumer {
                                 KafkaTemplate<String, DataAcquisitionRequested> dataAcquisitionRequestedTemplate,
                                 @Qualifier("compressedKafkaTemplate")
                                 KafkaTemplate<ResourceEvaluated.Key, ResourceEvaluated> resourceEvaluatedTemplate,
-                                MeasureEvalMetrics measureEvalMetrics, PatientStatusBundler patientStatusBundler, ResourceEvaluatedProducer resourceEvaluatedProducer, EvaluateMeasureService evaluateMeasureService) {
+                                MeasureEvalMetrics measureEvalMetrics,
+                                PatientStatusBundler patientStatusBundler,
+                                ResourceEvaluatedProducer resourceEvaluatedProducer,
+                                EvaluateMeasureService evaluateMeasureService,
+                                PatientReportingEvaluationStatusTemplateRepository patientReportingEvaluationStatusTemplateRepository) {
         this.patientStatusRepository = patientStatusRepository;
         this.measureEvalMetrics = measureEvalMetrics;
         this.patientStatusBundler = patientStatusBundler;
         this.resourceEvaluatedProducer = resourceEvaluatedProducer;
         this.evaluateMeasureService = evaluateMeasureService;
+        this.patientReportingEvaluationStatusTemplateRepository = patientReportingEvaluationStatusTemplateRepository;
     }
 
     @KafkaListener(topics = Topics.EVALUATION_REQUESTED)
@@ -67,11 +74,11 @@ public class EvaluationRequestedConsumer {
         measureEvalMetrics.IncrementRecordsReceivedCounter(attributes);
 
         String facilityId = record.key();
-        var patientReportStatus = patientStatusRepository.findOne(facilityId, record.value().getPatientId(), record.value().getPreviousReportId());
+        var patientReportStatus = patientReportingEvaluationStatusTemplateRepository.getFirstByFacilityIdAndPatientIdAndReports_ReportTrackingId(facilityId, record.value().getPatientId(), record.value().getPreviousReportId());
 
-        if (patientReportStatus.isPresent()) {
-            var bundle = patientStatusBundler.createBundle(patientReportStatus.get());
-            evaluateMeasures(reportTrackingID, correlationId, record.value(), patientReportStatus.get(), bundle);
+        if (patientReportStatus != null) {
+            var bundle = patientStatusBundler.createBundle(patientReportStatus);
+            evaluateMeasures(reportTrackingID, correlationId, record.value(), patientReportStatus, bundle);
         } else {
             logger.warn("Patient status not found for facilityId: {}, patientId: {}, reportTrackingId: {}. EvaluationRequested event not fully processed.", facilityId, record.value().getPatientId(), record.value().getPreviousReportId());
         }
@@ -99,8 +106,7 @@ public class EvaluationRequestedConsumer {
         newPatientStatus.setReportableEvent(ReportableEvent.ADHOC.name());
         newPatientStatus.setReports(reports);
         newPatientStatus.setResources(patientStatus.getResources());
-
-        patientStatusRepository.save(patientStatus);
+        patientStatusRepository.insert(newPatientStatus);
 
         reports.forEach(r -> {
             MeasureReport measureReport = evaluateMeasureService.evaluateMeasure(patientStatus, r, bundle);

--- a/Java/measureeval/src/main/java/com/lantanagroup/link/measureeval/services/PatientStatusBundler.java
+++ b/Java/measureeval/src/main/java/com/lantanagroup/link/measureeval/services/PatientStatusBundler.java
@@ -1,0 +1,59 @@
+package com.lantanagroup.link.measureeval.services;
+
+import com.lantanagroup.link.measureeval.entities.AbstractResourceEntity;
+import com.lantanagroup.link.measureeval.entities.PatientReportingEvaluationStatus;
+import com.lantanagroup.link.measureeval.models.NormalizationStatus;
+import com.lantanagroup.link.measureeval.repositories.AbstractResourceRepository;
+import org.hl7.fhir.r4.model.Bundle;
+import org.hl7.fhir.r4.model.Resource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import java.util.*;
+
+@Service
+public class PatientStatusBundler {
+
+    private static final Logger logger = LoggerFactory.getLogger(PatientStatusBundler.class);
+
+    private final AbstractResourceRepository resourceRepository;
+
+    public PatientStatusBundler(AbstractResourceRepository resourceRepository) {
+        this.resourceRepository = resourceRepository;
+    }
+
+    public Bundle createBundle (PatientReportingEvaluationStatus patientStatus) {
+        if (logger.isDebugEnabled()) {
+            logger.debug("Creating bundle");
+        }
+        Bundle bundle = new Bundle();
+        bundle.setType(Bundle.BundleType.COLLECTION);
+        retrieveResources(patientStatus).stream()
+                .map(AbstractResourceEntity::getResource)
+                .map(Resource.class::cast)
+                .forEachOrdered(resource -> bundle.addEntry().setResource(resource));
+        return bundle;
+    }
+
+    private List<AbstractResourceEntity> retrieveResources (PatientReportingEvaluationStatus patientStatus) {
+        if (logger.isDebugEnabled()) {
+            logger.debug("Retrieving resources");
+        }
+
+        Set<Map.Entry<String, String>> singles = new HashSet<>();
+
+        return patientStatus.getResources().stream()
+                .filter(resource -> resource.getNormalizationStatus() == NormalizationStatus.NORMALIZED)
+                .filter(resource -> singles.add(new AbstractMap.SimpleEntry<>(resource.getResourceType().toString(), resource.getResourceId())))
+                .map(resource -> retrieveResource(patientStatus.getFacilityId(), resource))
+                .toList();
+    }
+
+    private AbstractResourceEntity retrieveResource (
+            String facilityId,
+            PatientReportingEvaluationStatus.Resource resource) {
+        logger.trace("Retrieving resource: {}/{}", resource.getResourceType(), resource.getResourceId());
+        return resourceRepository.findOne(facilityId, resource);
+    }
+}

--- a/Java/measureeval/src/main/java/com/lantanagroup/link/measureeval/services/ResourceAcquiredErrorConsumer.java
+++ b/Java/measureeval/src/main/java/com/lantanagroup/link/measureeval/services/ResourceAcquiredErrorConsumer.java
@@ -23,22 +23,26 @@ public class ResourceAcquiredErrorConsumer extends AbstractResourceConsumer<Reso
     public ResourceAcquiredErrorConsumer(
             AbstractResourceRepository resourceRepository,
             PatientReportingEvaluationStatusRepository patientStatusRepository,
-            MeasureEvaluatorCache measureEvaluatorCache,
             MeasureReportNormalizer measureReportNormalizer,
             Predicate<MeasureReport> reportabilityPredicate,
             KafkaTemplate<String, DataAcquisitionRequested> dataAcquisitionRequestedTemplate,
             @Qualifier("compressedKafkaTemplate")
             KafkaTemplate<ResourceEvaluated.Key, ResourceEvaluated> resourceEvaluatedTemplate,
-            MeasureEvalMetrics measureEvalMetrics){
+            MeasureEvalMetrics measureEvalMetrics,
+            EvaluateMeasureService evaluateMeasureService,
+            PatientStatusBundler patientStatusBundler,
+            ResourceEvaluatedProducer resourceEvaluatedProducer){
         super(
                 resourceRepository,
                 patientStatusRepository,
-                measureEvaluatorCache,
                 measureReportNormalizer,
                 reportabilityPredicate,
                 dataAcquisitionRequestedTemplate,
                 resourceEvaluatedTemplate,
-                measureEvalMetrics);
+                measureEvalMetrics,
+                evaluateMeasureService,
+                patientStatusBundler,
+                resourceEvaluatedProducer);
     }
 
     @Override

--- a/Java/measureeval/src/main/java/com/lantanagroup/link/measureeval/services/ResourceEvaluatedProducer.java
+++ b/Java/measureeval/src/main/java/com/lantanagroup/link/measureeval/services/ResourceEvaluatedProducer.java
@@ -13,7 +13,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Service;
 
+@Service
 public class ResourceEvaluatedProducer {
     private static final Logger logger = LoggerFactory.getLogger(ResourceEvaluatedProducer.class);
     private final MeasureReportNormalizer measureReportNormalizer;
@@ -68,6 +70,10 @@ public class ResourceEvaluatedProducer {
             PatientReportingEvaluationStatus.Report report,
             String measureReportId,
             Resource resource) {
+
+        if (patientStatus == null || report == null || measureReportId == null || resource == null) {
+            throw new IllegalArgumentException("All parameters are required");
+        }
 
         if (logger.isTraceEnabled()) {
             logger.trace(

--- a/Java/measureeval/src/main/java/com/lantanagroup/link/measureeval/services/ResourceEvaluatedProducer.java
+++ b/Java/measureeval/src/main/java/com/lantanagroup/link/measureeval/services/ResourceEvaluatedProducer.java
@@ -1,0 +1,100 @@
+package com.lantanagroup.link.measureeval.services;
+
+import com.lantanagroup.link.measureeval.entities.PatientReportingEvaluationStatus;
+import com.lantanagroup.link.measureeval.kafka.Headers;
+import com.lantanagroup.link.measureeval.kafka.Topics;
+import com.lantanagroup.link.measureeval.models.QueryType;
+import com.lantanagroup.link.measureeval.records.ResourceEvaluated;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.header.internals.RecordHeaders;
+import org.hl7.fhir.r4.model.MeasureReport;
+import org.hl7.fhir.r4.model.Resource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.kafka.core.KafkaTemplate;
+
+public class ResourceEvaluatedProducer {
+    private static final Logger logger = LoggerFactory.getLogger(ResourceEvaluatedProducer.class);
+    private final MeasureReportNormalizer measureReportNormalizer;
+    @Qualifier("compressedKafkaTemplate")
+    private final KafkaTemplate<ResourceEvaluated.Key, ResourceEvaluated> resourceEvaluatedTemplate;
+
+    public ResourceEvaluatedProducer(MeasureReportNormalizer measureReportNormalizer, KafkaTemplate<ResourceEvaluated.Key, ResourceEvaluated> resourceEvaluatedTemplate) {
+        this.measureReportNormalizer = measureReportNormalizer;
+        this.resourceEvaluatedTemplate = resourceEvaluatedTemplate;
+    }
+
+    public void produceResourceEvaluatedRecords (
+            PatientReportingEvaluationStatus patientStatus,
+            PatientReportingEvaluationStatus.Report report,
+            MeasureReport measureReport) {
+
+        if (logger.isDebugEnabled()) {
+            logger.debug("Producing {} records", Topics.RESOURCE_EVALUATED);
+        }
+
+        var list = measureReportNormalizer.normalize(measureReport);
+        for (Resource resource : list) {
+            produceResourceEvaluatedRecord(patientStatus, report, measureReport.getIdPart(), resource);
+        }
+    }
+
+    public void produceResourceEvaluatedRecords (
+            QueryType phase,
+            PatientReportingEvaluationStatus patientStatus,
+            PatientReportingEvaluationStatus.Report report,
+            MeasureReport measureReport) {
+
+        if (logger.isDebugEnabled()) {
+            logger.debug("Producing {} records", Topics.RESOURCE_EVALUATED);
+        }
+
+        var list = measureReportNormalizer.normalize(measureReport);
+
+        if (phase == QueryType.INITIAL && !report.getReportable()) { // produce Evaluated Resource the Initial phase only if the measure is not reportable
+            list.stream().filter(resource -> resource instanceof MeasureReport).findFirst().ifPresent(measure -> produceResourceEvaluatedRecord(patientStatus, report, measure.getIdPart(), measure));
+        }  else if (phase == QueryType.SUPPLEMENTAL && report.getReportable())  { //produce Evaluated Resource only on the Supplemental phase if the measure is reportable
+            for (Resource resource : list) {
+                produceResourceEvaluatedRecord(patientStatus, report, measureReport.getIdPart(), resource);
+            }
+        }
+
+
+    }
+
+    public void produceResourceEvaluatedRecord (
+            PatientReportingEvaluationStatus patientStatus,
+            PatientReportingEvaluationStatus.Report report,
+            String measureReportId,
+            Resource resource) {
+
+        if (logger.isTraceEnabled()) {
+            logger.trace(
+                    "Producing {} record: {}/{}",
+                    Topics.RESOURCE_EVALUATED, resource.getResourceType(), resource.getIdPart());
+        }
+        ResourceEvaluated.Key key = new ResourceEvaluated.Key();
+        key.setFacilityId(patientStatus.getFacilityId());
+        key.setStartDate(report.getStartDate());
+        key.setEndDate(report.getEndDate());
+        key.setFrequency(report.getFrequency());
+        ResourceEvaluated value = new ResourceEvaluated();
+        value.setMeasureReportId(measureReportId);
+        value.setPatientId(patientStatus.getPatientId());
+        value.setResource(resource);
+        value.setReportType(report.getReportType());
+        value.setIsReportable(report.getReportable());
+        value.setReportTrackingId(report.getReportTrackingId());
+
+        org.apache.kafka.common.header.Headers headers = new RecordHeaders()
+                .add(Headers.CORRELATION_ID, Headers.getBytes(patientStatus.getCorrelationId()));
+
+        resourceEvaluatedTemplate.send(new ProducerRecord<>(
+                Topics.RESOURCE_EVALUATED,
+                null,
+                key,
+                value,
+                headers));
+    }
+}

--- a/Java/measureeval/src/main/java/com/lantanagroup/link/measureeval/services/ResourceNormalizedConsumer.java
+++ b/Java/measureeval/src/main/java/com/lantanagroup/link/measureeval/services/ResourceNormalizedConsumer.java
@@ -24,22 +24,26 @@ public class ResourceNormalizedConsumer extends AbstractResourceConsumer<Resourc
   public ResourceNormalizedConsumer (
           AbstractResourceRepository resourceRepository,
           PatientReportingEvaluationStatusRepository patientStatusRepository,
-          MeasureEvaluatorCache measureEvaluatorCache,
           MeasureReportNormalizer measureReportNormalizer,
           Predicate<MeasureReport> reportabilityPredicate,
           KafkaTemplate<String, DataAcquisitionRequested> dataAcquisitionRequestedTemplate,
           @Qualifier("compressedKafkaTemplate")
           KafkaTemplate<ResourceEvaluated.Key, ResourceEvaluated> resourceEvaluatedTemplate,
-          MeasureEvalMetrics measureEvalMetrics) {
+          MeasureEvalMetrics measureEvalMetrics,
+          EvaluateMeasureService evaluateMeasureService,
+          PatientStatusBundler patientStatusBundler,
+          ResourceEvaluatedProducer resourceEvaluatedProducer){
     super(
             resourceRepository,
             patientStatusRepository,
-            measureEvaluatorCache,
             measureReportNormalizer,
             reportabilityPredicate,
             dataAcquisitionRequestedTemplate,
             resourceEvaluatedTemplate,
-            measureEvalMetrics);
+            measureEvalMetrics,
+            evaluateMeasureService,
+            patientStatusBundler,
+            resourceEvaluatedProducer);
   }
 
   @Override

--- a/Java/measureeval/src/test/java/com/lantanagroup/link/measureeval/services/EvaluateMeasureServiceTest.java
+++ b/Java/measureeval/src/test/java/com/lantanagroup/link/measureeval/services/EvaluateMeasureServiceTest.java
@@ -1,0 +1,73 @@
+package com.lantanagroup.link.measureeval.services;
+
+import com.lantanagroup.link.measureeval.entities.PatientReportingEvaluationStatus;
+import com.lantanagroup.link.measureeval.repositories.PatientReportingEvaluationStatusRepository;
+import org.hl7.fhir.r4.model.Bundle;
+
+import org.hl7.fhir.r4.model.MeasureReport;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+
+import java.util.Date;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.*;
+
+public class EvaluateMeasureServiceTest {
+
+    @Mock
+    private PatientReportingEvaluationStatusRepository patientStatusRepository;
+
+    @Mock
+    private MeasureEvaluatorCache measureEvaluatorCache;
+
+    @Mock
+    private MeasureEvaluator measureEvaluator;
+
+    @InjectMocks
+    private EvaluateMeasureService evaluateMeasureService;
+
+    @Mock
+    private MeasureEvalMetrics measureEvalMetrics;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    void testEvaluateMeasure() {
+        // Arrange
+        PatientReportingEvaluationStatus patientStatus = new PatientReportingEvaluationStatus();
+        patientStatus.setPatientId("Patient/simple-patient");
+
+        PatientReportingEvaluationStatus.Report report = new PatientReportingEvaluationStatus.Report();
+        report.setReportType("measureId");
+        report.setStartDate(new Date()); // Set startDate to today
+        report.setEndDate(new Date()); // Set endDate to today
+        Bundle bundle = KnowledgeArtifactBuilder.SimpleCohortMeasureTrue.bundle();
+
+        MeasureReport mockMeasureReport = new MeasureReport();
+        MeasureReport.MeasureReportGroupComponent group = new MeasureReport.MeasureReportGroupComponent();
+        MeasureReport.MeasureReportGroupPopulationComponent population = new MeasureReport.MeasureReportGroupPopulationComponent();
+        population.setCount(100);
+        group.addPopulation(population);
+        mockMeasureReport.addGroup(group);
+
+        when(patientStatusRepository.save(any(PatientReportingEvaluationStatus.class))).thenReturn(patientStatus);
+        when(patientStatusRepository.insert(any(PatientReportingEvaluationStatus.class))).thenReturn(patientStatus);
+        when(measureEvaluatorCache.get(anyString())).thenReturn(measureEvaluator);
+        when(measureEvaluatorCache.get("measureId")).thenReturn(measureEvaluator);
+        when(measureEvaluator.evaluate(any(Date.class), any(Date.class), any(String.class), any(Bundle.class))).thenReturn(mockMeasureReport);
+
+        // Act
+        MeasureReport result = evaluateMeasureService.evaluateMeasure(patientStatus, report, bundle);
+
+        // Assert
+        assertNotNull(result);
+    }
+}


### PR DESCRIPTION
### 🛠️ Description of Changes
Create new listener in MeasureEval service for the new EvaluationRequested message.

### 🧪 Testing Performed
Performed local testing:
1. validated that the message is consumed by the listener
2. the listener is creating a new PatientReportingEvaluationStatus record in MongoDB.
3. the listener is then re-evaluating patients and creating a ResourceEvaluated message.

### 🧑‍🔬 Unit Testing
- [X ] I have written or updated unit tests to cover my changes

### 📓 Documentation Updated
no API or documentation changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Enhanced messaging functionality with new header identifiers to improve tracking of evaluation requests.
  - Expanded support for evaluation processing with additional message topics covering requests, errors, and retries.
  - Introduced backend services to consume evaluation requests, bundle patient reporting data, evaluate measures, and produce corresponding evaluation result notifications.
  - Added a new class for evaluating measures and generating reports based on patient statuses and reports.
  - Introduced a new service for bundling patient statuses into FHIR bundles.

- **Bug Fixes**
  - Resolved redundancy in dependency configuration for testing libraries.

- **Tests**
  - Added a new test class to validate the functionality of the EvaluateMeasureService.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->