### PR TITLE
LNK-4167: Data acquisition new trace id s are being generated post acquisition

### DIFF
--- a/DotNet/DataAcquisition.Domain/Application/Services/PatientDataService.cs
+++ b/DotNet/DataAcquisition.Domain/Application/Services/PatientDataService.cs
@@ -232,6 +232,7 @@ public class PatientDataService : IPatientDataService
                                 QueryPhase = QueryPhaseUtilities.ToDomain(request.ConsumeResult.Message.Value.QueryType),
                                 ScheduledReport = schedReport,
                                 TimeZone = fhirQueryConfiguration.TimeZone ?? "UTC",
+                                TraceId = Activity.Current?.ParentId,
                                 FhirQuery = new List<FhirQuery>
                                 {
                                         new FhirQuery
@@ -319,18 +320,22 @@ public class PatientDataService : IPatientDataService
                     throw new ArgumentException($"Facility ID {request.facilityId} does not match log's facility ID {log.FacilityId}.");
                 }
 
+                Activity activity = new Activity(log.Id);
+
                 //set trace parent id based on log trace id
                 if (!string.IsNullOrWhiteSpace(log.TraceId))
                 {
                     try
                     {
-                        Activity.Current?.SetParentId(log.TraceId);
+                        activity.SetParentId(log.TraceId);
                     }
                     catch (Exception ex)
                     {
                         _logger.LogError(ex, "Error setting Activity.Current for log ID {logId} with TraceId {traceId}", log.Id, log.TraceId);
                     }
                 }
+
+                activity.Start();
 
                 //check if log is flagged as a reference, if yes, check if all non-reference logs for a facility, correlationId, and reportTrackingId are marked as 'Completed'
                 if (log.FhirQuery.Any(x => x.isReference.HasValue && x.isReference.Value))
@@ -417,90 +422,99 @@ public class PatientDataService : IPatientDataService
 
                 List<string> resourceIds = new List<string>();
 
