### PR TITLE
LNK-3991: Exception Thrown for Category Without Associated Rule

### DIFF
--- a/Java/validation/src/main/java/com/lantanagroup/link/validation/services/CategorizationService.java
+++ b/Java/validation/src/main/java/com/lantanagroup/link/validation/services/CategorizationService.java
@@ -18,6 +18,7 @@ import org.springframework.stereotype.Service;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
+import java.util.Objects;
 
 @Service
 @Scope(value = "prototype", proxyMode = ScopedProxyMode.TARGET_CLASS)
@@ -61,6 +62,7 @@ public class CategorizationService {
     private void doCategorize(List<Result> results, List<CategoryRule> categoryRules) {
         results.parallelStream().forEach(result -> {
             List<Category> categories = categoryRules.stream()
+                    .filter(Objects::nonNull)
                     .filter(categoryRule -> categoryRule.getMatcher().isMatch(result))
                     .map(CategoryRule::getCategory)
                     .toList();

--- a/Java/validation/src/test/java/com/lantanagroup/link/validation/services/CategorizationServiceTest.java
+++ b/Java/validation/src/test/java/com/lantanagroup/link/validation/services/CategorizationServiceTest.java
@@ -5,8 +5,8 @@ import com.lantanagroup.link.validation.entities.CategoryRule;
 import com.lantanagroup.link.validation.entities.Result;
 import com.lantanagroup.link.validation.entities.ResultField;
 import com.lantanagroup.link.validation.matchers.RegexMatcher;
+import com.lantanagroup.link.validation.matchers.CompositeMatcher;
 import com.lantanagroup.link.validation.repositories.CategoryRepository;
-import com.lantanagroup.link.validation.repositories.CategoryRuleRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
@@ -22,9 +22,6 @@ import static org.mockito.Mockito.when;
 public class CategorizationServiceTest {
     @Mock
     private CategoryRepository categoryRepository;
-
-    @Mock
-    private CategoryRuleRepository categoryRuleRepository;
 
     @InjectMocks
     private CategorizationService categorizationService;
@@ -106,6 +103,153 @@ public class CategorizationServiceTest {
         categorizationService.categorize(List.of(result));
 
         assertNotNull(result.getCategories());
+        assertFalse(result.getCategories().contains(category));
+    }
+
+    @Test
+    void categorizeAssignsCategoryForAnyCompositeChildMatch() {
+        Category category = new Category();
+        category.setId("Unknown_Code_System");
+
+        RegexMatcher m1 = new RegexMatcher();
+        m1.setField(ResultField.MESSAGE);
+        m1.setRegex("^Unknown Code System '.*'$");
+
+        RegexMatcher m2 = new RegexMatcher();
+        m2.setField(ResultField.MESSAGE);
+        m2.setRegex("A code with no system .* A system should be provided");
+
+        RegexMatcher m3 = new RegexMatcher();
+        m3.setField(ResultField.MESSAGE);
+        m3.setRegex("^CodeSystem is unknown and can't be validated");
+
+        CompositeMatcher matcher = new CompositeMatcher();
+        matcher.setChildren(List.of(m1, m2, m3));
+        matcher.setRequiresAllChildren(false);
+
+        CategoryRule rule = new CategoryRule();
+        rule.setCategory(category);
+        rule.setMatcher(matcher);
+        category.setRules(List.of(rule));
+
+        when(categoryRepository.findAll()).thenReturn(List.of(category));
+
+        Result r1 = new Result();
+        r1.setMessage("Unknown Code System 'foo'");
+
+        Result r2 = new Result();
+        r2.setMessage("A code with no system bar A system should be provided");
+
+        Result r3 = new Result();
+        r3.setMessage("CodeSystem is unknown and can't be validated");
+
+        List<Result> results = List.of(r1, r2, r3);
+        categorizationService.categorize(results);
+
+        for (Result r : results) {
+            assertTrue(r.getCategories().contains(category));
+        }
+    }
+
+    @Test
+    void categorizeDoesNotAssignCategoryWhenCompositeNoneMatch() {
+        Category category = new Category();
+        category.setId("Unknown_Code_System");
+
+        RegexMatcher m1 = new RegexMatcher();
+        m1.setField(ResultField.MESSAGE);
+        m1.setRegex("^Unknown Code System '.*'$");
+
+        RegexMatcher m2 = new RegexMatcher();
+        m2.setField(ResultField.MESSAGE);
+        m2.setRegex("A code with no system .* A system should be provided");
+
+        RegexMatcher m3 = new RegexMatcher();
+        m3.setField(ResultField.MESSAGE);
+        m3.setRegex("^CodeSystem is unknown and can't be validated");
+
+        CompositeMatcher matcher = new CompositeMatcher();
+        matcher.setChildren(List.of(m1, m2, m3));
+        matcher.setRequiresAllChildren(false);
+
+        CategoryRule rule = new CategoryRule();
+        rule.setCategory(category);
+        rule.setMatcher(matcher);
+        category.setRules(List.of(rule));
+
+        when(categoryRepository.findAll()).thenReturn(List.of(category));
+
+        Result result = new Result();
+        result.setMessage("Something unrelated");
+
+        categorizationService.categorize(List.of(result));
+
+        assertFalse(result.getCategories().contains(category));
+    }
+
+    @Test
+    void categorizeAssignsCategoryWhenAllCompositeChildrenMatch() {
+        Category category = new Category();
+        category.setId("Unresolved_Code_System");
+
+        RegexMatcher m1 = new RegexMatcher();
+        m1.setField(ResultField.MESSAGE);
+        m1.setRegex("^URL value '.*' does not resolve");
+
+        RegexMatcher m2 = new RegexMatcher();
+        m2.setField(ResultField.EXPRESSION);
+        m2.setRegex("\\.coding\\[[0-9]+\\]\\.system");
+
+        CompositeMatcher matcher = new CompositeMatcher();
+        matcher.setChildren(List.of(m1, m2));
+        matcher.setRequiresAllChildren(true);
+
+        CategoryRule rule = new CategoryRule();
+        rule.setCategory(category);
+        rule.setMatcher(matcher);
+        category.setRules(List.of(rule));
+
+        when(categoryRepository.findAll()).thenReturn(List.of(category));
+
+        Result result = new Result();
+        result.setMessage("URL value 'http://foo' does not resolve");
+        result.setExpression("Patient.code.coding[0].system");
+
+        categorizationService.categorize(List.of(result));
+
+        assertTrue(result.getCategories().contains(category));
+    }
+
+    @Test
+    void categorizeDoesNotAssignCategoryWhenCompositeMissingChildMatch() {
+        Category category = new Category();
+        category.setId("Unresolved_Code_System");
+
+        RegexMatcher m1 = new RegexMatcher();
+        m1.setField(ResultField.MESSAGE);
+        m1.setRegex("^URL value '.*' does not resolve");
+
+        RegexMatcher m2 = new RegexMatcher();
+        m2.setField(ResultField.EXPRESSION);
+        m2.setRegex("\\.coding\\[[0-9]+\\]\\.system");
+
+        CompositeMatcher matcher = new CompositeMatcher();
+        matcher.setChildren(List.of(m1, m2));
+        matcher.setRequiresAllChildren(true);
+
+        CategoryRule rule = new CategoryRule();
+        rule.setCategory(category);
+        rule.setMatcher(matcher);
+        category.setRules(List.of(rule));
+
+        when(categoryRepository.findAll()).thenReturn(List.of(category));
+
+        Result result = new Result();
+        result.setMessage("URL value 'http://foo' does not resolve");
+        result.setExpression("other.field");
+
+        categorizationService.categorize(List.of(result));
+
         assertFalse(result.getCategories().contains(category));
     }
 }

--- a/Java/validation/src/test/java/com/lantanagroup/link/validation/services/CategorizationServiceTest.java
+++ b/Java/validation/src/test/java/com/lantanagroup/link/validation/services/CategorizationServiceTest.java
@@ -1,0 +1,61 @@
+package com.lantanagroup.link.validation.services;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.lantanagroup.link.validation.entities.Category;
+import com.lantanagroup.link.validation.entities.CategoryRule;
+import com.lantanagroup.link.validation.entities.Result;
+import com.lantanagroup.link.validation.repositories.CategoryRepository;
+import com.lantanagroup.link.validation.repositories.CategoryRuleRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.when;
+
+public class CategorizationServiceTest {
+    @Mock
+    private CategoryRepository categoryRepository;
+
+    @Mock
+    private CategoryRuleRepository categoryRuleRepository;
+
+    @InjectMocks
+    private CategorizationService categorizationService;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    void categorizeWithMissingRuleDoesNotThrow() {
+        Category withRule = new Category();
+        withRule.setId("with");
+        CategoryRule rule = new CategoryRule();
+        rule.setCategory(withRule);
+        rule.setMatcher(result -> true);
+        withRule.setRules(List.of(rule));
+
+        Category withoutRule = new Category();
+        withoutRule.setId("without");
+        withoutRule.setRules(null);
+
+        when(categoryRepository.findAll()).thenReturn(List.of(withRule, withoutRule));
+
+        Result result = new Result();
+        List<Result> results = new ArrayList<>();
+        results.add(result);
+
+        assertDoesNotThrow(() -> categorizationService.categorize(results));
+        assertNotNull(result.getCategories());
+        assertTrue(result.getCategories().contains(withRule));
+        assertFalse(result.getCategories().contains(withoutRule));
+    }
+}
+

--- a/Java/validation/src/test/java/com/lantanagroup/link/validation/services/CategorizationServiceTest.java
+++ b/Java/validation/src/test/java/com/lantanagroup/link/validation/services/CategorizationServiceTest.java
@@ -1,9 +1,10 @@
 package com.lantanagroup.link.validation.services;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.lantanagroup.link.validation.entities.Category;
 import com.lantanagroup.link.validation.entities.CategoryRule;
 import com.lantanagroup.link.validation.entities.Result;
+import com.lantanagroup.link.validation.entities.ResultField;
+import com.lantanagroup.link.validation.matchers.RegexMatcher;
 import com.lantanagroup.link.validation.repositories.CategoryRepository;
 import com.lantanagroup.link.validation.repositories.CategoryRuleRepository;
 import org.junit.jupiter.api.BeforeEach;
@@ -56,6 +57,56 @@ public class CategorizationServiceTest {
         assertNotNull(result.getCategories());
         assertTrue(result.getCategories().contains(withRule));
         assertFalse(result.getCategories().contains(withoutRule));
+    }
+
+    @Test
+    void categorizeAssignsCategoryWhenRegexMatches() {
+        Category category = new Category();
+        category.setId("Incorrect_display_value_for_code");
+
+        RegexMatcher matcher = new RegexMatcher();
+        matcher.setField(ResultField.MESSAGE);
+        matcher.setRegex("^Wrong Display Name '.*' for .* should be .*'.*' .*");
+
+        CategoryRule rule = new CategoryRule();
+        rule.setCategory(category);
+        rule.setMatcher(matcher);
+        category.setRules(List.of(rule));
+
+        when(categoryRepository.findAll()).thenReturn(List.of(category));
+
+        Result result = new Result();
+        result.setMessage("Wrong Display Name 'foo' for bar should be baz 'qux' 123");
+
+        categorizationService.categorize(List.of(result));
+
+        assertNotNull(result.getCategories());
+        assertTrue(result.getCategories().contains(category));
+    }
+
+    @Test
+    void categorizeDoesNotAssignCategoryWhenRegexDoesNotMatch() {
+        Category category = new Category();
+        category.setId("Incorrect_display_value_for_code");
+
+        RegexMatcher matcher = new RegexMatcher();
+        matcher.setField(ResultField.MESSAGE);
+        matcher.setRegex("^Wrong Display Name '.*' for .* should be .*'.*' .*");
+
+        CategoryRule rule = new CategoryRule();
+        rule.setCategory(category);
+        rule.setMatcher(matcher);
+        category.setRules(List.of(rule));
+
+        when(categoryRepository.findAll()).thenReturn(List.of(category));
+
+        Result result = new Result();
+        result.setMessage("Some other message");
+
+        categorizationService.categorize(List.of(result));
+
+        assertNotNull(result.getCategories());
+        assertFalse(result.getCategories().contains(category));
     }
 }
 

--- a/Java/validation/src/test/java/com/lantanagroup/link/validation/services/CategorizationServiceTest.java
+++ b/Java/validation/src/test/java/com/lantanagroup/link/validation/services/CategorizationServiceTest.java
@@ -1,5 +1,6 @@
 package com.lantanagroup.link.validation.services;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.lantanagroup.link.validation.entities.Category;
 import com.lantanagroup.link.validation.entities.CategoryRule;
 import com.lantanagroup.link.validation.entities.Result;
@@ -17,6 +18,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 public class CategorizationServiceTest {
@@ -40,9 +42,10 @@ public class CategorizationServiceTest {
         rule.setMatcher(result -> true);
         withRule.setRules(List.of(rule));
 
-        Category withoutRule = new Category();
-        withoutRule.setId("without");
-        withoutRule.setRules(null);
+        Category withoutRule = mock(Category.class);
+        when(withoutRule.getLatestRule()).thenReturn(null);
+        when(withoutRule.getRules()).thenReturn(null);
+        when(withoutRule.getId()).thenReturn("without");
 
         when(categoryRepository.findAll()).thenReturn(List.of(withRule, withoutRule));
 


### PR DESCRIPTION
### 🛠️ Description of Changes

- prevent `NullPointerException` in `CategorizationService` by ignoring null category rules
- add `CategorizationServiceTest` to verify `categorize` handles categories with missing rules
- add other unit tests unrelated to this defect

### 🧪 Testing Performed
- Ran unit tests that verified categorization no longer throws an exception when a category doesn't have a rule

### 🧑‍🔬 Unit Testing
- [x] I have written or updated unit tests to cover my changes

### 📓 Documentation Updated
None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of categorization by ensuring null category rules are safely handled.

* **Tests**
  * Added comprehensive tests to verify correct categorization behavior under various matching scenarios, including handling of missing rules and complex matchers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->