### PR TITLE
LNK-3542: Remove More ReportTrackingID and Fix AddAsync Mongo

### DIFF
--- a/DotNet/DataAcquisition.Domain/Settings/DataAcquisitionConstants.cs
+++ b/DotNet/DataAcquisition.Domain/Settings/DataAcquisitionConstants.cs
@@ -34,7 +34,6 @@ public static class DataAcquisitionConstants
     public static class HeaderNames
     {
         public const string CorrelationId = "X-Correlation-Id";
-        public const string ReportId = "X-Report-Tracking-Id";
     }
 
     public static class ContentTypes

--- a/DotNet/QueryDispatch/Domain/Managers/ScheduledReportManager.cs
+++ b/DotNet/QueryDispatch/Domain/Managers/ScheduledReportManager.cs
@@ -46,11 +46,6 @@ namespace QueryDispatch.Domain.Managers
 
                 _logger.LogInformation($"Created schedule report for faciltiy {HtmlInputSanitizer.Sanitize(scheduledReport.FacilityId)}");
 
-                var headers = new Headers
-                        {
-                            { "X-Report-Tracking-Id", System.Text.Encoding.ASCII.GetBytes(scheduledReport.ReportPeriods[0].ReportTrackingId) }
-                        };
-
                 var auditMessage = new AuditEventMessage
                 {
                     FacilityId = scheduledReport.FacilityId,
@@ -64,12 +59,10 @@ namespace QueryDispatch.Domain.Managers
                 _producer.Produce(nameof(KafkaTopic.AuditableEventOccurred), new Message<string, AuditEventMessage>
                 {
                     Value = auditMessage,
-                    Headers = headers
-                });
+                    Headers = new Headers()
+            });
 
                 _producer.Flush();
-
-
 
                 return scheduledReport.FacilityId;
             }
@@ -129,11 +122,6 @@ namespace QueryDispatch.Domain.Managers
 
                 _logger.LogInformation($"Update scheduled report type {HtmlInputSanitizer.Sanitize(newReportPeriod.ReportTypes.ToString())} for facility id {HtmlInputSanitizer.Sanitize(existingReport.FacilityId)}");
 
-                var headers = new Headers
-                    {
-                        { "X-Report-Tracking-Id", System.Text.Encoding.ASCII.GetBytes(newReportPeriod.ReportTrackingId) }
-                    };
-
                 var auditMessage = new AuditEventMessage
                 {
                     FacilityId = existingReport.FacilityId,
@@ -148,8 +136,8 @@ namespace QueryDispatch.Domain.Managers
                 _producer.Produce(nameof(KafkaTopic.AuditableEventOccurred), new Message<string, AuditEventMessage>
                 {
                     Value = auditMessage,
-                    Headers = headers
-                });
+                    Headers = new Headers()
+            });
 
                 _producer.Flush();
 

--- a/DotNet/Report/Application/Models/EvaluationRequestedValue.cs
+++ b/DotNet/Report/Application/Models/EvaluationRequestedValue.cs
@@ -4,5 +4,6 @@
     {
         public string PreviousReportId { get; set; }
         public string PatientId { get; set; }
+        public string ReportTrackingId { get; set; }
     }
 }

--- a/DotNet/Report/KafkaProducers/DataAcquisitionRequestedProducer.cs
+++ b/DotNet/Report/KafkaProducers/DataAcquisitionRequestedProducer.cs
@@ -41,6 +41,9 @@ namespace LantanaGroup.Link.Report.KafkaProducers
                     case Frequency.Daily:
                         reportableEvent = "EOD";
                         break;
+                    case Frequency.Adhoc:
+                        reportableEvent = "Adhoc";
+                        break;
                 }
 
                 var darValue = new DataAcquisitionRequestedValue()

--- a/DotNet/Report/Listeners/GenerateReportListener.cs
+++ b/DotNet/Report/Listeners/GenerateReportListener.cs
@@ -8,6 +8,7 @@ using LantanaGroup.Link.Report.Application.Models;
 using LantanaGroup.Link.Report.Domain.Enums;
 using LantanaGroup.Link.Report.Domain.Managers;
 using LantanaGroup.Link.Report.Entities;