-                //4. call api
-                foreach (var fhirQuery in log.FhirQuery.ToList())
+                try
                 {
-                    foreach (var resourceType in fhirQuery.ResourceTypes)
+                    //4. call api
+                    foreach (var fhirQuery in log.FhirQuery.ToList())
                     {
-
-                        if (fhirQuery.QueryType == FhirQueryType.Read)
-                        {
-                            try
-                            {
-                                resourceIds = await _fhirApiService.ExecuteRead(log, fhirQuery, resourceType, fhirQueryConfiguration, resourceIds, cancellationToken);
-                            }
-                            catch (ProduceException<string, ResourceAcquired> ex)
-                            {
-                                log.Status = RequestStatus.Failed;
-                                log.Notes.Add($"[{DateTime.UtcNow}] Error producing ResourceAcquired message for facility: {log.FacilityId}\n{ex.Message}\n{ex.InnerException}");
-                                await _dataAcquisitionLogManager.UpdateAsync(log, cancellationToken);
-                                throw;
-                            }
-                            catch (TimeoutException tEx)
-                            {
-                                _logger.LogError(tEx, "Timeout while retrieving data from EHR for facility: {facilityId}", log.FacilityId);
-
-                                log.Status = RequestStatus.Failed;
-                                log.Notes.Add($"[{DateTime.UtcNow}] Timeout while retrieving data from EHR for facility: {log.FacilityId}\n. Please check logs for more details.");
-                                await _dataAcquisitionLogManager.UpdateAsync(log, cancellationToken);
-                                throw new DeadLetterException($"Timeout while retrieving data from EHR for facility: {log.FacilityId}", tEx);
-                            }
-                            catch (Exception ex)
-                            {
-                                _logger.LogError(ex, "Error retrieving data from EHR for facility: {facilityId}", log.FacilityId);
-
-                                log.Status = RequestStatus.Failed;
-                                log.Notes.Add($"[{DateTime.UtcNow}] Error retrieving data from EHR for facility: {log.FacilityId}\n{ex.Message}\n{ex.InnerException}");
-                                await _dataAcquisitionLogManager.UpdateAsync(log, cancellationToken);
-                                throw;
-                            }
-                        }
-                        else if (fhirQuery.QueryType == FhirQueryType.Search)
+                        foreach (var resourceType in fhirQuery.ResourceTypes)
                         {
 
-                            try
+                            if (fhirQuery.QueryType == FhirQueryType.Read)
                             {
-                                resourceIds = await _fhirApiService.ExecuteSearch(log, fhirQuery, fhirQueryConfiguration, resourceIds, resourceType, cancellationToken);
-                            }
-                            catch (ProduceException<string, ResourceAcquired> ex)
-                            {
-                                log.Status = RequestStatus.Failed;
-                                log.Notes.Add($"[{DateTime.UtcNow}] Error producing ResourceAcquired message for facility: {log.FacilityId}\n{ex.Message}\n{ex.InnerException}");
-                                await _dataAcquisitionLogManager.UpdateAsync(log, cancellationToken);
-                                throw;
-                            }
-                            catch (TimeoutException tEx)
-                            {
-                                _logger.LogError(tEx, "Timeout while retrieving data from EHR for facility: {facilityId}", log.FacilityId);
+                                try
+                                {
+                                    resourceIds = await _fhirApiService.ExecuteRead(log, fhirQuery, resourceType, fhirQueryConfiguration, resourceIds, cancellationToken);
+                                }
+                                catch (ProduceException<string, ResourceAcquired> ex)
+                                {
+                                    log.Status = RequestStatus.Failed;
+                                    log.Notes.Add($"[{DateTime.UtcNow}] Error producing ResourceAcquired message for facility: {log.FacilityId}\n{ex.Message}\n{ex.InnerException}");
+                                    await _dataAcquisitionLogManager.UpdateAsync(log, cancellationToken);
+                                    throw;
+                                }
+                                catch (TimeoutException tEx)
+                                {
+                                    _logger.LogError(tEx, "Timeout while retrieving data from EHR for facility: {facilityId}", log.FacilityId);
 
-                                log.Status = RequestStatus.Failed;
-                                log.Notes.Add($"[{DateTime.UtcNow}] Timeout while retrieving data from EHR for facility: {log.FacilityId}\n. Please check logs for more details.");
-                                await _dataAcquisitionLogManager.UpdateAsync(log, cancellationToken);
-                                throw new DeadLetterException($"Timeout while retrieving data from EHR for facility: {log.FacilityId}", tEx);
-                            }
-                            catch (Exception ex)
-                            {
-                                _logger.LogError(ex, "Error retrieving data from EHR for facility: {facilityId}", log.FacilityId);
+                                    log.Status = RequestStatus.Failed;
+                                    log.Notes.Add($"[{DateTime.UtcNow}] Timeout while retrieving data from EHR for facility: {log.FacilityId}\n. Please check logs for more details.");
+                                    await _dataAcquisitionLogManager.UpdateAsync(log, cancellationToken);
+                                    throw new DeadLetterException($"Timeout while retrieving data from EHR for facility: {log.FacilityId}", tEx);
+                                }
+                                catch (Exception ex)
+                                {
+                                    _logger.LogError(ex, "Error retrieving data from EHR for facility: {facilityId}", log.FacilityId);
 
-                                log.Status = RequestStatus.Failed;
-                                log.Notes.Add($"[{DateTime.UtcNow}] Error retrieving data from EHR for facility: {log.FacilityId}\n{ex.Message}\n{ex.InnerException}");
-                                await _dataAcquisitionLogManager.UpdateAsync(log, cancellationToken);
-                                throw;
+                                    log.Status = RequestStatus.Failed;
+                                    log.Notes.Add($"[{DateTime.UtcNow}] Error retrieving data from EHR for facility: {log.FacilityId}\n{ex.Message}\n{ex.InnerException}");
+                                    await _dataAcquisitionLogManager.UpdateAsync(log, cancellationToken);
+                                    throw;
+                                }
                             }
+                            else if (fhirQuery.QueryType == FhirQueryType.Search)
+                            {
+
+                                try
+                                {
+                                    resourceIds = await _fhirApiService.ExecuteSearch(log, fhirQuery, fhirQueryConfiguration, resourceIds, resourceType, cancellationToken);
+                                }
+                                catch (ProduceException<string, ResourceAcquired> ex)
+                                {
+                                    log.Status = RequestStatus.Failed;
+                                    log.Notes.Add($"[{DateTime.UtcNow}] Error producing ResourceAcquired message for facility: {log.FacilityId}\n{ex.Message}\n{ex.InnerException}");
+                                    await _dataAcquisitionLogManager.UpdateAsync(log, cancellationToken);
+                                    throw;
+                                }
+                                catch (TimeoutException tEx)
+                                {
+                                    _logger.LogError(tEx, "Timeout while retrieving data from EHR for facility: {facilityId}", log.FacilityId);
+
+                                    log.Status = RequestStatus.Failed;
+                                    log.Notes.Add($"[{DateTime.UtcNow}] Timeout while retrieving data from EHR for facility: {log.FacilityId}\n. Please check logs for more details.");
+                                    await _dataAcquisitionLogManager.UpdateAsync(log, cancellationToken);
+                                    throw new DeadLetterException($"Timeout while retrieving data from EHR for facility: {log.FacilityId}", tEx);
+                                }
+                                catch (Exception ex)
+                                {
+                                    _logger.LogError(ex, "Error retrieving data from EHR for facility: {facilityId}", log.FacilityId);
+
+                                    log.Status = RequestStatus.Failed;
+                                    log.Notes.Add($"[{DateTime.UtcNow}] Error retrieving data from EHR for facility: {log.FacilityId}\n{ex.Message}\n{ex.InnerException}");
+                                    await _dataAcquisitionLogManager.UpdateAsync(log, cancellationToken);
+                                    throw;
+                                }
+                            }
+                            else if (fhirQuery.QueryType == FhirQueryType.BulkDataRequest) { throw new NotSupportedException("Bulk Data is currently not supported."); }
+                            else if (fhirQuery.QueryType == FhirQueryType.BulkDataPoll) { throw new NotSupportedException("Bulk Data is currently not supported."); }
+
                         }
-                        else if (fhirQuery.QueryType == FhirQueryType.BulkDataRequest) { throw new NotSupportedException("Bulk Data is currently not supported."); }
-                        else if (fhirQuery.QueryType == FhirQueryType.BulkDataPoll) { throw new NotSupportedException("Bulk Data is currently not supported."); }
                     }
+
+                    //5. stop timer and update log
+                    stopwatch.Stop();
+
+                    log.CompletionTimeMilliseconds = stopwatch.ElapsedMilliseconds;
+                    log.CompletionDate = System.DateTime.UtcNow;
+                    log.Status = RequestStatus.Completed;
+                    log.ResourceAcquiredIds = resourceIds;
+                    await _dataAcquisitionLogManager.UpdateAsync(log, cancellationToken);
                 }
