### PR TITLE
LNK-4066: UAT Fixes – disable in-memory rule updating for edit rule modal

### DIFF
--- a/Web/Admin.UI/src/app/components/validation-config/validation-categories/edit-validation-category/edit-validation-category.component.ts
+++ b/Web/Admin.UI/src/app/components/validation-config/validation-categories/edit-validation-category/edit-validation-category.component.ts
@@ -165,7 +165,9 @@ export class EditValidationCategoryComponent implements OnInit {
       panelClass: ['vd-dialog', 'rule-add-edit-dialog'],
       data: {
         dialogTitle: 'Edit Rule',
-        rule: rule
+        // TODO:
+        // use the actual rule, not a clone of the rule, when implementing onSave functionality for edit rule modal
+        rule: structuredClone(rule)
       }
     });
   }


### PR DESCRIPTION
### 🛠️ Description of Changes

- Use structuredClone to send a deep copy of the rule to the edit rule modal so that updating fields in the modal doesn't change the rule in the table.
- Leave a TODO note to revert back to using the actual rule when implementing save capability.

### 🧪 Testing Performed
Please describe the testing that was performed on the changes included in this PR.

### 🧑‍🔬 Unit Testing
- [ ] I have written or updated unit tests to cover my changes

### 📓 Documentation Updated
Please update any relevant sections in the project documentation that were impacted by the changes in the PR.