+using LantanaGroup.Link.Report.KafkaProducers;
 using LantanaGroup.Link.Report.Settings;
 using LantanaGroup.Link.Shared.Application.Error.Exceptions;
 using LantanaGroup.Link.Shared.Application.Error.Interfaces;
@@ -40,8 +41,9 @@ namespace LantanaGroup.Link.Report.Listeners
         private readonly IOptions<LinkTokenServiceSettings> _linkTokenServiceConfig;
         private readonly ICreateSystemToken _createSystemToken;
 
-        private readonly IProducer<string, DataAcquisitionRequestedValue> _dataAcqProducer;
         private readonly IProducer<string, EvaluationRequestedValue> _evaluationProducer;
+
+        private readonly DataAcquisitionRequestedProducer _dataAcqProducer;
 
         private string Name => this.GetType().Name;
 
@@ -54,7 +56,7 @@ namespace LantanaGroup.Link.Report.Listeners
             IOptions<LinkTokenServiceSettings> linkTokenService,
             ICreateSystemToken createSystemToken,
             IOptions<ServiceRegistry> serviceRegistry,
-            IProducer<string, DataAcquisitionRequestedValue> dataAcqProducer,
+            DataAcquisitionRequestedProducer dataAcqProducer,
             IProducer<string, EvaluationRequestedValue> evaluationProducer)
         {
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
@@ -130,19 +132,11 @@ namespace LantanaGroup.Link.Report.Listeners
 
                                 facilityId = key;
 
-
                                 if (string.IsNullOrWhiteSpace(facilityId))
                                 {
                                     throw new DeadLetterException(
                                         $"{Name}: FacilityId is null or empty.");
                                 }
-
-                                result.Message.Headers.TryGetLastBytes("X-Report-Tracking-Id", out var headerValue);
-                                if (headerValue == null)
-                                {
-                                    throw new DeadLetterException("Header 'X-Report-Tracking-Id' not found in message headers.");
-                                }
-                                var newReportId = System.Text.Encoding.UTF8.GetString(headerValue);
 
                                 //If we are re-running an existing report, fetch the details from the database and replace the Values retrieved from the message
                                 if (value.ReportId != null)
@@ -174,13 +168,12 @@ namespace LantanaGroup.Link.Report.Listeners
                                     {
                                         throw new DeadLetterException("End date must be after start date.");
                                     }
-
                                 }
 
                                 // Create ReportSchedule for AdHoc Report
                                 var reportSchedule = new ReportScheduleModel
                                 {
-                                    Id = newReportId,
+                                    Id = Guid.NewGuid().ToString(),
                                     FacilityId = facilityId,
                                     ReportStartDate = startDate.Value,
                                     ReportEndDate = endDate.Value,
@@ -208,10 +201,10 @@ namespace LantanaGroup.Link.Report.Listeners
                                             {
                                                 PreviousReportId = value.ReportId,
                                                 PatientId = p,
+                                                ReportTrackingId = reportSchedule.Id
                                             },
                                             Headers = new Headers
                                             {
-                                                { "X-Report-Tracking-Id", Encoding.ASCII.GetBytes(newReportId) },
                                                 { "X-Correlation-Id", Encoding.ASCII.GetBytes(Guid.NewGuid().ToString()) }
                                             }
                                         });
@@ -234,39 +227,15 @@ namespace LantanaGroup.Link.Report.Listeners
                                             {
                                                 PatientId = patient,
                                                 Status = PatientSubmissionStatus.PendingEvaluation,
-                                                ReportScheduleId = newReportId,
+                                                ReportScheduleId = reportSchedule.Id,
                                                 FacilityId = facilityId,
                                                 ReportType = reportType,
                                             }, cancellationToken);
                                         }
