### PR TITLE
LNK-3966: Even More Fhir Path Validation

### DIFF
--- a/DotNet/Normalization/Application/FhirJsonConverter.cs
+++ b/DotNet/Normalization/Application/FhirJsonConverter.cs
@@ -11,7 +11,15 @@ public class FhirResourceConverter : JsonConverter<DomainResource>
     {
         // Read the JSON string for the resource
         var json = JsonSerializer.Deserialize<JsonElement>(ref reader, options).GetRawText();
-        return _fhirParser.Parse<DomainResource>(json);
+
+        try
+        {
+            return _fhirParser.Parse<DomainResource>(json);
+        }
+        catch (Exception ex)
+        {
+            throw new JsonException("Invalid FHIR resource payload.", ex);
+        }
     }
 
     public override void Write(Utf8JsonWriter writer, DomainResource value, JsonSerializerOptions options)

--- a/DotNet/Normalization/Application/FhirJsonConverter.cs
+++ b/DotNet/Normalization/Application/FhirJsonConverter.cs
@@ -9,11 +9,10 @@ public class FhirResourceConverter : JsonConverter<DomainResource>
 
     public override DomainResource Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
     {
-        // Read the JSON string for the resource
-        var json = JsonSerializer.Deserialize<JsonElement>(ref reader, options).GetRawText();
-
         try
         {
+            // Read the JSON string for the resource
+            var json = JsonSerializer.Deserialize<JsonElement>(ref reader, options).GetRawText();
             return _fhirParser.Parse<DomainResource>(json);
         }
         catch (Exception ex)

--- a/DotNet/Normalization/Application/FhirJsonConverter.cs
+++ b/DotNet/Normalization/Application/FhirJsonConverter.cs
@@ -1,0 +1,24 @@
+﻿using Hl7.Fhir.Model;
+using Hl7.Fhir.Serialization;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+public class FhirResourceConverter : JsonConverter<DomainResource>
+{
+    private readonly FhirJsonParser _fhirParser = new FhirJsonParser();
+
+    public override DomainResource Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        // Read the JSON string for the resource
+        var json = JsonSerializer.Deserialize<JsonElement>(ref reader, options).GetRawText();
+        return _fhirParser.Parse<DomainResource>(json);
+    }
+
+    public override void Write(Utf8JsonWriter writer, DomainResource value, JsonSerializerOptions options)
+    {
+        // Serialize the FHIR resource to JSON
+        var fhirSerializer = new FhirJsonSerializer();
+        var json = fhirSerializer.SerializeToString(value);
+        writer.WriteRawValue(json);
+    }
+}

--- a/DotNet/Normalization/Application/Models/Operations/Business/Manager/DeleteOperationSequencesModel.cs
+++ b/DotNet/Normalization/Application/Models/Operations/Business/Manager/DeleteOperationSequencesModel.cs
@@ -11,6 +11,7 @@ namespace LantanaGroup.Link.Normalization.Application.Models.Operations.Business
         public required string FacilityId { get; set; }
         [DataMember]
         public string? ResourceType { get; set; }
+        [DataMember]
         public Guid? OperationId { get; set; }
     }
 }

--- a/DotNet/Normalization/Application/Models/Operations/Business/Manager/DeleteOperationSequencesModel.cs
+++ b/DotNet/Normalization/Application/Models/Operations/Business/Manager/DeleteOperationSequencesModel.cs
@@ -11,5 +11,6 @@ namespace LantanaGroup.Link.Normalization.Application.Models.Operations.Business
         public required string FacilityId { get; set; }
         [DataMember]
         public string? ResourceType { get; set; }
+        public Guid? OperationId { get; set; }
     }
 }

--- a/DotNet/Normalization/Application/Models/Operations/HttpModels/TestOperationModel.cs
+++ b/DotNet/Normalization/Application/Models/Operations/HttpModels/TestOperationModel.cs
@@ -1,4 +1,5 @@
-﻿using LantanaGroup.Link.Normalization.Application.Operations;
+﻿using Hl7.Fhir.Model;
+using LantanaGroup.Link.Normalization.Application.Operations;
 using System.ComponentModel.DataAnnotations;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.Serialization;
@@ -11,7 +12,7 @@ namespace LantanaGroup.Link.Normalization.Application.Models.Operations.HttpMode
         [Required, DataMember]
         public required IOperation Operation { get; set; }
         [Required, DataMember]
-        public string? Resource { get; set; }
+        public DomainResource? Resource { get; set; }
 
     }
 }