-
-                //5. stop timer and update log
-                stopwatch.Stop();
-
-                log.CompletionTimeMilliseconds = stopwatch.ElapsedMilliseconds;
-                log.CompletionDate = System.DateTime.UtcNow;
-                log.Status = RequestStatus.Completed;
-                log.ResourceAcquiredIds = resourceIds;
-                await _dataAcquisitionLogManager.UpdateAsync(log, cancellationToken);
+                finally
+                {
+                    //6. stop activity
+                    activity.Stop();
+                }
             }
         }
         catch (TimeoutException tEx)

--- a/DotNet/DataAcquisition.Domain/Application/Services/PatientDataService.cs
+++ b/DotNet/DataAcquisition.Domain/Application/Services/PatientDataService.cs
@@ -319,6 +319,19 @@ public class PatientDataService : IPatientDataService
                     throw new ArgumentException($"Facility ID {request.facilityId} does not match log's facility ID {log.FacilityId}.");
                 }
 
+                //set trace parent id based on log trace id
+                if (!string.IsNullOrWhiteSpace(log.TraceId))
+                {
+                    try
+                    {
+                        Activity.Current?.SetParentId(log.TraceId);
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.LogError(ex, "Error setting Activity.Current for log ID {logId} with TraceId {traceId}", log.Id, log.TraceId);
+                    }
+                }
+
                 //check if log is flagged as a reference, if yes, check if all non-reference logs for a facility, correlationId, and reportTrackingId are marked as 'Completed'
                 if (log.FhirQuery.Any(x => x.isReference.HasValue && x.isReference.Value))
                 {

--- a/DotNet/DataAcquisition.Domain/Application/Services/PatientDataService.cs
+++ b/DotNet/DataAcquisition.Domain/Application/Services/PatientDataService.cs
@@ -320,7 +320,7 @@ public class PatientDataService : IPatientDataService
                     throw new ArgumentException($"Facility ID {request.facilityId} does not match log's facility ID {log.FacilityId}.");
                 }
 
-                Activity activity = new Activity(log.Id);
+                Activity activity = new Activity("PatientDataService.ExecuteLogRequest");
 
                 //set trace parent id based on log trace id
                 if (!string.IsNullOrWhiteSpace(log.TraceId))
@@ -332,8 +332,18 @@ public class PatientDataService : IPatientDataService
                     catch (Exception ex)
                     {
                         _logger.LogError(ex, "Error setting Activity.Current for log ID {logId} with TraceId {traceId}", log.Id, log.TraceId);
+                        if (!string.IsNullOrWhiteSpace(Activity.Current?.Id))
+                        {
+                            activity.SetParentId(Activity.Current.Id);
+                        }
                     }
                 }
