### PR TITLE
TECH_DEBT: Make smoke test rerunnable

### DIFF
--- a/DotNet/DataAcquisition.Domain/Application/Managers/FhirQueryConfigurationManager.cs
+++ b/DotNet/DataAcquisition.Domain/Application/Managers/FhirQueryConfigurationManager.cs
@@ -139,6 +139,7 @@ public class FhirQueryConfigurationManager : IFhirQueryConfigurationManager
             throw new NotFoundException($"No configuration found for facilityId: {facilityId}. Unable to delete configuration.");
 
         _database.FhirQueryConfigurationRepository.Remove(entity);
+        await _database.FhirQueryConfigurationRepository.SaveChangesAsync();
 
         return true;
     }

--- a/Tests/BackendE2ETests/AdhocReportingSmokeTest.cs
+++ b/Tests/BackendE2ETests/AdhocReportingSmokeTest.cs
@@ -811,11 +811,11 @@ public sealed class AdhocReportingSmokeTest(ITestOutputHelper output) : IAsyncLi
     private async Task DeleteFacilityNormalization()
     {
         output.WriteLine("Deleting facility normalization...");
-        var deleteNormalizationRequest = new RestRequest($"/normalization/{FacilityId}", Method.Delete);
+        var deleteNormalizationRequest = new RestRequest($"/normalization/operations/facility/{FacilityId}", Method.Delete);
         var deleteNormalizationResponse = await AdminBffClient.ExecuteAsync(deleteNormalizationRequest);
 
-        if (deleteNormalizationResponse.StatusCode != HttpStatusCode.Accepted)
-            output.WriteLine($"Expected HTTP 202 Accepted for normalization deletion but received {deleteNormalizationResponse.StatusCode}: {deleteNormalizationResponse.Content}");
+        if (deleteNormalizationResponse.StatusCode != HttpStatusCode.NoContent)
+            output.WriteLine($"Expected HTTP 204 No Content for normalization deletion but received {deleteNormalizationResponse.StatusCode}: {deleteNormalizationResponse.Content}");
     }
 
     private async Task DeleteFacilityQueryPlan()

--- a/Tests/BackendE2ETests/AdhocReportingSmokeTest.cs
+++ b/Tests/BackendE2ETests/AdhocReportingSmokeTest.cs
@@ -48,7 +48,7 @@ public sealed class AdhocReportingSmokeTest(ITestOutputHelper output) : IAsyncLi
 
         // Clear all data from the FHIR server
         if (TestConfig.CleanupSmokeTestData)
-            FhirDataLoader.DeleteResourcesWithExpunge(output);
+            FhirDataLoader.ExpungeEverything(output);
 
         if (TestConfig.AdhocReportingSmokeTestConfig.RemoveReport)
         {

--- a/Tests/BackendE2ETests/FhirDataLoader.cs
+++ b/Tests/BackendE2ETests/FhirDataLoader.cs
@@ -126,4 +126,33 @@ public class FhirDataLoader
             }
         }
     }
+
+    public void ExpungeEverything(ITestOutputHelper output)
+    {
+        output.WriteLine("Removing data from FHIR server...");
+
+        var request = new RestRequest("$expunge", Method.Post);
+        request.AddHeader("Content-Type", "application/fhir+json");
+
+        if (!string.IsNullOrEmpty(this._authorization))
+            request.AddHeader("Authorization", this._authorization);
+
+        string body = """
+            {
+              "resourceType": "Parameters",
+              "parameter": [
+                { "name": "expungeEverything", "valueBoolean": true }
+              ]
+            }
+            """;
+        request.AddStringBody(body, DataFormat.Json);
+
+        var response = this._restClient.Execute(request);
+
+        output.WriteLine($"Expunging everything => Status: {response.StatusCode}");
+        if (!response.IsSuccessful)
+        {
+            output.WriteLine($"Failed to expunge everything: {response.Content}");
+        }
+    }
 }

--- a/Tests/BackendE2ETests/TestConfig.cs
+++ b/Tests/BackendE2ETests/TestConfig.cs
@@ -42,7 +42,7 @@ public static class TestConfig
         public string StartDate => Environment.GetEnvironmentVariable($"{prefix}_START_DATE") ?? "2023-01-01T00:00:00Z";
         public string EndDate => Environment.GetEnvironmentVariable($"{prefix}_END_DATE") ?? "2023-12-31T23:59:59Z";
         public List<string> PatientIds = Environment.GetEnvironmentVariable($"{prefix}_PATIENT_IDS")?.Split(',')?.ToList() ?? ["207727"];
-        public bool RemoveFacilityConfig = Environment.GetEnvironmentVariable($"{prefix}_REMOVE_FACILITY_CONFIG") == null || Environment.GetEnvironmentVariable($"{prefix}_REMOVE_FACILITY_CONFIG")?.ToLower() == "true";
+        public bool RemoveFacilityConfig = bool.Parse(Environment.GetEnvironmentVariable($"{prefix}_REMOVE_FACILITY_CONFIG") ?? "true");
         public bool RemoveReport = Environment.GetEnvironmentVariable($"{prefix}_REMOVE_REPORT")?.ToLower() == "true";
     }
 


### PR DESCRIPTION
### 🛠️ Description of Changes
Tweaks to the smoke test (and one fix to DA) to make the smoke test rerunnable.

### 🧪 Testing Performed
Ran the smoke test three times without restarting containers or pruning volumes.  Verified that the test succeeded and produced a submission with the same resource type distribution on each run.

### 🧑‍🔬 Unit Testing
N/A

### 📓 Documentation Updated
N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured that deletions in FHIR query configuration are properly saved to the database.

* **New Features**
  * Added a method to fully expunge all resources from the FHIR server during test cleanup.

* **Tests**
  * Updated test cleanup to use the new expunge-all method for FHIR data.
  * Changed the endpoint and expected status code for facility normalization deletion in tests.
  * Simplified configuration for removing facility config in smoke tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->