--- a/DotNet/Normalization/Application/Operations/TransformCondition.cs
+++ b/DotNet/Normalization/Application/Operations/TransformCondition.cs
@@ -2,7 +2,7 @@
 {
     public class TransformCondition
     {
-        public string Fhir_Path_Source { get; set; }
+        public string FhirPathSource { get; set; }
 
         public ConditionOperator Operator { get; set; }
 
@@ -13,7 +13,7 @@
         public TransformCondition() { }
         public TransformCondition(string fhirPathSource, ConditionOperator @operator, object value = null, ILogger<TransformCondition> logger = null)
         {
-            Fhir_Path_Source = fhirPathSource;
+            FhirPathSource = fhirPathSource;
             Operator = @operator;
             Value = value;
             _logger = logger;

--- a/DotNet/Normalization/Application/Services/FhirValidation/FhirPathValidator.cs
+++ b/DotNet/Normalization/Application/Services/FhirValidation/FhirPathValidator.cs
@@ -56,9 +56,8 @@ namespace LantanaGroup.Link.Normalization.Application.Services.FhirPathValidatio
                         continue;
                     }
 
-                    // Non-index segment
-                    currentBasePath = currentBasePath == resourceTypeName ? $"{currentBasePath}.{segment}" : $"{currentBasePath}.{segment}";
-                    displayPath = displayPath == resourceTypeName ? $"{displayPath}.{segment}" : $"{displayPath}.{segment}";
+                    currentBasePath = $"{currentBasePath}.{segment}";
+                    displayPath = $"{displayPath}.{segment}";
 
                     var element = currentStructure.Snapshot.Element.FirstOrDefault(e => e.Path == currentBasePath);
                     if (element == null)

--- a/DotNet/Normalization/Application/Services/FhirValidation/FhirPathValidator.cs
+++ b/DotNet/Normalization/Application/Services/FhirValidation/FhirPathValidator.cs
@@ -1,9 +1,6 @@
-﻿using Hl7.Fhir.ElementModel;
-using Hl7.Fhir.Model;
+﻿using Hl7.Fhir.Model;
 using Hl7.Fhir.Specification.Snapshot;
 using Hl7.Fhir.Specification.Source;
-using Hl7.FhirPath;
-using Hl7.FhirPath.Expressions;
 using System.Collections.Concurrent;
 
 namespace LantanaGroup.Link.Normalization.Application.Services.FhirPathValidation
@@ -21,32 +18,68 @@ namespace LantanaGroup.Link.Normalization.Application.Services.FhirPathValidatio
         {
             if (string.IsNullOrWhiteSpace(fhirPath))
                 throw new ArgumentException("FHIRPath expression cannot be null or empty.", nameof(fhirPath));
-
             if (string.IsNullOrWhiteSpace(resourceTypeName))
                 throw new ArgumentException("Resource type cannot be null or empty.", nameof(resourceTypeName));
 
             try
             {
-                var sd = await GetStructureDefinitionAsync(resourceTypeName);
-                if (sd == null) return (false, "No StructureDefinition Found to Validate FHirPath");
+                var structureDefinition = await GetStructureDefinitionAsync(resourceTypeName);
+                if (structureDefinition == null || structureDefinition.Snapshot == null)
+                    return (false, "StructureDefinition or snapshot not found.");
 
-                var resourceType = Type.GetType($"Hl7.Fhir.Model.{resourceTypeName}, Hl7.Fhir.R4", throwOnError: true);
-                var dummyResource = (DomainResource)Activator.CreateInstance(resourceType);
-                var typed = dummyResource.ToTypedElement();
+                var segments = fhirPath.Split('.');
+                var currentStructure = structureDefinition;
+                var currentPath = resourceTypeName;
 
-                var symbolTable = new SymbolTable();
-                symbolTable.AddStandardFP();
-                var compiler = new FhirPathCompiler(symbolTable);
-                var expression = compiler.Compile(fhirPath);
-                var result = expression(typed, EvaluationContext.CreateDefault());
+                for (int i = 0; i < segments.Length; i++)
+                {
+                    var segment = segments[i];
+                    currentPath += "." + segment;
+
+                    var element = currentStructure.Snapshot.Element.FirstOrDefault(e => e.Path == currentPath);
+                    if (element == null)
+                        return (false, $"Path segment '{segment}' not found at '{currentPath}'.");
+
+                    // If this is the last segment, we're done
+                    if (i == segments.Length - 1)
+                        return (true, null);
+
+                    // If the element has a complex type, resolve its StructureDefinition
+                    var typeCode = element.Type?.FirstOrDefault()?.Code;
+                    if (string.IsNullOrEmpty(typeCode))
+                        return (false, $"Element '{segment}' has no type information.");
+
+                    if (IsPrimitive(typeCode))
+                        return (false, $"Element '{segment}' is a primitive type and cannot have child elements.");
+
+                    var nextStructure = await GetStructureDefinitionAsync(typeCode);
+                    if (nextStructure == null || nextStructure.Snapshot == null)
+                        return (false, $"StructureDefinition for type '{typeCode}' not found.");
+
+                    currentStructure = nextStructure;
+                    currentPath = typeCode; // Reset path for the new structure
+                }
 
                 return (true, null);
             }
             catch (Exception ex)
             {
-                return (false, ex.Message);
+                return (false, $"Exception during validation: {ex.Message}");
             }
         }
+
+
+        private static bool IsPrimitive(string typeCode)
+        {
+            var primitives = new HashSet<string>
+            {
+                "boolean", "integer", "decimal", "base64Binary", "instant", "string",
+                "uri", "date", "dateTime", "time", "code", "oid", "id", "markdown",
+                "unsignedInt", "positiveInt", "uuid", "xhtml"
+            };
+            return primitives.Contains(typeCode);
+        }
+
 
         private static async Task<StructureDefinition?> GetStructureDefinitionAsync(string resourceTypeName)
         {

--- a/DotNet/Normalization/Application/Services/FhirValidation/FhirPathValidator.cs
+++ b/DotNet/Normalization/Application/Services/FhirValidation/FhirPathValidator.cs
@@ -1,8 +1,13 @@
-﻿using Hl7.Fhir.Model;
+﻿using System;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using Hl7.Fhir.Model;
 using Hl7.Fhir.Specification.Snapshot;
 using Hl7.Fhir.Specification.Source;
-using System.Collections.Concurrent;
-using System.Text.RegularExpressions;
 
 namespace LantanaGroup.Link.Normalization.Application.Services.FhirPathValidation
 {
@@ -11,13 +16,22 @@ namespace LantanaGroup.Link.Normalization.Application.Services.FhirPathValidatio
         private static readonly ConcurrentDictionary<string, StructureDefinition> _structureDefinitionCache = new();
         private static readonly string _structureDefinitionsPath = Path.Combine(AppContext.BaseDirectory, "Application", "Services", "FhirValidation", "StructureDefinitions");
         private static readonly CachedResolver _resolver = new CachedResolver(new DirectorySource(_structureDefinitionsPath));
+        private static readonly string _logFilePath = Path.Combine(AppContext.BaseDirectory, "FhirPathValidator.log");
 
-        private readonly static HashSet<string> _primitives = new HashSet<string>
+        /// <summary>
+        /// Logs a message to a file for debugging in environments like Test Explorer.
+        /// </summary>
+        private static void LogToFile(string message)
+        {
+            try
             {
-                "boolean", "integer", "decimal", "base64Binary", "instant", "string",
-                "uri", "date", "dateTime", "time", "code", "oid", "id", "markdown",
-                "unsignedInt", "positiveInt", "uuid", "xhtml"
-            };
+                File.AppendAllText(_logFilePath, $"{DateTime.Now:yyyy-MM-dd HH:mm:ss} - {message}{Environment.NewLine}");
+            }
+            catch
+            {
+                // Ignore logging errors to avoid affecting validation
+            }
+        }
 
         /// <summary>
         /// Validates if a FHIR Path is valid for a given resource type using its structure definition.
@@ -35,15 +49,23 @@ namespace LantanaGroup.Link.Normalization.Application.Services.FhirPathValidatio
                 if (structureDefinition == null || structureDefinition.Snapshot == null)
                     return (false, "StructureDefinition or snapshot not found for " + resourceTypeName);
 
+                // Log all snapshot element paths for debugging
+                var elementPaths = structureDefinition.Snapshot.Element.Select(e => e.Path).ToList();
+                LogToFile($"Snapshot element paths for '{resourceTypeName}': {string.Join(", ", elementPaths)}");
+
                 // Parse the FHIR path
                 var segments = ParseFhirPath(fhirPath);
+                LogToFile($"Parsed segments: {string.Join(", ", segments)}");
 
                 var currentStructure = structureDefinition;
-                var currentBasePath = resourceTypeName; // Path for Element.Path matching (e.g., Encounter.type)
-                var displayPath = resourceTypeName; // Path for error messages (e.g., Encounter.type[0])
+                var currentBasePath = resourceTypeName; // Path for Element.Path matching (e.g., Observation.value[x])
+                var displayPath = resourceTypeName; // Path for error messages (e.g., Observation.valueQuantity)
 
-                foreach (var segment in segments)
+                for (int i = 0; i < segments.Length; i++)
                 {
+                    var segment = segments[i];
+                    LogToFile($"Processing segment: '{segment}', basePath: '{currentBasePath}', displayPath: '{displayPath}'");
+
                     // Check if the segment is an index (e.g., [0])
                     if (Regex.IsMatch(segment, @"^\[\d+\]$"))
                     {
@@ -60,63 +82,162 @@ namespace LantanaGroup.Link.Normalization.Application.Services.FhirPathValidatio
 
                         // Update display path but not base path
                         displayPath += segment;
+                        LogToFile($"Index validated, new displayPath: '{displayPath}'");
                         continue;
                     }
 
-                    currentBasePath = $"{currentBasePath}.{segment}";
-                    displayPath = $"{displayPath}.{segment}";
+                    // Handle choice types first (e.g., valueQuantity -> value[x])
+                    string elementPath = null;
+                    ElementDefinition element = null;
+                    string choiceType = null;
 
-                    var element = currentStructure.Snapshot.Element.FirstOrDefault(e => e.Path == currentBasePath);
+                    // Try choice path (e.g., Observation.value[x])
+                    var validTypes = new List<string>();
+                    string choicePath = null;
+                    // Find potential choice paths by checking if segment contains any valid type
+                    var snapshotElements = currentStructure.Snapshot.Element;
+                    foreach (var elem in snapshotElements.Where(e => e.Path.StartsWith(currentBasePath) && e.Path.EndsWith("[x]")))
+                    {
+                        var baseName = elem.Path.Substring(0, elem.Path.Length - 3); // Remove [x]
+                        var types = elem.Type?.Select(t => t.Code).ToList() ?? new List<string>();
+                        foreach (var type in types)
+                        {
+                            if (segment.Equals(baseName.Replace(currentBasePath + ".", "") + type, StringComparison.OrdinalIgnoreCase))
+                            {
+                                choicePath = elem.Path;
+                                validTypes = types;
+                                element = elem;
+                                choiceType = type;
+                                break;
+                            }
+                        }
+                        if (element != null) break;
+                    }
+
+                    if (element != null)
+                    {
+                        elementPath = choicePath;
+                        LogToFile($"Checking choice types for '{choicePath}': {string.Join(", ", validTypes)}");
+                        LogToFile($"Matched choice type: '{choiceType}' for segment '{segment}'");
+                    }
+                    else
+                    {
+                        LogToFile($"Choice path for segment '{segment}' not found in snapshot");
+                    }
+
+                    // Try exact path if choice path not matched
                     if (element == null)
-                        return (false, $"Path segment '{segment}' not found at '{currentBasePath}'");
+                    {
+                        elementPath = currentBasePath == resourceTypeName ? $"{currentBasePath}.{segment}" : $"{currentBasePath}.{segment}";
+                        LogToFile($"Trying exact path: '{elementPath}'");
+                        element = currentStructure.Snapshot.Element.FirstOrDefault(e => string.Equals(e.Path, elementPath, StringComparison.OrdinalIgnoreCase));
+                    }
+
+                    if (element == null)
+                        return (false, $"Path segment '{segment}' not found at '{elementPath}'");
+
+                    LogToFile($"Found element with path: '{elementPath}'");
+
+                    // Update paths
+                    currentBasePath = elementPath;
+                    displayPath = displayPath == resourceTypeName ? $"{displayPath}.{segment}" : $"{displayPath}.{segment}";
 
                     // If this is the last segment, we're done
-                    if (segment == segments.Last())
+                    if (i == segments.Length - 1)
                     {
+                        LogToFile("Reached last segment, path is valid");
                         return (true, null);
                     }
 
                     // Resolve the next StructureDefinition for complex types
-                    var typeCode = element.Type?.FirstOrDefault()?.Code;
-                    if (string.IsNullOrEmpty(typeCode))
+                    var typeCodes = element.Type?.Select(t => t.Code).ToList() ?? new List<string>();
+                    if (!typeCodes.Any())
                         return (false, $"Element '{segment}' has no type information at '{currentBasePath}'");
 
-                    if (IsPrimitive(typeCode))
+                    // Check if the element is a primitive list (e.g., HumanName.given)
+                    if (typeCodes.All(IsPrimitive) && element.Max == "*")
+                    {
+                        // Allow indexing into primitive lists, no further children
+                        if (segments.Skip(i + 1).Any(s => !Regex.IsMatch(s, @"^\[\d+\]$")))
+                            return (false, $"Element '{segment}' is a primitive list and cannot have non-index child elements at '{currentBasePath}'");
+                        LogToFile($"Primitive list detected: '{currentBasePath}'");
+                        continue;
+                    }
+
+                    if (typeCodes.All(IsPrimitive))
                         return (false, $"Element '{segment}' is a primitive type and cannot have child elements at '{currentBasePath}'");
 
-                    var nextStructure = await GetStructureDefinitionAsync(typeCode);
-                    if (nextStructure == null || nextStructure.Snapshot == null)
-                        return (false, $"StructureDefinition for type '{typeCode}' not found");
+                    // Handle choice type for the next segment
+                    string typeCode = choiceType ?? typeCodes.FirstOrDefault(t => !t.EndsWith("[x]", StringComparison.OrdinalIgnoreCase)) ?? typeCodes.First();
 
-                    currentStructure = nextStructure;
-                    currentBasePath = typeCode;
-                    displayPath = typeCode;
+                    // Prefer Quantity for dose[x] if next segment is 'value'
+                    if (elementPath.EndsWith("[x]") && i + 1 < segments.Length && segments[i + 1] == "value")
+                    {
+                        if (typeCodes.Contains("Quantity"))
+                            typeCode = "Quantity"; // Prefer Quantity for .value
+                        LogToFile($"Preferring 'Quantity' for choice type due to next segment 'value'");
+                    }
+
+                    if (typeCode != "BackboneElement" && typeCode != "Element")
+                    {
+                        var nextStructure = await GetStructureDefinitionAsync(typeCode);
+                        if (nextStructure == null || nextStructure.Snapshot == null)
+                            return (false, $"StructureDefinition for type '{typeCode}' not found");
+
+                        currentStructure = nextStructure;
+                        currentBasePath = typeCode;
+                        displayPath = typeCode;
+                        LogToFile($"Moving to new structure: '{typeCode}'");
+                    }
+                    else
+                    {
+                        LogToFile($"Staying with current structure for {typeCode}: '{currentBasePath}'");
+                    }
                 }
 
                 return (true, null);
             }
             catch (Exception ex)
             {
+                LogToFile($"Exception during validation: {ex.Message}");
                 return (false, $"Exception during validation: {ex.Message}");
             }
         }
+
         private static bool IsPrimitive(string typeCode)
         {
-            return _primitives.Contains(typeCode);
+            var primitives = new HashSet<string>
+            {
+                "boolean", "integer", "decimal", "base64Binary", "instant", "string",
+                "uri", "date", "dateTime", "time", "code", "oid", "id", "markdown",
+                "unsignedInt", "positiveInt", "uuid", "xhtml"
+            };
+            return primitives.Contains(typeCode);
         }
 
         private static async Task<StructureDefinition?> GetStructureDefinitionAsync(string resourceTypeName)
         {
             if (_structureDefinitionCache.TryGetValue(resourceTypeName, out var definition))
             {
+                LogToFile($"Cache hit for '{resourceTypeName}'");
                 return definition;
             }
 
+            LogToFile($"Fetching StructureDefinition for '{resourceTypeName}'");
             definition = await _resolver.FindStructureDefinitionAsync($"http://hl7.org/fhir/StructureDefinition/{resourceTypeName}");
             if (definition != null && !definition.HasSnapshot)
             {
-                var generator = new SnapshotGenerator(_resolver);
-                await generator.UpdateAsync(definition);
+                LogToFile($"Generating snapshot for '{resourceTypeName}'");
+                try
+                {
+                    var generator = new SnapshotGenerator(_resolver);
+                    await generator.UpdateAsync(definition);
+                }
+                catch (Exception ex)
+                {
+                    LogToFile($"Snapshot generation failed for '{resourceTypeName}': {ex.Message}");
+                    throw;
+                }
                 _structureDefinitionCache.TryAdd(resourceTypeName, definition);
             }
             else if (definition != null)
@@ -129,7 +250,7 @@ namespace LantanaGroup.Link.Normalization.Application.Services.FhirPathValidatio
 
         private static string[] ParseFhirPath(string fhirPath)
         {
-            // Split path into segments, preserving indices (e.g., type[0].coding -> type, [0], coding)
+            // Split path into segments, preserving indices (e.g., valueQuantity.value -> valueQuantity, value)
             var segments = new List<string>();
             var regex = new Regex(@"(\w+|\[\d+\])");
             var matches = regex.Matches(fhirPath);

--- a/DotNet/Normalization/Application/Services/FhirValidation/FhirPathValidator.cs
+++ b/DotNet/Normalization/Application/Services/FhirValidation/FhirPathValidator.cs
@@ -2,6 +2,7 @@
 using Hl7.Fhir.Specification.Snapshot;
 using Hl7.Fhir.Specification.Source;
 using System.Collections.Concurrent;
+using System.Text.RegularExpressions;
 
 namespace LantanaGroup.Link.Normalization.Application.Services.FhirPathValidation
 {
@@ -25,39 +26,72 @@ namespace LantanaGroup.Link.Normalization.Application.Services.FhirPathValidatio
             {
                 var structureDefinition = await GetStructureDefinitionAsync(resourceTypeName);
                 if (structureDefinition == null || structureDefinition.Snapshot == null)
-                    return (false, "StructureDefinition or snapshot not found.");
+                    return (false, "StructureDefinition or snapshot not found for " + resourceTypeName);
 
-                var segments = fhirPath.Split('.');
+                // Parse the FHIR path
+                var segments = ParseFhirPath(fhirPath);
+                Console.WriteLine($"Parsed segments: {string.Join(", ", segments)}"); // Debug
+
                 var currentStructure = structureDefinition;
-                var currentPath = resourceTypeName;
+                var currentBasePath = resourceTypeName; // Path for Element.Path matching (e.g., Encounter.type)
+                var displayPath = resourceTypeName; // Path for error messages (e.g., Encounter.type[0])
 
-                for (int i = 0; i < segments.Length; i++)
+                foreach (var segment in segments)
                 {
-                    var segment = segments[i];
-                    currentPath += "." + segment;
+                    Console.WriteLine($"Processing segment: '{segment}', basePath: '{currentBasePath}', displayPath: '{displayPath}'"); // Debug
 
-                    var element = currentStructure.Snapshot.Element.FirstOrDefault(e => e.Path == currentPath);
+                    // Check if the segment is an index (e.g., [0])
+                    if (Regex.IsMatch(segment, @"^\[\d+\]$"))
+                    {
+                        if (!int.TryParse(segment.Trim('[', ']'), out int index) || index < 0)
+                            return (false, $"Invalid index '{segment}' at '{displayPath}'");
+
+                        // Ensure the previous element supports indexing
+                        var prevElement = currentStructure.Snapshot.Element.FirstOrDefault(e => e.Path == currentBasePath);
+                        if (prevElement == null)
+                            return (false, $"Path '{currentBasePath}' not found for index '{segment}'");
+
+                        if (prevElement.Max != "*" && (prevElement.Max == null || int.Parse(prevElement.Max) <= 1))
+                            return (false, $"Element '{currentBasePath}' does not support indexing (max cardinality: {prevElement.Max})");
+
+                        // Update display path but not base path
+                        displayPath += segment;
+                        Console.WriteLine($"Index validated, new displayPath: '{displayPath}'"); // Debug
+                        continue;
+                    }
+
+                    // Non-index segment
+                    currentBasePath = currentBasePath == resourceTypeName ? $"{currentBasePath}.{segment}" : $"{currentBasePath}.{segment}";
+                    displayPath = displayPath == resourceTypeName ? $"{displayPath}.{segment}" : $"{displayPath}.{segment}";
+
+                    Console.WriteLine($"Looking for element with path: '{currentBasePath}'"); // Debug
+                    var element = currentStructure.Snapshot.Element.FirstOrDefault(e => e.Path == currentBasePath);
                     if (element == null)
-                        return (false, $"Path segment '{segment}' not found at '{currentPath}'.");
+                        return (false, $"Path segment '{segment}' not found at '{currentBasePath}'");
 
                     // If this is the last segment, we're done
-                    if (i == segments.Length - 1)
+                    if (segment == segments.Last())
+                    {
+                        Console.WriteLine("Reached last segment, path is valid"); // Debug
                         return (true, null);
+                    }
 
-                    // If the element has a complex type, resolve its StructureDefinition
+                    // Resolve the next StructureDefinition for complex types
                     var typeCode = element.Type?.FirstOrDefault()?.Code;
                     if (string.IsNullOrEmpty(typeCode))
-                        return (false, $"Element '{segment}' has no type information.");
+                        return (false, $"Element '{segment}' has no type information at '{currentBasePath}'");
 
                     if (IsPrimitive(typeCode))
-                        return (false, $"Element '{segment}' is a primitive type and cannot have child elements.");
+                        return (false, $"Element '{segment}' is a primitive type and cannot have child elements at '{currentBasePath}'");
 
                     var nextStructure = await GetStructureDefinitionAsync(typeCode);
                     if (nextStructure == null || nextStructure.Snapshot == null)
-                        return (false, $"StructureDefinition for type '{typeCode}' not found.");
+                        return (false, $"StructureDefinition for type '{typeCode}' not found");
 
                     currentStructure = nextStructure;
-                    currentPath = typeCode; // Reset path for the new structure
+                    currentBasePath = typeCode;
+                    displayPath = typeCode;
+                    Console.WriteLine($"Moving to new structure: '{typeCode}'"); // Debug
                 }
 
                 return (true, null);
@@ -67,7 +101,6 @@ namespace LantanaGroup.Link.Normalization.Application.Services.FhirPathValidatio
                 return (false, $"Exception during validation: {ex.Message}");
             }
         }
-
 
         private static bool IsPrimitive(string typeCode)
         {
@@ -80,19 +113,19 @@ namespace LantanaGroup.Link.Normalization.Application.Services.FhirPathValidatio
             return primitives.Contains(typeCode);
         }
 
-
         private static async Task<StructureDefinition?> GetStructureDefinitionAsync(string resourceTypeName)
         {
-            var result = _structureDefinitionCache.TryGetValue(resourceTypeName, out var definition);
-
-            if(result)
+            if (_structureDefinitionCache.TryGetValue(resourceTypeName, out var definition))
             {
+                Console.WriteLine($"Cache hit for '{resourceTypeName}'"); // Debug
                 return definition;
             }
 
+            Console.WriteLine($"Fetching StructureDefinition for '{resourceTypeName}'"); // Debug
             definition = await _resolver.FindStructureDefinitionAsync($"http://hl7.org/fhir/StructureDefinition/{resourceTypeName}");
             if (definition != null && !definition.HasSnapshot)
             {
+                Console.WriteLine($"Generating snapshot for '{resourceTypeName}'"); // Debug
                 var generator = new SnapshotGenerator(_resolver);
                 await generator.UpdateAsync(definition);
                 _structureDefinitionCache.TryAdd(resourceTypeName, definition);
@@ -103,6 +136,21 @@ namespace LantanaGroup.Link.Normalization.Application.Services.FhirPathValidatio
             }
 
             return definition;
+        }
+
+        private static string[] ParseFhirPath(string fhirPath)
+        {
+            // Split path into segments, preserving indices (e.g., type[0].coding -> type, [0], coding)
+            var segments = new List<string>();
+            var regex = new Regex(@"(\w+|\[\d+\])");
+            var matches = regex.Matches(fhirPath);
+
+            foreach (Match match in matches)
+            {
+                segments.Add(match.Value);
+            }
+
+            return segments.ToArray();
         }
     }
 }

--- a/DotNet/Normalization/Application/Services/FhirValidation/FhirPathValidator.cs
+++ b/DotNet/Normalization/Application/Services/FhirValidation/FhirPathValidator.cs
@@ -30,7 +30,6 @@ namespace LantanaGroup.Link.Normalization.Application.Services.FhirPathValidatio
 
                 // Parse the FHIR path
                 var segments = ParseFhirPath(fhirPath);
-                Console.WriteLine($"Parsed segments: {string.Join(", ", segments)}"); // Debug
 
                 var currentStructure = structureDefinition;
                 var currentBasePath = resourceTypeName; // Path for Element.Path matching (e.g., Encounter.type)
@@ -38,8 +37,6 @@ namespace LantanaGroup.Link.Normalization.Application.Services.FhirPathValidatio
 
                 foreach (var segment in segments)
                 {
-                    Console.WriteLine($"Processing segment: '{segment}', basePath: '{currentBasePath}', displayPath: '{displayPath}'"); // Debug
-
                     // Check if the segment is an index (e.g., [0])
                     if (Regex.IsMatch(segment, @"^\[\d+\]$"))
                     {
@@ -56,7 +53,6 @@ namespace LantanaGroup.Link.Normalization.Application.Services.FhirPathValidatio
 
                         // Update display path but not base path
                         displayPath += segment;
-                        Console.WriteLine($"Index validated, new displayPath: '{displayPath}'"); // Debug
                         continue;
                     }
 
@@ -64,7 +60,6 @@ namespace LantanaGroup.Link.Normalization.Application.Services.FhirPathValidatio
                     currentBasePath = currentBasePath == resourceTypeName ? $"{currentBasePath}.{segment}" : $"{currentBasePath}.{segment}";
                     displayPath = displayPath == resourceTypeName ? $"{displayPath}.{segment}" : $"{displayPath}.{segment}";
 
-                    Console.WriteLine($"Looking for element with path: '{currentBasePath}'"); // Debug
                     var element = currentStructure.Snapshot.Element.FirstOrDefault(e => e.Path == currentBasePath);
                     if (element == null)
                         return (false, $"Path segment '{segment}' not found at '{currentBasePath}'");
@@ -72,7 +67,6 @@ namespace LantanaGroup.Link.Normalization.Application.Services.FhirPathValidatio
                     // If this is the last segment, we're done
                     if (segment == segments.Last())
                     {
-                        Console.WriteLine("Reached last segment, path is valid"); // Debug
                         return (true, null);
                     }
 
@@ -91,7 +85,6 @@ namespace LantanaGroup.Link.Normalization.Application.Services.FhirPathValidatio
                     currentStructure = nextStructure;
                     currentBasePath = typeCode;
                     displayPath = typeCode;
-                    Console.WriteLine($"Moving to new structure: '{typeCode}'"); // Debug
                 }
 
                 return (true, null);
@@ -117,15 +110,12 @@ namespace LantanaGroup.Link.Normalization.Application.Services.FhirPathValidatio
         {
             if (_structureDefinitionCache.TryGetValue(resourceTypeName, out var definition))
             {
-                Console.WriteLine($"Cache hit for '{resourceTypeName}'"); // Debug
                 return definition;
             }
 
-            Console.WriteLine($"Fetching StructureDefinition for '{resourceTypeName}'"); // Debug
             definition = await _resolver.FindStructureDefinitionAsync($"http://hl7.org/fhir/StructureDefinition/{resourceTypeName}");
             if (definition != null && !definition.HasSnapshot)
             {
-                Console.WriteLine($"Generating snapshot for '{resourceTypeName}'"); // Debug
                 var generator = new SnapshotGenerator(_resolver);
                 await generator.UpdateAsync(definition);
                 _structureDefinitionCache.TryAdd(resourceTypeName, definition);

--- a/DotNet/Normalization/Application/Services/FhirValidation/FhirPathValidator.cs
+++ b/DotNet/Normalization/Application/Services/FhirValidation/FhirPathValidator.cs
@@ -12,6 +12,13 @@ namespace LantanaGroup.Link.Normalization.Application.Services.FhirPathValidatio
         private static readonly string _structureDefinitionsPath = Path.Combine(AppContext.BaseDirectory, "Application", "Services", "FhirValidation", "StructureDefinitions");
         private static readonly CachedResolver _resolver = new CachedResolver(new DirectorySource(_structureDefinitionsPath));
 
+        private readonly static HashSet<string> _primitives = new HashSet<string>
+            {
+                "boolean", "integer", "decimal", "base64Binary", "instant", "string",
+                "uri", "date", "dateTime", "time", "code", "oid", "id", "markdown",
+                "unsignedInt", "positiveInt", "uuid", "xhtml"
+            };
+
         /// <summary>
         /// Validates if a FHIR Path is valid for a given resource type using its structure definition.
         /// </summary>
@@ -93,16 +100,9 @@ namespace LantanaGroup.Link.Normalization.Application.Services.FhirPathValidatio
                 return (false, $"Exception during validation: {ex.Message}");
             }
         }
-
         private static bool IsPrimitive(string typeCode)
         {
-            var primitives = new HashSet<string>
-            {
-                "boolean", "integer", "decimal", "base64Binary", "instant", "string",
-                "uri", "date", "dateTime", "time", "code", "oid", "id", "markdown",
-                "unsignedInt", "positiveInt", "uuid", "xhtml"
-            };
-            return primitives.Contains(typeCode);
+            return _primitives.Contains(typeCode);
         }
 
         private static async Task<StructureDefinition?> GetStructureDefinitionAsync(string resourceTypeName)

--- a/DotNet/Normalization/Application/Services/FhirValidation/FhirPathValidator.cs
+++ b/DotNet/Normalization/Application/Services/FhirValidation/FhirPathValidator.cs
@@ -1,13 +1,8 @@
-﻿using System;
-using System.IO;
-using System.Linq;
-using System.Text.RegularExpressions;
-using System.Threading.Tasks;
-using System.Collections.Concurrent;
-using System.Collections.Generic;
-using Hl7.Fhir.Model;
+﻿using Hl7.Fhir.Model;
 using Hl7.Fhir.Specification.Snapshot;
 using Hl7.Fhir.Specification.Source;
+using System.Collections.Concurrent;
+using System.Text.RegularExpressions;
 
 namespace LantanaGroup.Link.Normalization.Application.Services.FhirPathValidation
 {
@@ -16,25 +11,9 @@ namespace LantanaGroup.Link.Normalization.Application.Services.FhirPathValidatio
         private static readonly ConcurrentDictionary<string, StructureDefinition> _structureDefinitionCache = new();
         private static readonly string _structureDefinitionsPath = Path.Combine(AppContext.BaseDirectory, "Application", "Services", "FhirValidation", "StructureDefinitions");
         private static readonly CachedResolver _resolver = new CachedResolver(new DirectorySource(_structureDefinitionsPath));
-        private static readonly string _logFilePath = Path.Combine(AppContext.BaseDirectory, "FhirPathValidator.log");
 
         /// <summary>
-        /// Logs a message to a file for debugging in environments like Test Explorer.
-        /// </summary>
-        private static void LogToFile(string message)
-        {
-            try
-            {
-                File.AppendAllText(_logFilePath, $"{DateTime.Now:yyyy-MM-dd HH:mm:ss} - {message}{Environment.NewLine}");
-            }
-            catch
-            {
-                // Ignore logging errors to avoid affecting validation
-            }
-        }
-
-        /// <summary>
-        /// Validates if a FHIR Path is valid for a given resource type using its structure definition.
+        /// Validates if a FHIRPath is valid for a given resource type using its StructureDefinition.
         /// </summary>
         public static async Task<(bool IsValid, string? ErrorMessage)> IsFhirPathValidForResourceType(string fhirPath, string resourceTypeName)
         {
@@ -46,162 +25,141 @@ namespace LantanaGroup.Link.Normalization.Application.Services.FhirPathValidatio
             try
             {
                 var structureDefinition = await GetStructureDefinitionAsync(resourceTypeName);
-                if (structureDefinition == null || structureDefinition.Snapshot == null)
-                    return (false, "StructureDefinition or snapshot not found for " + resourceTypeName);
+                if (structureDefinition?.Snapshot == null)
+                    return (false, $"StructureDefinition or snapshot not found for {resourceTypeName}");
 
-                // Log all snapshot element paths for debugging
-                var elementPaths = structureDefinition.Snapshot.Element.Select(e => e.Path).ToList();
-                LogToFile($"Snapshot element paths for '{resourceTypeName}': {string.Join(", ", elementPaths)}");
-
-                // Parse the FHIR path
                 var segments = ParseFhirPath(fhirPath);
-                LogToFile($"Parsed segments: {string.Join(", ", segments)}");
-
-                var currentStructure = structureDefinition;
-                var currentBasePath = resourceTypeName; // Path for Element.Path matching (e.g., Observation.value[x])
-                var displayPath = resourceTypeName; // Path for error messages (e.g., Observation.valueQuantity)
-
-                for (int i = 0; i < segments.Length; i++)
-                {
-                    var segment = segments[i];
-                    LogToFile($"Processing segment: '{segment}', basePath: '{currentBasePath}', displayPath: '{displayPath}'");
-
-                    // Check if the segment is an index (e.g., [0])
-                    if (Regex.IsMatch(segment, @"^\[\d+\]$"))
-                    {
-                        if (!int.TryParse(segment.Trim('[', ']'), out int index) || index < 0)
-                            return (false, $"Invalid index '{segment}' at '{displayPath}'");
-
-                        // Ensure the previous element supports indexing
-                        var prevElement = currentStructure.Snapshot.Element.FirstOrDefault(e => e.Path == currentBasePath);
-                        if (prevElement == null)
-                            return (false, $"Path '{currentBasePath}' not found for index '{segment}'");
-
-                        if (prevElement.Max != "*" && (prevElement.Max == null || int.Parse(prevElement.Max) <= 1))
-                            return (false, $"Element '{currentBasePath}' does not support indexing (max cardinality: {prevElement.Max})");
-
-                        // Update display path but not base path
-                        displayPath += segment;
-                        LogToFile($"Index validated, new displayPath: '{displayPath}'");
-                        continue;
-                    }
-
-                    // Handle choice types first (e.g., valueQuantity -> value[x])
-                    string elementPath = null;
-                    ElementDefinition element = null;
-                    string choiceType = null;
-
-                    // Try choice path (e.g., Observation.value[x])
-                    var validTypes = new List<string>();
-                    string choicePath = null;
-                    // Find potential choice paths by checking if segment contains any valid type
-                    var snapshotElements = currentStructure.Snapshot.Element;
-                    foreach (var elem in snapshotElements.Where(e => e.Path.StartsWith(currentBasePath) && e.Path.EndsWith("[x]")))
-                    {
-                        var baseName = elem.Path.Substring(0, elem.Path.Length - 3); // Remove [x]
-                        var types = elem.Type?.Select(t => t.Code).ToList() ?? new List<string>();
-                        foreach (var type in types)
-                        {
-                            if (segment.Equals(baseName.Replace(currentBasePath + ".", "") + type, StringComparison.OrdinalIgnoreCase))
-                            {
-                                choicePath = elem.Path;
-                                validTypes = types;
-                                element = elem;
-                                choiceType = type;
-                                break;
-                            }
-                        }
-                        if (element != null) break;
-                    }
-
-                    if (element != null)
-                    {
-                        elementPath = choicePath;
-                        LogToFile($"Checking choice types for '{choicePath}': {string.Join(", ", validTypes)}");
-                        LogToFile($"Matched choice type: '{choiceType}' for segment '{segment}'");
-                    }
-                    else
-                    {
-                        LogToFile($"Choice path for segment '{segment}' not found in snapshot");
-                    }
-
-                    // Try exact path if choice path not matched
-                    if (element == null)
-                    {
-                        elementPath = currentBasePath == resourceTypeName ? $"{currentBasePath}.{segment}" : $"{currentBasePath}.{segment}";
-                        LogToFile($"Trying exact path: '{elementPath}'");
-                        element = currentStructure.Snapshot.Element.FirstOrDefault(e => string.Equals(e.Path, elementPath, StringComparison.OrdinalIgnoreCase));
-                    }
-
-                    if (element == null)
-                        return (false, $"Path segment '{segment}' not found at '{elementPath}'");
-
-                    LogToFile($"Found element with path: '{elementPath}'");
-
-                    // Update paths
-                    currentBasePath = elementPath;
-                    displayPath = displayPath == resourceTypeName ? $"{displayPath}.{segment}" : $"{displayPath}.{segment}";
-
-                    // If this is the last segment, we're done
-                    if (i == segments.Length - 1)
-                    {
-                        LogToFile("Reached last segment, path is valid");
-                        return (true, null);
-                    }
-
-                    // Resolve the next StructureDefinition for complex types
-                    var typeCodes = element.Type?.Select(t => t.Code).ToList() ?? new List<string>();
-                    if (!typeCodes.Any())
-                        return (false, $"Element '{segment}' has no type information at '{currentBasePath}'");
-
-                    // Check if the element is a primitive list (e.g., HumanName.given)
-                    if (typeCodes.All(IsPrimitive) && element.Max == "*")
-                    {
-                        // Allow indexing into primitive lists, no further children
-                        if (segments.Skip(i + 1).Any(s => !Regex.IsMatch(s, @"^\[\d+\]$")))
-                            return (false, $"Element '{segment}' is a primitive list and cannot have non-index child elements at '{currentBasePath}'");
-                        LogToFile($"Primitive list detected: '{currentBasePath}'");
-                        continue;
-                    }
-
-                    if (typeCodes.All(IsPrimitive))
-                        return (false, $"Element '{segment}' is a primitive type and cannot have child elements at '{currentBasePath}'");
-
-                    // Handle choice type for the next segment
-                    string typeCode = choiceType ?? typeCodes.FirstOrDefault(t => !t.EndsWith("[x]", StringComparison.OrdinalIgnoreCase)) ?? typeCodes.First();
-
-                    // Prefer Quantity for dose[x] if next segment is 'value'
-                    if (elementPath.EndsWith("[x]") && i + 1 < segments.Length && segments[i + 1] == "value")
-                    {
-                        if (typeCodes.Contains("Quantity"))
-                            typeCode = "Quantity"; // Prefer Quantity for .value
-                        LogToFile($"Preferring 'Quantity' for choice type due to next segment 'value'");
-                    }
-
-                    if (typeCode != "BackboneElement" && typeCode != "Element")
-                    {
-                        var nextStructure = await GetStructureDefinitionAsync(typeCode);
-                        if (nextStructure == null || nextStructure.Snapshot == null)
-                            return (false, $"StructureDefinition for type '{typeCode}' not found");
-
-                        currentStructure = nextStructure;
-                        currentBasePath = typeCode;
-                        displayPath = typeCode;
-                        LogToFile($"Moving to new structure: '{typeCode}'");
-                    }
-                    else
-                    {
-                        LogToFile($"Staying with current structure for {typeCode}: '{currentBasePath}'");
-                    }
-                }
-
-                return (true, null);
+                return await ValidatePath(segments, resourceTypeName, structureDefinition);
             }
             catch (Exception ex)
             {
-                LogToFile($"Exception during validation: {ex.Message}");
                 return (false, $"Exception during validation: {ex.Message}");
             }
+        }
+
+        private static async Task<(bool IsValid, string? ErrorMessage)> ValidatePath(string[] segments, string resourceTypeName, StructureDefinition structureDefinition)
+        {
+            var currentStructure = structureDefinition;
+            var currentBasePath = resourceTypeName; // Tracks the current path in the StructureDefinition
+            var displayPath = resourceTypeName; // Tracks the user-provided FHIRPath for error messages
+
+            for (int i = 0; i < segments.Length; i++)
+            {
+                var segment = segments[i];
+
+                // Handle index segments (e.g., [0])
+                if (Regex.IsMatch(segment, @"^\[\d+\]$"))
+                {
+                    if (!TryValidateIndex(segment, currentStructure, currentBasePath, out var error))
+                        return (false, error);
+
+                    displayPath += segment;
+                    continue;
+                }
+
+                // Find the element for the current segment
+                var (element, elementPath, choiceType) = FindElement(segment, currentStructure, currentBasePath, i < segments.Length - 1 ? segments[i + 1] : null);
+                if (element == null)
+                    return (false, $"Path segment '{segment}' not found at '{displayPath}.{segment}'");
+
+                // Update paths
+                currentBasePath = elementPath;
+                displayPath = displayPath == resourceTypeName ? $"{displayPath}.{segment}" : $"{displayPath}.{segment}";
+
+                // If last segment, path is valid
+                if (i == segments.Length - 1)
+                    return (true, null);
+
+                // Validate element types and prepare for next segment
+                var typeCodes = element.Type?.Select(t => t.Code).ToList() ?? new List<string>();
+                if (!typeCodes.Any())
+                    return (false, $"Element '{segment}' has no type information at '{currentBasePath}'");
+
+                // Handle primitive lists (e.g., HumanName.given)
+                if (typeCodes.All(IsPrimitive) && element.Max == "*")
+                {
+                    if (segments.Skip(i + 1).Any(s => !Regex.IsMatch(s, @"^\[\d+\]$")))
+                        return (false, $"Element '{segment}' is a primitive list and cannot have non-index child elements at '{currentBasePath}'");
+                    continue;
+                }
+
+                // Handle primitive types
+                if (typeCodes.All(IsPrimitive))
+                    return (false, $"Element '{segment}' is a primitive type and cannot have child elements at '{currentBasePath}'");
+
+                // Select type for next StructureDefinition
+                string typeCode = choiceType ?? typeCodes.FirstOrDefault(t => !t.EndsWith("[x]", StringComparison.OrdinalIgnoreCase)) ?? typeCodes.First();
+
+                // Prefer Quantity for dose[x] if next segment is 'value'
+                if (elementPath.EndsWith("[x]") && i + 1 < segments.Length && segments[i + 1] == "value" && typeCodes.Contains("Quantity"))
+                    typeCode = "Quantity";
+
+                // Move to next StructureDefinition for non-BackboneElement/Element types
+                if (typeCode != "BackboneElement" && typeCode != "Element")
+                {
+                    currentStructure = await GetStructureDefinitionAsync(typeCode);
+                    if (currentStructure?.Snapshot == null)
+                        return (false, $"StructureDefinition for type '{typeCode}' not found");
+
+                    currentBasePath = typeCode;
+                    displayPath = typeCode;
+                }
+            }
+
+            return (true, null);
+        }
+
+        private static (ElementDefinition? Element, string? Path, string? ChoiceType) FindElement(string segment, StructureDefinition structure, string basePath, string? nextSegment)
+        {
+            // Try exact path first
+            var elementPath = basePath == structure.Type ? $"{basePath}.{segment}" : $"{basePath}.{segment}";
+            var element = structure.Snapshot.Element.FirstOrDefault(e => string.Equals(e.Path, elementPath, StringComparison.OrdinalIgnoreCase));
+            if (element != null)
+                return (element, elementPath, null);
+
+            // Try choice path (e.g., value[x], dose[x])
+            foreach (var elem in structure.Snapshot.Element.Where(e => e.Path.StartsWith(basePath) && e.Path.EndsWith("[x]")))
+            {
+                var baseName = elem.Path.Substring(basePath.Length + 1).Replace("[x]", "");
+                var types = elem.Type?.Select(t => t.Code).ToList() ?? new List<string>();
+
+                foreach (var type in types)
+                {
+                    // Match segment to baseName (e.g., 'dose') or baseName + type (e.g., 'doseQuantity')
+                    if (segment.Equals(baseName, StringComparison.OrdinalIgnoreCase) ||
+                        segment.Equals(baseName + type, StringComparison.OrdinalIgnoreCase))
+                    {
+                        return (elem, elem.Path, type);
+                    }
+                }
+            }
+
+            return (null, elementPath, null);
+        }
+
+        private static bool TryValidateIndex(string segment, StructureDefinition structure, string basePath, out string? error)
+        {
+            error = null;
+            if (!int.TryParse(segment.Trim('[', ']'), out var index) || index < 0)
+            {
+                error = $"Invalid index '{segment}' at '{basePath}'";
+                return false;
+            }
+
+            var element = structure.Snapshot.Element.FirstOrDefault(e => e.Path == basePath);
+            if (element == null)
+            {
+                error = $"Path '{basePath}' not found for index '{segment}'";
+                return false;
+            }
+
+            if (element.Max != "*" && (element.Max == null || int.Parse(element.Max) <= 1))
+            {
+                error = $"Element '{basePath}' does not support indexing (max cardinality: {element.Max})";
+                return false;
+            }
+
+            return true;
         }
 
         private static bool IsPrimitive(string typeCode)
@@ -218,26 +176,13 @@ namespace LantanaGroup.Link.Normalization.Application.Services.FhirPathValidatio
         private static async Task<StructureDefinition?> GetStructureDefinitionAsync(string resourceTypeName)
         {
             if (_structureDefinitionCache.TryGetValue(resourceTypeName, out var definition))
-            {
-                LogToFile($"Cache hit for '{resourceTypeName}'");
                 return definition;
-            }
 
-            LogToFile($"Fetching StructureDefinition for '{resourceTypeName}'");
             definition = await _resolver.FindStructureDefinitionAsync($"http://hl7.org/fhir/StructureDefinition/{resourceTypeName}");
             if (definition != null && !definition.HasSnapshot)
             {
-                LogToFile($"Generating snapshot for '{resourceTypeName}'");
-                try
-                {
-                    var generator = new SnapshotGenerator(_resolver);
-                    await generator.UpdateAsync(definition);
-                }
-                catch (Exception ex)
-                {
-                    LogToFile($"Snapshot generation failed for '{resourceTypeName}': {ex.Message}");
-                    throw;
-                }
+                var generator = new SnapshotGenerator(_resolver);
+                await generator.UpdateAsync(definition);
                 _structureDefinitionCache.TryAdd(resourceTypeName, definition);
             }
             else if (definition != null)
@@ -250,7 +195,6 @@ namespace LantanaGroup.Link.Normalization.Application.Services.FhirPathValidatio
 
         private static string[] ParseFhirPath(string fhirPath)
         {
-            // Split path into segments, preserving indices (e.g., valueQuantity.value -> valueQuantity, value)
             var segments = new List<string>();
             var regex = new Regex(@"(\w+|\[\d+\])");
             var matches = regex.Matches(fhirPath);

--- a/DotNet/Normalization/Application/Services/Operations/ConditionalTransformationOperationService.cs
+++ b/DotNet/Normalization/Application/Services/Operations/ConditionalTransformationOperationService.cs
@@ -31,16 +31,16 @@ namespace LantanaGroup.Link.Normalization.Application.Services.Operations
         {
             if (condition.Operator == ConditionOperator.Exists || condition.Operator == ConditionOperator.NotExists)
             {
-                var elements = resource.Select(condition.Fhir_Path_Source).ToList();
+                var elements = resource.Select(condition.FhirPathSource).ToList();
                 bool exists = elements != null && elements.Any();
                 return condition.Operator == ConditionOperator.Exists ? exists : !exists;
             }
 
             var scopedNode = resource.ToTypedElement();
-            var sourceValueResult = OperationServiceHelper.ExtractValueFromFhirPath(scopedNode, condition.Fhir_Path_Source, Logger);
+            var sourceValueResult = OperationServiceHelper.ExtractValueFromFhirPath(scopedNode, condition.FhirPathSource, Logger);
             object propertyValue = sourceValueResult.Success
                 ? sourceValueResult.Value
-                : OperationServiceHelper.GetValueReflectively(resource, condition.Fhir_Path_Source) ?? throw new InvalidOperationException($"No value found at {condition.Fhir_Path_Source}");
+                : OperationServiceHelper.GetValueReflectively(resource, condition.FhirPathSource) ?? throw new InvalidOperationException($"No value found at {condition.FhirPathSource}");
 
             var value = condition.Value is JsonElement jsonElement
                 ? OperationServiceHelper.ConvertJsonElementToBaseType(jsonElement)
@@ -56,12 +56,12 @@ namespace LantanaGroup.Link.Normalization.Application.Services.Operations
                     double dblValue => CompareNumber(dblValue, ConvertToNumber<double>(value, typeof(double)), condition.Operator),
                     bool boolValue => CompareBoolean(boolValue, ConvertToBoolean(value), condition.Operator),
                     DateTime dateValue => CompareDateTime(dateValue, ConvertToDateTime(value), condition.Operator),
-                    _ => throw new InvalidOperationException($"Unsupported property type {propertyValue.GetType().Name} for FHIRPath {condition.Fhir_Path_Source}.")
+                    _ => throw new InvalidOperationException($"Unsupported property type {propertyValue.GetType().Name} for FHIRPath {condition.FhirPathSource}.")
                 };
             }
             catch (InvalidCastException ex)
             {
-                Logger.LogError(ex, "Type conversion failed for value {Value} against FHIRPath {FhirPath}.", condition.Value, condition.Fhir_Path_Source);
+                Logger.LogError(ex, "Type conversion failed for value {Value} against FHIRPath {FhirPath}.", condition.Value, condition.FhirPathSource);
                 return false;
             }
         }

--- a/DotNet/Normalization/Controllers/OperationsController.cs
+++ b/DotNet/Normalization/Controllers/OperationsController.cs
@@ -470,7 +470,7 @@ namespace LantanaGroup.Link.Normalization.Controllers
 
                 var result = await _operationManager.DeleteOperation(new DeleteOperationModel()
                 {
-                    VendorId = vendorId,
+                    VendorId = foundVendor.Id,
                     OperationId = operationId,
                     ResourceType = resourceType
                 });

--- a/DotNet/Normalization/Controllers/OperationsController.cs
+++ b/DotNet/Normalization/Controllers/OperationsController.cs
@@ -331,7 +331,7 @@ namespace LantanaGroup.Link.Normalization.Controllers
                     return BadRequest("TestOperationModel.Operation cannot be null.");
                 }
 
-                if (string.IsNullOrEmpty(model.Resource))
+                if (model.Resource == null)
                 {
                     return BadRequest("TestOperationModel.Resource cannot be null.");
                 }
@@ -344,8 +344,7 @@ namespace LantanaGroup.Link.Normalization.Controllers
                     return BadRequest("Operation did not match any existing Operation Types.");
                 }
 
