### PR TITLE
LNK-3867: Added type-ahead/autocomplete functionality to select resou…

### DIFF
--- a/Web/Admin.UI/src/app/components/normalization/operations/code-map/code-map.component.html
+++ b/Web/Admin.UI/src/app/components/normalization/operations/code-map/code-map.component.html
@@ -59,6 +59,7 @@
         [formControl]="resourceTypeControl"
         [matAutocomplete]="auto"
         (keydown)="onInputKeydown($event)"
+        (mousedown)="userClicked = true"
         [readonly]="viewOnly"
         (focus)="openAutocompletePanel()"
       />

--- a/Web/Admin.UI/src/app/components/normalization/operations/code-map/code-map.component.html
+++ b/Web/Admin.UI/src/app/components/normalization/operations/code-map/code-map.component.html
@@ -22,18 +22,6 @@
     <mat-error *ngIf="form.hasError('facilityOrVendorRequired') && (form.touched || form.dirty)">
         Vendor must be selected.
     </mat-error>
-    <!-- Resource Types -->
-    <mat-form-field appearance="outline" class="full-width">
-      <mat-label>Resource Types</mat-label>
-      <mat-select formControlName="selectedResourceTypes" multiple [compareWith]="compareResourceTypes"
-                  [disabled]="viewOnly">
-        <mat-option *ngFor="let type of resourceTypes" [value]="type">{{ type }}</mat-option>
-      </mat-select>
-      <mat-error
-        *ngIf="selectedResourceTypesControl.hasError('required') && (selectedResourceTypesControl.dirty || selectedResourceTypesControl.touched)">
-        <strong>At least one resource type is required</strong>
-      </mat-error>
-    </mat-form-field>
 
     <!-- Name -->
     <mat-form-field appearance="outline" class="full-width">
@@ -57,6 +45,39 @@
         <mat-icon>close</mat-icon>
       </button>
     </mat-form-field>
+
+    <!-- Resource Types -->
+    <div *ngIf="selectedResourceTypesControl.value?.length > 0" class="selected-resource-types">
+      <strong>Selected Resource Types: </strong> {{ selectedResourceTypesControl.value.join(', ') }}
+    </div>
+
+    <mat-form-field appearance="outline" class="full-width">
+      <mat-label>Select Resource Types</mat-label>
+      <input
+        matInput
+        placeholder="Start typing to search"
+        [formControl]="resourceTypeControl"
+        [matAutocomplete]="auto"
+        (keydown)="onInputKeydown($event)"
+        [readonly]="viewOnly"
+        (focus)="openAutocompletePanel()"
+      />
+
+      <mat-autocomplete #auto="matAutocomplete" autoActiveFirstOption="">
+        <mat-option *ngFor="let type of filteredResourceTypes" [value]="type">
+          <mat-checkbox [checked]="selectedResourceTypesControl.value?.includes(type)"
+                        (click)="$event.stopPropagation()"
+                        (change)="toggleSelection(type, $event.source.checked)">
+            {{ type }}
+          </mat-checkbox>
+        </mat-option>
+      </mat-autocomplete>
+    </mat-form-field>
+
+    <div class="validation-error" *ngIf="selectedResourceTypesControl.hasError('required')">
+      Resource Type is <strong>required</strong>
+    </div>
+
 
     <!-- FHIR Path -->
     <mat-form-field appearance="outline" class="full-width">
@@ -166,6 +187,10 @@
       <button type="button" mat-raised-button color="accent" (click)="addCodeSystemMap()">
         Add Code System Map
       </button>
+    </div>
+
+    <div *ngIf="form.get('codeSystemMaps')?.hasError('atLeastOneRequired')" class="validation-error">
+      At least code system map is required.
     </div>
     <!-- Enable/Disable checkbox -->
     <mat-checkbox formControlName="isEnabled">Enabled</mat-checkbox>

--- a/Web/Admin.UI/src/app/components/normalization/operations/code-map/code-map.component.scss
+++ b/Web/Admin.UI/src/app/components/normalization/operations/code-map/code-map.component.scss
@@ -104,8 +104,13 @@ button[color="warn"] {
   color: #e53935; // Custom red
 }
 
+
 .validation-error {
-  color: red;
+  color: #f44336;
   font-weight: 600; /* optional, makes it stand out */
-  margin-top: 8px;
+  margin-top: 4px;
+}
+
+.selected-resource-types {
+  margin-bottom: 12px; /* Adjust as needed */
 }

--- a/Web/Admin.UI/src/app/components/normalization/operations/code-map/code-map.component.ts
+++ b/Web/Admin.UI/src/app/components/normalization/operations/code-map/code-map.component.ts
@@ -10,7 +10,7 @@ import {
   ReactiveFormsModule
 } from '@angular/forms';
 import {MatSnackBar} from '@angular/material/snack-bar';
-import {Observable, Subject, takeUntil} from 'rxjs';
+import {map, Observable, startWith, Subject, takeUntil} from 'rxjs';
 
 import {FormMode} from '../../../../models/FormMode.enum';
 import {IEntityCreatedResponse} from '../../../../interfaces/entity-created-response.model';
@@ -29,6 +29,7 @@ import {AtLeastOneConditionValidator} from "../validators/AtLeastOneConditionVal
 import {IVendor} from "../../../../interfaces/normalization/vendor-interface";
 import {facilityOrVendorRequiredValidator} from "../validators/facilityOrVendorRequiredValidator";
 import {MatCheckbox} from "@angular/material/checkbox";
