### PR TITLE
LNK-3578: Fixed issue with route for integration test page

### DIFF
--- a/DotNet/Tenant/appsettings.Development.json
+++ b/DotNet/Tenant/appsettings.Development.json
@@ -73,10 +73,6 @@
       },
       "https": {
         "Url": "https://localhost:7332"
-      },
-      "Grpc": {
-        "Url": "http://localhost:7333",
-        "Protocols": "Http2"
       }
     }
   },

--- a/Web/Admin.UI/src/app/app.component.html
+++ b/Web/Admin.UI/src/app/app.component.html
@@ -87,7 +87,7 @@
               <mat-icon>bug_report</mat-icon>&nbsp;Testing
             </mat-panel-title>
           </mat-expansion-panel-header>
-          <a mat-list-item routerLink="monitor/health" routerLinkActive="active">
+          <a mat-list-item routerLink="integration-test" routerLinkActive="active">
             <mat-icon matListItemIcon>integration_instructions</mat-icon>
             <div class="side-nav-menu-title" matListItemTitle *ngIf="showMenuText">Integration Test</div>
           </a>


### PR DESCRIPTION
### 🛠️ Description of Changes
Fix an issue where the route in the menu item for the integration test page was pointing to the wrong route and sending it to the new service health page.

### 🧪 Testing Performed
Navigated to both the integration test and service health check pages.

### 🧑‍🔬 Unit Testing
- [ ] I have written or updated unit tests to cover my changes

### 📓 Documentation Updated
Please update any relevant sections in the project documentation that were impacted by the changes in the PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Removed a non-essential connectivity option from the development configuration.
  
- **New Features**
  - Updated the navigation menu to now direct users to the Integration Test page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->