### PR TITLE
LNK-3715: Producer shared DbContext with Caller

### DIFF
--- a/DotNet/Report/Domain/Managers/SubmissionEntryManager.cs
+++ b/DotNet/Report/Domain/Managers/SubmissionEntryManager.cs
@@ -55,7 +55,7 @@ namespace LantanaGroup.Link.Report.Domain.Managers
         Task<List<string>> GetMeasureReportResourceTypeList(
             string facilityId, string reportId, CancellationToken cancellationToken = default);
 
-        Task UpdateStatusToValidationRequested(string patientSubmissionId);
+        Task UpdateStatusToValidationRequested(string patientSubmissionId, CancellationToken cancellationToken = default)
         Task UpdateStatusToValidationRequested(IEnumerable<string> patientSubmissionIds);
     }
 

--- a/DotNet/Report/Domain/Managers/SubmissionEntryManager.cs
+++ b/DotNet/Report/Domain/Managers/SubmissionEntryManager.cs
@@ -275,13 +275,9 @@ namespace LantanaGroup.Link.Report.Domain.Managers
 
         public async Task UpdateStatusToValidationRequested(IEnumerable<string> patientSubmissionIds)
         {
-            var patientSubs = await _database.SubmissionEntryRepository.FindAsync(s => patientSubmissionIds.Contains(s.Id), CancellationToken.None);
-
-            foreach (var patientSub in patientSubs)
+            foreach (var patientSub in patientSubmissionIds)
             {
-                patientSub.Status = PatientSubmissionStatus.ReadyForValidation;
-                patientSub.ValidationStatus = ValidationStatus.Requested;
-                await _database.SubmissionEntryRepository.UpdateAsync(patientSub);
+                await UpdateStatusToValidationRequested(patientSub);
             }            
         }
     }

--- a/DotNet/Report/Domain/Managers/SubmissionEntryManager.cs
+++ b/DotNet/Report/Domain/Managers/SubmissionEntryManager.cs
@@ -1,13 +1,13 @@
-﻿using LantanaGroup.Link.Report.Entities;
-using System.Linq.Expressions;
-using Hl7.Fhir.Model;
+﻿using Hl7.Fhir.Model;
 using LantanaGroup.Link.Report.Application.Factory;
 using LantanaGroup.Link.Report.Domain.Enums;
+using LantanaGroup.Link.Report.Entities;
 using LantanaGroup.Link.Shared.Application.Enums;
-using LantanaGroup.Link.Shared.Application.Models.Census;
 using LantanaGroup.Link.Shared.Application.Models.Report;
 using LantanaGroup.Link.Shared.Application.Models.Responses;
 using LantanaGroup.Link.Shared.Application.Utilities;
+using System.Linq.Expressions;
+using Task = System.Threading.Tasks.Task;
 
 namespace LantanaGroup.Link.Report.Domain.Managers
 {
@@ -54,6 +54,9 @@ namespace LantanaGroup.Link.Report.Domain.Managers
 
         Task<List<string>> GetMeasureReportResourceTypeList(
             string facilityId, string reportId, CancellationToken cancellationToken = default);
+
+        Task UpdateStatusToValidationRequested(string patientSubmissionId);
+        Task UpdateStatusToValidationRequested(IEnumerable<string> patientSubmissionIds);
     }
 
     public class SubmissionEntryManager : ISubmissionEntryManager
@@ -258,6 +261,28 @@ namespace LantanaGroup.Link.Report.Domain.Managers
         public async Task<MeasureReportSubmissionEntryModel> UpdateAsync(MeasureReportSubmissionEntryModel entity, CancellationToken cancellationToken = default)
         {
             return await _database.SubmissionEntryRepository.UpdateAsync(entity, cancellationToken);
+        }
+
+        public async Task UpdateStatusToValidationRequested(string patientSubmissionId)
+        {
+            var patientSub = await _database.SubmissionEntryRepository.GetAsync(patientSubmissionId, CancellationToken.None);
+
+            patientSub.Status = PatientSubmissionStatus.ReadyForValidation;
+            patientSub.ValidationStatus = ValidationStatus.Requested;
+
+            await _database.SubmissionEntryRepository.UpdateAsync(patientSub);
+        }
+
+        public async Task UpdateStatusToValidationRequested(IEnumerable<string> patientSubmissionIds)
+        {
+            var patientSubs = await _database.SubmissionEntryRepository.FindAsync(s => patientSubmissionIds.Contains(s.Id), CancellationToken.None);
+
+            foreach (var patientSub in patientSubs)
+            {
+                patientSub.Status = PatientSubmissionStatus.ReadyForValidation;
+                patientSub.ValidationStatus = ValidationStatus.Requested;
+                await _database.SubmissionEntryRepository.UpdateAsync(patientSub);
+            }            
         }
     }
 }