+
+                // helpful attributes for correlation
+                activity.AddTag("link.log_id", log.Id.ToString());
+                activity.AddTag("link.facility_id", log.FacilityId);
+                activity.AddTag("link.correlation_id", log.CorrelationId ?? string.Empty);
+                activity.AddTag("link.report_tracking_id", log.ReportTrackingId ?? string.Empty);
 
                 activity.Start();
 

--- a/DotNet/DataAcquisition.Domain/Application/Services/QueryListProcessor.cs
+++ b/DotNet/DataAcquisition.Domain/Application/Services/QueryListProcessor.cs
@@ -16,6 +16,7 @@ using LantanaGroup.Link.DataAcquisition.Domain.Infrastructure.Models.QueryConfig
 using LantanaGroup.Link.Shared.Application.Models;
 using LantanaGroup.Link.Shared.Application.Utilities;
 using Microsoft.Extensions.Logging;
+using System.Diagnostics;
 using RequestStatus = LantanaGroup.Link.DataAcquisition.Domain.Infrastructure.Models.Enums.RequestStatus;
 using ResourceType = Hl7.Fhir.Model.ResourceType;
 using Task = System.Threading.Tasks.Task;
@@ -207,6 +208,7 @@ public class QueryListProcessor : IQueryListProcessor
                 {
 
                 },
+                TraceId = Activity.Current?.Id
             };
 
             var fhirQuery = new FhirQuery

--- a/DotNet/DataAcquisition.Domain/Application/Services/QueryListProcessor.cs
+++ b/DotNet/DataAcquisition.Domain/Application/Services/QueryListProcessor.cs
@@ -208,7 +208,7 @@ public class QueryListProcessor : IQueryListProcessor
                 {
 
                 },
-                TraceId = Activity.Current?.Id
+                TraceId = Activity.Current?.ParentId
             };
 
             var fhirQuery = new FhirQuery

--- a/DotNet/DataAcquisition.Domain/Application/Services/ReferenceResourceService.cs
+++ b/DotNet/DataAcquisition.Domain/Application/Services/ReferenceResourceService.cs
@@ -15,6 +15,7 @@ using RequestStatus = LantanaGroup.Link.DataAcquisition.Domain.Infrastructure.Mo
 using LantanaGroup.Link.DataAcquisition.Domain.Infrastructure.Models.Enums;
 using ResourceType = Hl7.Fhir.Model.ResourceType;
 using LantanaGroup.Link.DataAcquisition.Domain.Application.Queries;
+using System.Diagnostics;
 
 
 namespace LantanaGroup.Link.DataAcquisition.Domain.Application.Services;
@@ -256,7 +257,8 @@ public class ReferenceResourceService : IReferenceResourceService
             TimeZone = log.TimeZone,
             ScheduledReport = log.ScheduledReport,
             ExecutionDate = DateTime.UtcNow,
-            FhirQuery = fhirQueries
+            FhirQuery = fhirQueries,
+            TraceId = log.TraceId
         };
     }
 

--- a/DotNet/DataAcquisition.Domain/Infrastructure/Entities/DataAcquisitionLog.cs
+++ b/DotNet/DataAcquisition.Domain/Infrastructure/Entities/DataAcquisitionLog.cs
@@ -1,6 +1,7 @@
-﻿using LantanaGroup.Link.DataAcquisition.Domain.Infrastructure.Models.Enums;
-using LantanaGroup.Link.DataAcquisition.Domain.Application.Models;
+﻿using LantanaGroup.Link.DataAcquisition.Domain.Application.Models;
+using LantanaGroup.Link.DataAcquisition.Domain.Infrastructure.Models.Enums;
 using LantanaGroup.Link.Shared.Domain.Entities;
+using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
 
 namespace LantanaGroup.Link.DataAcquisition.Domain.Infrastructure.Entities;
@@ -33,6 +34,7 @@ public class DataAcquisitionLog : BaseEntityExtended
     public LantanaGroup.Link.Shared.Application.Models.ScheduledReport? ScheduledReport { get; set; }
     public bool TailSent { get; set; }
     public bool IsCensus { get; set; }
+    [MaxLength(64)]
     public string? TraceId { get; set; }
 
     public static bool ValidateForQuerySummaryLog(DataAcquisitionLog log)

--- a/DotNet/DataAcquisition.Domain/Infrastructure/Entities/DataAcquisitionLog.cs
+++ b/DotNet/DataAcquisition.Domain/Infrastructure/Entities/DataAcquisitionLog.cs
@@ -33,6 +33,7 @@ public class DataAcquisitionLog : BaseEntityExtended
     public LantanaGroup.Link.Shared.Application.Models.ScheduledReport? ScheduledReport { get; set; }
     public bool TailSent { get; set; }
     public bool IsCensus { get; set; }
