### PR TITLE
LNK-4074: Get Measure ID from Bundle instead of passed ID

### DIFF
--- a/Java/measureeval/src/main/java/com/lantanagroup/link/measureeval/controllers/MeasureDefinitionController.java
+++ b/Java/measureeval/src/main/java/com/lantanagroup/link/measureeval/controllers/MeasureDefinitionController.java
@@ -81,25 +81,24 @@ public class MeasureDefinitionController {
         return repository.findById(id).orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND));
     }
 
-    @PutMapping("/{id}")
+    @PutMapping
     @PreAuthorize("hasAuthority('IsLinkAdmin')")
     @Operation(summary = "Put (create or update) a measure definition", tags = {"Measure Definitions"})
-    public MeasureDefinition put(@AuthenticationPrincipal PrincipalUser user, @PathVariable String id, @RequestBody Bundle bundle) {
-        _logger.info("Put measure definition {}", StringEscapeUtils.escapeJava(id));
+    public MeasureDefinition put(@AuthenticationPrincipal PrincipalUser user, @RequestBody Bundle bundle) {
 
         if (user != null){
             Span currentSpan = Span.current();
             currentSpan.setAttribute("user", user.getEmailAddress());
         }
         bundleValidator.validate(bundle);
-        MeasureDefinition entity = repository.findById(id).orElseGet(() -> {
+        MeasureDefinition entity = repository.findById(bundle.getIdPart()).orElseGet(() -> {
             MeasureDefinition _entity = new MeasureDefinition();
-            _entity.setId(id);
+            _entity.setId(bundle.getIdPart());
             return _entity;
         });
         entity.setBundle(bundle);
         repository.save(entity);
-        evaluatorCache.remove(id);
+        evaluatorCache.remove(bundle.getIdPart());
         return entity;
     }
 

--- a/Java/measureeval/src/main/java/com/lantanagroup/link/measureeval/controllers/MeasureDefinitionController.java
+++ b/Java/measureeval/src/main/java/com/lantanagroup/link/measureeval/controllers/MeasureDefinitionController.java
@@ -90,15 +90,19 @@ public class MeasureDefinitionController {
             Span currentSpan = Span.current();
             currentSpan.setAttribute("user", user.getEmailAddress());
         }
+        String id = (bundle.getIdElement() != null) ? bundle.getIdElement().getIdPart() : null;
+        if (id == null || id.isBlank()) {
+           throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Bundle.id is required");
+        }
         bundleValidator.validate(bundle);
-        MeasureDefinition entity = repository.findById(bundle.getIdPart()).orElseGet(() -> {
+        MeasureDefinition entity = repository.findById(id).orElseGet(() -> {
             MeasureDefinition _entity = new MeasureDefinition();
-            _entity.setId(bundle.getIdPart());
+            _entity.setId(id);
             return _entity;
         });
         entity.setBundle(bundle);
         repository.save(entity);
-        evaluatorCache.remove(bundle.getIdPart());
+        evaluatorCache.remove(id);
         return entity;
     }
 

--- a/Java/measureeval/src/main/java/com/lantanagroup/link/measureeval/controllers/MeasureDefinitionController.java
+++ b/Java/measureeval/src/main/java/com/lantanagroup/link/measureeval/controllers/MeasureDefinitionController.java
@@ -84,11 +84,15 @@ public class MeasureDefinitionController {
     @PutMapping
     @PreAuthorize("hasAuthority('IsLinkAdmin')")
     @Operation(summary = "Put (create or update) a measure definition", tags = {"Measure Definitions"})
+    @JsonView(Views.Detail.class)
     public MeasureDefinition put(@AuthenticationPrincipal PrincipalUser user, @RequestBody Bundle bundle) {
 
         if (user != null){
             Span currentSpan = Span.current();
             currentSpan.setAttribute("user", user.getEmailAddress());
+        }
+        if (bundle == null) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Request body must be a FHIR Bundle");
         }
         String id = (bundle.getIdElement() != null) ? bundle.getIdElement().getIdPart() : null;
         if (id == null || id.isBlank()) {

--- a/Tests/BackendE2ETests/MeasureLoader.cs
+++ b/Tests/BackendE2ETests/MeasureLoader.cs
@@ -87,7 +87,7 @@ public class MeasureLoader(RestClient adminBffClient, ITestOutputHelper output)
         await this.GetMeasureBundleAsync();
         
         output.WriteLine("Loading measure bundle for evaluation...");
-        var request = new RestRequest($"measure-definition/{this.MeasureId}", Method.Put);
+        var request = new RestRequest($"measure-definition", Method.Put);
         request.AddJsonBody(this._evaluationBundle.ToJson());
         var response = adminBffClient.ExecuteAsync(request);
         

--- a/Tests/BackendE2ETests/MeasureLoader.cs
+++ b/Tests/BackendE2ETests/MeasureLoader.cs
@@ -67,6 +67,7 @@ public class MeasureLoader(RestClient adminBffClient, ITestOutputHelper output)
         this._evaluationBundle = new Bundle
         {
             Type = Bundle.BundleType.Transaction,
+            Id = originalBundle.Id,
             Entry = originalBundle.Entry
                 .Where(e => e.Resource != null && evaluationTypes.Contains(e.Resource.TypeName))
                 .ToList()

--- a/Web/Admin.UI/src/app/services/gateway/measure-definition/measure.service.ts
+++ b/Web/Admin.UI/src/app/services/gateway/measure-definition/measure.service.ts
@@ -14,7 +14,7 @@ export class MeasureDefinitionService {
   constructor(private http: HttpClient, private errorHandler: ErrorHandlingService, public appConfigService: AppConfigService) { }
 
   createMeasureDefinitionConfiguration(measureConfiguration: IMeasureDefinitionConfigModel): Observable<IEntityCreatedResponse> {
-    return this.http.post<IEntityCreatedResponse>(`${this.appConfigService.config?.baseApiUrl}/measure-definition/`, measureConfiguration)
+    return this.http.post<IEntityCreatedResponse>(`${this.appConfigService.config?.baseApiUrl}/measure-definition`, measureConfiguration.bundle)
       .pipe(
         tap(_ => console.log(`Request for configuration creation was sent.`)),
         map((response: IEntityCreatedResponse) => {
@@ -25,7 +25,7 @@ export class MeasureDefinitionService {
   }
 
   updateMeasureDefinitionConfiguration(measureConfiguration: IMeasureDefinitionConfigModel): Observable<IEntityCreatedResponse> {
-    return this.http.put<IEntityCreatedResponse>(`${this.appConfigService.config?.baseApiUrl}/measure-definition/${measureConfiguration.id}`, measureConfiguration.bundle)
+    return this.http.put<IEntityCreatedResponse>(`${this.appConfigService.config?.baseApiUrl}/measure-definition`, measureConfiguration.bundle)
       .pipe(
         tap(_ => console.log(`Request for configuration update was sent.`)),
         map((response: IEntityCreatedResponse) => {

--- a/Web/Admin.UI/src/app/services/gateway/measure-definition/measure.service.ts
+++ b/Web/Admin.UI/src/app/services/gateway/measure-definition/measure.service.ts
@@ -13,40 +13,10 @@ import { AppConfigService } from '../../app-config.service';
 export class MeasureDefinitionService {
   constructor(private http: HttpClient, private errorHandler: ErrorHandlingService, public appConfigService: AppConfigService) { }
 
-  createMeasureDefinitionConfiguration(measureConfiguration: IMeasureDefinitionConfigModel): Observable<IEntityCreatedResponse> {
-    return this.http.post<IEntityCreatedResponse>(`${this.appConfigService.config?.baseApiUrl}/measure-definition`, measureConfiguration.bundle)
-      .pipe(
-        tap(_ => console.log(`Request for configuration creation was sent.`)),
-        map((response: IEntityCreatedResponse) => {
-          return response;
-        }),
-        catchError((error) => this.errorHandler.handleError(error))
-      )
-  }
-
   updateMeasureDefinitionConfiguration(measureConfiguration: IMeasureDefinitionConfigModel): Observable<IEntityCreatedResponse> {
-    return this.http.put<IEntityCreatedResponse>(`${this.appConfigService.config?.baseApiUrl}/measure-definition`, measureConfiguration.bundle)
+    return this.http.put<IEntityCreatedResponse>(`${this.appConfigService.config?.baseApiUrl}/measure-definition`, measureConfiguration.bundle, { headers: { 'Content-Type': 'application/fhir+json' } })
       .pipe(
         tap(_ => console.log(`Request for configuration update was sent.`)),
-        map((response: IEntityCreatedResponse) => {
-          return response;
-        }),
-        catchError((error) => this.errorHandler.handleError(error))
-      )
-  }
-
-  getMeasureDefinitionConfiguration(bundleId: string): Observable<IMeasureDefinitionConfigModel> {
-    return this.http.get<IMeasureDefinitionConfigModel>(`${this.appConfigService.config?.baseApiUrl}/measure-definition/${bundleId}`)
-      .pipe(
-        tap(_ => console.log(`Fetched configuration.`)),
-        catchError((error) => this.errorHandler.handleError(error))
-      )
-  }
-
-  deleteMeasureDefinitionConfiguration(bundleId: string): Observable<IEntityDeletedResponse> {
-    return this.http.delete<IEntityDeletedResponse>(`${this.appConfigService.config?.baseApiUrl}/measure-definition/${bundleId}`)
-      .pipe(
-        tap(_ => console.log(`Request for configuration deletion was sent.`)),
         catchError((error) => this.errorHandler.handleError(error))
       )
   }

--- a/docs/domains/Report/services/MeasureEvalService/index.mdx
+++ b/docs/domains/Report/services/MeasureEvalService/index.mdx
@@ -107,7 +107,7 @@ This approach ensures consistent, reliable evaluation of healthcare quality meas
 The measure engine may be tested against arbitrary data using the $evaluate operation (which is custom-built for this purpose in the measure evaluation service) or using the `measureeval-cli.jar` that can be built separately from the service; see <a href="https://github.com/lantanagroup/link-cloud/blob/dev/Java/measureeval/README.md" target="new">measureeval/README.md</a> for more information.
 
 ### Upload & Storage
-- Bundles are uploaded via: `PUT /api/measureDefinition/:id`
+- Bundles are uploaded via: `PUT /api/measureDefinition`
 - The uploaded bundle is a FHIR JSON Bundle and typically includes: `Measure`, `Library`, `StructureDefinition` (Profile), `ValueSet`, `CodeSystem`
 - Bundles are stored **as-is** in the measureeval service's database.
 

--- a/docs/domains/Report/services/MeasureEvalService/openapi.yml
+++ b/docs/domains/Report/services/MeasureEvalService/openapi.yml
@@ -24,12 +24,7 @@ paths:
       - Measure Definitions
       summary: Put (create or update) a measure definition
       operationId: put
-      parameters:
-      - name: id
-        in: path
-        required: true
-        schema:
-          type: string
+      description: Creates or updates a measure definition. The measure ID is derived from the Bundle.id field in the request body rather than being specified as a path parameter.
       requestBody:
         content:
           application/json: {}


### PR DESCRIPTION
/### 🛠️ Description of Changes
Get Measure ID from Bundle ID instead of passed ID.
This is a breaking change of the existing API (interface change)

### 🧪 Testing Performed
Tested locally

### 🧑‍🔬 Unit Testing
- [ ] I have written or updated unit tests to cover my changes

### 📓 Documentation Updated
Please update any relevant sections in the project documentation that were impacted by the changes in the PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Create/update of measure definitions now derives the measure ID from the uploaded Bundle.id in the request body (PUT /measure-definition).

* **Bug Fixes**
  * Requests missing a Bundle or a Bundle.id now return 400 Bad Request to enforce valid input.

* **Chores**
  * Frontend and tests updated to use the unified measure-definition endpoint; legacy UI endpoints removed.

* **Documentation**
  * API docs updated to reflect the new PUT /measure-definition behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->