--- a/DotNet/Report/Domain/Managers/SubmissionEntryManager.cs
+++ b/DotNet/Report/Domain/Managers/SubmissionEntryManager.cs
@@ -263,14 +263,19 @@ namespace LantanaGroup.Link.Report.Domain.Managers
             return await _database.SubmissionEntryRepository.UpdateAsync(entity, cancellationToken);
         }
 
-        public async Task UpdateStatusToValidationRequested(string patientSubmissionId)
+        public async Task UpdateStatusToValidationRequested(string patientSubmissionId, CancellationToken cancellationToken = default)
         {
-            var patientSub = await _database.SubmissionEntryRepository.GetAsync(patientSubmissionId, CancellationToken.None);
+            var patientSub = await _database.SubmissionEntryRepository.GetAsync(patientSubmissionId, cancellationToken);
+            
+            if (patientSub == null)
+            {
+                throw new ArgumentException($"Patient submission with ID {patientSubmissionId} not found.");
+            }
 
             patientSub.Status = PatientSubmissionStatus.ReadyForValidation;
             patientSub.ValidationStatus = ValidationStatus.Requested;
 
-            await _database.SubmissionEntryRepository.UpdateAsync(patientSub);
+            await _database.SubmissionEntryRepository.UpdateAsync(patientSub, cancellationToken);
         }
 
         public async Task UpdateStatusToValidationRequested(IEnumerable<string> patientSubmissionIds)

--- a/DotNet/Report/Domain/Managers/SubmissionEntryManager.cs
+++ b/DotNet/Report/Domain/Managers/SubmissionEntryManager.cs
@@ -269,7 +269,7 @@ namespace LantanaGroup.Link.Report.Domain.Managers
             
             if (patientSub == null)
             {
-                throw new ArgumentException($"Patient submission with ID {patientSubmissionId} not found.");
+                throw new ArgumentException($"Patient Submission Entry with ID {patientSubmissionId} not found.");
             }
 
             patientSub.Status = PatientSubmissionStatus.ReadyForValidation;

--- a/DotNet/Report/Domain/Managers/SubmissionEntryManager.cs
+++ b/DotNet/Report/Domain/Managers/SubmissionEntryManager.cs
@@ -55,7 +55,7 @@ namespace LantanaGroup.Link.Report.Domain.Managers
         Task<List<string>> GetMeasureReportResourceTypeList(
             string facilityId, string reportId, CancellationToken cancellationToken = default);
 
-        Task UpdateStatusToValidationRequested(string patientSubmissionId, CancellationToken cancellationToken = default)
+        Task UpdateStatusToValidationRequested(string patientSubmissionId, CancellationToken cancellationToken = default);
         Task UpdateStatusToValidationRequested(IEnumerable<string> patientSubmissionIds);
     }
 

--- a/DotNet/Report/Jobs/EndOfReportPeriodJob.cs
+++ b/DotNet/Report/Jobs/EndOfReportPeriodJob.cs
@@ -73,7 +73,7 @@ namespace LantanaGroup.Link.Report.Jobs
 
                     if(needsValidation.Any())
                     {
-                        await _readyForValidationProducer.Produce(schedule, needsValidation);
+                        await _readyForValidationProducer.Produce(_database, schedule, needsValidation);
                     }
                 }
                 

--- a/DotNet/Report/Jobs/EndOfReportPeriodJob.cs
+++ b/DotNet/Report/Jobs/EndOfReportPeriodJob.cs
@@ -1,5 +1,6 @@
 ﻿using LantanaGroup.Link.Report.Domain;
 using LantanaGroup.Link.Report.Domain.Enums;
