### PR TITLE
LNK-4152: No manifest file / duplication of data?

### DIFF
--- a/DotNet/Report/Core/PatientReportSubmissionBundler.cs
+++ b/DotNet/Report/Core/PatientReportSubmissionBundler.cs
@@ -203,9 +203,9 @@ namespace LantanaGroup.Link.Report.Core
         /// <returns></returns>
         protected Bundle.EntryComponent AddResourceToBundle(Bundle bundle, Resource resource)
         {
-            var entry = bundle.AddResourceEntry(resource, GetFullUrl(resource));
-
-            return entry;
+            var fullUrl = GetFullUrl(resource);
+            var existingEntry = bundle.FindEntry(fullUrl).FirstOrDefault();
+            return existingEntry ?? bundle.AddResourceEntry(resource, fullUrl);
         }
 
         #endregion

--- a/DotNet/Report/Jobs/EndOfReportPeriodJob.cs
+++ b/DotNet/Report/Jobs/EndOfReportPeriodJob.cs
@@ -59,7 +59,8 @@ namespace LantanaGroup.Link.Report.Jobs
                 var allReady = !await _database.SubmissionEntryRepository.AnyAsync(e => e.FacilityId == schedule.FacilityId
                                                                                             && e.ReportScheduleId == schedule.Id
                                                                                             && e.Status != PatientSubmissionStatus.NotReportable
-                                                                                            && e.Status != PatientSubmissionStatus.ValidationComplete, CancellationToken.None);
+                                                                                            && e.Status != PatientSubmissionStatus.ValidationComplete
+                                                                                            && e.Status != PatientSubmissionStatus.Submitted, CancellationToken.None);
                 if (allReady)
                 {
                     try

--- a/DotNet/Report/Jobs/EndOfReportPeriodJob.cs
+++ b/DotNet/Report/Jobs/EndOfReportPeriodJob.cs
@@ -1,6 +1,7 @@
 ﻿using Confluent.Kafka;
 using LantanaGroup.Link.Report.Domain;
 using LantanaGroup.Link.Report.Domain.Enums;
+using LantanaGroup.Link.Report.Domain.Managers;
 using LantanaGroup.Link.Report.Entities;
 using LantanaGroup.Link.Report.KafkaProducers;
 using LantanaGroup.Link.Report.Services;
@@ -8,6 +9,7 @@ using LantanaGroup.Link.Report.Settings;
 using LantanaGroup.Link.Shared.Application.Enums;
 using LantanaGroup.Link.Shared.Application.Models.Kafka;
 using Quartz;
+using System.Threading;
 using static LantanaGroup.Link.Report.KafkaProducers.ReadyForValidationProducer;
 using Task = System.Threading.Tasks.Task;
 
@@ -56,23 +58,9 @@ namespace LantanaGroup.Link.Report.Jobs
 
                 _logger.LogInformation($"Executing EndOfReportPeriodJob for MeasureReportScheduleModel {schedule.Id}");
 
-                var allReady = !await _database.SubmissionEntryRepository.AnyAsync(e => e.FacilityId == schedule.FacilityId
-                                                                                            && e.ReportScheduleId == schedule.Id
-                                                                                            && e.Status != PatientSubmissionStatus.NotReportable
-                                                                                            && e.Status != PatientSubmissionStatus.ValidationComplete
-                                                                                            && e.Status != PatientSubmissionStatus.Submitted, CancellationToken.None);
-                if (allReady)
-                {
-                    try
-                    {
-                        await _reportManifestProducer.Produce(schedule);
-                    }
-                    catch (ProduceException<SubmitPayloadKey, SubmitPayloadValue> ex)
-                    {
-                        _logger.LogError(ex, "An error was encountered generating an End of Report Period Report Manifest Submit Payload event.\n\tFacilityId: {facilityId}\n\t", schedule.FacilityId);
-                    }
-                }
-                else
+                var manifestProduced = await _reportManifestProducer.Produce(schedule);
+
+                if(!manifestProduced)
                 {
                     var patientsToEvaluate = await _database.SubmissionEntryRepository.AnyAsync(x => x.ReportScheduleId == schedule.Id && x.Status == PatientSubmissionStatus.PendingEvaluation, CancellationToken.None);
 

--- a/DotNet/Report/Listeners/ResourceEvaluatedListener.cs
+++ b/DotNet/Report/Listeners/ResourceEvaluatedListener.cs
@@ -331,7 +331,8 @@ namespace LantanaGroup.Link.Report.Listeners
                 var allReady = !await submissionEntryManager.AnyAsync(e => e.FacilityId == schedule.FacilityId
                                         && e.ReportScheduleId == schedule.Id
                                         && e.Status != PatientSubmissionStatus.NotReportable
-                                        && e.Status != PatientSubmissionStatus.ValidationComplete, cancellationToken);
+                                        && e.Status != PatientSubmissionStatus.ValidationComplete
+                                        && e.Status != PatientSubmissionStatus.Submitted, cancellationToken);
 
                 if (allReady)
                 {

--- a/DotNet/Report/Listeners/ResourceEvaluatedListener.cs
+++ b/DotNet/Report/Listeners/ResourceEvaluatedListener.cs
@@ -328,23 +328,7 @@ namespace LantanaGroup.Link.Report.Listeners
             }
             else
             {
-                var allReady = !await submissionEntryManager.AnyAsync(e => e.FacilityId == schedule.FacilityId
-                                        && e.ReportScheduleId == schedule.Id
-                                        && e.Status != PatientSubmissionStatus.NotReportable
-                                        && e.Status != PatientSubmissionStatus.ValidationComplete
-                                        && e.Status != PatientSubmissionStatus.Submitted, cancellationToken);
-
-                if (allReady)
-                {
-                    try
-                    {
-                        await _reportManifestProducer.Produce(schedule);
-                    }
-                    catch (ProduceException<SubmitPayloadKey, SubmitPayloadValue> ex)
-                    {
-                        _logger.LogError(ex, "An error was encountered generating a Report Manifest Submit Payload event.\n\tFacilityId: {facilityId}\n\t", schedule.FacilityId);
-                    }
-                }
+                await _reportManifestProducer.Produce(schedule);
             }
         }
 

