### PR TITLE
LNK-3747: Fix health check for Validation

### DIFF
--- a/DotNet/Admin.BFF/Application/Clients/ValidationService.cs
+++ b/DotNet/Admin.BFF/Application/Clients/ValidationService.cs
@@ -43,10 +43,16 @@ public class ValidationService
         try
         {
             var response = await _client.GetAsync($"health", cancellationToken);
-            var healthResult = await response.Content.ReadFromJsonAsync<LinkServiceHealthReport>(cancellationToken: cancellationToken);
-            if (healthResult is not null) healthResult.Service = "Validation";
 
-            return healthResult;
+            //TODO: update when further functionality within the java services have been added
+            if (response.IsSuccessStatusCode)
+            {
+                return new LinkServiceHealthReport { Service = "Validation", Status = HealthStatus.Healthy };
+            }
+            else
+            {
+                return new LinkServiceHealthReport { Service = "Validation", Status = HealthStatus.Unhealthy };
+            }
         }
         catch (Exception ex)
         {

--- a/DotNet/Admin.BFF/Presentation/Endpoints/System/Hanlders/GetSystemHealth.cs
+++ b/DotNet/Admin.BFF/Presentation/Endpoints/System/Hanlders/GetSystemHealth.cs
@@ -30,8 +30,7 @@ public static class GetSystemHealth
             queryDispatchService.LinkServiceHealthCheck(context.RequestAborted),
             reportService.LinkServiceHealthCheck(context.RequestAborted),
             submissionService.LinkServiceHealthCheck(context.RequestAborted),
-            tenantService.LinkServiceHealthCheck(context.RequestAborted),
-            validationService.LinkServiceHealthCheck(context.RequestAborted)
+            tenantService.LinkServiceHealthCheck(context.RequestAborted)
         };
 
         //if we upgrade to .NET 9, we can use Task.WhenEach
@@ -43,9 +42,15 @@ public static class GetSystemHealth
         measureEvalHealthSummary.KafkaConnection = LinkServiceHealthStatus.Unknown;
         measureEvalHealthSummary.DatabaseConnection = LinkServiceHealthStatus.Unknown;
         measureEvalHealthSummary.CacheConnection = LinkServiceHealthStatus.Unknown;
+        var validationHealthCheckResult = await validationService.LinkServiceHealthCheck(context.RequestAborted);
+        var validationHealthSummary = LinkServiceHealthReportExtensions.FromDomain(validationHealthCheckResult);
+        validationHealthSummary.KafkaConnection = LinkServiceHealthStatus.Unknown;
+        validationHealthSummary.DatabaseConnection = LinkServiceHealthStatus.Unknown;
+        validationHealthSummary.CacheConnection = LinkServiceHealthStatus.Unknown;
         
         var healthSummary = results.Select(LinkServiceHealthReportExtensions.FromDomain).ToList();
         healthSummary.Add(measureEvalHealthSummary);
+        healthSummary.Add(validationHealthSummary);
         
         return Results.Ok(healthSummary);
     }

--- a/DotNet/Admin.BFF/appsettings.Development.json
+++ b/DotNet/Admin.BFF/appsettings.Development.json
@@ -30,7 +30,8 @@
       "TenantServiceUrl": "http://localhost:7331",
       "CheckIfTenantExists": true,
       "GetTenantRelativeEndpoint": "/api/facility"
-    }
+    },
+    "ValidationServiceUrl": "http://localhost:31820"
   },
   "KafkaConnection": {
     "BootstrapServers": [ "localhost:9092/" ],


### PR DESCRIPTION
This resolves the issue of Validation always reporting an unhealthy status.  However, as the preexisting TODOs indicate, better integration with the Java services is still needed.

### 🛠️ Description of Changes
Basically copied BFF's Measure Eval health check logic to Validation.

### 🧪 Testing Performed
Tested with a locally running BFF and Validation.

### 🧑‍🔬 Unit Testing
N/A

### 📓 Documentation Updated
N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configuration for a new Validation Service URL to support service health checks.

- **Bug Fixes**
  - Improved system health reporting by updating how the validation service health status is determined and included in health summaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->