+using LantanaGroup.Link.Report.Domain.Managers;
 using LantanaGroup.Link.Report.Entities;
 using LantanaGroup.Link.Report.KafkaProducers;
 using LantanaGroup.Link.Report.Services;
@@ -16,6 +17,7 @@ namespace LantanaGroup.Link.Report.Jobs
         
         private readonly ISchedulerFactory _schedulerFactory;
         private readonly IDatabase _database;
+        private readonly SubmissionEntryManager _submissionEntryManager;
 
         private readonly SubmitReportProducer _submitReportProducer;
         private readonly ReadyForValidationProducer _readyForValidationProducer;
@@ -25,6 +27,7 @@ namespace LantanaGroup.Link.Report.Jobs
             ILogger<EndOfReportPeriodJob> logger,
             ISchedulerFactory schedulerFactory,
             IDatabase database,
+            SubmissionEntryManager submissionEntryManager,
             DataAcquisitionRequestedProducer dataAcqProducer,
             ReadyForValidationProducer readyForValidationProducer,
             SubmitReportProducer submitReportProducer)
@@ -35,6 +38,7 @@ namespace LantanaGroup.Link.Report.Jobs
             _dataAcqProducer = dataAcqProducer;
             _readyForValidationProducer = readyForValidationProducer;
             _submitReportProducer = submitReportProducer;
+            _submissionEntryManager = submissionEntryManager;
         }
 
 
@@ -73,7 +77,8 @@ namespace LantanaGroup.Link.Report.Jobs
 
                     if(needsValidation.Any())
                     {
-                        await _readyForValidationProducer.Produce(_database, schedule, needsValidation);
+                        _readyForValidationProducer.Produce(schedule, needsValidation);
+                        await _submissionEntryManager.UpdateStatusToValidationRequested(needsValidation.Select(s => s.Id!));
                     }
                 }
                 

--- a/DotNet/Report/KafkaProducers/ReadyForValidationProducer.cs
+++ b/DotNet/Report/KafkaProducers/ReadyForValidationProducer.cs
@@ -1,6 +1,5 @@
 ﻿using Confluent.Kafka;
 using LantanaGroup.Link.Report.Application.Models;
-using LantanaGroup.Link.Report.Core;
 using LantanaGroup.Link.Report.Domain;
 using LantanaGroup.Link.Report.Domain.Enums;
 using LantanaGroup.Link.Report.Entities;
