### PR TITLE
LNK-4118: Add Category and Issue Retrieval Operations to Validation Service

### DIFF
--- a/.github/workflows/smoke-test.yaml
+++ b/.github/workflows/smoke-test.yaml
@@ -6,45 +6,10 @@ on:
   pull_request:
     branches:
       - dev
-  merge_group:
-    branches:
-      - dev
 
 jobs:
-  skip_if_only_docs:
-    runs-on: ubuntu-latest
-    outputs:
-      only_docs: ${{ steps.changes.outputs.only_docs }}
-      
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-
-      - name: Check for non-docs changes
-        id: check_changes
-        run: |
-          git fetch origin ${{ github.base_ref }}
-          DIFF=$(git diff --name-only origin/${{ github.base_ref }}...HEAD | grep -v '^docs/' || true)
-          if [ -z "$DIFF" ]; then
-            echo "Only docs changed. Skipping tests."
-            echo "only_docs=true" > result.txt
-          else
-            echo "Changes outside docs detected."
-            echo "only_docs=false" > result.txt
-          fi
-
-      - name: Set output
-        id: set_output
-        run: |
-          ONLY_DOCS=$(cat result.txt)
-          echo "only_docs=$ONLY_DOCS" >> $GITHUB_OUTPUT
           
-  docker-build-and-run:
-    needs: skip_if_only_docs
-    if: needs.skip_if_only_docs.outputs.only_docs == 'false'
-    
+  docker-build-and-run:    
     runs-on: [docker-16core-64gb]
 
     env:

--- a/Java/validation/src/main/java/com/lantanagroup/link/validation/controllers/CategoryController.java
+++ b/Java/validation/src/main/java/com/lantanagroup/link/validation/controllers/CategoryController.java
@@ -49,6 +49,9 @@ public class CategoryController {
         if (StringUtils.isEmpty(category.getId())) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, formatReason("No ID provided", index));
         }
+        if ("uncategorized".equalsIgnoreCase(category.getId())) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, formatReason("'uncategorized' is a reserved ID and cannot be used", index));
+        }
         if (StringUtils.isEmpty(category.getTitle())) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, formatReason("No title provided", index));
         }
@@ -157,6 +160,9 @@ public class CategoryController {
     @Operation(summary = "Creates or updates a category")
     @PutMapping("/{id}")
     public void saveCategory(@PathVariable String id, @RequestBody Category category) {
+        if ("uncategorized".equalsIgnoreCase(id)) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "'uncategorized' is a reserved ID and cannot be used");
+        }
         validateCategory(category, null);
         if (!StringUtils.equals(category.getId(), id)) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "ID does not match URL");
@@ -167,6 +173,9 @@ public class CategoryController {
     @Operation(summary = "Creates a rule for a category", description = "Creating a rule for a category automatically makes it the `latest` rule.")
     @PutMapping("/{id}/rule")
     public void saveCategoryRule(@PathVariable String id, @RequestBody Matcher matcher) {
+        if ("uncategorized".equalsIgnoreCase(id)) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "'uncategorized' is a reserved ID and cannot be modified");
+        }
         Category category = getCategory(id);
         CategoryRule categoryRule = new CategoryRule();
         categoryRule.setCategory(category);

--- a/Java/validation/src/main/java/com/lantanagroup/link/validation/models/CategoryIssueModel.java
+++ b/Java/validation/src/main/java/com/lantanagroup/link/validation/models/CategoryIssueModel.java
@@ -1,0 +1,16 @@
+package com.lantanagroup.link.validation.models;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class CategoryIssueModel {
+    private String location;
+    private String message;
+    private String code;
+    private String expression;
+    private String patientId;
+}

--- a/Java/validation/src/main/java/com/lantanagroup/link/validation/models/CategorySummaryModel.java
+++ b/Java/validation/src/main/java/com/lantanagroup/link/validation/models/CategorySummaryModel.java
@@ -1,0 +1,14 @@
+package com.lantanagroup.link.validation.models;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class CategorySummaryModel {
+    private String categoryId;
+    private int issues;
+    private boolean acceptable;
+}

--- a/Java/validation/src/main/java/com/lantanagroup/link/validation/services/ResultService.java
+++ b/Java/validation/src/main/java/com/lantanagroup/link/validation/services/ResultService.java
@@ -18,7 +18,7 @@ public class ResultService {
         this.resultRepository = resultRepository;
     }
 
