### PR TITLE
LNK-4189: static scan fixes - Report

### DIFF
--- a/DotNet/Report/Application/Models/GetMeasureReportsQueryParameters.cs
+++ b/DotNet/Report/Application/Models/GetMeasureReportsQueryParameters.cs
@@ -1,0 +1,19 @@
+﻿using LantanaGroup.Link.Report.Domain.Enums;
+using LantanaGroup.Link.Report.Entities;
+using LantanaGroup.Link.Shared.Application.Enums;
+
+namespace LantanaGroup.Link.Report.Application.Models;
+
+public class GetMeasureReportsQueryParameters
+{
+    public string? ReportId { get; set; }
+    public string? PatientId { get; set; }
+    public string? MeasureReportId { get; set; }
+    public string? Measure { get; set; }
+    public PatientSubmissionStatus? ReportStatus { get; set; }
+    public ValidationStatus? ValidationStatus { get; set; }
+    public string? SortBy { get; set; }
+    public SortOrder SortOrder { get; set; } = SortOrder.Descending;
+    public int PageNumber { get; set; } = 1;
+    public int PageSize { get; set; } = 10;
+}


### PR DESCRIPTION
* add DTO for query params in GetMeasureReports()

### 🛠️ Description of Changes
Add DTO for GetMeasureReports due to Fortify Static Scan results for the Report service.

### 🧪 Testing Performed
e2e smoketest

### 🧑‍🔬 Unit Testing
- [X ] I have written or updated unit tests to cover my changes

### 📓 Documentation Updated
No changes to endpoints.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Unified measure report filters into a single query object for simpler requests.
  - Added sorting by report type, status, and validation status, with a default sort applied when not specified.
  - Preserved sensible defaults for pagination and sort order (descending, page 1, size 10).

- Refactor
  - Streamlined the GetMeasureReports endpoint to accept the new parameter object, centralizing filters, sorting, and paging.
  - Improved validation for required facility ID and query parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->