@@ -11,27 +10,23 @@ namespace LantanaGroup.Link.Report.KafkaProducers
 {
     public class ReadyForValidationProducer
     {
-        private readonly IDatabase _database;
         private readonly IProducer<ReadyForValidationKey, ReadyForValidationValue> _readyForValidationProducer;
 
-        public ReadyForValidationProducer(IDatabase database, MeasureReportAggregator aggregator, IProducer<ReadyForValidationKey, ReadyForValidationValue> readyForValidationProducer)
+        public ReadyForValidationProducer(IProducer<ReadyForValidationKey, ReadyForValidationValue> readyForValidationProducer)
         {
             _readyForValidationProducer = readyForValidationProducer;
-            _database = database;
         }
 
 
-        public async Task<bool> Produce(ReportScheduleModel schedule, IEnumerable<MeasureReportSubmissionEntryModel> needValidation)
+        public async Task Produce(IDatabase database, ReportScheduleModel schedule, IEnumerable<MeasureReportSubmissionEntryModel> needValidation)
         {
             foreach (var entry in needValidation)
             {
-                await Produce(schedule, entry);
+                await Produce(database, schedule, entry);
             }
-
-            return true;
         }
 
-        public async Task<bool> Produce(ReportScheduleModel schedule, MeasureReportSubmissionEntryModel entry)
+        public async Task Produce(IDatabase database, ReportScheduleModel schedule, MeasureReportSubmissionEntryModel entry)
         {
             _readyForValidationProducer.Produce(nameof(KafkaTopic.ReadyForValidation),
                 new Message<ReadyForValidationKey, ReadyForValidationValue>
@@ -57,9 +52,7 @@ namespace LantanaGroup.Link.Report.KafkaProducers
 
             entry.ValidationStatus = ValidationStatus.Requested;
             entry.Status = PatientSubmissionStatus.ValidationRequested;
-            await _database.SubmissionEntryRepository.UpdateAsync(entry);
-
-            return true;
+            await database.SubmissionEntryRepository.UpdateAsync(entry);
         }
     }
 }

--- a/DotNet/Report/KafkaProducers/ReadyForValidationProducer.cs
+++ b/DotNet/Report/KafkaProducers/ReadyForValidationProducer.cs
@@ -1,7 +1,5 @@
 ﻿using Confluent.Kafka;
 using LantanaGroup.Link.Report.Application.Models;
-using LantanaGroup.Link.Report.Domain;
-using LantanaGroup.Link.Report.Domain.Enums;
 using LantanaGroup.Link.Report.Entities;
 using LantanaGroup.Link.Shared.Application.Models;
 using System.Text;
@@ -12,21 +10,21 @@ namespace LantanaGroup.Link.Report.KafkaProducers
     {
         private readonly IProducer<ReadyForValidationKey, ReadyForValidationValue> _readyForValidationProducer;
 
-        public ReadyForValidationProducer(IProducer<ReadyForValidationKey, ReadyForValidationValue> readyForValidationProducer)
+        public ReadyForValidationProducer( IProducer<ReadyForValidationKey, ReadyForValidationValue> readyForValidationProducer)
         {
             _readyForValidationProducer = readyForValidationProducer;
         }
 
 
-        public async Task Produce(IDatabase database, ReportScheduleModel schedule, IEnumerable<MeasureReportSubmissionEntryModel> needValidation)
+        public void Produce(ReportScheduleModel schedule, IEnumerable<MeasureReportSubmissionEntryModel> needValidation)
         {
             foreach (var entry in needValidation)
             {
-                await Produce(database, schedule, entry);
+                Produce(schedule, entry);
             }
         }
 
-        public async Task Produce(IDatabase database, ReportScheduleModel schedule, MeasureReportSubmissionEntryModel entry)
+        public void Produce(ReportScheduleModel schedule, MeasureReportSubmissionEntryModel entry)
         {
             _readyForValidationProducer.Produce(nameof(KafkaTopic.ReadyForValidation),
                 new Message<ReadyForValidationKey, ReadyForValidationValue>
@@ -49,10 +47,6 @@ namespace LantanaGroup.Link.Report.KafkaProducers
                 });
 
             _readyForValidationProducer.Flush();
-
-            entry.ValidationStatus = ValidationStatus.Requested;
-            entry.Status = PatientSubmissionStatus.ValidationRequested;
-            await database.SubmissionEntryRepository.UpdateAsync(entry);
         }
     }
 }

--- a/DotNet/Report/Listeners/ResourceEvaluatedListener.cs
+++ b/DotNet/Report/Listeners/ResourceEvaluatedListener.cs
@@ -4,6 +4,7 @@ using Hl7.Fhir.Model;
 using Hl7.Fhir.Serialization;
 using LantanaGroup.Link.Report.Application.Interfaces;
 using LantanaGroup.Link.Report.Application.Models;
+using LantanaGroup.Link.Report.Domain;
 using LantanaGroup.Link.Report.Domain.Enums;
 using LantanaGroup.Link.Report.Domain.Managers;
 using LantanaGroup.Link.Report.Entities;
@@ -100,7 +101,7 @@ namespace LantanaGroup.Link.Report.Listeners
                             var scope = _serviceScopeFactory.CreateScope();
                             var resourceManager = scope.ServiceProvider.GetRequiredService<IResourceManager>();
                             var measureReportScheduledManager = scope.ServiceProvider.GetRequiredService<IReportScheduledManager>();
