### PR TITLE
TECH_DEBT: Using dedicated build runner for smoke tests

### DIFF
--- a/.github/workflows/smoke-test.yaml
+++ b/.github/workflows/smoke-test.yaml
@@ -50,7 +50,3 @@ jobs:
         with:
           name: test-results
           path: ./Tests/BackendE2ETests/TestResults/adhoc-reporting-smoke-test-submission.zip
-
-      - name: Shutdown Services
-        run: docker compose -p $PROJECT_NAME down --volumes
-        if: always()

--- a/.github/workflows/smoke-test.yaml
+++ b/.github/workflows/smoke-test.yaml
@@ -20,17 +20,27 @@ jobs:
       CHECK_INTERVAL: 5
 
     steps:
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ vars.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          
       - name: Checkout code
         uses: actions/checkout@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       - name: Build Docker Services
-        run: docker compose -p $PROJECT_NAME build
+        run: |
+          docker buildx bake \
+            --file docker-compose.yml \
+            --set '*.cache-from=type=registry,ref=lantanagroup/link:buildcache' \
+            --set '*.cache-to=type=registry,ref=lantanagroup/link:buildcache,mode=max'
 
       - name: Start Docker Services
-        run: docker compose -p $PROJECT_NAME up -d
+        run: docker compose up -d
 
       - name: Wait for services to start
         run: sleep 30

--- a/.github/workflows/smoke-test.yaml
+++ b/.github/workflows/smoke-test.yaml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   docker-build-and-run:
-    runs-on: ['ubuntu-latest']
+    runs-on: [docker-8core-32gb]
 
     env:
       PROJECT_NAME: link

--- a/.github/workflows/smoke-test.yaml
+++ b/.github/workflows/smoke-test.yaml
@@ -19,25 +19,28 @@ jobs:
       HEALTH_CHECK_TIMEOUT: 10
       CHECK_INTERVAL: 5
 
-    steps:
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ vars.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-          
+    steps:          
       - name: Checkout code
         uses: actions/checkout@v4
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+        
+      - name: Cache Docker BuildKit layers
+        uses: actions/cache@v4
+        with:
+          path: buildkit-cache
+          key: buildkit-${{ runner.os }}-${{ github.ref }}-${{ hashFiles('**/Dockerfile', '**/docker-compose.yml') }}
+          restore-keys: |
+            buildkit-${{ runner.os }}-${{ github.ref }}-
+            buildkit-${{ runner.os }}-
 
       - name: Build Docker Services
         run: |
           docker buildx bake \
             --file docker-compose.yml \
-            --set '*.cache-from=type=registry,ref=lantanagroup/link:buildcache' \
-            --set '*.cache-to=type=registry,ref=lantanagroup/link:buildcache,mode=max'
+            --set '*.cache-from=type=local,src=buildkit-cache' \
+            --set '*.cache-to=type=local,dest=buildkit-cache,mode=max'
 
       - name: Start Docker Services
         run: docker compose up -d

--- a/.github/workflows/smoke-test.yaml
+++ b/.github/workflows/smoke-test.yaml
@@ -23,7 +23,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Start Docker Services
+      - name: Build and Start Services
         run: docker compose up --build -d
 
       - name: Wait for services to start

--- a/.github/workflows/smoke-test.yaml
+++ b/.github/workflows/smoke-test.yaml
@@ -23,27 +23,8 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-        
-      - name: Cache Docker BuildKit layers
-        uses: actions/cache@v4
-        with:
-          path: buildkit-cache
-          key: buildkit-${{ runner.os }}-${{ github.ref }}-${{ hashFiles('**/Dockerfile', '**/docker-compose.yml') }}
-          restore-keys: |
-            buildkit-${{ runner.os }}-${{ github.ref }}-
-            buildkit-${{ runner.os }}-
-
-      - name: Build Docker Services
-        run: |
-          docker buildx bake \
-            --file docker-compose.yml \
-            --set '*.cache-from=type=local,src=buildkit-cache' \
-            --set '*.cache-to=type=local,dest=buildkit-cache,mode=max'
-
       - name: Start Docker Services
-        run: docker compose up -d
+        run: docker compose up --build -d
 
       - name: Wait for services to start
         run: sleep 30

--- a/.github/workflows/smoke-test.yaml
+++ b/.github/workflows/smoke-test.yaml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   docker-build-and-run:
-    runs-on: [docker-8core-32gb]
+    runs-on: [docker-16core-64gb]
 
     env:
       PROJECT_NAME: link


### PR DESCRIPTION
### 🛠️ Description of Changes
* Collapsing two tasks into one
* Using a dedicated runner that has more CPU cores; smoke test runs in ~12-13 minutes instead of ~19-20
* Removing unnecessary `docker compose down` task; the action is already executed in isolation

### 🧪 Testing Performed
Smoke test executed as part of the PR Check

### 🧑‍🔬 Unit Testing
N/A

### 📓 Documentation Updated
N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

* **Chores**
  * Improved workflow reliability and efficiency for smoke tests by updating Docker build and cache steps in the automation process. No changes to user-facing features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->