### PR TITLE
LNK-3909: add token handling for report regeneration

### DIFF
--- a/DotNet/Tenant/Controllers/FacilityController.cs
+++ b/DotNet/Tenant/Controllers/FacilityController.cs
@@ -2,6 +2,7 @@
 using Confluent.Kafka;
 using LantanaGroup.Link.Shared.Application.Enums;
 using LantanaGroup.Link.Shared.Application.Interfaces;
+using LantanaGroup.Link.Shared.Application.Interfaces.Services.Security.Token;
 using LantanaGroup.Link.Shared.Application.Models;
 using LantanaGroup.Link.Shared.Application.Models.Configs;
 using LantanaGroup.Link.Shared.Application.Models.Kafka;
@@ -19,6 +20,8 @@ using OpenTelemetry.Trace;
 using Quartz;
 using System.Diagnostics;
 using System.Net;
+using System.Net.Http.Headers;
+using static LantanaGroup.Link.Shared.Application.Extensions.Security.BackendAuthenticationServiceExtension;
 
 namespace LantanaGroup.Link.Tenant.Controllers
 {
@@ -41,6 +44,9 @@ namespace LantanaGroup.Link.Tenant.Controllers
 
         private readonly IHttpClientFactory _httpClient;
         private readonly ServiceRegistry _serviceRegistry;
+        private readonly IOptions<LinkTokenServiceSettings> _linkTokenServiceConfig;
+        private readonly ICreateSystemToken _createSystemToken;
+        private readonly IOptions<LinkBearerServiceOptions> _linkBearerServiceOptions;
 
         public FacilityController(ILogger<FacilityController> logger,
             IFacilityConfigurationService facilityConfigurationService, ISchedulerFactory schedulerFactory,
@@ -476,6 +482,15 @@ namespace LantanaGroup.Link.Tenant.Controllers
 
                 string requestUrl =
                     $"{_serviceRegistry.ReportServiceApiUrl.Trim('/')}/Report/Schedule?FacilityId={facilityId}&reportScheduleId={request.ReportId}";
+
+                if (!_linkBearerServiceOptions.Value.AllowAnonymous)
+                {
+                    //TODO: add method to get key that includes looking at redis for future use case
+                    if (_linkTokenServiceConfig.Value.SigningKey is null) throw new Exception("Link Token Service Signing Key is missing.");
+
+                    var token = await _createSystemToken.ExecuteAsync(_linkTokenServiceConfig.Value.SigningKey, 2);
+                    httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+                }
 
                 using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
                 var response = await httpClient.GetAsync(requestUrl, cts.Token);

--- a/DotNet/Tenant/Controllers/FacilityController.cs
+++ b/DotNet/Tenant/Controllers/FacilityController.cs
@@ -15,6 +15,7 @@ using LantanaGroup.Link.Tenant.Services;
 using Link.Authorization.Policies;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.WebUtilities;
 using Microsoft.Extensions.Options;
 using OpenTelemetry.Trace;
 using Quartz;
@@ -484,8 +485,8 @@ namespace LantanaGroup.Link.Tenant.Controllers
                 var httpClient = _httpClient.CreateClient();
                 httpClient.Timeout = TimeSpan.FromSeconds(30);
 
-                string requestUrl =
-                    $"{_serviceRegistry.ReportServiceApiUrl.Trim('/')}/Report/Schedule?FacilityId={facilityId}&reportScheduleId={request.ReportId}";
+                var baseUrl = $"{_serviceRegistry.ReportServiceApiUrl.TrimEnd('/')}/Report/Schedule";
+                var requestUrl = QueryHelpers.AddQueryString(baseUrl, new Dictionary<string, string?> { ["facilityId"] = facilityId, ["reportScheduleId"] = request.ReportId } );
 
                 if (!_linkBearerServiceOptions.Value.AllowAnonymous)
                 {

--- a/DotNet/Tenant/Controllers/FacilityController.cs
+++ b/DotNet/Tenant/Controllers/FacilityController.cs
@@ -51,7 +51,8 @@ namespace LantanaGroup.Link.Tenant.Controllers
         public FacilityController(ILogger<FacilityController> logger,
             IFacilityConfigurationService facilityConfigurationService, ISchedulerFactory schedulerFactory,
             IKafkaProducerFactory<string, GenerateReportValue> adHocKafkaProducerFactory,
-            IOptions<ServiceRegistry> serviceRegistry, IHttpClientFactory httpClient)
+            IOptions<ServiceRegistry> serviceRegistry, IHttpClientFactory httpClient, 
+            IOptions<LinkTokenServiceSettings> linkTokenServiceConfig, ICreateSystemToken createSystemToken, IOptions<LinkBearerServiceOptions> linkBearerServiceOptions)
         {
             _facilityConfigurationService = facilityConfigurationService;
             _schedulerFactory = schedulerFactory;
@@ -77,6 +78,9 @@ namespace LantanaGroup.Link.Tenant.Controllers
             _adHocKafkaProducerFactory = adHocKafkaProducerFactory;
             _serviceRegistry = serviceRegistry?.Value ?? throw new ArgumentNullException(nameof(serviceRegistry));
             _httpClient = httpClient;
+            _linkTokenServiceConfig = linkTokenServiceConfig ?? throw new ArgumentNullException(nameof(linkTokenServiceConfig));
+            _createSystemToken = createSystemToken ?? throw new ArgumentNullException(nameof(createSystemToken));
+            _linkBearerServiceOptions = linkBearerServiceOptions ?? throw new ArgumentNullException(nameof(linkBearerServiceOptions));
         }
 
         /// <summary>


### PR DESCRIPTION
🛠️ Description of Changes
Added token handling to report regeneration.

🧪 Testing Performed
•	Manually verified that endpoint is working.
🧑‍🔬 Unit Testing
•	[x] I have written or updated unit tests to cover my changes
📓 Documentation Updated
n.a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Report regeneration now performs authenticated internal requests when required; a system token is attached for non-anonymous flows while anonymous flows remain unchanged.

* **Bug Fixes**
  * Added explicit error messaging when required security configuration is missing, preventing ambiguous failures and aiding faster troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->