### PR TITLE
LNK-4164: Missing-x-correlation-id in the header to ReadyToAcquire topic

### DIFF
--- a/DotNet/DataAcquisition/Jobs/AcquisitionProcessingJob.cs
+++ b/DotNet/DataAcquisition/Jobs/AcquisitionProcessingJob.cs
@@ -92,6 +92,11 @@ public class AcquisitionProcessingJob : IJob
                     {
                         _logger.LogInformation("Producing ReadyToAcquire message for log id: {logId} and facility id: {facilityId}", request.Id, request.FacilityId);
 
+                        var headers = new Headers
+                        {
+                            { "X-Correlation-Id", Encoding.UTF8.GetBytes(request.CorrelationId?.ToString() ?? string.Empty) }
+                        };
+
                         await _readyToAcquireProducer.ProduceAsync(
                                         KafkaTopic.ReadyToAcquire.ToString(),
                                         new Message<string, ReadyToAcquire>
@@ -100,8 +105,9 @@ public class AcquisitionProcessingJob : IJob
                                             Value = new ReadyToAcquire
                                             {
                                                 LogId = request.Id,
-                                                FacilityId = request.FacilityId
-                                            }
+                                                FacilityId = request.FacilityId                                  
+                                            },
+                                            Headers = headers
                                         });
                         _readyToAcquireProducer.Flush();
 


### PR DESCRIPTION
### 🛠️ Description of Changes
Added x-correlation-id  

### 🧪 Testing Performed
Please describe the testing that was performed on the changes included in this PR.

### 🧑‍🔬 Unit Testing
- [ ] I have written or updated unit tests to cover my changes

### 📓 Documentation Updated
Please update any relevant sections in the project documentation that were impacted by the changes in the PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added correlation ID propagation to acquisition readiness messages, enabling end-to-end traceability across systems and improving observability.
  - Enhances support and debugging by allowing requests to be tracked consistently without altering message content or delivery behavior.
  - No changes to user workflows or data payloads; existing identifiers and fields remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->