+    public string? TraceId { get; set; }
 
     public static bool ValidateForQuerySummaryLog(DataAcquisitionLog log)
     {

--- a/DotNet/DataAcquisition.Domain/Migrations/20250815154126_data_acq_log_add_trace_field.Designer.cs
+++ b/DotNet/DataAcquisition.Domain/Migrations/20250815154126_data_acq_log_add_trace_field.Designer.cs
@@ -4,6 +4,7 @@ using LantanaGroup.Link.DataAcquisition.Domain.Infrastructure.Context;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace DataAcquisition.Domain.Migrations
 {
     [DbContext(typeof(DataAcquisitionDbContext))]
-    partial class DataAcquisitionDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250815154126_data_acq_log_add_trace_field")]
+    partial class data_acq_log_add_trace_field
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/DotNet/DataAcquisition.Domain/Migrations/20250815154126_data_acq_log_add_trace_field.cs
+++ b/DotNet/DataAcquisition.Domain/Migrations/20250815154126_data_acq_log_add_trace_field.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace DataAcquisition.Domain.Migrations
+{
+    /// <inheritdoc />
+    public partial class data_acq_log_add_trace_field : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "TraceId",
+                table: "DataAcquisitionLog",
+                type: "nvarchar(max)",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "TraceId",
+                table: "DataAcquisitionLog");
+        }
+    }
+}

--- a/DotNet/DataAcquisition.Domain/Migrations/20250819151358_data_acq_log_add_max_length_traceid.Designer.cs
+++ b/DotNet/DataAcquisition.Domain/Migrations/20250819151358_data_acq_log_add_max_length_traceid.Designer.cs
@@ -4,6 +4,7 @@ using LantanaGroup.Link.DataAcquisition.Domain.Infrastructure.Context;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace DataAcquisition.Domain.Migrations
 {
     [DbContext(typeof(DataAcquisitionDbContext))]
-    partial class DataAcquisitionDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250819151358_data_acq_log_add_max_length_traceid")]
+    partial class data_acq_log_add_max_length_traceid
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/DotNet/DataAcquisition.Domain/Migrations/20250819151358_data_acq_log_add_max_length_traceid.cs
+++ b/DotNet/DataAcquisition.Domain/Migrations/20250819151358_data_acq_log_add_max_length_traceid.cs
@@ -1,0 +1,38 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace DataAcquisition.Domain.Migrations
+{
+    /// <inheritdoc />
+    public partial class data_acq_log_add_max_length_traceid : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "TraceId",
+                table: "DataAcquisitionLog",
+                type: "nvarchar(64)",
+                maxLength: 64,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(max)",
+                oldNullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "TraceId",
+                table: "DataAcquisitionLog",
+                type: "nvarchar(max)",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(64)",
+                oldMaxLength: 64,
+                oldNullable: true);
+        }
+    }
+}


### PR DESCRIPTION
### 🛠️ Description of Changes
•	Refactored trace context propagation in PatientDataService.ExecuteLogRequest to ensure the traceparent header is correctly set for downstream telemetry and logging.
•	Replaced usage of Activity.Current?.SetParentId(log.TraceId) with explicit creation and starting of a new Activity using the log's TraceId as the parent, ensuring proper trace linkage.
•	Improved error handling and logging around activity creation and trace context assignment.

### 🧪 Testing Performed
•	Manually verified that the traceparent header in outgoing messages and logs matches the expected value from the database log entry.
•	Ran integration tests to confirm that trace context is correctly propagated through the data acquisition workflow.
•	Validated error scenarios to ensure trace context is still set and logged appropriately.

### 🧑‍🔬 Unit Testing
•	[x] I have written or updated unit tests to cover my changes
•	Added/updated unit tests for trace context propagation in PatientDataService.
•	Verified error handling and logging for activity creation and traceparent assignment.

### 📓 Documentation Updated
•	Added comments in code to clarify the correct usage of Activity and traceparent assignment.
•	No changes required for public API documentation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added trace IDs to data acquisition logs and per-log tracing activities with correlation tags for end-to-end request correlation.

- **Bug Fixes / Improvements**
  - Improved error handling for read and search flows with clearer status updates, detailed notes, and guaranteed tracing cleanup.
  - More reliable timing and completion recording for logs.

- **Chores**
  - Database schema updated to add TraceId and propagate trace context across processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->