### PR TITLE
LNK-4153: made correlation id same across multiple services

### DIFF
--- a/DotNet/Report/KafkaProducers/ReadyForValidationProducer.cs
+++ b/DotNet/Report/KafkaProducers/ReadyForValidationProducer.cs
@@ -33,7 +33,7 @@ namespace LantanaGroup.Link.Report.KafkaProducers
 
             foreach (var entry in needValidation)
             {
-               await Produce(entry.ReportScheduleId, entry.ReportTypes, entry.FacilityId, entry.PatientId, entry.PayloadUri, null, submissionEntryManager);
+               await Produce(entry.ReportScheduleId, entry.ReportTypes, entry.FacilityId, entry.PatientId, entry.PayloadUri, Guid.NewGuid().ToString(), submissionEntryManager);
             }
         }
 

--- a/DotNet/Report/KafkaProducers/ReadyForValidationProducer.cs
+++ b/DotNet/Report/KafkaProducers/ReadyForValidationProducer.cs
@@ -33,12 +33,16 @@ namespace LantanaGroup.Link.Report.KafkaProducers
 
             foreach (var entry in needValidation)
             {
-               await Produce(entry.ReportScheduleId, entry.ReportTypes, entry.FacilityId, entry.PatientId, entry.PayloadUri, submissionEntryManager);
+               await Produce(entry.ReportScheduleId, entry.ReportTypes, entry.FacilityId, entry.PatientId, entry.PayloadUri, null, submissionEntryManager);
             }
         }
 
-        public async Task Produce(string scheduleId, List<string> reportTypes, string facilityId, string patientId, string payloadUri,  ISubmissionEntryManager? manager = null)
+        public async Task Produce(string scheduleId, List<string> reportTypes, string facilityId, string patientId, string payloadUri, string correlationId, ISubmissionEntryManager? manager = null)
         {
+            var corrId = string.IsNullOrWhiteSpace(correlationId)
+                       ? Guid.NewGuid().ToString()
+                       : correlationId;
+
             _readyForValidationProducer.Produce(nameof(KafkaTopic.ReadyForValidation),
                 new Message<ReadyForValidationKey, ReadyForValidationValue>
                 {
@@ -56,7 +60,7 @@ namespace LantanaGroup.Link.Report.KafkaProducers
                     },
                     Headers = new Headers
                     {
-                        { "X-Correlation-Id", Encoding.UTF8.GetBytes(Guid.NewGuid().ToString()) }
+                        { "X-Correlation-Id",  Encoding.UTF8.GetBytes(corrId) }
                     }
                 });
 

--- a/DotNet/Report/KafkaProducers/SubmitPayLoadProducer.cs
+++ b/DotNet/Report/KafkaProducers/SubmitPayLoadProducer.cs
@@ -21,8 +21,13 @@ namespace LantanaGroup.Link.Report.KafkaProducers
             _database = database;
         }
 
-        public async Task<bool> Produce(ReportScheduleModel schedule, PayloadType payloadType, string? patientId = null, string? payloadUri = null)
+        public async Task<bool> Produce(ReportScheduleModel schedule, PayloadType payloadType, string? patientId = null, string? correlationId = null, string? payloadUri = null)
         {
+
+            var corrId = string.IsNullOrWhiteSpace(correlationId)
+                      ? Guid.NewGuid().ToString()
+                      : correlationId;
+
             if (string.IsNullOrEmpty(payloadUri))
             {
                 throw new InvalidOperationException("payloadUri is null or empty - cannot produce SubmitPayload event");
@@ -59,7 +64,7 @@ namespace LantanaGroup.Link.Report.KafkaProducers
 
                     Headers = new Headers
                     {
-                        { "X-Correlation-Id", Encoding.UTF8.GetBytes(Guid.NewGuid().ToString()) }
+                        { "X-Correlation-Id", Encoding.UTF8.GetBytes(corrId) }
                     }
                 });
 

--- a/DotNet/Report/Listeners/ResourceEvaluatedListener.cs
+++ b/DotNet/Report/Listeners/ResourceEvaluatedListener.cs
@@ -319,7 +319,7 @@ namespace LantanaGroup.Link.Report.Listeners
 
                 try
                 {
-                    await _readyForValidationProducer.Produce(schedule.Id, schedule.ReportTypes, schedule.FacilityId, entry.PatientId, payloadUri);
+                    await _readyForValidationProducer.Produce(schedule.Id, schedule.ReportTypes, schedule.FacilityId, entry.PatientId, payloadUri, correlationIdStr);
                 }
                 catch (ProduceException<ReadyForValidationKey, ReadyForValidationValue> ex)
                 {


### PR DESCRIPTION
### 🛠️ Description of Changes
Made correlation id same across multiple services

### 🧪 Testing Performed
Tested locally

### 🧑‍🔬 Unit Testing
- [ ] I have written or updated unit tests to cover my changes

### 📓 Documentation Updated
Please update any relevant sections in the project documentation that were impacted by the changes in the PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support to pass a correlation ID when producing report-related messages for consistent cross-system tracing.
  * If no correlation ID is provided, one is automatically generated and included in message headers for observability.

* **Bug Fixes / Reliability**
  * Listeners now validate the X-Correlation-Id header; messages missing it are dead-lettered with diagnostic info to aid troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->