### PR TITLE
LNK-3822: Multi-Measure profile fixes

### DIFF
--- a/DotNet/Report/Entities/MeasureReportSubmissionEntryModel.cs
+++ b/DotNet/Report/Entities/MeasureReportSubmissionEntryModel.cs
@@ -52,29 +52,32 @@ namespace LantanaGroup.Link.Report.Entities
         {
             MeasureReport = measureReport;
 
-            foreach (var evaluatedResource in measureReport.EvaluatedResource)
+            if (Status != PatientSubmissionStatus.NotReportable)
             {
-                //If the resource is already in the list, skip it
-                if (ContainedResources.Any(x => x.Reference() == evaluatedResource.Reference))
+                foreach (var evaluatedResource in measureReport.EvaluatedResource)
                 {
-                    continue;
-                }
-
-                var reference = evaluatedResource.Reference.Split('/');
-                var resourceCategoryType = ResourceCategory.GetResourceCategoryByType(reference[0]);
-
-                if (resourceCategoryType != null)
-                {
-                    ContainedResources.Add(new ContainedResource
+                    //If the resource is already in the list, skip it
+                    if (ContainedResources.Any(x => x.Reference() == evaluatedResource.Reference))
                     {
-                        ResourceType = reference[0],
-                        ResourceId = reference[1],
-                        CategoryType = (ResourceCategoryType)resourceCategoryType
-                    });
-                }
-            }
+                        continue;
+                    }
 
-            UpdateStatus();
+                    var reference = evaluatedResource.Reference.Split('/');
+                    var resourceCategoryType = ResourceCategory.GetResourceCategoryByType(reference[0]);
+
+                    if (resourceCategoryType != null)
+                    {
+                        ContainedResources.Add(new ContainedResource
+                        {
+                            ResourceType = reference[0],
+                            ResourceId = reference[1],
+                            CategoryType = (ResourceCategoryType)resourceCategoryType
+                        });
+                    }
+                }
+                
+                UpdateStatus();
+            }
         }
 
 

--- a/DotNet/Report/Listeners/ResourceEvaluatedListener.cs
+++ b/DotNet/Report/Listeners/ResourceEvaluatedListener.cs
@@ -85,7 +85,7 @@ namespace LantanaGroup.Link.Report.Listeners
             try
             {
                 consumer.Subscribe(nameof(KafkaTopic.ResourceEvaluated));
-                _logger.LogInformation($"Started resource evaluated consumer for topic '{nameof(KafkaTopic.ResourceEvaluated)}' at {DateTime.UtcNow}");
+                _logger.LogInformation("Started resource evaluated consumer for topic '{ResourceEvaluatedName}' at {DateTime}", nameof(KafkaTopic.ResourceEvaluated), DateTime.UtcNow);
 
                 while (!cancellationToken.IsCancellationRequested)
                 {
@@ -116,8 +116,13 @@ namespace LantanaGroup.Link.Report.Listeners
                                     throw new DeadLetterException($"{Name}: Received message without correlation ID: {result.Topic}");
                                 }
 
-                                string CorrelationIdStr = Encoding.UTF8.GetString(headerValue);
-                                if(string.IsNullOrWhiteSpace(CorrelationIdStr))
+                                if (value.Resource.ValueKind == JsonValueKind.Null || value.Resource.ValueKind == JsonValueKind.Undefined || (value.Resource.ValueKind == JsonValueKind.String && string.IsNullOrEmpty(value.Resource.GetString())))
+                                {
+                                    throw new DeadLetterException($"{Name}: Received message without resource: {result.Topic}");
+                                }
+
+                                var correlationIdStr = Encoding.UTF8.GetString(headerValue);
+                                if(string.IsNullOrWhiteSpace(correlationIdStr))
                                 {
                                     throw new DeadLetterException($"{Name}: Received message without correlation ID: {result.Topic}");
                                 }
@@ -272,7 +277,7 @@ namespace LantanaGroup.Link.Report.Listeners
             }
             catch (OperationCanceledException oce)
             {
-                _logger.LogError(oce, $"Operation Canceled: {oce.Message}");
+                _logger.LogError(oce, "Operation Canceled: {OceMessage}", oce.Message);
                 consumer.Close();
                 consumer.Dispose();
             }

--- a/DotNet/Report/Listeners/ResourceEvaluatedListener.cs
+++ b/DotNet/Report/Listeners/ResourceEvaluatedListener.cs
@@ -133,29 +133,31 @@ namespace LantanaGroup.Link.Report.Listeners
                                             throw new TransientException($"{Name}: report schedule not found for Facility {key.FacilityId} and reportId: {value.ReportTrackingId}");
 
 