+import {MatAutocomplete, MatAutocompleteTrigger} from "@angular/material/autocomplete";
 
 @Component({
   selector: 'app-code-map',
@@ -52,13 +53,17 @@ import {MatCheckbox} from "@angular/material/checkbox";
     MatCardHeader,
     MatError,
     MatSuffix,
-    MatCheckbox
+    MatCheckbox,
+    MatAutocomplete,
+    MatAutocompleteTrigger
   ],
   styleUrls: ['./code-map.component.scss']
 })
 export class CodeMapComponent implements OnInit, OnDestroy {
 
   @ViewChild('errorDiv') errorDiv!: ElementRef;
+  @ViewChild(MatAutocompleteTrigger) trigger!: MatAutocompleteTrigger;
+
 
   @Input() operation!: IOperationModel;
   @Input() formMode!: FormMode;
@@ -90,6 +95,10 @@ export class CodeMapComponent implements OnInit, OnDestroy {
 
   errorMessage: string = "";
 
+  filteredResourceTypes: string[] = [];
+
+  private userClicked = false;
+
   constructor(
     private fb: FormBuilder,
     private snackBar: MatSnackBar,
@@ -97,6 +106,7 @@ export class CodeMapComponent implements OnInit, OnDestroy {
   ) {
     this.form = this.fb.group({
       selectedResourceTypes: new FormControl([], Validators.required),
+      resourceType: new FormControl(''),
       facilityId: new FormControl({value: '', disabled: true}, Validators.required),
       description: new FormControl(''),
       name: new FormControl('', Validators.required),
@@ -124,6 +134,13 @@ export class CodeMapComponent implements OnInit, OnDestroy {
             verticalPosition: 'top'
           })
       });
+
+    this.filteredResourceTypes = this.resourceTypes;
+
+    this.resourceTypeControl.valueChanges.pipe(
+      startWith(''),
+      map(value => this._filter(value || ''))
+    ).subscribe(filtered => this.filteredResourceTypes = filtered);
 
     this.operationService.getVendors().subscribe({
       next: (data) => {
@@ -163,6 +180,66 @@ export class CodeMapComponent implements OnInit, OnDestroy {
     });
   }
 
+  _filter(value: string): string[] {
+    const filterValue = value?.toLowerCase() || '';
+    if (!filterValue) {
+      return this.resourceTypes.slice(); // all resources when empty input
+    }
+    return this.resourceTypes.filter(type => type.toLowerCase().startsWith(filterValue));
+  }
+
+  openAutocompletePanel() {
+    if (!this.viewOnly) {
+      // Reset the filter to show all
+      this.filteredResourceTypes = this.resourceTypes.slice();
+      if (this.userClicked) {
+        this.trigger.openPanel();
+      } else {
+        this.trigger.closePanel(); // Prevent accidental opening
+      }
+      this.userClicked = false;
+    }
+  }
+
+  toggleSelection(type: string, selected: boolean): void {
+    const currentSelection: string[] = this.selectedResourceTypesControl.value || [];
+
+    const updatedSelection = selected
+      ? [...currentSelection, type].filter((v, i, self) => self.indexOf(v) === i)
+      : currentSelection.filter(t => t !== type);
+
+    this.selectedResourceTypesControl.setValue(updatedSelection);
+
+    setTimeout(() => this.trigger.openPanel(), 0);
+  }
+
+  ngAfterViewInit(): void {
+    this.trigger.panelClosingActions.subscribe((event) => {
+      // Only clear input if no option was selected (i.e., click outside or ESC)
+      if (!event) {
+        this.resourceTypeControl.setValue('');
+      }
+    });
+  }
+
+  onInputKeydown(event: KeyboardEvent) {
+    if (event.key === 'Enter' && this.trigger?.activeOption) {
+      const selectedType = this.trigger.activeOption.value;
+      const currentValues: string[] = this.selectedResourceTypesControl.value || [];
+
+      const alreadySelected = currentValues.includes(selectedType);
+      const updatedValues = alreadySelected
+        ? currentValues.filter(t => t !== selectedType)
+        : [...currentValues, selectedType];
+
+      this.selectedResourceTypesControl.setValue(updatedValues);
+
+      setTimeout(() => this.trigger.openPanel(), 0);
+      event.preventDefault(); // prevent closing
+    }
+  }
+
+
   getResourceTypes(): Observable<string[]> {
     return this.operationService.getResourceTypes();
   }
@@ -171,6 +248,10 @@ export class CodeMapComponent implements OnInit, OnDestroy {
   // Getters for form controls
   get facilityIdControl(): FormControl {
     return this.form.get('facilityId') as FormControl;
+  }
+
+  get resourceTypeControl(): FormControl {
+    return this.form.get('resourceType') as FormControl;
   }
 
   get selectedResourceTypesControl(): FormControl {
@@ -226,6 +307,8 @@ export class CodeMapComponent implements OnInit, OnDestroy {
     this.descriptionControl.setValue(this.operation.description);
     this.nameControl.setValue(codeMapOp?.Name || '');
     this.fhirPathControl.setValue(codeMapOp?.FhirPath || '');
+    this.isEnabledControl.setValue(!this.operation?.isDisabled);
+
     this.selectedResourceTypesControl.setValue(
       [...new Set(this.operation?.operationResourceTypes?.map(r => r.resource?.resourceName) ?? [])]
     );

--- a/Web/Admin.UI/src/app/components/normalization/operations/code-map/code-map.component.ts
+++ b/Web/Admin.UI/src/app/components/normalization/operations/code-map/code-map.component.ts
@@ -1,4 +1,14 @@
-import {Component, ElementRef, EventEmitter, Input, OnDestroy, OnInit, Output, ViewChild} from '@angular/core';
+import {
+  AfterViewInit,
+  Component,
+  ElementRef,
+  EventEmitter,
+  Input,
+  OnDestroy,
+  OnInit,
+  Output,
+  ViewChild
+} from '@angular/core';
 import {
   FormBuilder,
   FormControl,
@@ -59,7 +69,7 @@ import {MatAutocomplete, MatAutocompleteTrigger} from "@angular/material/autocom
   ],
   styleUrls: ['./code-map.component.scss']
 })
-export class CodeMapComponent implements OnInit, OnDestroy {
+export class CodeMapComponent implements OnInit, OnDestroy, AfterViewInit {
 
   @ViewChild('errorDiv') errorDiv!: ElementRef;
   @ViewChild(MatAutocompleteTrigger) trigger!: MatAutocompleteTrigger;
@@ -97,7 +107,7 @@ export class CodeMapComponent implements OnInit, OnDestroy {
 
   filteredResourceTypes: string[] = [];
 
-  private userClicked = false;
+  userClicked = false;
 
   constructor(
     private fb: FormBuilder,
@@ -383,10 +393,6 @@ export class CodeMapComponent implements OnInit, OnDestroy {
 
   removeCodeMap(codeSystemIndex: number, codeMapIndex: number): void {
     this.codeMapsAt(codeSystemIndex).removeAt(codeMapIndex);
-  }
-
-  compareResourceTypes(o1: any, o2: any): boolean {
-    return o1 === o2;
   }
 
   private buildCodeSystemMapsPayload(): any[] {

--- a/Web/Admin.UI/src/app/components/normalization/operations/conditional-transformation/conditional-transformation.component.html
+++ b/Web/Admin.UI/src/app/components/normalization/operations/conditional-transformation/conditional-transformation.component.html
@@ -58,6 +58,7 @@
         [formControl]="resourceTypeControl"
         [matAutocomplete]="auto"
         (keydown)="onInputKeydown($event)"
+        (mousedown)="userClicked = true"
         [readonly]="viewOnly"
         (focus)="openAutocompletePanel()"
       />

--- a/Web/Admin.UI/src/app/components/normalization/operations/conditional-transformation/conditional-transformation.component.html
+++ b/Web/Admin.UI/src/app/components/normalization/operations/conditional-transformation/conditional-transformation.component.html
@@ -22,16 +22,6 @@
     <mat-error *ngIf="form.hasError('facilityOrVendorRequired') && (form.touched || form.dirty)">
        Vendor must be selected.
     </mat-error>
-    <!-- Resource Types -->
-    <mat-form-field appearance="outline" class="full-width">
-      <mat-label>Resource Types</mat-label>
-      <mat-select formControlName="selectedResourceTypes" [compareWith]="compareResourceTypes" multiple>
-        <mat-option *ngFor="let type of resourceTypes" [value]="type">{{ type }}</mat-option>
-      </mat-select>
-      <mat-error *ngIf="selectedResourceTypesControl.hasError('required') && (selectedResourceTypesControl.touched || selectedResourceTypesControl.dirty)">
-        Resource is <strong>required</strong>
-      </mat-error>
-    </mat-form-field>
 
     <!-- Name -->
     <mat-form-field appearance="fill" class="full-width">
@@ -54,6 +44,38 @@
         <mat-icon>close</mat-icon>
       </button>
     </mat-form-field>
+
+    <!-- Resource Types -->
+    <div *ngIf="selectedResourceTypesControl.value?.length > 0" class="selected-resource-types">
+      <strong>Selected Resource Types: </strong> {{ selectedResourceTypesControl.value.join(', ') }}
+    </div>
+
+    <mat-form-field appearance="outline" class="full-width">
+      <mat-label>Select Resource Types</mat-label>
+      <input
+        matInput
+        placeholder="Start typing to search"
+        [formControl]="resourceTypeControl"
+        [matAutocomplete]="auto"
+        (keydown)="onInputKeydown($event)"
+        [readonly]="viewOnly"
+        (focus)="openAutocompletePanel()"
+      />
+
+      <mat-autocomplete #auto="matAutocomplete" autoActiveFirstOption="">
+        <mat-option *ngFor="let type of filteredResourceTypes" [value]="type">
+          <mat-checkbox [checked]="selectedResourceTypesControl.value?.includes(type)"
+            (click)="$event.stopPropagation()"
+            (change)="toggleSelection(type, $event.source.checked)">
+            {{ type }}
+          </mat-checkbox>
+        </mat-option>
+      </mat-autocomplete>
+    </mat-form-field>
+
+    <div class="validation-error" *ngIf="selectedResourceTypesControl.hasError('required')">
+      Resource Type is <strong>required</strong>
+    </div>
 
     <!-- Target Fhir Path -->
     <div class="form-row">
@@ -115,7 +137,11 @@
         </button>
       </div>
     </div>
+    <div *ngIf="form.get('conditions')?.hasError('atLeastOneRequired')" class="validation-error">
+      At least one condition is required.
+    </div>
     <!-- Enable/Disable checkbox -->
     <mat-checkbox formControlName="isEnabled">Enabled</mat-checkbox>
+
   </form>
 </mat-card-content>

--- a/Web/Admin.UI/src/app/components/normalization/operations/conditional-transformation/conditional-transformation.component.scss
+++ b/Web/Admin.UI/src/app/components/normalization/operations/conditional-transformation/conditional-transformation.component.scss
@@ -65,3 +65,13 @@ button[color="warn"] {
   color: #e53935;
 }
 
+.validation-error {
+  color: #f44336;
+  font-weight: 600; /* optional, makes it stand out */
+  margin-top: 4px;
+}
+
+.selected-resource-types {
+  margin-bottom: 12px; /* Adjust as needed */
+}
+

--- a/Web/Admin.UI/src/app/components/normalization/operations/conditional-transformation/conditional-transformation.component.ts
+++ b/Web/Admin.UI/src/app/components/normalization/operations/conditional-transformation/conditional-transformation.component.ts
@@ -1,20 +1,30 @@
-import {Component, ElementRef, EventEmitter, Input, OnDestroy, OnInit, Output, ViewChild} from '@angular/core';
+import {
+  AfterViewInit,
+  Component,
+  ElementRef,
+  EventEmitter,
+  Input,
+  OnDestroy,
+  OnInit,
+  Output,
+  ViewChild
+} from '@angular/core';
 import {FormMode} from "../../../../models/FormMode.enum";
 import {IEntityCreatedResponse} from "../../../../interfaces/entity-created-response.model";
 import {IOperationModel} from "../../../../interfaces/normalization/operation-get-model.interface";
 import {FormArray, FormBuilder, FormControl, FormGroup, ReactiveFormsModule, Validators} from "@angular/forms";
 import {MatCardContent} from "@angular/material/card";
-import {MatIcon} from "@angular/material/icon";
+import {MatIcon, MatIconModule} from "@angular/material/icon";
 import {MatSnackBar} from "@angular/material/snack-bar";
 import {OperationService} from "../../../../services/gateway/normalization/operation.service";
 import {NgForOf, NgIf} from "@angular/common";
 import {MatOption, MatSelect} from "@angular/material/select";
 import {MatButton, MatIconButton} from "@angular/material/button";
-import {Observable, Subject, takeUntil} from "rxjs";
+import {map, Observable, startWith, Subject, takeUntil} from "rxjs";
 import {ISaveOperationModel} from "../../../../interfaces/normalization/operation-save-model.interface";
 import {AtLeastOneConditionValidator} from "../validators/AtLeastOneConditionValidator";
-import {MatInput} from "@angular/material/input";
-import {MatFormField, MatLabel, MatError, MatSuffix} from "@angular/material/form-field";
+import {MatInput, MatInputModule} from "@angular/material/input";
+import {MatFormField, MatLabel, MatError, MatSuffix, MatFormFieldModule} from "@angular/material/form-field";
 
 import {
   ConditionalTransformOperation,
@@ -24,11 +34,16 @@ import {OperationType} from "../../../../interfaces/normalization/operation-type
 import {MatTooltip} from "@angular/material/tooltip";
 import {IVendor} from "../../../../interfaces/normalization/vendor-interface";
 import {facilityOrVendorRequiredValidator} from "../validators/facilityOrVendorRequiredValidator";
-import {CopyPropertyOperation} from "../../../../interfaces/normalization/copy-property-interface";
 import {MatCheckbox} from "@angular/material/checkbox";
+import {
+  MatAutocompleteModule,
+  MatAutocompleteTrigger
+} from "@angular/material/autocomplete";
+
 
 @Component({
   selector: 'app-conditional-transformation',
+  standalone: true,
   imports: [
     MatFormField,
     ReactiveFormsModule,
@@ -45,14 +60,20 @@ import {MatCheckbox} from "@angular/material/checkbox";
     MatSuffix,
     MatButton,
     MatTooltip,
-    MatCheckbox
+    MatCheckbox,
+    MatFormFieldModule,
+    MatInputModule,
+    MatAutocompleteModule,
+    MatIconModule
   ],
   templateUrl: './conditional-transformation.component.html',
   styleUrl: './conditional-transformation.component.scss'
 })
-export class ConditionalTransformationComponent implements OnInit, OnDestroy {
+export class ConditionalTransformationComponent implements OnInit, OnDestroy, AfterViewInit {
 
   @ViewChild('errorDiv') errorDiv!: ElementRef;
+  @ViewChild(MatAutocompleteTrigger) trigger!: MatAutocompleteTrigger;
+
 
   form!: FormGroup;
 
@@ -85,6 +106,10 @@ export class ConditionalTransformationComponent implements OnInit, OnDestroy {
 
   errorMessage: string = "";
 
+  filteredResourceTypes: string[] = [];
+
+  private userClicked = false;
+
   operatorList = Object.entries(Operator)
     .filter(([key, value]) => typeof value === 'number') // filter out reverse mappings
     .map(([key, value]) => ({
@@ -100,6 +125,7 @@ export class ConditionalTransformationComponent implements OnInit, OnDestroy {
   constructor(private fb: FormBuilder, private snackBar: MatSnackBar, private operationService: OperationService) {
     this.form = this.fb.group({
       selectedResourceTypes: new FormControl([], Validators.required),
+      resourceType: new FormControl(''),
       facilityId: new FormControl({value: '', disabled: true}, Validators.required),
       description: new FormControl(''),
       name: new FormControl('', Validators.required),
@@ -126,6 +152,13 @@ export class ConditionalTransformationComponent implements OnInit, OnDestroy {
             verticalPosition: 'top'
           })
       });
+
+    this.filteredResourceTypes = this.resourceTypes;
+
+    this.resourceTypeControl.valueChanges.pipe(
+      startWith(''),
+      map(value => this._filter(value || ''))
+    ).subscribe(filtered => this.filteredResourceTypes = filtered);
 
     this.operationService.getVendors().subscribe({
       next: (data) => {
@@ -154,6 +187,7 @@ export class ConditionalTransformationComponent implements OnInit, OnDestroy {
       error: (err) => console.error('Error loading vendors', err)
     });
 
+
     // Add the initial condition row
     this.addCondition();
 
@@ -175,10 +209,12 @@ export class ConditionalTransformationComponent implements OnInit, OnDestroy {
       this.nameControl.setValue(conditionalTransformOperation?.Name);
       this.nameControl.updateValueAndValidity();
 
+      this.isEnabledControl.setValue(!this.operation?.isDisabled);
+      this.isEnabledControl.updateValueAndValidity();
+
       // get resource types
-      this.selectedResourceTypesControl.setValue(
-        [...new Set(this.operation?.operationResourceTypes?.map(r => r.resource?.resourceName) ?? [])]
-      );
+      const selected = [...new Set(this.operation?.operationResourceTypes?.map(r => r.resource?.resourceName) ?? [])];
+      this.selectedResourceTypesControl.setValue(selected);
       this.selectedResourceTypesControl.updateValueAndValidity();
 
       this.targetFhirPathControl.setValue(conditionalTransformOperation?.TargetFhirPath);
@@ -195,12 +231,75 @@ export class ConditionalTransformationComponent implements OnInit, OnDestroy {
     }
   }
 
+  _filter(value: string): string[] {
+    const filterValue = value?.toLowerCase() || '';
+    if (!filterValue) {
+      return this.resourceTypes.slice(); // all resources when empty input
+    }
+    return this.resourceTypes.filter(type => type.toLowerCase().startsWith(filterValue));
+  }
+
+  openAutocompletePanel() {
+    if (!this.viewOnly) {
+      // Reset the filter to show all
+      this.filteredResourceTypes = this.resourceTypes.slice();
+      if (this.userClicked) {
+        this.trigger.openPanel();
+      } else {
+        this.trigger.closePanel(); // Prevent accidental opening
+      }
+      this.userClicked = false;
+    }
+  }
+
+  toggleSelection(type: string, selected: boolean): void {
+    const currentSelection: string[] = this.selectedResourceTypesControl.value || [];
+
+    const updatedSelection = selected
+      ? [...currentSelection, type].filter((v, i, self) => self.indexOf(v) === i)
+      : currentSelection.filter(t => t !== type);
+
+    this.selectedResourceTypesControl.setValue(updatedSelection);
+
+    setTimeout(() => this.trigger.openPanel(), 0);
+  }
+
+  ngAfterViewInit(): void {
+    this.trigger.panelClosingActions.subscribe((event) => {
+      // Only clear input if no option was selected (i.e., click outside or ESC)
+      if (!event) {
+        this.resourceTypeControl.setValue('');
+      }
+    });
+  }
+
+  onInputKeydown(event: KeyboardEvent) {
+    if (event.key === 'Enter' && this.trigger?.activeOption) {
+      const selectedType = this.trigger.activeOption.value;
+      const currentValues: string[] = this.selectedResourceTypesControl.value || [];
+
+      const alreadySelected = currentValues.includes(selectedType);
+      const updatedValues = alreadySelected
+        ? currentValues.filter(t => t !== selectedType)
+        : [...currentValues, selectedType];
+
+      this.selectedResourceTypesControl.setValue(updatedValues);
+
+      setTimeout(() => this.trigger.openPanel(), 0);
+      event.preventDefault(); // prevent closing
+    }
+  }
+
   getResourceTypes(): Observable<string[]> {
     return this.operationService.getResourceTypes();
   }
 
   get facilityIdControl(): FormControl {
     return this.form.get('facilityId') as FormControl;
+  }
+
+  get resourceTypeControl(): FormControl {
+    return this.form.get('resourceType') as FormControl;
   }
 
   get selectedResourceTypesControl(): FormControl {
@@ -270,10 +369,6 @@ export class ConditionalTransformationComponent implements OnInit, OnDestroy {
 
   removeCondition(i: number) {
     this.conditions.removeAt(i);
-  }
-
-  compareResourceTypes(object1: any, object2: any) {
-    return (object1 && object2) && object1 === object2;
   }
 
   populateConditionsFromOperation(operationJson: any) {
@@ -346,7 +441,7 @@ export class ConditionalTransformationComponent implements OnInit, OnDestroy {
 
     // Give Angular time to render the div
     setTimeout(() => {
-      this.errorDiv?.nativeElement.scrollIntoView({ behavior: 'smooth', block: 'center' });
+      this.errorDiv?.nativeElement.scrollIntoView({behavior: 'smooth', block: 'center'});
       this.errorDiv?.nativeElement.focus?.(); // Optional for accessibility
     });
   }

--- a/Web/Admin.UI/src/app/components/normalization/operations/conditional-transformation/conditional-transformation.component.ts
+++ b/Web/Admin.UI/src/app/components/normalization/operations/conditional-transformation/conditional-transformation.component.ts
@@ -108,7 +108,7 @@ export class ConditionalTransformationComponent implements OnInit, OnDestroy, Af
 
   filteredResourceTypes: string[] = [];
 
-  private userClicked = false;
+  userClicked = false;
 
   operatorList = Object.entries(Operator)
     .filter(([key, value]) => typeof value === 'number') // filter out reverse mappings

--- a/Web/Admin.UI/src/app/components/normalization/operations/copy-property/copy-property.component.html
+++ b/Web/Admin.UI/src/app/components/normalization/operations/copy-property/copy-property.component.html
@@ -24,16 +24,6 @@
       <mat-error  *ngIf="form.hasError('facilityOrVendorRequired') &&  form.get('selectedVendor')?.touched">
         Vendor is <strong>required</strong>
       </mat-error>
-      <!-- Resource Type -->
-      <mat-form-field appearance="outline" class="full-width">
-        <mat-label>Resource Types</mat-label>
-        <mat-select formControlName="selectedResourceTypes" [compareWith]="compareResourceTypes" multiple>
-          <mat-option *ngFor="let type of resourceTypes" [value]="type">{{ type }}</mat-option>
-        </mat-select>
-        <mat-error *ngIf="selectedResourceTypesControl.hasError('required')">
-          Resource is <strong>required</strong>
-        </mat-error>
-      </mat-form-field>
 
       <!-- Name -->
       <mat-form-field appearance="fill" class="full-width">
@@ -55,6 +45,39 @@
           <mat-icon>close</mat-icon>
         </button>
       </mat-form-field>
+
+      <!-- Resource Types -->
+      <div *ngIf="selectedResourceTypesControl.value?.length > 0" class="selected-resource-types">
+        <strong>Selected Resource Types: </strong> {{ selectedResourceTypesControl.value.join(', ') }}
+      </div>
+
+      <mat-form-field appearance="outline" class="full-width">
+        <mat-label>Select Resource Types</mat-label>
+        <input
+          matInput
+          placeholder="Start typing to search"
+          [formControl]="resourceTypeControl"
+          [matAutocomplete]="auto"
+          (keydown)="onInputKeydown($event)"
+          [readonly]="viewOnly"
+          (focus)="openAutocompletePanel()"
+        />
+
+        <mat-autocomplete #auto="matAutocomplete" autoActiveFirstOption="">
+          <mat-option *ngFor="let type of filteredResourceTypes" [value]="type">
+            <mat-checkbox [checked]="selectedResourceTypesControl.value?.includes(type)"
+                          (click)="$event.stopPropagation()"
+                          (change)="toggleSelection(type, $event.source.checked)">
+              {{ type }}
+            </mat-checkbox>
+          </mat-option>
+        </mat-autocomplete>
+
+      </mat-form-field>
+
+      <div class="validation-error" *ngIf="selectedResourceTypesControl.hasError('required')">
+        Resource Type is <strong>required</strong>
+      </div>
 
       <!-- Source/Target Paths -->
       <div class="form-row">

--- a/Web/Admin.UI/src/app/components/normalization/operations/copy-property/copy-property.component.html
+++ b/Web/Admin.UI/src/app/components/normalization/operations/copy-property/copy-property.component.html
@@ -59,6 +59,7 @@
           [formControl]="resourceTypeControl"
           [matAutocomplete]="auto"
           (keydown)="onInputKeydown($event)"
+          (mousedown)="userClicked = true"
           [readonly]="viewOnly"
           (focus)="openAutocompletePanel()"
         />

--- a/Web/Admin.UI/src/app/components/normalization/operations/copy-property/copy-property.component.scss
+++ b/Web/Admin.UI/src/app/components/normalization/operations/copy-property/copy-property.component.scss
@@ -44,3 +44,13 @@ $primary: #398eb4;
     }
   }
 }
+
+.validation-error {
+  color: #f44336;
+  font-weight: 600; /* optional, makes it stand out */
+  margin-top: 4px;
+}
+
+.selected-resource-types {
+  margin-bottom: 12px; /* Adjust as needed */
+}

--- a/Web/Admin.UI/src/app/components/normalization/operations/copy-property/copy-property.component.ts
+++ b/Web/Admin.UI/src/app/components/normalization/operations/copy-property/copy-property.component.ts
@@ -10,7 +10,7 @@ import {OperationService} from "../../../../services/gateway/normalization/opera
 import {ISaveOperationModel} from "../../../../interfaces/normalization/operation-save-model.interface";
 import {NgForOf, NgIf} from "@angular/common";
 import {MatOption, MatSelect} from "@angular/material/select";
-import {Observable, of, Subject, takeUntil} from "rxjs";
+import {map, Observable, of, startWith, Subject, takeUntil} from "rxjs";
 import {MatIconButton} from "@angular/material/button";
 import {MatIcon} from "@angular/material/icon";
 import {MatCheckbox} from "@angular/material/checkbox";
@@ -19,6 +19,7 @@ import {OperationType} from "../../../../interfaces/normalization/operation-type
 import {IOperationModel} from "../../../../interfaces/normalization/operation-get-model.interface";
 import {IVendor} from "../../../../interfaces/normalization/vendor-interface";
 import {facilityOrVendorRequiredValidator} from "../validators/facilityOrVendorRequiredValidator";
+import {MatAutocomplete, MatAutocompleteTrigger} from "@angular/material/autocomplete";
 
 @Component({
   selector: 'app-copy-property',
@@ -39,12 +40,15 @@ import {facilityOrVendorRequiredValidator} from "../validators/facilityOrVendorR
     MatIconButton,
     MatSuffix,
     NgIf,
-    MatCheckbox
+    MatCheckbox,
+    MatAutocomplete,
+    MatAutocompleteTrigger
   ],
 })
 export class CopyPropertyComponent implements OnInit, OnDestroy {
 
   @ViewChild('errorDiv') errorDiv!: ElementRef;
+  @ViewChild(MatAutocompleteTrigger) trigger!: MatAutocompleteTrigger;
 
   @Input() operation!: IOperationModel;
 
@@ -79,9 +83,14 @@ export class CopyPropertyComponent implements OnInit, OnDestroy {
 
   errorMessage: string = "";
 
+  filteredResourceTypes: string[] = [];
+
+  private userClicked = false;
+
   constructor(private fb: FormBuilder, private snackBar: MatSnackBar, private operationService: OperationService) {
     this.form = this.fb.group({
       selectedResourceTypes: new FormControl([], Validators.required),
+      resourceType: new FormControl(''),
       facilityId: new FormControl(''),
       description: new FormControl(''),
       name: new FormControl('', Validators.required),
@@ -109,6 +118,13 @@ export class CopyPropertyComponent implements OnInit, OnDestroy {
             verticalPosition: 'top'
           })
       });
+
+    this.filteredResourceTypes = this.resourceTypes;
+
+    this.resourceTypeControl.valueChanges.pipe(
+      startWith(''),
+      map(value => this._filter(value || ''))
+    ).subscribe(filtered => this.filteredResourceTypes = filtered);
 
     this.operationService.getVendors().subscribe({
       next: (data) => {
@@ -175,6 +191,64 @@ export class CopyPropertyComponent implements OnInit, OnDestroy {
 
     }
   }
+  _filter(value: string): string[] {
+    const filterValue = value?.toLowerCase() || '';
+    if (!filterValue) {
+      return this.resourceTypes.slice(); // all resources when empty input
+    }
+    return this.resourceTypes.filter(type => type.toLowerCase().startsWith(filterValue));
+  }
+
+  openAutocompletePanel() {
+    if (!this.viewOnly) {
+      // Reset the filter to show all
+      this.filteredResourceTypes = this.resourceTypes.slice();
+      if (this.userClicked) {
+        this.trigger.openPanel();
+      } else {
+        this.trigger.closePanel(); // Prevent accidental opening
+      }
+      this.userClicked = false;
+    }
+  }
+
+  toggleSelection(type: string, selected: boolean): void {
+    const currentSelection: string[] = this.selectedResourceTypesControl.value || [];
+
+    const updatedSelection = selected
+      ? [...currentSelection, type].filter((v, i, self) => self.indexOf(v) === i)
+      : currentSelection.filter(t => t !== type);
+
+    this.selectedResourceTypesControl.setValue(updatedSelection);
+
+    setTimeout(() => this.trigger.openPanel(), 0);
+  }
+
+  ngAfterViewInit(): void {
+    this.trigger.panelClosingActions.subscribe((event) => {
+      // Only clear input if no option was selected (i.e., click outside or ESC)
+      if (!event) {
+        this.resourceTypeControl.setValue('');
+      }
+    });
+  }
+
+  onInputKeydown(event: KeyboardEvent) {
+    if (event.key === 'Enter' && this.trigger?.activeOption) {
+      const selectedType = this.trigger.activeOption.value;
+      const currentValues: string[] = this.selectedResourceTypesControl.value || [];
+
+      const alreadySelected = currentValues.includes(selectedType);
+      const updatedValues = alreadySelected
+        ? currentValues.filter(t => t !== selectedType)
+        : [...currentValues, selectedType];
+
+      this.selectedResourceTypesControl.setValue(updatedValues);
+
+      setTimeout(() => this.trigger.openPanel(), 0);
+      event.preventDefault(); // prevent closing
+    }
+  }
 
   getResourceTypes(): Observable<string[]> {
     return this.operationService.getResourceTypes();
@@ -198,6 +272,10 @@ export class CopyPropertyComponent implements OnInit, OnDestroy {
 
   get facilityIdControl(): FormControl {
     return this.form.get('facilityId') as FormControl;
+  }
+
+  get resourceTypeControl(): FormControl {
+    return this.form.get('resourceType') as FormControl;
   }
 
   get sourceFhirPathControl(): FormControl {

--- a/Web/Admin.UI/src/app/components/normalization/operations/copy-property/copy-property.component.ts
+++ b/Web/Admin.UI/src/app/components/normalization/operations/copy-property/copy-property.component.ts
@@ -1,5 +1,15 @@
 import {MatCardContent} from "@angular/material/card";
-import {Component, ElementRef, EventEmitter, Input, OnDestroy, OnInit, Output, ViewChild} from '@angular/core';
+import {
+  AfterViewInit,
+  Component,
+  ElementRef,
+  EventEmitter,
+  Input,
+  OnDestroy,
+  OnInit,
+  Output,
+  ViewChild
+} from '@angular/core';
 import {FormMode} from '../../../../models/FormMode.enum';
 import {IEntityCreatedResponse} from '../../../../interfaces/entity-created-response.model';
 
@@ -45,7 +55,7 @@ import {MatAutocomplete, MatAutocompleteTrigger} from "@angular/material/autocom
     MatAutocompleteTrigger
   ],
 })
-export class CopyPropertyComponent implements OnInit, OnDestroy {
+export class CopyPropertyComponent implements OnInit, OnDestroy, AfterViewInit  {
 
   @ViewChild('errorDiv') errorDiv!: ElementRef;
   @ViewChild(MatAutocompleteTrigger) trigger!: MatAutocompleteTrigger;
@@ -85,7 +95,7 @@ export class CopyPropertyComponent implements OnInit, OnDestroy {
 
   filteredResourceTypes: string[] = [];
 
-  private userClicked = false;
+  userClicked = false;
 
   constructor(private fb: FormBuilder, private snackBar: MatSnackBar, private operationService: OperationService) {
     this.form = this.fb.group({

--- a/Web/Admin.UI/src/app/components/tenant/facility-edit/facility-edit.component.ts
+++ b/Web/Admin.UI/src/app/components/tenant/facility-edit/facility-edit.component.ts
@@ -558,23 +558,13 @@ export class FacilityEditComponent implements OnInit {
   }
 
   loadOperations() {
-    this.operationService.searchGlobalOperations(
-      this.facilityConfig.facilityId, // facilityId
-      null,
-      null, // resourceType
-      null, // operationId
-      true,
-      null, //vendorId
-      null,
-      "ascending",
-      this.paginationMetadata.pageSize || 5,
-      this.paginationMetadata.pageNumber || 0
+    this.operationService.getOperationsByFacility(
+      this.facilityId
     ).subscribe({
       next: (operationsSearch) => {
-        this.operations = operationsSearch.records;
+        this.operations =  operationsSearch.records;
         this.paginationMetadata = operationsSearch.metadata;
-      }
-      ,
+      },
       error: (error) => {
         console.error('Error loading operations:', error);
       }

--- a/Web/Admin.UI/src/app/services/gateway/normalization/operation.service.ts
+++ b/Web/Admin.UI/src/app/services/gateway/normalization/operation.service.ts
@@ -8,9 +8,11 @@ import {ISaveOperationModel} from "../../../interfaces/normalization/operation-s
 import {OperationType} from "../../../interfaces/normalization/operation-type-enumeration";
 import {CopyPropertyOperation} from "../../../interfaces/normalization/copy-property-interface";
 import {IResource} from "../../../interfaces/normalization/resource-interface";
-import { ConditionalTransformOperation } from "../../../interfaces/normalization/conditional-transformation-operation-interface";
-import { IPagedOperationModel } from 'src/app/interfaces/normalization/operation-get-model.interface';
-import { CodeMapOperation } from 'src/app/interfaces/normalization/code-map-operation-interface';
+import {
+  ConditionalTransformOperation
+} from "../../../interfaces/normalization/conditional-transformation-operation-interface";
+import {IPagedOperationModel} from 'src/app/interfaces/normalization/operation-get-model.interface';
+import {CodeMapOperation} from 'src/app/interfaces/normalization/code-map-operation-interface';
 import {IVendor} from "../../../interfaces/normalization/vendor-interface";
 
 
@@ -62,7 +64,7 @@ export class OperationService {
   deleteOperationByFacility(facilityId: string, operationId: string): Observable<any> {
     return this.http.delete<IResource[]>(`${this.appConfigService.config?.baseApiUrl}/normalization/operations/facility/${facilityId}?operationId=${operationId}`)
       .pipe(
-          tap(_ => console.log('Request for operation deletion by facility was sent.')),
+        tap(_ => console.log('Request for operation deletion by facility was sent.')),
       );
   }
 
@@ -73,7 +75,7 @@ export class OperationService {
       );
   }
 
-  getOperationsByFacility(facilityId : string,  vendorId? : string, resourceType?:string): Observable<IPagedOperationModel> {
+  getOperationsByFacility(facilityId: string, vendorId?: string, resourceType?: string): Observable<IPagedOperationModel> {
     const url = `${this.appConfigService.config?.baseApiUrl}/normalization/operations/facility/${facilityId}`;
 
     let params = new HttpParams();
@@ -86,40 +88,19 @@ export class OperationService {
       params = params.set('vendorId', vendorId);
     }
 
-    return this.http.get<IPagedOperationModel>(url, { params })
+    return this.http.get<IPagedOperationModel>(url, {params})
       .pipe(
         map((response: IPagedOperationModel) => {
           //revert back to zero based paging
           response.metadata.pageNumber--;
 
           // parse the operationJson field to parsedOperationJson
-          response.records.forEach(record => {
-            try {
-              const parsedJson = JSON.parse(record.operationJson);
-              switch(record.operationType) {
-                case OperationType.CopyProperty:
-                  record.parsedOperationJson = parsedJson as CopyPropertyOperation;
-                  break;
-                case OperationType.ConditionalTransform:
-                  record.parsedOperationJson = parsedJson as ConditionalTransformOperation;
-                  break;
-                case OperationType.CodeMap:
-                  record.parsedOperationJson = parsedJson as CodeMapOperation;
-                  break;
-                default:
-                  console.warn(`Unsupported operation type: ${record.operationType} for record with id ${record.id}`);
-                  record.parsedOperationJson = parsedJson;
-                  break;
-              }
-            } catch (e) {
-              console.error(`Error parsing operationJson for record with id ${record.id}:`, e);
-            }
-          });
+          this.parseOperationRecords(response.records);
 
           return response;
         }),
         catchError((error: HttpErrorResponse) => {
-          return  this.errorHandler.handleError(error);
+          return this.errorHandler.handleError(error);
         })
       );
   }
@@ -145,66 +126,70 @@ export class OperationService {
     params = params.set('pageSize', pageSize.toString());
 
     //add filters to query string
-    if(facilityId) {
-        params = params.set('facilityId', facilityId);
+    if (facilityId) {
+      params = params.set('facilityId', facilityId);
     }
-    if(operationType) {
-        params = params.set('operationType', operationType);
+    if (operationType) {
+      params = params.set('operationType', operationType);
     }
-    if(resourceType) {
-        params = params.set('resourceType', resourceType);
+    if (resourceType) {
+      params = params.set('resourceType', resourceType);
     }
-    if(operationId) {
-        params = params.set('operationId', operationId);
+    if (operationId) {
+      params = params.set('operationId', operationId);
     }
-    if(includeDisabled !== null) {
-        params = params.set('includeDisabled', includeDisabled.toString());
+    if (includeDisabled !== null) {
+      params = params.set('includeDisabled', includeDisabled.toString());
     }
-    if(vendorId !== null) {
-       params = params.set('vendorId', vendorId);
+    if (vendorId !== null) {
+      params = params.set('vendorId', vendorId);
     }
-    if(sortBy) {
-        params = params.set('sortBy', sortBy);
+    if (sortBy) {
+      params = params.set('sortBy', sortBy);
     }
-    if(sortOrder) {
-        params = params.set('sortOrder', sortOrder);
+    if (sortOrder) {
+      params = params.set('sortOrder', sortOrder);
     }
 
-    return this.http.get<IPagedOperationModel>(`${this.appConfigService.config?.baseApiUrl}/normalization/operations`, { params })
+    return this.http.get<IPagedOperationModel>(`${this.appConfigService.config?.baseApiUrl}/normalization/operations`, {params})
       .pipe(
         map((response: IPagedOperationModel) => {
           //revert back to zero based paging
           response.metadata.pageNumber--;
 
           // parse the operationJson field to parsedOperationJson
-          response.records.forEach(record => {
-            try {
-              const parsedJson = JSON.parse(record.operationJson);
-              switch(record.operationType) {
-                case OperationType.CopyProperty:
-                  record.parsedOperationJson = parsedJson as CopyPropertyOperation;
-                  break;
-                case OperationType.ConditionalTransform:
-                  record.parsedOperationJson = parsedJson as ConditionalTransformOperation;
-                  break;
-                case OperationType.CodeMap:
-                  record.parsedOperationJson = parsedJson as CodeMapOperation;
-                  break;
-                default:
-                  console.warn(`Unsupported operation type: ${record.operationType} for record with id ${record.id}`);
-                  record.parsedOperationJson = parsedJson;
-                  break;
-              }
-            } catch (e) {
-              console.error(`Error parsing operationJson for record with id ${record.id}:`, e);
-            }
-          });
+          this.parseOperationRecords(response.records);
 
           return response;
         }),
         catchError((error: HttpErrorResponse) => {
-           return  this.errorHandler.handleError(error);
+          return this.errorHandler.handleError(error);
         })
       );
+  }
+
+  private parseOperationRecords(records: any[]): void {
+    records.forEach(record => {
+      try {
+        const parsedJson = JSON.parse(record.operationJson);
+        switch (record.operationType) {
+          case OperationType.CopyProperty:
+            record.parsedOperationJson = parsedJson as CopyPropertyOperation;
+            break;
+          case OperationType.ConditionalTransform:
+            record.parsedOperationJson = parsedJson as ConditionalTransformOperation;
+            break;
+          case OperationType.CodeMap:
+            record.parsedOperationJson = parsedJson as CodeMapOperation;
+            break;
+          default:
+            console.warn(`Unsupported operation type: ${record.operationType} for record with id ${record.id}`);
+            record.parsedOperationJson = parsedJson;
+            break;
+        }
+      } catch (e) {
+        console.error(`Error parsing operationJson for record with id ${record.id}:`, e);
+      }
+    });
   }
 }

--- a/Web/Admin.UI/src/app/services/gateway/normalization/operation.service.ts
+++ b/Web/Admin.UI/src/app/services/gateway/normalization/operation.service.ts
@@ -12,7 +12,7 @@ import { ConditionalTransformOperation } from "../../../interfaces/normalization
 import { IPagedOperationModel } from 'src/app/interfaces/normalization/operation-get-model.interface';
 import { CodeMapOperation } from 'src/app/interfaces/normalization/code-map-operation-interface';
 import {IVendor} from "../../../interfaces/normalization/vendor-interface";
-import {throwError} from "rxjs/internal/observable/throwError";
+
 
 @Injectable({
   providedIn: 'root'
@@ -70,6 +70,57 @@ export class OperationService {
     return this.http.delete<IResource[]>(`${this.appConfigService.config?.baseApiUrl}/normalization/operations/vendor/${vendorName}?operationId=${operationId}`)
       .pipe(
         tap(_ => console.log('Request for operation deletion by vendor was sent.')),
+      );
+  }
+
+  getOperationsByFacility(facilityId : string,  vendorId? : string, resourceType?:string): Observable<IPagedOperationModel> {
+    const url = `${this.appConfigService.config?.baseApiUrl}/normalization/operations/facility/${facilityId}`;
+
+    let params = new HttpParams();
+
+    if (resourceType) {
+      params = params.set('resourceType', resourceType);
+    }
+
+    if (vendorId) {
+      params = params.set('vendorId', vendorId);
+    }
+
+    return this.http.get<IPagedOperationModel>(url, { params })
+      .pipe(
+        map((response: IPagedOperationModel) => {
+          //revert back to zero based paging
+          response.metadata.pageNumber--;
+
+          // parse the operationJson field to parsedOperationJson
+          response.records.forEach(record => {
+            try {
+              const parsedJson = JSON.parse(record.operationJson);
+              switch(record.operationType) {
+                case OperationType.CopyProperty:
+                  record.parsedOperationJson = parsedJson as CopyPropertyOperation;
+                  break;
+                case OperationType.ConditionalTransform:
+                  record.parsedOperationJson = parsedJson as ConditionalTransformOperation;
+                  break;
+                case OperationType.CodeMap:
+                  record.parsedOperationJson = parsedJson as CodeMapOperation;
+                  break;
+                default:
+                  console.warn(`Unsupported operation type: ${record.operationType} for record with id ${record.id}`);
+                  record.parsedOperationJson = parsedJson;
+                  break;
+              }
+            } catch (e) {
+              console.error(`Error parsing operationJson for record with id ${record.id}:`, e);
+            }
+          });
+
+          return response;
+        }),
+        catchError((error: HttpErrorResponse) => {
+          return  this.errorHandler.handleError(error);
+        })
       );
   }
 


### PR DESCRIPTION
Added type-ahead/autocomplete functionality to select resources control, fixed the enable/disable flag, add more validation errors

### 🛠️ Description of Changes
Tested locally

### 🧪 Testing Performed
Please describe the testing that was performed on the changes included in this PR.

### 🧑‍🔬 Unit Testing
- [ ] I have written or updated unit tests to cover my changes

### 📓 Documentation Updated
Please update any relevant sections in the project documentation that were impacted by the changes in the PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced an autocomplete input with checkboxes for selecting multiple resource types across several normalization operation forms, replacing the previous multi-select dropdowns.
  * Selected resource types are displayed as a comma-separated list above the input.
  * Added real-time filtering and keyboard navigation for resource type selection.
  * New validation error messages are shown when required fields or conditions are missing.
  * Added a new method to fetch operations filtered by facility, improving data retrieval efficiency.
  * Added a confirmation dialog and workflow for deleting operations from the list.

* **Bug Fixes**
  * Improved validation error display and styling for resource type selection and required conditions.

* **Style**
  * Updated validation error message styling for better visibility and consistency.
  * Added spacing for selected resource types display.

* **Chores**
  * Simplified operations loading by streamlining service calls in operations and facility management components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->