### PR TITLE
TECH_DEBT: Enable a merge queue for PRs entering the dev branch

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -4,7 +4,10 @@ on:
   pull_request:
     branches:
       - dev
-
+  merge_group:
+    branches:
+      - dev
+    
 jobs:
   integration-tests:
     runs-on: windows-latest  # Runner environment

--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -11,7 +11,7 @@ on:
   merge_group:
     branches:
       - dev
- 
+
 jobs:
   check-title:
     runs-on: ubuntu-latest
@@ -22,7 +22,14 @@ jobs:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         script: |
           const payload = context.payload
-          const prTitle = payload.pull_request.title
+          let prTitle
+          if (payload.pull_request) {
+            prTitle = payload.pull_request.title
+          } else if (payload.merge_group && payload.merge_group.pull_requests?.length) {
+            prTitle = payload.merge_group.pull_requests[0].title
+          } else {
+            core.setFailed('Cannot determine PR title for validation.')
+          }
           const prTitleExpectedPattern = /(^LNK-\d+:\s)|(^TECH_DEBT:\s)/g
           const prTitleMismatchError = 'Invalid PR title! Must begin with LNK-nnnn:<space> or TECH_DEBT:<space>, e.g. LNK-1234: My PR title, or TECH_DEBT: My PR title'
           if (!prTitleExpectedPattern.test(prTitle)) {

--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -8,6 +8,10 @@ on:
       - 'release/**'
       - 'hotfix/**'
     types: [opened, edited, synchronize]
+  merge_group:
+    branches:
+      - dev
+ 
 jobs:
   check-title:
     runs-on: ubuntu-latest

--- a/.github/workflows/smoke-test.yaml
+++ b/.github/workflows/smoke-test.yaml
@@ -6,9 +6,11 @@ on:
   pull_request:
     branches:
       - dev
+  merge_group:
+    branches:
+      - dev
 
 jobs:
-      
   docker-build-and-run:
     runs-on: ['ubuntu-latest']
 
@@ -29,7 +31,7 @@ jobs:
 
       - name: Start Docker Services
         run: docker compose -p $PROJECT_NAME up -d
-        
+
       - name: Wait for services to start
         run: sleep 30
 
@@ -37,7 +39,7 @@ jobs:
         run: |
           chmod +x Scripts/check_health.sh
           Scripts/check_health.sh $PROJECT_NAME $HEALTH_CHECK_TIMEOUT $CHECK_INTERVAL
-          
+
       - name: Run Backend E2E Tests
         run: dotnet test ./Tests/BackendE2ETests/BackendE2ETests.csproj --filter "Category=SmokeTest" --logger "trx;LogFileName=test-results.trx"
         env:

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches:
       - dev
+  merge_group:
+    branches:
+      - dev
 
 jobs:
   dotnet-unit-tests:


### PR DESCRIPTION
### 🛠️ Description of Changes
Adding a merge group to GitHub actions to enable a queue (depth is 5 by default), for dev-bound PRs. This should alleviate situations where tests have to be re-run in order to satisfy the branch rule that requires PRs to be up-to-date with the destination `dev` branch. This problem can happen when someone else gets their changes in before you do, so you have to go through the whole process again. Ordinarily, this isn't too common but can become more prevalent at the end of sprints, and when builds and tests are taking longer to run, and/or when tests randomly fail.

### 🧪 Testing Performed
None - need to merge and confirm that it works on `dev`. It also requires a branch rules setting to be changed in the repo itself, to enable queue depths, the merge strategy and timeouts, which I will do after these changes are merged to `dev`. Only then will be able to see if this works as expected.
![image](https://github.com/user-attachments/assets/ecadab44-daff-4924-a3a6-2f6d484d2a1c)

### 🧑‍🔬 Unit Testing
- [ ] I have written or updated unit tests to cover my changes

### 📓 Documentation Updated
N/A.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated automated workflow triggers to support merge group events on the dev branch, enhancing workflow runs for integration tests, PR title checks, smoke tests, and unit tests alongside pull requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->