### PR TITLE
LNK-3868: Add Oprtional Resource Parameter on Vendor Presets Get

### DIFF
--- a/DotNet/Normalization/Application/Models/Operations/Business/Query/OperationSearchModel.cs
+++ b/DotNet/Normalization/Application/Models/Operations/Business/Query/OperationSearchModel.cs
@@ -16,5 +16,6 @@ namespace LantanaGroup.Link.Normalization.Application.Models.Operations.Business
         public SortOrder? SortOrder { get; set; }
         public int? PageSize { get; set; }
         public int? PageNumber { get; set; }
+        public Guid? VendorId { get; set; }
     }
 }

--- a/DotNet/Normalization/Application/Models/Operations/Business/Query/VendorOperationPresetSearchModel.cs
+++ b/DotNet/Normalization/Application/Models/Operations/Business/Query/VendorOperationPresetSearchModel.cs
@@ -8,5 +8,6 @@ namespace LantanaGroup.Link.Normalization.Application.Models.Operations.Business
     {
         public Guid? Id { get; set; }
         public Guid? VendorId { get; set; }
+        public string? Resource { get; set; }
     }
 }

--- a/DotNet/Normalization/Controllers/OperationsController.cs
+++ b/DotNet/Normalization/Controllers/OperationsController.cs
@@ -59,7 +59,7 @@ namespace LantanaGroup.Link.Normalization.Controllers
         [ProducesResponseType(StatusCodes.Status404NotFound)]
         [ProducesResponseType(StatusCodes.Status500InternalServerError)]
         [Authorize(Policy = PolicyNames.IsLinkAdmin)]