-                FhirJsonParser? _fhirJsonParser = new FhirJsonParser();
-                var domainResource = (DomainResource)_fhirJsonParser.Parse(model.Resource);
+                var domainResource = model.Resource;
 
                 OperationResult? result = model.Operation.OperationType switch
                 {

--- a/DotNet/Normalization/Controllers/OperationsController.cs
+++ b/DotNet/Normalization/Controllers/OperationsController.cs
@@ -195,6 +195,7 @@ namespace LantanaGroup.Link.Normalization.Controllers
         [HttpPost("")]
         [ProducesResponseType(StatusCodes.Status201Created, Type = typeof(OperationModel))]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(StatusCodes.Status422UnprocessableEntity)]
         [ProducesResponseType(StatusCodes.Status500InternalServerError)]
         public async Task<IActionResult> PostOperation([FromBody] PostOperationModel model)
         {
@@ -241,7 +242,7 @@ namespace LantanaGroup.Link.Normalization.Controllers
 
                 if(!taskResult.IsSuccess)
                 {
-                    return Problem(detail: taskResult.ErrorMessage, statusCode: StatusCodes.Status500InternalServerError);
+                    return Problem(detail: taskResult.ErrorMessage, statusCode: StatusCodes.Status422UnprocessableEntity);
                 }
 
                 return Created("", taskResult.ObjectResult);
@@ -255,6 +256,7 @@ namespace LantanaGroup.Link.Normalization.Controllers
         [HttpPut("")]
         [ProducesResponseType(StatusCodes.Status202Accepted, Type = typeof(OperationModel))]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(StatusCodes.Status422UnprocessableEntity)]
         [ProducesResponseType(StatusCodes.Status500InternalServerError)]
         public async Task<IActionResult> PutOperation([FromBody] PutOperationModel model)
         {
@@ -305,7 +307,7 @@ namespace LantanaGroup.Link.Normalization.Controllers
 
                 if (!taskResult.IsSuccess)
                 {
-                    return Problem(detail: taskResult.ErrorMessage, statusCode: StatusCodes.Status500InternalServerError);
+                    return Problem(detail: taskResult.ErrorMessage, statusCode: StatusCodes.Status422UnprocessableEntity);
                 }
 
                 return Accepted("", taskResult.ObjectResult);

--- a/DotNet/Normalization/Domain/Managers/OperationManager.cs
+++ b/DotNet/Normalization/Domain/Managers/OperationManager.cs
@@ -300,6 +300,12 @@ namespace LantanaGroup.Link.Normalization.Domain.Managers
                                 });
                             }
 