-    private static String UNCATEGORIZED_CATEGORY_ID = "uncategorized";
+    private static final String UNCATEGORIZED_CATEGORY_ID = "uncategorized";
 
     /**
      * Gets results for a facility and report; optionally filters by a minimum severity

--- a/Java/validation/src/main/java/com/lantanagroup/link/validation/services/ResultService.java
+++ b/Java/validation/src/main/java/com/lantanagroup/link/validation/services/ResultService.java
@@ -1,0 +1,133 @@
+package com.lantanagroup.link.validation.services;
+
+import com.lantanagroup.link.shared.utils.IssueSeverityUtils;
+import com.lantanagroup.link.validation.entities.Result;
+import com.lantanagroup.link.validation.models.CategoryIssueModel;
+import com.lantanagroup.link.validation.models.CategorySummaryModel;
+import com.lantanagroup.link.validation.repositories.ResultRepository;
+import org.hl7.fhir.r4.model.OperationOutcome;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class ResultService {
+    private final ResultRepository resultRepository;
+
+    public ResultService(ResultRepository resultRepository) {
+        this.resultRepository = resultRepository;
+    }
+
+    private static String UNCATEGORIZED_CATEGORY_ID = "uncategorized";
+
+    /**
+     * Gets results for a facility and report; optionally filters by a minimum severity
+     *
+     * @param facilityId The facility ID
+     * @param reportId   The report ID
+     * @param severity   The minimum severity threshold
+     * @return List of filtered Result objects
+     */
+    public List<Result> getReportResults(String facilityId, String reportId, OperationOutcome.IssueSeverity severity) {
+        return resultRepository.findAllByFacilityIdAndReportId(facilityId, reportId).stream()
+                .filter(result -> IssueSeverityUtils.isAsSevere(result.getSeverity(), severity))
+                .toList();
+    }
+
+    /**
+     * Gets results for a facility, report, and patient; optionally filters by a minimum severity
+     *
+     * @param facilityId The facility ID
+     * @param reportId   The report ID
+     * @param patientId  The patient ID
+     * @param severity   The minimum severity threshold
+     * @return List of filtered Result objects
+     */
+    public List<Result> getReportPatientResults(String facilityId, String reportId, String patientId, 
+                                               OperationOutcome.IssueSeverity severity) {
+        return resultRepository.findAllByFacilityIdAndReportIdAndPatientId(facilityId, reportId, patientId).stream()
+                .filter(result -> IssueSeverityUtils.isAsSevere(result.getSeverity(), severity))
+                .toList();
+    }
+
+    /**
+     * Gets categories that have issues associated with them for a facility and report
+     *
+     * @param facilityId The facility ID
+     * @param reportId   The report ID
+     * @return List of CategorySummaryDTO objects
+     */
+    public List<CategorySummaryModel> getReportCategories(String facilityId, String reportId) {
+        List<Result> results = resultRepository.findAllByFacilityIdAndReportId(facilityId, reportId);
+
+        // Count results without categories for the Uncategorized group
+        long uncategorizedCount = results.stream()
+                .filter(result -> result.getCategories() == null || result.getCategories().isEmpty())
+                .count();
+
+        // Group results by category and count issues
+        var categories = results.stream()
+                .filter(result -> result.getCategories() != null && !result.getCategories().isEmpty())
+                .flatMap(result -> result.getCategories()
+                        .stream()
+                        .map(category -> new CategorySummaryModel(category.getId(), 1, category.isAcceptable())));
+
+        var groupedCategories = categories
+                .collect(java.util.stream.Collectors.groupingBy(
+                        CategorySummaryModel::getCategoryId,
+                        java.util.stream.Collectors.reducing(
+                                null,
+                                (a, b) -> new CategorySummaryModel(b.getCategoryId(), (a != null ? a.getIssues() : 0) + b.getIssues(), (a != null && a.isAcceptable()) || b.isAcceptable())
+                        )
+                ));
+
+        // Add the Uncategorized category if there are any uncategorized results
+        if (uncategorizedCount > 0) {
+            groupedCategories.put(UNCATEGORIZED_CATEGORY_ID,
+                    new CategorySummaryModel(UNCATEGORIZED_CATEGORY_ID, (int) uncategorizedCount, false));
+        }
+
+        return groupedCategories
+                .values()
+                .stream()
+                .filter(dto -> dto.getCategoryId() != null && !dto.getCategoryId().isEmpty())
+                .toList();
+    }
+
+    /**
+     * Gets issues associated with a specific category for a facility and report
+     *
+     * @param facilityId The facility ID
+     * @param reportId   The report ID
+     * @param categoryId The category ID
+     * @return List of CategoryIssueDTO objects
+     */
+    public List<CategoryIssueModel> getCategoryIssues(String facilityId, String reportId, String categoryId) {
+        List<Result> results = resultRepository.findAllByFacilityIdAndReportId(facilityId, reportId);
+
+        // Handle the special case for Uncategorized category
+        if (categoryId.equalsIgnoreCase(UNCATEGORIZED_CATEGORY_ID)) {
+            return results.stream()
+                    .filter(result -> result.getCategories() == null || result.getCategories().isEmpty())
+                    .map(result -> new CategoryIssueModel(
+                            result.getLocation(),
+                            result.getMessage(),
+                            result.getCode().toString(),
+                            result.getExpression(),
+                            result.getPatientId()))
+                    .toList();
+        }
+
+        // Handle regular categories
+        return results.stream()
+                .filter(result -> result.getCategories() != null && 
+                        result.getCategories().stream().anyMatch(category -> category.getId().equals(categoryId)))
+                .map(result -> new CategoryIssueModel(
+                        result.getLocation(),
+                        result.getMessage(),
+                        result.getCode().toString(),
+                        result.getExpression(),
+                        result.getPatientId()))
+                .toList();
+    }
+}

