### PR TITLE
LNK-3967: Failure to deserialize "existing referenced" resources of "unknown" types

### DIFF
--- a/DotNet/DataAcquisition.Domain/Application/Serializers/FhirResourceDeserializer.cs
+++ b/DotNet/DataAcquisition.Domain/Application/Serializers/FhirResourceDeserializer.cs
@@ -7,26 +7,10 @@ namespace LantanaGroup.Link.DataAcquisition.Domain.Application.Serializers;
 
 public static class FhirResourceDeserializer
 {
-    public static DomainResource DeserializeFhirResource(ReferenceResources resource)
+    public static Resource DeserializeFhirResource(ReferenceResources resource)
     {
         var options = new JsonSerializerOptions().ForFhir(ModelInfo.ModelInspector);
 
-        DomainResource? domainResource = resource.ResourceType switch
-        {
-            nameof(Condition) => JsonSerializer.Deserialize<Condition>(resource.ReferenceResource, options),
-            nameof(Coverage) => JsonSerializer.Deserialize<Coverage>(resource.ReferenceResource, options),
-            nameof(Encounter) => JsonSerializer.Deserialize<Encounter>(resource.ReferenceResource, options),
-            nameof(Location) => JsonSerializer.Deserialize<Location>(resource.ReferenceResource, options),
-            nameof(Medication) => JsonSerializer.Deserialize<Medication>(resource.ReferenceResource, options),
-            nameof(MedicationRequest) => JsonSerializer.Deserialize<MedicationRequest>(resource.ReferenceResource, options),
-            nameof(Observation) => JsonSerializer.Deserialize<Observation>(resource.ReferenceResource, options),
-            nameof(Patient) => JsonSerializer.Deserialize<Patient>(resource.ReferenceResource, options),
-            nameof(Procedure) => JsonSerializer.Deserialize<Procedure>(resource.ReferenceResource, options),
-            nameof(ServiceRequest) => JsonSerializer.Deserialize<ServiceRequest>(resource.ReferenceResource, options),
-            nameof(Specimen) => JsonSerializer.Deserialize<Specimen>(resource.ReferenceResource, options),
-            _ => throw new Exception($"Resource Type {resource.ResourceType} not configured for Read operation."),
-        };
-
-        return domainResource;
+        return JsonSerializer.Deserialize<Resource>(resource.ReferenceResource, options);
     }
 }

--- a/DotNet/DataAcquisition.Domain/Application/Serializers/FhirResourceDeserializer.cs
+++ b/DotNet/DataAcquisition.Domain/Application/Serializers/FhirResourceDeserializer.cs
@@ -7,10 +7,11 @@ namespace LantanaGroup.Link.DataAcquisition.Domain.Application.Serializers;
 
 public static class FhirResourceDeserializer
 {
+    private static readonly JsonSerializerOptions options =
+        new JsonSerializerOptions().ForFhir(ModelInfo.ModelInspector);
+
     public static Resource DeserializeFhirResource(ReferenceResources resource)
     {
-        var options = new JsonSerializerOptions().ForFhir(ModelInfo.ModelInspector);
-
         return JsonSerializer.Deserialize<Resource>(resource.ReferenceResource, options);
     }
 }


### PR DESCRIPTION
### 🛠️ Description of Changes
This enhances `FhirResourceDeserializer` to support arbitrary `Resource`s rather than a hard-coded list of resource types.

### 🧪 Testing Performed
Tested against Leo's enhanced version of the smoke test (see `LNK_3709_EnhancedAutomation_V2`).  Note that the defect did not manifest on the *initial* run in a freshly `compose up`'d environment.  Only *subsequent* runs (where referenced resources are pulled from persistence) demonstrated the issue.

### 🧑‍🔬 Unit Testing
N/A

### 📓 Documentation Updated
N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved the efficiency and maintainability of FHIR resource deserialization.
  * Enhanced performance by reusing JSON serializer options.
  * Broadened compatibility by supporting a wider range of FHIR resource types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->