+                            var orts = await _database.OperationResourceTypes.FindAsync(ort => ort.OperationId == operation.Id);
+                            orts.ForEach(_database.OperationResourceTypes.Remove);
+
+                            var vops = await _database.VendorVersionOperationPresets.FindAsync(vop => vop.OperationResourceType.OperationId == operation.Id);
+                            vops.ForEach(_database.VendorVersionOperationPresets.Remove);
+
                             var op = await _database.Operations.GetAsync(operation.Id);
                             _database.Operations.Remove(op);
                         }

--- a/DotNet/Normalization/Domain/Managers/OperationManager.cs
+++ b/DotNet/Normalization/Domain/Managers/OperationManager.cs
@@ -312,6 +312,11 @@ namespace LantanaGroup.Link.Normalization.Domain.Managers
                 throw new InvalidOperationException("All Sequence values must be greater than 0");
             }
 
+            if (model.OperationSequences.Select(os => os.Sequence).Distinct().Count() != model.OperationSequences.Count())
+            {
+                throw new InvalidOperationException("Repeated Sequence detected. Each sequence entry must have a unique numerical value that is greater than 0.");
+            }
+
             var existing = await _database.OperationSequences.FindAsync(s => s.FacilityId == model.FacilityId && s.OperationResourceType.ResourceType.Name == model.ResourceType);
 
             existing.ForEach(_database.OperationSequences.Remove);