-                            var submissionEntryManager = scope.ServiceProvider.GetRequiredService<ISubmissionEntryManager>();
+                            var database = scope.ServiceProvider.GetRequiredService<IDatabase>();
 
                             try
                             {
@@ -130,7 +131,7 @@ namespace LantanaGroup.Link.Report.Listeners
                                             throw new TransientException($"{Name}: report schedule not found for Facility {key.FacilityId} and reportId: {value.ReportTrackingId}");
 
 
-                                var entry = await submissionEntryManager.SingleAsync(e =>
+                                var entry = await database.SubmissionEntryRepository.SingleAsync(e =>
                                     e.ReportScheduleId == schedule.Id
                                     && e.PatientId == value.PatientId
                                     && e.ReportType == value.ReportType, consumeCancellationToken);
@@ -177,11 +178,11 @@ namespace LantanaGroup.Link.Report.Listeners
                                     entry.Status = PatientSubmissionStatus.NotReportable;
                                 }
 
-                                await submissionEntryManager.UpdateAsync(entry, cancellationToken);
+                                await database.SubmissionEntryRepository.UpdateAsync(entry, cancellationToken);
 
                                 if (entry.Status == PatientSubmissionStatus.ReadyForValidation && entry.ValidationStatus != ValidationStatus.Requested)
                                 {
-                                    await _readyForValidationProducer.Produce(schedule, entry);
+                                    await _readyForValidationProducer.Produce(database, schedule, entry);
                                 }
                             }
                             catch (DeadLetterException ex)

--- a/DotNet/Report/Listeners/ResourceEvaluatedListener.cs
+++ b/DotNet/Report/Listeners/ResourceEvaluatedListener.cs
@@ -101,7 +101,7 @@ namespace LantanaGroup.Link.Report.Listeners
                             var scope = _serviceScopeFactory.CreateScope();
                             var resourceManager = scope.ServiceProvider.GetRequiredService<IResourceManager>();
                             var measureReportScheduledManager = scope.ServiceProvider.GetRequiredService<IReportScheduledManager>();
-                            var database = scope.ServiceProvider.GetRequiredService<IDatabase>();
+                            var patientSubEntryManager = scope.ServiceProvider.GetRequiredService<SubmissionEntryManager>();
 
                             try
                             {
@@ -131,7 +131,7 @@ namespace LantanaGroup.Link.Report.Listeners
                                             throw new TransientException($"{Name}: report schedule not found for Facility {key.FacilityId} and reportId: {value.ReportTrackingId}");
 
 
-                                var entry = await database.SubmissionEntryRepository.SingleAsync(e =>
+                                var entry = await patientSubEntryManager.SingleAsync(e =>
                                     e.ReportScheduleId == schedule.Id
                                     && e.PatientId == value.PatientId
                                     && e.ReportType == value.ReportType, consumeCancellationToken);
@@ -178,11 +178,12 @@ namespace LantanaGroup.Link.Report.Listeners
                                     entry.Status = PatientSubmissionStatus.NotReportable;
                                 }
 
-                                await database.SubmissionEntryRepository.UpdateAsync(entry, cancellationToken);
+                                await patientSubEntryManager.UpdateAsync(entry, cancellationToken);
 
                                 if (entry.Status == PatientSubmissionStatus.ReadyForValidation && entry.ValidationStatus != ValidationStatus.Requested)
                                 {
-                                    await _readyForValidationProducer.Produce(database, schedule, entry);
+                                    _readyForValidationProducer.Produce(schedule, entry);
+                                    await patientSubEntryManager.UpdateStatusToValidationRequested(entry.Id!);
                                 }
                             }
                             catch (DeadLetterException ex)


### PR DESCRIPTION
### 🛠️ Description of Changes

Change to the ReadyForValidation Kafka producer to force callers to pass in their IDatabase instance to ensure that the caller and producer are using the same DbContext to track and save changes to entities.

### 🧪 Testing Performed
Please describe the testing that was performed on the changes included in this PR.

### 🧑‍🔬 Unit Testing
- [ ] I have written or updated unit tests to cover my changes

### 📓 Documentation Updated
Please update any relevant sections in the project documentation that were impacted by the changes in the PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Submission entries now have their status updated to "Validation Requested" after being marked as ready for validation.

- **Bug Fixes**
  - Improved consistency in updating submission entry statuses during the validation process.

- **Refactor**
  - Streamlined the process for producing validation events and updating entry statuses for better reliability and maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->