### PR TITLE
LNK-3822: Multi-Measure profile fixes (#844)

### DIFF
--- a/DotNet/Report/Entities/MeasureReportSubmissionEntryModel.cs
+++ b/DotNet/Report/Entities/MeasureReportSubmissionEntryModel.cs
@@ -52,29 +52,32 @@ namespace LantanaGroup.Link.Report.Entities
         {
             MeasureReport = measureReport;
 
-            foreach (var evaluatedResource in measureReport.EvaluatedResource)
+            if (Status != PatientSubmissionStatus.NotReportable)
             {
-                //If the resource is already in the list, skip it
-                if (ContainedResources.Any(x => x.Reference() == evaluatedResource.Reference))
+                foreach (var evaluatedResource in measureReport.EvaluatedResource)
                 {
-                    continue;
-                }
-
-                var reference = evaluatedResource.Reference.Split('/');
-                var resourceCategoryType = ResourceCategory.GetResourceCategoryByType(reference[0]);
-
-                if (resourceCategoryType != null)
-                {
-                    ContainedResources.Add(new ContainedResource
+                    //If the resource is already in the list, skip it
+                    if (ContainedResources.Any(x => x.Reference() == evaluatedResource.Reference))
                     {
-                        ResourceType = reference[0],
-                        ResourceId = reference[1],
-                        CategoryType = (ResourceCategoryType)resourceCategoryType
-                    });
-                }
-            }
+                        continue;
+                    }
 
-            UpdateStatus();
+                    var reference = evaluatedResource.Reference.Split('/');
+                    var resourceCategoryType = ResourceCategory.GetResourceCategoryByType(reference[0]);
+
+                    if (resourceCategoryType != null)
+                    {
+                        ContainedResources.Add(new ContainedResource
+                        {
+                            ResourceType = reference[0],
+                            ResourceId = reference[1],
+                            CategoryType = (ResourceCategoryType)resourceCategoryType
+                        });
+                    }
+                }
+                
+                UpdateStatus();
+            }
         }
 
 


### PR DESCRIPTION
### 🛠️ Description of Changes
Cherry pick of LNK-3822 fix:
- Updated report listener to capture all profiles in multi-measure situations. Also made an update to capture the measure report regardless if the patient is reportable.
- added null check for Resource.Meta
- added null and undefined checks for the Resource JsonElement property in the ResourceEvaluated listener

### 🧪 Testing Performed
See https://github.com/lantanagroup/link-cloud/pull/844

### 🧑‍🔬 Unit Testing
- [ ] I have written or updated unit tests to cover my changes

### 📓 Documentation Updated
N/A