-
-                                        //Submit a Data Acquisition Request for each patient
-                                        var darValue = new DataAcquisitionRequestedValue()
-                                        {
-                                            PatientId = patient,
-                                            ReportableEvent = "AdHoc",
-                                            ScheduledReports = new List<ScheduledReport>()
-                                            {
-                                                new ()
-                                                {
-                                                    StartDate = startDate.Value,
-                                                    EndDate = endDate.Value,
-                                                    Frequency = Frequency.Adhoc,
-                                                    ReportTypes = reportTypes
-                                                }
-                                            },
-                                            QueryType = QueryType.Initial.ToString(),
-                                        };
-
-                                        await _dataAcqProducer.ProduceAsync(nameof(KafkaTopic.DataAcquisitionRequested), new Message<string, DataAcquisitionRequestedValue>
-                                        {
-                                            Key = facilityId,
-                                            Value = darValue,
-                                            Headers = result.Message.Headers
-                                        });
-
-                                        _dataAcqProducer.Flush(cancellationToken);
                                     });
+
+                                    //Submit a Data Acquisition Request for each patient
+                                    await _dataAcqProducer.Produce(reportSchedule);
                                 }
                             }
                             catch (DeadLetterException ex)

--- a/DotNet/Shared/Application/Models/Kafka/ReportScheduledValue.cs
+++ b/DotNet/Shared/Application/Models/Kafka/ReportScheduledValue.cs
@@ -14,7 +14,7 @@ namespace LantanaGroup.Link.Shared.Application.Models.Kafka
         [DataMember]
         public DateTimeOffset EndDate { get; set; }
         [DataMember]
-        public string ReportTrackingId { get; set; }
+        public string? ReportTrackingId { get; set; }
 
         public bool IsValid()
         {

--- a/DotNet/Shared/Application/Repositories/Implementations/MongoEntityRepository.cs
+++ b/DotNet/Shared/Application/Repositories/Implementations/MongoEntityRepository.cs
@@ -65,7 +65,7 @@ public class MongoEntityRepository<T> : IEntityRepository<T> where T : BaseEntit
     {
         if (cancellationToken.IsCancellationRequested) return null;
 
-        entity.Id = Guid.NewGuid().ToString();
+        entity.Id ??= Guid.NewGuid().ToString();
 
         try
         {

--- a/DotNet/Tenant/Controllers/FacilityController.cs
+++ b/DotNet/Tenant/Controllers/FacilityController.cs
@@ -337,15 +337,10 @@ namespace LantanaGroup.Link.Tenant.Controllers
 
                 using var producer = _adHocKafkaProducerFactory.CreateProducer(producerConfig);
 
-                var headers = new Headers
-                {
-                    { "X-Report-Tracking-Id", System.Text.Encoding.ASCII.GetBytes(Guid.NewGuid().ToString()) }
-                };
-
                 var message = new Message<string, GenerateReportValue>
                 {
                     Key = facilityId,
-                    Headers = headers,
+                    Headers = new Headers(),
                     Value = new GenerateReportValue
                     {
                         StartDate = request.StartDate,
@@ -411,15 +406,10 @@ namespace LantanaGroup.Link.Tenant.Controllers
 
                 using var producer = _adHocKafkaProducerFactory.CreateProducer(producerConfig);
 
-                var headers = new Headers
-                {
-                    { "X-Report-Tracking-Id", System.Text.Encoding.ASCII.GetBytes(Guid.NewGuid().ToString()) }
-                };
-
                 var message = new Message<string, GenerateReportValue>
                 {
                     Key = reportScheduleSummary.FacilityId,
-                    Headers = headers,
+                    Headers = new Headers(),
                     Value = new GenerateReportValue()
                     {
                         ReportId = reportScheduleSummary.ReportId,


### PR DESCRIPTION
### 🛠️ Description of Changes
Please provide a high-level overview of the changes included in this PR.

### 🧪 Testing Performed
Please describe the testing that was performed on the changes included in this PR.

### 🧑‍🔬 Unit Testing
- [ ] I have written or updated unit tests to cover my changes

### 📓 Documentation Updated
Please update any relevant sections in the project documentation that were impacted by the changes in the PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced support for ad-hoc report generation via a new frequency option.

- **Refactor**
  - Streamlined report creation and scheduling flows by simplifying how report identifiers are generated and removing legacy tracking headers.
  - Enhanced data models for improved report evaluation tracking.

- **Chores**
  - Adjusted entity creation logic to preserve pre-existing identifiers when available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->