### PR TITLE
LNK-3409: Add Kafka health checks to the Validation service

### DIFF
--- a/Java/shared/src/main/java/com/lantanagroup/link/shared/health/KafkaHealthCheckIndicator.java
+++ b/Java/shared/src/main/java/com/lantanagroup/link/shared/health/KafkaHealthCheckIndicator.java
@@ -20,8 +20,8 @@ public class KafkaHealthCheckIndicator implements HealthIndicator {
 
     private final String serviceName;
 
-    public KafkaHealthCheckIndicator(KafkaTemplate<String, String> kafkaTemplate, @Value(" ${spring.application.name}") String serviceName) {
-        this.kafkaTemplate = kafkaTemplate;
+    public KafkaHealthCheckIndicator(KafkaTemplate<String, String> healthKafkaTemplate, @Value(" ${spring.application.name}") String serviceName) {
+        this.kafkaTemplate = healthKafkaTemplate;
         this.serviceName = serviceName;
     }
 

--- a/Java/validation/src/main/java/com/lantanagroup/link/validation/ValidationApplicationConfig.java
+++ b/Java/validation/src/main/java/com/lantanagroup/link/validation/ValidationApplicationConfig.java
@@ -2,9 +2,11 @@ package com.lantanagroup.link.validation;
 
 import com.lantanagroup.link.shared.BaseSpringConfig;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
+import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
+@ComponentScan({"com.lantanagroup.link.shared.health"})
 @ConfigurationPropertiesScan("com.lantanagroup.link.shared.config")
 public class ValidationApplicationConfig extends BaseSpringConfig {
 }

--- a/Java/validation/src/main/resources/application.yml
+++ b/Java/validation/src/main/resources/application.yml
@@ -19,6 +19,9 @@ springdoc:
 spring:
   application:
     name: ValidationService
+  cloud:
+    discovery:
+      enabled: false
   jackson:
     mapper:
       accept-case-insensitive-enums: true
@@ -49,6 +52,25 @@ spring:
     multipart:
       max-file-size: 10MB
       max-request-size: 100MB
+
+management:
+  endpoints:
+    web:
+      base-path: /
+      exposure:
+        include:
+          - health
+          - info
+  endpoint:
+    health:
+      show-details: always
+  health:
+    diskspace:
+      enabled: false
+    ping:
+      enabled: false
+    refresh:
+      enabled: false
 
 secret-management:
   key-vault-uri: ''

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -929,6 +929,8 @@ services:
         condition: service_completed_successfully
       mssql_init:
         condition: service_completed_successfully
+      report:
+        condition: service_healthy
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8075/health"]
       interval: 3s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,7 +57,7 @@ services:
     healthcheck:
       test: ["CMD", "java", "-jar", "/app/healthcheck.jar", "http://localhost:8080/fhir/metadata"]
       interval: 3s
-      timeout: 10s
+      timeout: 3s
       retries: 15
       
   ###########################################
@@ -103,7 +103,7 @@ services:
       interval: 10s
       retries: 50
       start_period: 30s
-      timeout: 30s
+      timeout: 10s
     networks:
       - link-nw
       
@@ -254,7 +254,7 @@ services:
      healthcheck:
       test: [ "CMD-SHELL", "kafka-topics.sh --bootstrap-server kafka-broker:9092 --command-config /etc/kafka-client.properties --list" ]
       interval: 5s
-      timeout: 10s
+      timeout: 5s
       retries: 5
      
   kafka_init:
@@ -668,7 +668,7 @@ services:
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8067/health"]
       interval: 3s
-      timeout: 10s
+      timeout: 3s
       retries: 15  
       
   normalization:
@@ -932,7 +932,7 @@ services:
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8075/health"]
       interval: 3s
-      timeout: 10s
+      timeout: 3s
       retries: 15
 
 networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -667,9 +667,6 @@ services:
         condition: service_healthy
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8067/health"]
-      interval: 3s
-      timeout: 3s
-      retries: 15  
       
   normalization:
     image: link-normalization
@@ -933,9 +930,6 @@ services:
         condition: service_healthy
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8075/health"]
-      interval: 3s
-      timeout: 3s
-      retries: 15
 
 networks:
   link-nw:


### PR DESCRIPTION
### 🛠️ Description of Changes
Added Kafka health check to Validation.

### 🧪 Testing Performed
Performed positive and negative local testing.

### 🧑‍🔬 Unit Testing
N/A: health check logic was previously implemented in LNK-3064.

### 📓 Documentation Updated
N/A: health check uses preexisting `/health` endpoint.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enabled automatic detection and registration of health-related components in the validation service.
  - Added a specialized Kafka health check with tailored producer settings.
  - Updated actuator endpoint configuration to expose only health and info endpoints, with health details always visible.

- **Chores**
  - Disabled unused health indicators and Spring Cloud service discovery for improved clarity and performance.
  - Improved service healthcheck configurations by reducing timeouts and simplifying intervals and retries.
  - Added service dependency conditions to ensure proper startup order.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->