### PR TITLE
TECH_DEBT: Fix invalid build config for docker-compose.dcproj

### DIFF
--- a/link-cloud.sln
+++ b/link-cloud.sln
@@ -180,12 +180,12 @@ Global
 		{E34B41C5-3093-05C2-C945-BCB49AC34E7F}.NoVariablesDefault|Any CPU.Build.0 = Release|Any CPU
 		{E34B41C5-3093-05C2-C945-BCB49AC34E7F}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{E34B41C5-3093-05C2-C945-BCB49AC34E7F}.Release|Any CPU.Build.0 = Release|Any CPU
-		{0FE36D9C-71D5-440F-B676-2A158E9D596D}.Debug|Any CPU.ActiveCfg = NoVariablesDefault
-		{0FE36D9C-71D5-440F-B676-2A158E9D596D}.Debug|Any CPU.Build.0 = NoVariablesDefault
-		{0FE36D9C-71D5-440F-B676-2A158E9D596D}.NoVariablesDefault|Any CPU.ActiveCfg = NoVariablesDefault
-		{0FE36D9C-71D5-440F-B676-2A158E9D596D}.NoVariablesDefault|Any CPU.Build.0 = NoVariablesDefault
-		{0FE36D9C-71D5-440F-B676-2A158E9D596D}.Release|Any CPU.ActiveCfg = NoVariablesDefault
-		{0FE36D9C-71D5-440F-B676-2A158E9D596D}.Release|Any CPU.Build.0 = NoVariablesDefault
+		{0FE36D9C-71D5-440F-B676-2A158E9D596D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0FE36D9C-71D5-440F-B676-2A158E9D596D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0FE36D9C-71D5-440F-B676-2A158E9D596D}.NoVariablesDefault|Any CPU.ActiveCfg = Debug|Any CPU
+		{0FE36D9C-71D5-440F-B676-2A158E9D596D}.NoVariablesDefault|Any CPU.Build.0 = Debug|Any CPU
+		{0FE36D9C-71D5-440F-B676-2A158E9D596D}.Release|Any CPU.ActiveCfg = Debug|Any CPU
+		{0FE36D9C-71D5-440F-B676-2A158E9D596D}.Release|Any CPU.Build.0 = Debug|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
### 🛠️ Description of Changes
Replaced the `NoVariablesDefault` config with `Debug|Any CPU` for the docker-compose.dcproj file.

### 🧪 Testing Performed
Ensured that F5 debugging works again with docker-compose as the startup project.

### 🧑‍🔬 Unit Testing
N/A

### 📓 Documentation Updated
N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project configuration mappings for the docker-compose project to use the Debug configuration for all build profiles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->