--- a/DotNet/Report/Listeners/ValidationCompleteListener.cs
+++ b/DotNet/Report/Listeners/ValidationCompleteListener.cs
@@ -223,23 +223,8 @@ namespace LantanaGroup.Link.Report.Listeners
                 throw new TransientException($"An error was encountered generating a Submit Payload event.\n\tFacilityId: {facilityId}\n\t", ex);
             }
 
-            var allReady = !await submissionEntryManager.AnyAsync(e => e.FacilityId == schedule.FacilityId
-                && e.ReportScheduleId == schedule.Id
-                && e.Status != PatientSubmissionStatus.NotReportable
-                && e.Status != PatientSubmissionStatus.ValidationComplete
-                && e.Status != PatientSubmissionStatus.Submitted, cancellationToken);
 
-            if (allReady)
-            {
-                try
-                {
-                    await _reportManifestProducer.Produce(schedule);
-                }
-                catch (ProduceException<SubmitPayloadKey, SubmitPayloadValue> ex)
-                {
-                    _logger.LogError(ex, "An error was encountered generating a Report Manifest Submit Payload event.\n\tFacilityId: {facilityId}\n\t", schedule.FacilityId);
-                }
-            }
+            await _reportManifestProducer.Produce(schedule);
         }
 
         private static string GetFacilityIdFromHeader(Headers headers)

--- a/DotNet/Report/Listeners/ValidationCompleteListener.cs
+++ b/DotNet/Report/Listeners/ValidationCompleteListener.cs
@@ -226,7 +226,8 @@ namespace LantanaGroup.Link.Report.Listeners
             var allReady = !await submissionEntryManager.AnyAsync(e => e.FacilityId == schedule.FacilityId
                 && e.ReportScheduleId == schedule.Id
                 && e.Status != PatientSubmissionStatus.NotReportable
-                && e.Status != PatientSubmissionStatus.ValidationComplete, cancellationToken);
+                && e.Status != PatientSubmissionStatus.ValidationComplete
+                && e.Status != PatientSubmissionStatus.Submitted, cancellationToken);
 
             if (allReady)
             {


### PR DESCRIPTION
### 🛠️ Description of Changes
  - Deduplicates resources in multi-measure submissions.
  - Allows `Submitted` status to trigger manifest.

### 🧪 Testing Performed
Ran a local ACHM/hypo report.  Verified resource deduplication and manifest generation.

### 🧑‍🔬 Unit Testing
To be addressed in enhanced smoke test?

### 📓 Documentation Updated
N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Bug Fixes
  * Prevents duplicate resources in bundled report submissions, reducing inconsistencies in generated reports.
* New Features
  * Automatically triggers data acquisition and validation notifications when a report manifest isn’t produced, keeping workflows moving without manual intervention.
* Refactor
  * Streamlined manifest generation flow with centralized readiness checks, improving reliability and predictability across listeners and end-of-period processing.
  * Unified post-processing of schedules at the end of report periods for more consistent job completion behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->