-        public async Task<ActionResult<PagedConfigModel<OperationModel>>> SearchOperations(string? facilityId, string? operationType, string? resourceType, Guid? operationId, bool includeDisabled = false,
+        public async Task<ActionResult<PagedConfigModel<OperationModel>>> SearchOperations(string? facilityId, string? operationType, string? resourceType, Guid? operationId, bool includeDisabled = false, Guid? vendorId = null,
             string sortBy = "CreateDate", SortOrder sortOrder = SortOrder.Descending, int pageSize = 10, int pageNumber = 1)
         {
             try
@@ -78,6 +78,7 @@ namespace LantanaGroup.Link.Normalization.Controllers
                     OperationId = operationId,
                     OperationType = operation == OperationType.None ? null : operation,
                     FacilityId = facilityId,
+                    VendorId = vendorId,
                     IncludeDisabled = includeDisabled,
                     ResourceType = resourceType,
                     SortBy = sortBy,

--- a/DotNet/Normalization/Controllers/VendorController.cs
+++ b/DotNet/Normalization/Controllers/VendorController.cs
@@ -123,7 +123,7 @@ namespace LantanaGroup.Link.Normalization.Controllers
         [ProducesResponseType(StatusCodes.Status204NoContent)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
         [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-        public async Task<ActionResult<List<VendorVersionOperationPresetModel>>> GetVendorOperationPresets(string vendor)
+        public async Task<ActionResult<List<VendorVersionOperationPresetModel>>> GetVendorOperationPresets(string vendor, string? resource = null)
         {
             try
             {
@@ -149,7 +149,8 @@ namespace LantanaGroup.Link.Normalization.Controllers
 
                 var vendorPresets = await _vendorQueries.SearchVendorVersionOperationPreset(new VendorOperationPresetSearchModel()
                 {
-                    VendorId = foundVendor.Id
+                    VendorId = foundVendor.Id,
+                    Resource = string.IsNullOrWhiteSpace(resource) ? null : resource
                 });
 
                 if (vendorPresets == null || vendorPresets.Count == 0)
@@ -170,7 +171,7 @@ namespace LantanaGroup.Link.Normalization.Controllers
         [ProducesResponseType(StatusCodes.Status204NoContent)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
         [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-        public async Task<ActionResult<List<VendorVersionOperationPresetModel>>> GetVendorOperationPresets(string vendor, Guid presetId, string? resource = null)
+        public async Task<ActionResult<List<VendorVersionOperationPresetModel>>> GetVendorOperationPresets(string vendor, Guid presetId)
         {
             try
             {
@@ -202,8 +203,7 @@ namespace LantanaGroup.Link.Normalization.Controllers
                 var vendorPresets = await _vendorQueries.SearchVendorVersionOperationPreset(new VendorOperationPresetSearchModel()
                 {
                     VendorId = foundVendor.Id,
-                    Id = presetId,
-                    Resource = string.IsNullOrWhiteSpace(resource) ? null : resource
+                    Id = presetId
                 });
 
                 if (vendorPresets == null || vendorPresets.Count == 0)

--- a/DotNet/Normalization/Controllers/VendorController.cs
+++ b/DotNet/Normalization/Controllers/VendorController.cs
@@ -170,7 +170,7 @@ namespace LantanaGroup.Link.Normalization.Controllers
         [ProducesResponseType(StatusCodes.Status204NoContent)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
         [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-        public async Task<ActionResult<List<VendorVersionOperationPresetModel>>> GetVendorOperationPresets(string vendor, Guid presetId)
+        public async Task<ActionResult<List<VendorVersionOperationPresetModel>>> GetVendorOperationPresets(string vendor, Guid presetId, string? resource = null)
         {
             try
             {
@@ -202,7 +202,8 @@ namespace LantanaGroup.Link.Normalization.Controllers
                 var vendorPresets = await _vendorQueries.SearchVendorVersionOperationPreset(new VendorOperationPresetSearchModel()
                 {
                     VendorId = foundVendor.Id,
-                    Id = presetId
+                    Id = presetId,
+                    Resource = string.IsNullOrWhiteSpace(resource) ? null : resource
                 });
 
                 if (vendorPresets == null || vendorPresets.Count == 0)

--- a/DotNet/Normalization/Domain/Queries/OperationQueries.cs
+++ b/DotNet/Normalization/Domain/Queries/OperationQueries.cs
@@ -43,8 +43,11 @@ namespace LantanaGroup.Link.Normalization.Domain.Queries
         {
             var query = from o in _dbContext.Operations
                         where  model.FacilityId == null //No facility ID provided, bring back everyting (Admin Use Only)
-                                    || (model.FacilityId != null && o.FacilityId == null && o.OperationResourceTypes.Any(ort => ort.OperationSequences.Any(os => os.FacilityId == model.FacilityId)))  //The caller wants a given facilities operations, so make sure to include vendor presets that are mapped
+                                    || (model.FacilityId != null //The caller wants a given facilities operations, so make sure to include vendor presets that are mapped
+                                        && o.FacilityId == null 
+                                        && o.OperationResourceTypes.Any(ort => ort.OperationSequences.Any(os => os.FacilityId == model.FacilityId)))  
                                     || o.FacilityId == model.FacilityId // The Operation is for the provided facilityID
+                                    || (model.VendorId != null && o.OperationResourceTypes.Any(ort => ort.VendorVersionOperationPresets.Any(vop => vop.VendorVersion.VendorId == model.VendorId)))
                         select new OperationModel()
                         {
                             Id = o.Id,

--- a/DotNet/Normalization/Domain/Queries/VendorQueries.cs
+++ b/DotNet/Normalization/Domain/Queries/VendorQueries.cs
@@ -98,7 +98,7 @@ namespace LantanaGroup.Link.Normalization.Domain.Queries
                             Id = o.Id,
                             VendorVersionId = o.VendorVersionId,
                             OperationResourceTypeId = o.OperationResourceTypeId,
-                            OperationResourceType = new OperationResourceTypeModel()
+                            OperationResourceType = o.OperationResourceType == null ? new() : new OperationResourceTypeModel()
                             {
                                 Id = o.OperationResourceType.Id,
                                 OperationId = o.OperationResourceType.OperationId,
@@ -139,6 +139,11 @@ namespace LantanaGroup.Link.Normalization.Domain.Queries
             if (model.VendorId != null)
             {
                 query = query.Where(q => q.VendorVersion.Vendor.Id == model.VendorId);
+            }
+
+            if (model.Resource != null)
+            {
+                query = query.Where(q => q.OperationResourceType.Resource.ResourceName == model.Resource);
             }
 
             return await query.ToListAsync();


### PR DESCRIPTION
### 🛠️ Description of Changes
Please provide a high-level overview of the changes included in this PR.

### 🧪 Testing Performed
Please describe the testing that was performed on the changes included in this PR.

### 🧑‍🔬 Unit Testing
- [ ] I have written or updated unit tests to cover my changes

### 📓 Documentation Updated
Please update any relevant sections in the project documentation that were impacted by the changes in the PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for filtering vendor operation presets by resource name in the vendor operation presets endpoint.
  - Enabled filtering operations by vendor ID in the operations search endpoint.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->