+                                // find existing submission entry for this facility, report schedule, and patient
                                 var entry = await submissionEntryManager.SingleAsync(e =>
                                     e.ReportScheduleId == schedule.Id
                                     && e.PatientId == value.PatientId
                                     && e.ReportType == value.ReportType, consumeCancellationToken);
 
-                                if (value.IsReportable)
+                                // deserialize the resource
+                                var resource = JsonSerializer.Deserialize<Resource>(value.Resource.ToString(),
+                                    new JsonSerializerOptions().ForFhir(ModelInfo.ModelInspector,
+                                        new FhirJsonPocoDeserializerSettings { Validator = null }));
+                                
+                                if (resource == null)
                                 {
-                                    var resource = JsonSerializer.Deserialize<Resource>(value.Resource.ToString(),
-                                        new JsonSerializerOptions().ForFhir(ModelInfo.ModelInspector,
-                                            new FhirJsonPocoDeserializerSettings { Validator = null }));
-
-                                    if (resource == null)
-                                    {
-                                        throw new DeadLetterException($"{Name}: Unable to deserialize event resource");
-                                    }
-
+                                    throw new DeadLetterException($"{Name}: Unable to deserialize event resource");
+                                }
+                                
+                                if (value.IsReportable)
+                                { 
                                     if (resource.TypeName == "MeasureReport")
                                     {
                                         entry.AddMeasureReport((MeasureReport)resource);
                                     }
                                     else
                                     {
-                                        IFacilityResource returnedResource = null;
+                                        IFacilityResource? returnedResource = null;
 
                                         var existingReportResource =
                                             await resourceManager.GetResourceAsync(key.FacilityId, resource.Id, resource.TypeName, value.PatientId,
@@ -163,6 +165,15 @@ namespace LantanaGroup.Link.Report.Listeners
 
                                         if (existingReportResource != null)
                                         {
+                                            // combine the meta profiles
+                                            var existingProfiles = existingReportResource.GetResource().Meta?.Profile ?? new List<string>();
+                                            var newProfiles = resource.Meta?.Profile ?? new List<string>();
+                                        
+                                            var profileSet = new HashSet<string>(existingProfiles);
+                                            profileSet.UnionWith(newProfiles);
+
+                                            existingReportResource.GetResource().Meta.Profile = profileSet.ToList();
+                                        
                                             returnedResource =
                                                 await resourceManager.UpdateResourceAsync(existingReportResource,
                                                     consumeCancellationToken);
@@ -178,6 +189,11 @@ namespace LantanaGroup.Link.Report.Listeners
                                 else
                                 {
                                     entry.Status = PatientSubmissionStatus.NotReportable;
+                                    
+                                    if (resource.TypeName == "MeasureReport")
+                                    {
+                                        entry.AddMeasureReport((MeasureReport)resource);
+                                    }
                                 }
 
                                 await submissionEntryManager.UpdateAsync(entry, cancellationToken);

--- a/DotNet/Report/Listeners/ResourceEvaluatedListener.cs
+++ b/DotNet/Report/Listeners/ResourceEvaluatedListener.cs
@@ -172,8 +172,16 @@ namespace LantanaGroup.Link.Report.Listeners
                                             var profileSet = new HashSet<string>(existingProfiles);
                                             profileSet.UnionWith(newProfiles);
 
-                                            existingReportResource.GetResource().Meta.Profile = profileSet.ToList();
-                                        
+                                            // update the existing resource meta profiles
+                                            if (existingReportResource.GetResource().Meta == null)
+                                            {
+                                                existingReportResource.GetResource().Meta = new Meta { Profile = profileSet.ToList() };
+                                            }
+                                            else
+                                            {
+                                                existingReportResource.GetResource().Meta.Profile = profileSet.ToList();
+                                            }
+                                            
                                             returnedResource =
                                                 await resourceManager.UpdateResourceAsync(existingReportResource,
                                                     consumeCancellationToken);


### PR DESCRIPTION
### 🛠️ Description of Changes
- Updated the report service to combine resource profiles when multiple measures are involved
- Updated the report service to save the measure report even if not reportable

### 🧪 Testing Performed
Generated multiple ad-hoc reports for a configured facility, verified that both measure profiles were present in resources associated with a patient that was reportable for both  measures.

### 🧑‍🔬 Unit Testing
- [ ] I have written or updated unit tests to cover my changes

### 📓 Documentation Updated
Please update any relevant sections in the project documentation that were impacted by the changes in the PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of evaluated resources to ensure processing only occurs when appropriate, preventing unnecessary updates.
  - Enhanced processing logic for incoming resources, ensuring "MeasureReport" resources are always handled correctly, even if not reportable.
  - Improved error handling for resource deserialization failures.

- **New Features**
  - Meta profile lists are now merged when updating existing resources, ensuring all relevant profiles are retained.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->