### PR TITLE
TECH_DEBT: Update CODEOWNERS and dependabot.yml with groups instead of individuals

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,7 @@
-# Stephen and DevOps are interested in config changes, and also version number changes
-**/appsettings.json @sdmcgeown @lantanagroup/devops
-**/pom.xml @sdmcgeown
-**/application*.yml @sdmcgeown @lantanagroup/devops
+# Release and DevOps teams are interested in config changes, and also version number changes
+**/appsettings.json @lantanagroup/link-release-management-team @lantanagroup/devops
+**/pom.xml @lantanagroup/link-release-management-team
+**/application*.yml @lantanagroup/link-release-management-team @lantanagroup/devops
 
 docs/* @lantanagroup/devops @lantanagroup/link-arch
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,7 +18,7 @@ updates:
       interval: "weekly"
       day: "tuesday"
     assignees:
-      - "sdmcgeown"
+      - "@lantanagroup/link-release-management-team"
     # Group minor and patch security and version updates into a PR
     # so we don't get overwhelmed
     groups:
@@ -41,7 +41,7 @@ updates:
       interval: "weekly"
       day: "tuesday"
     assignees:
-      - "sdmcgeown"
+      - "@lantanagroup/link-release-management-team"
     # Group minor and patch security and version updates into a PR
     # so we don't get overwhelmed
     groups:


### PR DESCRIPTION
### 🛠️ Description of Changes
Remove individuals from notifications generated via the CODEOWNERS and dependabot alerts and replace with GitHub teams for easier configuration in the GitHub interface itself.

### 🧪 Testing Performed
None performed - just a simple change to github workflows

### 🧑‍🔬 Unit Testing
N/A - [ ] I have written or updated unit tests to cover my changes

### 📓 Documentation Updated
N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository code ownership to reflect current team responsibilities for configuration and related assets, improving accountability and review coverage.
  * Adjusted automated dependency update assignees to the release management team, ensuring timely triage and consistency across ecosystems, with DevOps involvement retained where appropriate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->