### PR TITLE
TECH_DEBT: Force LF where necessary

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,6 +2,8 @@
 # Set default behavior to automatically normalize line endings.
 ###############################################################################
 * text=auto
+*.sh text eol=lf
+/topics.txt text eol=lf
 
 ###############################################################################
 # Set default behavior for command prompt diff.


### PR DESCRIPTION
### 🛠️ Description of Changes
For certain setups (Windows machines with `core.autocrlf` set to true), `docker compose up` fails due to line ending translation.  This PR forces LF endings for Bash scripts and the list of `topics.txt`.

### 🧪 Testing Performed
N/A

### 🧑‍🔬 Unit Testing
N/A

### 📓 Documentation Updated
N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated line ending settings to ensure shell scripts and topics.txt use consistent LF line endings across platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->