--- a/Java/validation/src/main/java/com/lantanagroup/link/validation/services/ResultService.java
+++ b/Java/validation/src/main/java/com/lantanagroup/link/validation/services/ResultService.java
@@ -90,7 +90,6 @@ public class ResultService {
         return groupedCategories
                 .values()
                 .stream()
-                .filter(dto -> dto.getCategoryId() != null && !dto.getCategoryId().isEmpty())
                 .toList();
     }
 

--- a/Java/validation/src/test/java/com/lantanagroup/link/validation/services/ResultServiceTest.java
+++ b/Java/validation/src/test/java/com/lantanagroup/link/validation/services/ResultServiceTest.java
@@ -1,0 +1,209 @@
+package com.lantanagroup.link.validation.services;
+
+import com.lantanagroup.link.validation.entities.Category;
+import com.lantanagroup.link.validation.entities.Result;
+import com.lantanagroup.link.validation.models.CategoryIssueModel;
+import com.lantanagroup.link.validation.models.CategorySummaryModel;
+import com.lantanagroup.link.validation.repositories.ResultRepository;
+import org.hl7.fhir.r4.model.OperationOutcome;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class ResultServiceTest {
+
+    @Mock
+    private ResultRepository resultRepository;
+
+    private ResultService resultService;
+
+    private static final String FACILITY_ID = "facility1";
+    private static final String REPORT_ID = "report1";
+    private static final String PATIENT_ID = "patient1";
+    private static final String CATEGORY_ID1 = "category1";
+    private static final String CATEGORY_ID2 = "category2";
+
+    @BeforeEach
+    void setUp() {
+        resultService = new ResultService(resultRepository);
+    }
+
+    @Test
+    void getReportResults_shouldFilterBySeverity() {
+        // Arrange
+        Result result1 = createResult(OperationOutcome.IssueSeverity.ERROR);
+        Result result2 = createResult(OperationOutcome.IssueSeverity.WARNING);
+        Result result3 = createResult(OperationOutcome.IssueSeverity.INFORMATION);
+
+        when(resultRepository.findAllByFacilityIdAndReportId(FACILITY_ID, REPORT_ID))
+                .thenReturn(Arrays.asList(result1, result2, result3));
+
+        // Act
+        List<Result> results = resultService.getReportResults(FACILITY_ID, REPORT_ID, OperationOutcome.IssueSeverity.WARNING);
+
+        // Assert
+        assertEquals(2, results.size());
+        assertTrue(results.contains(result1)); // ERROR is more severe than WARNING
+        assertTrue(results.contains(result2)); // WARNING matches the threshold
+        assertFalse(results.contains(result3)); // INFORMATION is less severe than WARNING
+
+        verify(resultRepository).findAllByFacilityIdAndReportId(FACILITY_ID, REPORT_ID);
+    }
+
+    @Test
+    void getReportPatientResults_shouldFilterBySeverity() {
+        // Arrange
+        Result result1 = createResult(OperationOutcome.IssueSeverity.ERROR);
+        Result result2 = createResult(OperationOutcome.IssueSeverity.WARNING);
+        Result result3 = createResult(OperationOutcome.IssueSeverity.INFORMATION);
+
+        when(resultRepository.findAllByFacilityIdAndReportIdAndPatientId(FACILITY_ID, REPORT_ID, PATIENT_ID))
+                .thenReturn(Arrays.asList(result1, result2, result3));
+
+        // Act
+        List<Result> results = resultService.getReportPatientResults(FACILITY_ID, REPORT_ID, PATIENT_ID, 
+                OperationOutcome.IssueSeverity.WARNING);
+
+        // Assert
+        assertEquals(2, results.size());
+        assertTrue(results.contains(result1)); // ERROR is more severe than WARNING
+        assertTrue(results.contains(result2)); // WARNING matches the threshold
+        assertFalse(results.contains(result3)); // INFORMATION is less severe than WARNING
+
+        verify(resultRepository).findAllByFacilityIdAndReportIdAndPatientId(FACILITY_ID, REPORT_ID, PATIENT_ID);
+    }
+
+    @Test
+    void getReportCategories_shouldGroupAndCountIssues() {
+        // Arrange
+        // Create results with categories
+        Result result1 = createResultWithCategory(CATEGORY_ID1, true);
+        Result result2 = createResultWithCategory(CATEGORY_ID1, false);
+        Result result3 = createResultWithCategory(CATEGORY_ID2, true);
+        Result resultNoCategory = createResult(OperationOutcome.IssueSeverity.ERROR);
+
+        when(resultRepository.findAllByFacilityIdAndReportId(FACILITY_ID, REPORT_ID))
+                .thenReturn(Arrays.asList(result1, result2, result3, resultNoCategory));
+
+        // Act
+        List<CategorySummaryModel> categories = resultService.getReportCategories(FACILITY_ID, REPORT_ID);
+
+        // Assert
+        assertEquals(3, categories.size()); // Now 3 categories including Uncategorized
+
+        // Find category1 in the results
+        CategorySummaryModel category1 = categories.stream()
+                .filter(c -> c.getCategoryId().equals(CATEGORY_ID1))
+                .findFirst()
+                .orElse(null);
+
+        assertNotNull(category1);
+        assertEquals(2, category1.getIssues()); // 2 issues for category1
+        assertTrue(category1.isAcceptable()); // One of the results for category1 is acceptable
+
+        // Verify the Uncategorized category
+        CategorySummaryModel uncategorizedCategory = categories.stream()
+                .filter(c -> c.getCategoryId().equals("uncategorized"))
+                .findFirst()
+                .orElse(null);
+
+        assertNotNull(uncategorizedCategory);
+        assertEquals(1, uncategorizedCategory.getIssues()); // 1 uncategorized issue
+        assertFalse(uncategorizedCategory.isAcceptable()); // Uncategorized issues are not acceptable
+
+        verify(resultRepository).findAllByFacilityIdAndReportId(FACILITY_ID, REPORT_ID);
+    }
+
+    @Test
+    void getCategoryIssues_shouldReturnOnlyMatchingCategoryIssues() {
+        // Arrange
+        Result result1 = createResultWithCategory(CATEGORY_ID1, true);
+        Result result2 = createResultWithCategory(CATEGORY_ID1, false);
+        Result result3 = createResultWithCategory(CATEGORY_ID2, true);
+        Result resultNoCategory = createResult(OperationOutcome.IssueSeverity.ERROR);
+
+        when(resultRepository.findAllByFacilityIdAndReportId(FACILITY_ID, REPORT_ID))
+                .thenReturn(Arrays.asList(result1, result2, result3, resultNoCategory));
+
+        // Act
+        List<CategoryIssueModel> issues = resultService.getCategoryIssues(FACILITY_ID, REPORT_ID, CATEGORY_ID1);
+
+        // Assert
+        assertEquals(2, issues.size());
+
+        // Check that all issues have the expected data
+        for (CategoryIssueModel issue : issues) {
+            assertEquals("location", issue.getLocation());
+            assertEquals("message", issue.getMessage());
+            assertEquals("NULL", issue.getCode());
+            assertEquals("expression", issue.getExpression());
+            assertEquals(PATIENT_ID, issue.getPatientId());
+        }
+
+        verify(resultRepository).findAllByFacilityIdAndReportId(FACILITY_ID, REPORT_ID);
+    }
+
+    @Test
+    void getCategoryIssues_shouldReturnUncategorizedIssues() {
+        // Arrange
+        Result result1 = createResultWithCategory(CATEGORY_ID1, true);
+        Result result2 = createResultWithCategory(CATEGORY_ID1, false);
+        Result resultNoCategory1 = createResult(OperationOutcome.IssueSeverity.ERROR);
+        Result resultNoCategory2 = createResult(OperationOutcome.IssueSeverity.WARNING);
+
+        when(resultRepository.findAllByFacilityIdAndReportId(FACILITY_ID, REPORT_ID))
+                .thenReturn(Arrays.asList(result1, result2, resultNoCategory1, resultNoCategory2));
+
+        // Act
+        List<CategoryIssueModel> issues = resultService.getCategoryIssues(FACILITY_ID, REPORT_ID, "uncategorized");
+
+        // Assert
+        assertEquals(2, issues.size());
+
+        // Check that all issues have the expected data and are indeed the uncategorized ones
+        for (CategoryIssueModel issue : issues) {
+            assertEquals("location", issue.getLocation());
+            assertEquals("message", issue.getMessage());
+            assertEquals("NULL", issue.getCode());
+            assertEquals("expression", issue.getExpression());
+            assertEquals(PATIENT_ID, issue.getPatientId());
+        }
+
+        verify(resultRepository).findAllByFacilityIdAndReportId(FACILITY_ID, REPORT_ID);
+    }
+
+    // Helper methods to create test data
+    private Result createResult(OperationOutcome.IssueSeverity severity) {
+        Result result = new Result();
+        result.setSeverity(severity);
+        result.setCode(OperationOutcome.IssueType.NULL);
+        result.setMessage("message");
+        result.setLocation("location");
+        result.setExpression("expression");
+        result.setPatientId(PATIENT_ID);
+        result.setFacilityId(FACILITY_ID);
+        result.setReportId(REPORT_ID);
+        return result;
+    }
+
+    private Result createResultWithCategory(String categoryId, boolean acceptable) {
+        Result result = createResult(OperationOutcome.IssueSeverity.ERROR);
+
+        Category category = new Category();
+        category.setId(categoryId);
+        category.setAcceptable(acceptable);
+
+        result.setCategories(Collections.singletonList(category));
+        return result;
+    }
+}

