### PR TITLE
TECH_DEBT: Support for PRs with "DOCS: XXX"

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -22,11 +22,16 @@ reviews:
     - path: "**"
       instructions: |
         Pull requests that have "TECH_DEBT" in the title should only contain changes related to typos, unused code, linter/IDE suggestions, swagger specification updates,
-        documentation (such as markdown files) and logging improvements. These TECH_DEBT PRs must not affect core functionality. All PRs that are not considered
-        technical debt must include information on what testing was performed in the description of the PR. If it does not, ask the author to provide details on
-        what testing was performed.
+        and logging improvements. These TECH_DEBT PRs must not affect core functionality. All PRs that are not considered technical debt must include information on what 
+        testing was performed in the description of the PR. If it does not, ask the author to provide details on what testing was performed.
         When reviewing code, suggest unit tests using XUnit in the following scenarios:
         - If/Else or Switch/Case blocks are introduced or modified — ensure each branch has a corresponding unit test.
         - Logic that depends on service or interface configuration — suggest tests to validate different implementations are correctly resolved.
         - No network activity (HTTP calls, sockets, etc.) should appear in unit tests. Recommend using mocks (via Moq) for any external communication.
         Large unit tests should be avoided; keeping unit tests small and focused on targeted business logic (i.e. string sanitization)
+    - path: '**'
+      instructions: |
+        Pull requests that have *DOCS* in the title should only contain changes related to documentation within the /docs folder or in .md files through-out the code-base. The description
+        of the PR should specify what documentation was updated. Documentation updates should use EventCatalog.dev structure, where service-specific functionality should be described
+        in the service's index.mdx (i.e. /services/XXX/index.mdx or /domains/XXX/services/YYY/index.mdx). Configurations that are shared by multiple services should be
+        reflected in the /docs/docs/config files.

--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -30,8 +30,8 @@ jobs:
           } else {
             core.setFailed('Cannot determine PR title for validation.')
           }
-          const prTitleExpectedPattern = /(^LNK-\d+:\s)|(^TECH_DEBT:\s)/g
-          const prTitleMismatchError = 'Invalid PR title! Must begin with LNK-nnnn:<space> or TECH_DEBT:<space>, e.g. LNK-1234: My PR title, or TECH_DEBT: My PR title'
+          const prTitleExpectedPattern = /(^LNK-\d+:\s)|(^TECH_DEBT:\s)|(^DOCS:\s)/g
+          const prTitleMismatchError = 'Invalid PR title! Must begin with LNK-nnnn:<space> or TECH_DEBT:<space> or DOCS:<space>, e.g. LNK-1234: My PR title, or TECH_DEBT: My PR title or DOCS: My PR title'
           if (!prTitleExpectedPattern.test(prTitle)) {
             // Fail the workflow
             console.log(prTitleMismatchError)


### PR DESCRIPTION
### 🛠️ Description of Changes

Allowing PRs to have DOCS instead of just LNK-XX and TECH_DEBT.
* Updating CodeRabbit.ai guidance.
* Updating the PR Title Check workflow.

### 🧪 Testing Performed
N/A

### 🧑‍🔬 Unit Testing
N/A

### 📓 Documentation Updated
N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added new guidelines for documentation-related pull requests, including requirements for file locations and PR descriptions.
* **Chores**
  * Updated pull request title validation to accept "DOCS:" as a valid prefix, alongside existing options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->