--- a/DotNet/Normalization/Domain/Managers/OperationManager.cs
+++ b/DotNet/Normalization/Domain/Managers/OperationManager.cs
@@ -253,6 +253,12 @@ namespace LantanaGroup.Link.Normalization.Domain.Managers
                     returned = 0;
                     count = 0;
 
+                    await DeleteOperationSequence(new DeleteOperationSequencesModel()
+                    {
+                        FacilityId = model.FacilityId,
+                        ResourceType = model.ResourceType
+                    });
+
                     var operations = await _operationQueries.Search(new OperationSearchModel()
                     {
                         FacilityId = model.FacilityId,

--- a/DotNet/Normalization/Domain/Managers/OperationManager.cs
+++ b/DotNet/Normalization/Domain/Managers/OperationManager.cs
@@ -273,12 +273,6 @@ namespace LantanaGroup.Link.Normalization.Domain.Managers
                     returned = 0;
                     count = 0;
 
-                    await DeleteOperationSequence(new DeleteOperationSequencesModel()
-                    {
-                        FacilityId = model.FacilityId,
-                        ResourceType = model.ResourceType
-                    });
-
                     var operations = await _operationQueries.Search(new OperationSearchModel()
                     {
                         FacilityId = model.FacilityId,
@@ -297,6 +291,15 @@ namespace LantanaGroup.Link.Normalization.Domain.Managers
 
                         foreach (var operation in operations.Records)
                         {
+                            if (!string.IsNullOrEmpty(model.FacilityId))
+                            {
+                                await DeleteOperationSequence(new DeleteOperationSequencesModel()
+                                {
+                                    FacilityId = model.FacilityId,
+                                    OperationId = operation.Id,
+                                });
+                            }
+
                             var op = await _database.Operations.GetAsync(operation.Id);
                             _database.Operations.Remove(op);
                         }
@@ -386,7 +389,9 @@ namespace LantanaGroup.Link.Normalization.Domain.Managers
 
             var resourceType = model.ResourceType ?? string.Empty;
 
-            var sequences = await _database.OperationSequences.FindAsync(s => s.FacilityId == model.FacilityId && (resourceType == string.Empty || s.OperationResourceType.ResourceType.Name.Equals(model.ResourceType)));
+            var sequences = await _database.OperationSequences.FindAsync(s => s.FacilityId == model.FacilityId 
+                                        && (resourceType == string.Empty || s.OperationResourceType.ResourceType.Name.Equals(model.ResourceType))
+                                        && (model.OperationId == null || s.OperationResourceType.OperationId == model.OperationId));
 
             if (sequences.Any())
             {

--- a/DotNet/Normalization/Domain/Managers/OperationManager.cs
+++ b/DotNet/Normalization/Domain/Managers/OperationManager.cs
@@ -17,7 +17,7 @@ namespace LantanaGroup.Link.Normalization.Domain.Managers
     public interface IOperationManager
     {
         Task<TaskResult> CreateOperation(CreateOperationModel model);
-        Task<TaskResult?> UpdateOperation(UpdateOperationModel model);
+        Task<TaskResult> UpdateOperation(UpdateOperationModel model);
         Task<bool> DeleteOperation(DeleteOperationModel deleteOperationModel);
         Task UpdateVendorPresetsForOperation(Guid operationId, List<Guid>? vendorIds);
         Task UpdateOperationResourceTypesForOperation(Guid operationId, List<ResourceModel> resources);
@@ -52,6 +52,16 @@ namespace LantanaGroup.Link.Normalization.Domain.Managers
             TaskResult taskResult = new();
             try
             {
+                if (string.IsNullOrEmpty(model.FacilityId) && (!model.VendorIds?.Any() ?? true))
+                {
+                    throw new Exception("An operation must either be configured with a FacilityID or one or more Vendor IDs.");
+                }
+
+                if (!string.IsNullOrEmpty(model.FacilityId) && (model.VendorIds?.Any() ?? false))
+                {
+                    throw new Exception("An operation must either be configured with a FacilityID or one or more Vendor IDs, but not both.");
+                }
+
                 var result = await OperationServiceHelper.ValidateOperation(model.OperationType, model.OperationJson, model.ResourceTypes);
 
                 if (!result.IsValid)
@@ -97,6 +107,16 @@ namespace LantanaGroup.Link.Normalization.Domain.Managers
             TaskResult taskResult = new();
             try
             {
+                if (string.IsNullOrEmpty(model.FacilityId) && (!model.VendorIds?.Any() ?? true))
+                {
+                    throw new Exception("An operation must either be configured with a FacilityID or one or more Vendor IDs.");
+                }
+
+                if (!string.IsNullOrEmpty(model.FacilityId) && (model.VendorIds?.Any() ?? false))
+                {
+                    throw new Exception("An operation must either be configured with a FacilityID or one or more Vendor IDs, but not both.");
+                }
+
                 var operation = await _database.Operations.GetAsync(model.Id);
                 operation.OperationResourceTypes = await _database.OperationResourceTypes.FindAsync(m => m.OperationId == model.Id);
 

--- a/DotNet/Normalization/Domain/Queries/OperationQueries.cs
+++ b/DotNet/Normalization/Domain/Queries/OperationQueries.cs
@@ -67,7 +67,7 @@ namespace LantanaGroup.Link.Normalization.Domain.Queries
                                 OperationResourceType = new OperationResourceTypeModel()
                                 {
                                     Id = vp.OperationResourceType.Id,
-                                    OperationId = vp.OperationResourceTypeId,
+                                    OperationId = vp.OperationResourceType.OperationId,
                                     ResourceTypeId = vp.OperationResourceType.ResourceTypeId,
                                     Operation = new OperationModel()
                                     {

--- a/DotNet/Normalization/Program.cs
+++ b/DotNet/Normalization/Program.cs
@@ -40,6 +40,7 @@ using Serilog;
 using Serilog.Enrichers.Span;
 using Serilog.Exceptions;
 using System.Reflection;
+using System.Text.Json;
 using AuditEventMessage = LantanaGroup.Link.Shared.Application.Models.Kafka.AuditEventMessage;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -124,7 +125,12 @@ static void RegisterServices(WebApplicationBuilder builder)
 
     builder.Services.AddTransient<ITenantApiService, TenantApiService>();
 
-    builder.Services.AddControllers();
+    builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new FhirResourceConverter());
+    });
+
     builder.Services.AddHttpClient();
     builder.Services.AddProblemDetails();
 

--- a/DotNet/ServiceTests/IntegrationTests/Normalization/NormalizationOperationManagerTests.cs
+++ b/DotNet/ServiceTests/IntegrationTests/Normalization/NormalizationOperationManagerTests.cs
@@ -44,7 +44,7 @@ namespace ServiceTests.IntegrationTests.Normalization
             {
                 OperationJson = JsonSerializer.Serialize(operation),
                 OperationType = OperationType.CopyProperty.ToString(),
-                FacilityId = "TestFacilityId",
+                FacilityId = null,
                 Description = "Integration Test Copy Property Operation",
                 IsDisabled = false,
                 ResourceTypes = ["Location"],


### PR DESCRIPTION
### 🛠️ Description of Changes
Please provide a high-level overview of the changes included in this PR.

### 🧪 Testing Performed
![image](https://github.com/user-attachments/assets/b3257f29-3463-45b1-835f-119f33dfff37)
![image](https://github.com/user-attachments/assets/228edff5-59ac-48c0-861d-a3e7f7070e7f)
![image](https://github.com/user-attachments/assets/d84c01e0-b6ac-4cef-864d-b6a8851e5775)

### 🧑‍🔬 Unit Testing
- [ ] I have written or updated unit tests to cover my changes

### 📓 Documentation Updated
Please update any relevant sections in the project documentation that were impacted by the changes in the PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new optional OperationId field to operation sequence deletion requests.
  * Introduced JSON serialization support for FHIR DomainResource objects via a custom converter.
  * Updated TestOperationModel to accept DomainResource objects directly for resource input.

* **Bug Fixes**
  * Improved deletion logic to ensure all related entities are properly removed when deleting an operation.
  * Corrected operation ID mapping in vendor version operation presets.

* **Refactor**
  * Overhauled FHIRPath validation to provide more accurate structural validation and clearer error messages.
  * Renamed Fhir_Path_Source to FhirPathSource for consistency across the application.

* **Documentation**
  * Updated API documentation to indicate HTTP 422 as a possible response for certain endpoints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->