--- a/docs/domains/Compliance/index.mdx
+++ b/docs/domains/Compliance/index.mdx
@@ -19,4 +19,29 @@ services:
 Responsible for ensuring that Link operates within defined policies. This includes both operational compliance (e.g., security controls auditing) and data compliance (e.g., validating data syntax and semantics against prescribed profiles and standards).
 
 ## Key Concepts
+
 * Data Governance: Setting policy and assuring compliance
+
+## Requirements
+
+### Stakeholder Requirements
+
+* Clinical data shall meet USCore standard compliance requirements
+* FHIR implementation guides containing profiles shall be loadable for validation purposes
+* Clinical data shall be validated prior to submission
+* Open source validation technologies shall be used for FHIR standard compliance validation
+* Validation results shall be persisted for future reference
+* Validation results shall be categorized to facilitate stakeholder review
+* Validation results and categories shall be visualized with drill-down capability
+* Uncategorized validation results shall be identifiable for category creation
+
+### System Requirements
+
+* The system shall validate all clinical data against USCore profiles
+* The system shall support importing FHIR implementation guides containing validation profiles
+* The system shall execute validation checks on clinical data before allowing submission
+* The system shall use [HAPI FHIR validator](https://hapifhir.io/hapi-fhir/docs/validation/instance_validator.html) for FHIR standard compliance validation
+* The system shall persist validation results in a queryable database
+* The system shall support creation and management of validation result categories
+* The system shall provide visualization of validation results with category-to-detail navigation
+* The system shall maintain an "uncategorized" category for validation results without defined categories

--- a/docs/domains/Compliance/services/ValidationService/index.mdx
+++ b/docs/domains/Compliance/services/ValidationService/index.mdx
@@ -137,7 +137,12 @@ The Validation Service supports two types of artifacts that define validation ru
 2. **FHIR Resource Artifacts**
  - Individual **StructureDefinitions**, **ValueSets**, and **CodeSystems** can be provided.
 
-In addition to artifacts, categories must be initialized/specified in order to have categorized results. Otherwise, all validation results end up being "uncategorized".
+In addition to artifacts, categories must be initialized/specified in order to have categorized results. Otherwise, 
+all validation results end up being "uncategorized".
+
+The system reserves a category with an ID of "uncategorized" for any validation issues within a report that are not 
+mapped or associated with a defined category. This ensures that all validation issues are always captured, even when 
+they don't match any of the configured category rules.
 
 Categories can be configured individually or in bulk.
 
@@ -161,7 +166,8 @@ It will:
 * Validate against the http://.../us-core-observation profile.
 * If the profile is missing, generate a warning.
 
-Similarly, for properties bound to a ValueSet or CodeSystem, the service expects these artifacts to be provided. If they are missing, it will issue warnings.
+Similarly, for properties bound to a ValueSet or CodeSystem, the service expects these artifacts to be provided. If they
+are missing, it will issue warnings.
 
 ### Sequence Diagram
 

--- a/docs/domains/Compliance/services/ValidationService/openapi.yml
+++ b/docs/domains/Compliance/services/ValidationService/openapi.yml
@@ -413,6 +413,71 @@ paths:
                   $ref: '#/components/schemas/Result'
       security:
       - bearer-key: []
+  /api/validation/result/{facilityId}/{reportId}/category:
+    get:
+      tags:
+      - result-controller
+      summary: >-
+        Gets categories that have issues associated with them for a facility and
+        report
+      operationId: getReportCategories
+      parameters:
+        - name: facilityId
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: reportId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: OK
+          content:
+            '*/*':
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/CategorySummaryModel'
+      security:
+        - bearer-key: []
+  /api/validation/result/{facilityId}/{reportId}/category/{categoryId}/issue:
+    get:
+      tags:
+        - result-controller
+      summary: >-
+        Gets issues associated with a specific category for a facility and
+        report
+      operationId: getCategoryIssues
+      parameters:
+        - name: facilityId
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: reportId
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: categoryId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: OK
+          content:
+            '*/*':
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/CategoryIssueModel'
+      security:
+        - bearer-key: []
   /api/validation/pre-qual/{facilityId}/{reportId}:
     get:
       tags:
@@ -753,6 +818,29 @@ components:
         content:
           type: string
           format: byte
+    CategorySummaryModel:
+      type: object
+      properties:
+        categoryId:
+          type: string
+        issues:
+          type: integer
+          format: int32
+        acceptable:
+          type: boolean
+    CategoryIssueModel:
+      type: object
+      properties:
+        location:
+          type: string
+        message:
+          type: string
+        code:
+          type: string
+        expression:
+          type: string
+        patientId:
+          type: string
   securitySchemes:
     bearer-key:
       type: http


### PR DESCRIPTION
### 🛠️ Description of Changes

* Added ability to get a list of categories for a given facility/report
* Added ability to get a list of issues in category, for a given facility/report
* Separated logic from controller into a ResultService

### 🧪 Testing Performed

* Ran locally, testing the endpoints using postman
* Ran in docker compose locally
* Ran new unit tests and ensured all pass successfully

### 🧑‍🔬 Unit Testing
- [x] I have written or updated unit tests to cover my changes

### 📓 Documentation Updated

* Auto-generated swagger specs include new endpoints
* Added new operations to validation service's openapi.yml spec in /docs
* Added requirements to Compliance domain broadly for validation, but specifically related to navigability of categories/issues
* Added statement about "uncategorized" to the validation service's spec in /docs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added two new API endpoints to retrieve validation result categories and their associated issues for a given facility and report.
  * Introduced models for category summaries and detailed category issues in validation results.

* **Bug Fixes**
  * Improved validation to prevent use or modification of the reserved "uncategorized" category ID.

* **Documentation**
  * Expanded Compliance domain documentation with detailed stakeholder and system requirements.
  * Clarified handling of the "uncategorized" category in the Validation Service documentation.
  * Updated API documentation to include new endpoints and response models.

* **Refactor**
  * Streamlined validation result retrieval and categorization logic for enhanced maintainability.

* **Tests**
  * Added unit tests to ensure correct filtering, grouping, and categorization of validation results.

* **Chores**
  * Simplified workflow configuration to always run build and test steps on pull requests to the "dev" branch.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->