### PR TITLE
LNK-4237: Enhanced smoke test fix output validation

### DIFF
--- a/Tests/BackendE2ETests/AdhocReportingSmokeTest.cs
+++ b/Tests/BackendE2ETests/AdhocReportingSmokeTest.cs
@@ -6,6 +6,7 @@ using System.Net;
 using Xunit;
 using Task = System.Threading.Tasks.Task;
 using LantanaGroup.Link.Tests.BackendE2ETests.ApiRequests;
+using System.Diagnostics;
 
 namespace LantanaGroup.Link.Tests.E2ETests;
 
@@ -84,6 +85,10 @@ public sealed class AdhocReportingSmokeTest(ITestOutputHelper output) : IAsyncLi
         AdhocReportingSmokeTest adhocReportingSmokeTest = new AdhocReportingSmokeTest(output);
         MeasureLoader measureLoader = new MeasureLoader(AdminBffClient, output);
 
+        Stopwatch stopwatch = new Stopwatch();
+        stopwatch.Start();
+        output.WriteLine($"Stopwatch start {DateTime.UtcNow.ToString()}");
+
         await measureLoader.LoadAsync();
         apiE2E.Create_SingleMeasureAdHocTestFacility();
         apiE2E.Create_SingleMeasureCensusConfiguration_AdHoc();
@@ -114,7 +119,11 @@ public sealed class AdhocReportingSmokeTest(ITestOutputHelper output) : IAsyncLi
                     output.WriteLine(fail);
                 Xunit.Assert.Fail($"{failures.Count} verification(s) failed. See console output below.");
             }
-            output.WriteLine("[PASS] Smoke test completed with all verifications passing.");
+            else
+                output.WriteLine("[PASS] Smoke test completed with all verifications passing.");
+
+            stopwatch.Stop();
+            output.WriteLine($"Stopwatch stop {DateTime.UtcNow.ToString()} - Total Time: {stopwatch.Elapsed}");
         }      
     }
 

--- a/Tests/BackendE2ETests/ApiRequests/SubmissionZipReader.cs
+++ b/Tests/BackendE2ETests/ApiRequests/SubmissionZipReader.cs
@@ -1,339 +1,299 @@
-﻿using Azure.Storage.Blobs;
-using Azure.Storage.Blobs.Models;
-using LantanaGroup.Link.Tests.E2ETests;
+﻿using LantanaGroup.Link.Tests.E2ETests;
 using Newtonsoft.Json.Linq;
+using System.IO.Compression;
 using Xunit.Abstractions;
 
+namespace LantanaGroup.Link.Tests.BackendE2ETests.ApiRequests;
 
-namespace LantanaGroup.Link.Tests.BackendE2ETests.ApiRequests
+public class SubmissionZipReader(ITestOutputHelper output)
 {
-    public class SubmissionZipReader(ITestOutputHelper output)
+    protected static readonly string api_LinkAdminBffURL = TestConfig.AdminBffBase;
+    protected static readonly string fhirServerBaseUrl = TestConfig.InternalFhirServerBase;
+    protected static readonly string SingleMeasureAdHocFacility = TestConfig.SingleMeasureAdHocFacility;
+    protected static readonly string SingleMeasureAdHocAchDqmVersion = TestConfig.SingleMeasureAdHocAchDqmVersion;
+    private readonly HttpClient _client = new HttpClient();
+    private readonly Dictionary<string, string> _zipContents = new();
+    string AdHocReportGuid => TestConfig.TestContextStore.AdHocReportTrackingIdGuid;
+
+    public async Task DownloadAndExtractSingleMeasureZipAsync(bool save = false)
     {
-        private static readonly string azuriteConnectionString = "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1";
-        private static readonly string azuriteBaseDirectoryName = "singlemeasureadhocfacility_nhsnacutecarehospitalmonthlyinitialpopulation";
-        protected static readonly string api_LinkAdminBffURL = TestConfig.AdminBffBase;
-        protected static readonly string fhirServerBaseUrl = TestConfig.InternalFhirServerBase;
-        protected static readonly string SingleMeasureAdHocFacility = TestConfig.SingleMeasureAdHocFacility;
-        protected static readonly string SingleMeasureAdHocAchDqmVersion = TestConfig.SingleMeasureAdHocAchDqmVersion;
-        private readonly Dictionary<string, string> _zipContents = new();
-        string AdHocReportGuid => TestConfig.TestContextStore.AdHocReportTrackingIdGuid;
 
-        public async Task DownloadAndExtractSingleMeasureZipAsync(bool save = false)
+        if (string.IsNullOrEmpty(SingleMeasureAdHocFacility))
+            throw new InvalidOperationException("Facility ID must be set using UseSingleMeasureFacility() or UseMultiMeasureFacility().");
+
+        var url = $"{api_LinkAdminBffURL}/Submission/{SingleMeasureAdHocFacility}/{AdHocReportGuid}";
+        var response = await _client.GetAsync(url);
+        response.EnsureSuccessStatusCode();
+
+        byte[] zipBytes = await response.Content.ReadAsByteArrayAsync();
+        using var zipStream = new MemoryStream(zipBytes);
+        using var archive = new ZipArchive(zipStream, ZipArchiveMode.Read);
+
+        if (save && !string.IsNullOrEmpty(TestConfig.SmokeTestDownloadPath))
         {
+            if (!Directory.Exists(TestConfig.SmokeTestDownloadPath))
+                Directory.CreateDirectory(TestConfig.SmokeTestDownloadPath);
 
-            BlobContainerClient blobContainerClient = null;
-            List<Azure.Storage.Blobs.Models.BlobItem> blobs = null;
-            List<BlobItem> filteredBlobList = null;
+            var downloadPath = Path.Combine(TestConfig.SmokeTestDownloadPath, "adhoc-reporting-smoke-test-submission.zip");
+            await File.WriteAllBytesAsync(downloadPath, zipBytes);
+            output.WriteLine($"Report downloaded to {downloadPath}");
+        }
 
+        foreach (var entry in archive.Entries)
+        {
+            if (!entry.FullName.EndsWith(".ndjson", StringComparison.OrdinalIgnoreCase))
+                continue;
+
+            using var reader = new StreamReader(entry.Open());
+            string content = await reader.ReadToEndAsync();
+            _zipContents[entry.FullName] = content;
+        }
+    }
+
+    public void SingleMeasureAdHocValidateFilesAppear()
+    {
+        var expectedFiles = new List<string>
+        {
+            "manifest.ndjson",
+            "patient-x25sJU80vVa51mxJ6vSDcjbNC3BcdCQujJbXQwqdppFOO.ndjson",
+            "patient-MVLkMLWErl3gQGRCuA2mygtVuix7PMBFBh9WVayaCL7xM.ndjson",
+            "patient-CYUcGIlSrpJxCBMeEml30YSmE0Ea7loNBPVZfhCUkv7A3.ndjson",
+            "patient-VsZkAG8h9vkGcL528ZcJxVXynyj8X39GaDfjHbA9AnvyA.ndjson",
+            "patient-jjMZxCVWUbZgLkPf2LTzvZIBOW76YLJdIGCw8JFaTPiZg.ndjson",
+            "patient-6tZ8Wt8maJdDFLvEsDcKmAaCAcSOxjr0mB8RjEi5Szw7H.ndjson"
+        };
+
+        var missingFiles = expectedFiles
+            .Where(expected => !_zipContents.Keys.Any(actual => actual.EndsWith(expected, StringComparison.OrdinalIgnoreCase)))
+            .ToList();
+
+        if (missingFiles.Any())
+        {
+            foreach (var file in missingFiles)
+                output.WriteLine($"🔴  [ERROR] {file} is missing.");
+
+            string fileList = string.Join(", ", missingFiles);
+            throw new Exception($"Verification failed: {missingFiles.Count} file(s) missing: {fileList}");
+        }
+        output.WriteLine("[PASS] All expected files appear in the ZIP archive.");
+    }
+    public void SingleMeasureAdHocValidateFilesDoNotAppear()
+    {
+        if(_zipContents.Count == 0)
+            throw new InvalidOperationException("[FAIL] SingleMeasureAdHocValidateFilesDoNotAppear(): ZIP contents have not been loaded.");
+
+        var disallowedFiles = new List<string>
+        {
+            "patient-jbbPDJeGWyEyudcf6EBKTgmeCLxB7jTgu5Ugm27JAO494.ndjson",
+            "patient-DJxsHpmWuBezhV9hJNgEHT4szaKW3uP5vUNzXUCkltpXj.ndjson",
+            "patient-9i6Xi6uG2WjuGxHTmpbin4ct2ZwevRwTWhIkJkRjVFZ4C.ndjson",
+            "patient-5ieWogP3EGV24Kus8QsGh6rpmUaJBP5Hl0nCSJJXmh6TI.ndjson"
+        };
+
+        var foundDisallowedFiles = disallowedFiles
+            .Where(disallowed => _zipContents.Keys.Any(actual => actual.EndsWith(disallowed, StringComparison.OrdinalIgnoreCase)))
+            .ToList();
+
+        if (foundDisallowedFiles.Any())
+        {
+            foreach (var file in foundDisallowedFiles)
+                output.WriteLine($"🔴  [ERROR] {file} was found but should NOT be present.");
+
+            throw new Exception($"Verification failed: {foundDisallowedFiles.Count} disallowed file(s) were found.");
+        }
+        output.WriteLine("[PASS] No disallowed files were found in the ZIP archive.");
+    }
+    public void ValidateSpecificPatientFileContents(int timeoutSeconds = 10, int pollIntervalMs = 1000)
+    {
+        string fileName = "patient-x25sJU80vVa51mxJ6vSDcjbNC3BcdCQujJbXQwqdppFOO.ndjson";
+
+        var entry = _zipContents.Keys.FirstOrDefault(name => name.EndsWith(fileName, StringComparison.OrdinalIgnoreCase));
+        if (entry == null)
+            throw new Exception($"{fileName} is missing from the ZIP archive.");
+
+        var content = _zipContents[entry];
+        JObject json = null;
+
+        var expectedResourceCounts = new Dictionary<string, int>
+            {
+                { "Encounter", 2 },
+                { "Observation", 23 },
+                { "Device", 1 },
+                { "MedicationRequest", 4 },
+                { "Procedure", 3 },
+                { "Condition", 4 },
+                { "Patient", 1 },
+                { "Coverage", 2 },
+                { "DiagnosticReport", 2 },
+                { "MeasureReport", 1 },
+                { "ServiceRequest", 116 },
+                { "Location", 2 },
+                {"Medication", 4 }
+            };
+        Dictionary<string, int> actualCounts = null;
+        DateTime startTime = DateTime.Now;
+        while ((DateTime.Now - startTime).TotalSeconds < timeoutSeconds)
+        {
+            //the content is ndjson, so we need to split it into lines and parse each line as JSON
+            foreach (var line in content.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries))
+            {
+                var lineJson = JObject.Parse(line);
+                var resourceType = (string)lineJson["resourceType"] ?? "null";
+                
+                if (actualCounts == null)
+                    actualCounts = new Dictionary<string, int>();
+                if (actualCounts.ContainsKey(resourceType))
+                    actualCounts[resourceType]++;
+                else
+                    actualCounts[resourceType] = 1;
+
+                var entryCounts = lineJson["entry"]?
+                    .GroupBy(e => (string)e["resource"]?["resourceType"])
+                    .ToDictionary(g => g.Key ?? "null", g => g.Count()) ?? new Dictionary<string, int>();
+
+                foreach (var kvp in entryCounts)
+                {
+                    if (actualCounts.ContainsKey(kvp.Key))
+                        actualCounts[kvp.Key] += kvp.Value;
+                    else
+                        actualCounts[kvp.Key] = kvp.Value;
+                }
+            }
+
+            if (expectedResourceCounts.All(kvp =>
+                actualCounts.TryGetValue(kvp.Key, out int actual) && actual >= kvp.Value))
+            {
+                break;
+            }
+            Thread.Sleep(pollIntervalMs);
+        }
+
+        if (actualCounts == null)
+            throw new Exception("Validation failed: Could not parse resourceType counts from JSON content.");
+        var mismatches = new List<string>();
+        var unexpected = new List<string>();
+
+        foreach (var expected in expectedResourceCounts)
+        {
+            actualCounts.TryGetValue(expected.Key, out int actualCount);
+            if (actualCount != expected.Value)
+            {
+                mismatches.Add($"🔴 [ERROR] ResourceType '{expected.Key}': Expected {expected.Value}, Found {actualCount}");
+            }
+        }
+
+        foreach (var actual in actualCounts.Keys)
+        {
+            if (!expectedResourceCounts.ContainsKey(actual))
+            {
+                unexpected.Add($"[WARNING] Unexpected resourceType found: '{actual}' (Count: {actualCounts[actual]})");
+            }
+        }
+        foreach (var line in mismatches.Concat(unexpected))
+            output.WriteLine(line);
+        if (mismatches.Any())
+            throw new Exception("Validation failed: One or more expected resourceType counts are incorrect.");
+        output.WriteLine("[PASS] All expected resourceType counts match, and no unexpected types found.");
+    }
+    public void ValidateSingleMeasureAdHocAggregateACHMFile()
+    {
+        string fileName = "manifest.ndjson";
+
+        var entry = _zipContents.Keys.FirstOrDefault(name => name.EndsWith(fileName, StringComparison.OrdinalIgnoreCase));
+        if (entry == null)
+            throw new Exception($"{fileName} is missing from the ZIP archive.");
+        var content = _zipContents[entry];
+
+        //loop through each line and find the MeasureReport resource
+        var measureReportLine = content.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries)
+                                        .FirstOrDefault(line => line.Contains("\"resourceType\":\"MeasureReport\"", StringComparison.OrdinalIgnoreCase));
+
+        if (string.IsNullOrWhiteSpace(measureReportLine))
+            throw new Exception("Verification failed: MeasureReport resource is missing from manifest.ndjson.");
+
+        JObject json = JObject.Parse(measureReportLine);
+        int actualCount = (int?)json["group"]?[0]?["population"]?[0]?["count"] ?? -1;
+        if (actualCount != 8)
+        {
+            output.WriteLine($"🔴  [ERROR] MeasureReport count mismatch: Expected 8, Found {actualCount}");
+            throw new Exception("Verification failed: MeasureReport 'count' is incorrect.");
+        }
+        string? measureValue = (string?)json["measure"];
+        if (string.IsNullOrWhiteSpace(measureValue) || !measureValue.Contains("|"))
+        {
+            output.WriteLine($"🔴  [ERROR] MeasureReport 'measure' value is missing or malformed: '{measureValue}'");
+            throw new Exception("Verification failed: MeasureReport 'measure' field is missing or malformed.");
+        }
+        string version = measureValue.Split('|').Last();
+        if (version != SingleMeasureAdHocAchDqmVersion)
+        {
+            output.WriteLine($"🔴  [ERROR] MeasureReport version mismatch: Expected '{SingleMeasureAdHocAchDqmVersion}', Found '{version}'");
+            throw new Exception("Verification failed: MeasureReport 'measure' version is incorrect.");
+        }
+        output.WriteLine($"[PASS] aggregate-ACHM.json: 'count' == 8 and 'measure' version == '{SingleMeasureAdHocAchDqmVersion}'.");
+    }
+    public async Task WaitForSingleMeasureZipContentsAsync(
+        int timeoutInSeconds = 600,
+        int stableCycles = 60,
+        List<string>? requiredFiles = null,
+        int pollingIntervalMs = 3000)
+        {
+        DateTime deadline = DateTime.UtcNow.AddSeconds(timeoutInSeconds);
+        int attempt = 0;
+        int stableCount = 0;
+        HashSet<string>? previousNames = null;
+        string? lastError = null;
+
+        output.WriteLine("[INFO] Waiting for ZIP contents to stabilize…");
+
+        while (DateTime.UtcNow < deadline)
+        {
+            attempt++;
             try
             {
-                blobContainerClient = new BlobContainerClient(azuriteConnectionString, "internal");
-                blobs = blobContainerClient.GetBlobs()
-                        .Where(b => b.Name.StartsWith(azuriteBaseDirectoryName, StringComparison.OrdinalIgnoreCase))
-                        .ToList();
-                
-                if (blobs.Any())
-                {   
-                    var latestBlob =  blobs.OrderByDescending(x => x.Properties.CreatedOn).ToList().FirstOrDefault();
-                    //get the id from the file name. split on '/' and take the first segment and then split on '_' and take the last segment
-                    var idFromFileName = latestBlob.Name.Split('/').FirstOrDefault()?.Split('_').LastOrDefault();
-
-                    if (string.IsNullOrWhiteSpace(idFromFileName))
-                    {
-                        //output.WriteLine($"🔴  [ERROR] Unable to extract report ID from blob name: {latestBlob.Name}");
-                        throw new Exception("Verification failed: Unable to extract report ID from blob name.");
-                    }
-
-                    //grab all files with the same id and created within 5 minutes of the latest file
-                    filteredBlobList = blobs.Where(b => b.Name.Contains(idFromFileName) && 
-                                            b.Properties.CreatedOn.HasValue && 
-                                            Math.Abs((b.Properties.CreatedOn.Value.UtcDateTime - latestBlob.Properties.CreatedOn.Value.UtcDateTime).TotalMinutes) <= 5)
-                                 .ToList();
-
-                    foreach (var blob in blobs.OrderByDescending(x => x.Properties.CreatedOn).ToList())
-                    {
-                        if (save)
-                        {
-                            //download the blob
-                            output.WriteLine($"Downloading blob: {blob.Name}, CreatedOn: {blob.Properties.CreatedOn}");
-                            var blobClient = blobContainerClient.GetBlobClient(blob.Name);
-                            var downloadInfo = await blobClient.DownloadAsync();
-                            using (var ms = new MemoryStream())
-                            {
-                                await downloadInfo.Value.Content.CopyToAsync(ms);
-                                _zipContents[Path.GetFileName(blob.Name)] = System.Text.Encoding.UTF8.GetString(ms.ToArray());
-
-
-                                var localPath = Path.Combine(Directory.GetCurrentDirectory(), "DownloadedZips");
-                                if (!Directory.Exists(localPath))
-                                    Directory.CreateDirectory(localPath);
-                                var filePath = Path.Combine(localPath, Path.GetFileName(blob.Name));
-                                await File.WriteAllBytesAsync(filePath, ms.ToArray());
-                                output.WriteLine($"Saved blob to: {filePath}");
-
-                            } 
-                        }
-                        else
-                        {
-                            _zipContents[Path.GetFileName(blob.Name)] = string.Empty;
-                        }
-                    }
+                await DownloadAndExtractSingleMeasureZipAsync();
+                var currentNames = _zipContents.Keys
+                                               .Where(n => n.EndsWith(".ndjson", StringComparison.OrdinalIgnoreCase))
+                                               .ToHashSet(StringComparer.OrdinalIgnoreCase);
+                if (requiredFiles != null &&
+                    !requiredFiles.All(req => currentNames.Any(n => n.EndsWith(req, StringComparison.OrdinalIgnoreCase))))
+                {
+                    stableCount = 0;
                 }
                 else
                 {
-                    //output.WriteLine($"🔴  [ERROR] No files found in azurite/internal!");
-                    throw new Exception($"Verification failed: Unable to connect to blob storage or no files are found.");
+                    if (previousNames != null && currentNames.SetEquals(previousNames))
+                        stableCount++;
+                    else
+                        stableCount = 0;
+                }
+
+                previousNames = currentNames;
+                lastError = null; 
+
+                if (stableCount >= stableCycles)
+                {
+                    if (lastError != null)
+                        output.WriteLine($"[WARN] Last poll failure: {lastError}");
+
+                    output.WriteLine($"[INFO] ZIP contents stable after {attempt} poll(s). File count: {currentNames.Count}");
+                    return;
                 }
             }
             catch (Exception ex)
             {
-                //output.WriteLine($"🔴  [ERROR] Exception while accessing blobs: {ex.Message}\n\t{ex.StackTrace}");
-                throw;
+                lastError = $"Poll {attempt} failed: {ex.Message}";
+                stableCount = 0;
             }
+
+            await Task.Delay(pollingIntervalMs);
         }
 
-        public void SingleMeasureAdHocValidateFilesAppear()
-        {
-            var expectedFiles = new List<string>
-            {
-                "manifest.ndjson",
-                "patient-x25sJU80vVa51mxJ6vSDcjbNC3BcdCQujJbXQwqdppFOO.ndjson",
-                "patient-MVLkMLWErl3gQGRCuA2mygtVuix7PMBFBh9WVayaCL7xM.ndjson",
-                "patient-CYUcGIlSrpJxCBMeEml30YSmE0Ea7loNBPVZfhCUkv7A3.ndjson",
-                "patient-VsZkAG8h9vkGcL528ZcJxVXynyj8X39GaDfjHbA9AnvyA.ndjson",
-                "patient-jjMZxCVWUbZgLkPf2LTzvZIBOW76YLJdIGCw8JFaTPiZg.ndjson",
-                "patient-6tZ8Wt8maJdDFLvEsDcKmAaCAcSOxjr0mB8RjEi5Szw7H.ndjson"
-            };
+        if (lastError != null)
+            output.WriteLine($"[WARN] Last poll failure: {lastError}");
 
-            var missingFiles = expectedFiles
-                .Where(expected => !_zipContents.Keys.Any(actual => actual.EndsWith(expected, StringComparison.OrdinalIgnoreCase)))
-                .ToList();
-
-            if (missingFiles.Any())
-            {
-                foreach (var file in missingFiles)
-                    output.WriteLine($"🔴  [ERROR] {file} is missing.");
-
-                string fileList = string.Join(", ", missingFiles);
-                throw new Exception($"Verification failed: {missingFiles.Count} file(s) missing: {fileList}");
-            }
-            output.WriteLine("[PASS] All expected files appear in the ZIP archive.");
-        }
-        public void SingleMeasureAdHocValidateFilesDoNotAppear()
-        {
-            var disallowedFiles = new List<string>
-            {
-                "patient-jbbPDJeGWyEyudcf6EBKTgmeCLxB7jTgu5Ugm27JAO494.ndjson",
-                "patient-DJxsHpmWuBezhV9hJNgEHT4szaKW3uP5vUNzXUCkltpXj.ndjson",
-                "patient-9i6Xi6uG2WjuGxHTmpbin4ct2ZwevRwTWhIkJkRjVFZ4C.ndjson",
-                "patient-5ieWogP3EGV24Kus8QsGh6rpmUaJBP5Hl0nCSJJXmh6TI.ndjson"
-            };
-
-            var foundDisallowedFiles = disallowedFiles
-                .Where(disallowed => _zipContents.Keys.Any(actual => actual.EndsWith(disallowed, StringComparison.OrdinalIgnoreCase)))
-                .ToList();
-
-            if (foundDisallowedFiles.Any())
-            {
-                foreach (var file in foundDisallowedFiles)
-                    output.WriteLine($"🔴  [ERROR] {file} was found but should NOT be present.");
-
-                throw new Exception($"Verification failed: {foundDisallowedFiles.Count} disallowed file(s) were found.");
-            }
-            output.WriteLine("[PASS] No disallowed files were found in the ZIP archive.");
-        }
-        public void ValidateSpecificPatientFileContents(int timeoutSeconds = 10, int pollIntervalMs = 1000)
-        {
-            string fileName = "patient-x25sJU80vVa51mxJ6vSDcjbNC3BcdCQujJbXQwqdppFOO.ndjson";
-
-            var entry = _zipContents.Keys.FirstOrDefault(name => name.EndsWith(fileName, StringComparison.OrdinalIgnoreCase));
-            if (entry == null)
-                throw new Exception($"{fileName} is missing from the ZIP archive.");
-
-            var content = _zipContents[entry];
-            JObject json = null;
-
-            var expectedResourceCounts = new Dictionary<string, int>
-                {
-                    { "Encounter", 2 },
-                    { "Observation", 23 },
-                    { "Device", 1 },
-                    { "MedicationRequest", 4 },
-                    { "Procedure", 3 },
-                    { "Condition", 4 },
-                    { "Patient", 1 },
-                    { "Coverage", 2 },
-                    { "DiagnosticReport", 2 },
-                    { "MeasureReport", 1 },
-                    { "ServiceRequest", 116 },
-                    { "Location", 2 },
-                    {"Medication", 4 }
-                };
-            Dictionary<string, int> actualCounts = null;
-            DateTime startTime = DateTime.Now;
-            while ((DateTime.Now - startTime).TotalSeconds < timeoutSeconds)
-            {
-                //the content is ndjson, so we need to split it into lines and parse each line as JSON
-                foreach (var line in content.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries))
-                {
-                    var lineJson = JObject.Parse(line);
-                    var resourceType = (string)lineJson["resourceType"] ?? "null";
-                    
-                    if (actualCounts == null)
-                        actualCounts = new Dictionary<string, int>();
-                    if (actualCounts.ContainsKey(resourceType))
-                        actualCounts[resourceType]++;
-                    else
-                        actualCounts[resourceType] = 1;
-
-                    var entryCounts = lineJson["entry"]?
-                        .GroupBy(e => (string)e["resource"]?["resourceType"])
-                        .ToDictionary(g => g.Key ?? "null", g => g.Count()) ?? new Dictionary<string, int>();
-
-                    foreach (var kvp in entryCounts)
-                    {
-                        if (actualCounts.ContainsKey(kvp.Key))
-                            actualCounts[kvp.Key] += kvp.Value;
-                        else
-                            actualCounts[kvp.Key] = kvp.Value;
-                    }
-                }
-
-                if (expectedResourceCounts.All(kvp =>
-                    actualCounts.TryGetValue(kvp.Key, out int actual) && actual >= kvp.Value))
-                {
-                    break;
-                }
-                Thread.Sleep(pollIntervalMs);
-            }
-
-            if (actualCounts == null)
-                throw new Exception("Validation failed: Could not parse resourceType counts from JSON content.");
-            var mismatches = new List<string>();
-            var unexpected = new List<string>();
-
-            foreach (var expected in expectedResourceCounts)
-            {
-                actualCounts.TryGetValue(expected.Key, out int actualCount);
-                if (actualCount != expected.Value)
-                {
-                    mismatches.Add($"🔴 [ERROR] ResourceType '{expected.Key}': Expected {expected.Value}, Found {actualCount}");
-                }
-            }
-
-            foreach (var actual in actualCounts.Keys)
-            {
-                if (!expectedResourceCounts.ContainsKey(actual))
-                {
-                    unexpected.Add($"[WARNING] Unexpected resourceType found: '{actual}' (Count: {actualCounts[actual]})");
-                }
-            }
-            foreach (var line in mismatches.Concat(unexpected))
-                output.WriteLine(line);
-            if (mismatches.Any())
-                throw new Exception("Validation failed: One or more expected resourceType counts are incorrect.");
-            output.WriteLine("[PASS] All expected resourceType counts match, and no unexpected types found.");
-        }
-        public void ValidateSingleMeasureAdHocAggregateACHMFile()
-        {
-            string fileName = "manifest.ndjson";
-
-            var entry = _zipContents.Keys.FirstOrDefault(name => name.EndsWith(fileName, StringComparison.OrdinalIgnoreCase));
-            if (entry == null)
-                throw new Exception($"{fileName} is missing from the ZIP archive.");
-            var content = _zipContents[entry];
-
-            //loop through each line and find the MeasureReport resource
-            var measureReportLine = content.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries)
-                                            .FirstOrDefault(line => line.Contains("\"resourceType\":\"MeasureReport\"", StringComparison.OrdinalIgnoreCase));
-
-            if (string.IsNullOrWhiteSpace(measureReportLine))
-                throw new Exception("Verification failed: MeasureReport resource is missing from manifest.ndjson.");
-
-            JObject json = JObject.Parse(measureReportLine);
-            int actualCount = (int?)json["group"]?[0]?["population"]?[0]?["count"] ?? -1;
-            if (actualCount != 8)
-            {
-                output.WriteLine($"🔴  [ERROR] MeasureReport count mismatch: Expected 8, Found {actualCount}");
-                throw new Exception("Verification failed: MeasureReport 'count' is incorrect.");
-            }
-            string? measureValue = (string?)json["measure"];
-            if (string.IsNullOrWhiteSpace(measureValue) || !measureValue.Contains("|"))
-            {
-                output.WriteLine($"🔴  [ERROR] MeasureReport 'measure' value is missing or malformed: '{measureValue}'");
-                throw new Exception("Verification failed: MeasureReport 'measure' field is missing or malformed.");
-            }
-            string version = measureValue.Split('|').Last();
-            if (version != SingleMeasureAdHocAchDqmVersion)
-            {
-                output.WriteLine($"🔴  [ERROR] MeasureReport version mismatch: Expected '{SingleMeasureAdHocAchDqmVersion}', Found '{version}'");
-                throw new Exception("Verification failed: MeasureReport 'measure' version is incorrect.");
-            }
-            output.WriteLine($"[PASS] aggregate-ACHM.json: 'count' == 8 and 'measure' version == '{SingleMeasureAdHocAchDqmVersion}'.");
-        }
-        public async Task WaitForSingleMeasureZipContentsAsync(
-            int timeoutInSeconds = 300,
-            int stableCycles = 5,
-            List<string>? requiredFiles = null,
-            int pollingIntervalMs = 1000)
-            {
-            DateTime deadline = DateTime.UtcNow.AddSeconds(timeoutInSeconds);
-            int attempt = 0;
-            int stableCount = 0;
-            HashSet<string>? previousNames = null;
-            string? lastError = null;
-
-            output.WriteLine("[INFO] Waiting for ZIP contents to stabilize…");
-
-            while (DateTime.UtcNow < deadline)
-            {
-                attempt++;
-                try
-                {
-                    await DownloadAndExtractSingleMeasureZipAsync();
-                    var currentNames = _zipContents.Keys
-                                                   .Where(n => n.EndsWith(".ndjson", StringComparison.OrdinalIgnoreCase))
-                                                   .ToHashSet(StringComparer.OrdinalIgnoreCase);
-                    if (requiredFiles != null &&
-                        !requiredFiles.All(req => currentNames.Any(n => n.EndsWith(req, StringComparison.OrdinalIgnoreCase))))
-                    {
-                        stableCount = 0;
-                    }
-                    else
-                    {
-                        if (previousNames != null && currentNames.SetEquals(previousNames))
-                            stableCount++;
-                        else
-                            stableCount = 0;
-                    }
-
-                    previousNames = currentNames;
-                    lastError = null; 
-
-                    if (stableCount >= stableCycles)
-                    {
-                        if (lastError != null)
-                            output.WriteLine($"[WARN] Last poll failure: {lastError}");
-
-                        output.WriteLine($"[INFO] ZIP contents stable after {attempt} poll(s). File count: {currentNames.Count}");
-                        return;
-                    }
-                }
-                catch (Exception ex)
-                {
-                    lastError = $"Poll {attempt} failed: {ex.Message}";
-                    stableCount = 0;
-                }
-
-                await Task.Delay(pollingIntervalMs);
-            }
-
-            if (lastError != null)
-                output.WriteLine($"[WARN] Last poll failure: {lastError}");
-
-            throw new TimeoutException(
-                $"🔴 ZIP did not reach a stable state within {timeoutInSeconds}s after {attempt} poll(s).");
-        }
+        throw new TimeoutException(
+            $"🔴 ZIP did not reach a stable state within {timeoutInSeconds}s after {attempt} poll(s).");
     }
 }
 

--- a/Tests/BackendE2ETests/ApiRequests/SubmissionZipReader.cs
+++ b/Tests/BackendE2ETests/ApiRequests/SubmissionZipReader.cs
@@ -40,7 +40,7 @@ namespace LantanaGroup.Link.Tests.BackendE2ETests.ApiRequests
 
                     if (string.IsNullOrWhiteSpace(idFromFileName))
                     {
-                        output.WriteLine($"🔴  [ERROR] Unable to extract report ID from blob name: {latestBlob.Name}");
+                        //output.WriteLine($"🔴  [ERROR] Unable to extract report ID from blob name: {latestBlob.Name}");
                         throw new Exception("Verification failed: Unable to extract report ID from blob name.");
                     }
 
@@ -50,45 +50,44 @@ namespace LantanaGroup.Link.Tests.BackendE2ETests.ApiRequests
                                             Math.Abs((b.Properties.CreatedOn.Value.UtcDateTime - latestBlob.Properties.CreatedOn.Value.UtcDateTime).TotalMinutes) <= 5)
                                  .ToList();
 
-                    //log the filtered files
-                    output.WriteLine($"Found {filteredBlobList.Count} blobs related to report ID {idFromFileName}:");
-                    foreach (var blob in filteredBlobList)
-                    {
-                        output.WriteLine($" - {blob.Name}, CreatedOn: {blob.Properties.CreatedOn}");
-                    }
-
                     foreach (var blob in blobs.OrderByDescending(x => x.Properties.CreatedOn).ToList())
                     {
-                        //download the blob
-                        output.WriteLine($"Downloading blob: {blob.Name}, CreatedOn: {blob.Properties.CreatedOn}");
-                        var blobClient = blobContainerClient.GetBlobClient(blob.Name);
-                        var downloadInfo = await blobClient.DownloadAsync();
-                        using (var ms = new MemoryStream())
+                        if (save)
                         {
-                            await downloadInfo.Value.Content.CopyToAsync(ms);
-                            _zipContents[Path.GetFileName(blob.Name)] = System.Text.Encoding.UTF8.GetString(ms.ToArray());
-
-                            if (save)
+                            //download the blob
+                            output.WriteLine($"Downloading blob: {blob.Name}, CreatedOn: {blob.Properties.CreatedOn}");
+                            var blobClient = blobContainerClient.GetBlobClient(blob.Name);
+                            var downloadInfo = await blobClient.DownloadAsync();
+                            using (var ms = new MemoryStream())
                             {
+                                await downloadInfo.Value.Content.CopyToAsync(ms);
+                                _zipContents[Path.GetFileName(blob.Name)] = System.Text.Encoding.UTF8.GetString(ms.ToArray());
+
+
                                 var localPath = Path.Combine(Directory.GetCurrentDirectory(), "DownloadedZips");
                                 if (!Directory.Exists(localPath))
                                     Directory.CreateDirectory(localPath);
                                 var filePath = Path.Combine(localPath, Path.GetFileName(blob.Name));
                                 await File.WriteAllBytesAsync(filePath, ms.ToArray());
                                 output.WriteLine($"Saved blob to: {filePath}");
-                            }
+
+                            } 
+                        }
+                        else
+                        {
+                            _zipContents[Path.GetFileName(blob.Name)] = string.Empty;
                         }
                     }
                 }
                 else
                 {
-                    output.WriteLine($"🔴  [ERROR] No files found in azurite/internal!");
+                    //output.WriteLine($"🔴  [ERROR] No files found in azurite/internal!");
                     throw new Exception($"Verification failed: Unable to connect to blob storage or no files are found.");
                 }
             }
             catch (Exception ex)
             {
-                output.WriteLine($"🔴  [ERROR] Exception while accessing blobs: {ex.Message}\n\t{ex.StackTrace}");
+                //output.WriteLine($"🔴  [ERROR] Exception while accessing blobs: {ex.Message}\n\t{ex.StackTrace}");
                 throw;
             }
         }
@@ -156,7 +155,6 @@ namespace LantanaGroup.Link.Tests.BackendE2ETests.ApiRequests
 
             var expectedResourceCounts = new Dictionary<string, int>
                 {
-                    { "Bundle", 1 },
                     { "Encounter", 2 },
                     { "Observation", 23 },
                     { "Device", 1 },
@@ -166,7 +164,10 @@ namespace LantanaGroup.Link.Tests.BackendE2ETests.ApiRequests
                     { "Patient", 1 },
                     { "Coverage", 2 },
                     { "DiagnosticReport", 2 },
-                    { "MeasureReport", 1 }
+                    { "MeasureReport", 1 },
+                    { "ServiceRequest", 116 },
+                    { "Location", 2 },
+                    {"Medication", 4 }
                 };
             Dictionary<string, int> actualCounts = null;
             DateTime startTime = DateTime.Now;
@@ -219,6 +220,7 @@ namespace LantanaGroup.Link.Tests.BackendE2ETests.ApiRequests
                     mismatches.Add($"🔴 [ERROR] ResourceType '{expected.Key}': Expected {expected.Value}, Found {actualCount}");
                 }
             }
+
             foreach (var actual in actualCounts.Keys)
             {
                 if (!expectedResourceCounts.ContainsKey(actual))
@@ -234,7 +236,7 @@ namespace LantanaGroup.Link.Tests.BackendE2ETests.ApiRequests
         }
         public void ValidateSingleMeasureAdHocAggregateACHMFile()
         {
-            string fileName = "manfiest.ndjson";
+            string fileName = "manifest.ndjson";
 
             var entry = _zipContents.Keys.FirstOrDefault(name => name.EndsWith(fileName, StringComparison.OrdinalIgnoreCase));
             if (entry == null)
@@ -290,7 +292,7 @@ namespace LantanaGroup.Link.Tests.BackendE2ETests.ApiRequests
                 {
                     await DownloadAndExtractSingleMeasureZipAsync();
                     var currentNames = _zipContents.Keys
-                                                   .Where(n => n.EndsWith(".json", StringComparison.OrdinalIgnoreCase))
+                                                   .Where(n => n.EndsWith(".ndjson", StringComparison.OrdinalIgnoreCase))
                                                    .ToHashSet(StringComparer.OrdinalIgnoreCase);
                     if (requiredFiles != null &&
                         !requiredFiles.All(req => currentNames.Any(n => n.EndsWith(req, StringComparison.OrdinalIgnoreCase))))

--- a/Tests/BackendE2ETests/ApiRequests/SubmissionZipReader.cs
+++ b/Tests/BackendE2ETests/ApiRequests/SubmissionZipReader.cs
@@ -1,58 +1,95 @@
-﻿using System.IO.Compression;
+﻿using Azure.Storage.Blobs;
+using Azure.Storage.Blobs.Models;
+using LantanaGroup.Link.Tests.E2ETests;
 using Newtonsoft.Json.Linq;
 using Xunit.Abstractions;
-using LantanaGroup.Link.Tests.E2ETests;
-using Azure.Storage.Blobs;
 
 
 namespace LantanaGroup.Link.Tests.BackendE2ETests.ApiRequests
 {
     public class SubmissionZipReader(ITestOutputHelper output)
     {
-        private static readonly string azuriteUrl = "http://127.0.0.1:10000/devstoreaccount1/internal"
+        private static readonly string azuriteConnectionString = "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1";
+        private static readonly string azuriteBaseDirectoryName = "singlemeasureadhocfacility_nhsnacutecarehospitalmonthlyinitialpopulation";
         protected static readonly string api_LinkAdminBffURL = TestConfig.AdminBffBase;
         protected static readonly string fhirServerBaseUrl = TestConfig.InternalFhirServerBase;
         protected static readonly string SingleMeasureAdHocFacility = TestConfig.SingleMeasureAdHocFacility;
         protected static readonly string SingleMeasureAdHocAchDqmVersion = TestConfig.SingleMeasureAdHocAchDqmVersion;
-        private readonly HttpClient _client = new HttpClient();
         private readonly Dictionary<string, string> _zipContents = new();
         string AdHocReportGuid => TestConfig.TestContextStore.AdHocReportTrackingIdGuid;
 
         public async Task DownloadAndExtractSingleMeasureZipAsync(bool save = false)
         {
 
-            var blobServiceClient = new BlobServiceClient("http://127.0.0.1:10000/devstoreaccount1/internal");
+            BlobContainerClient blobContainerClient = null;
+            List<Azure.Storage.Blobs.Models.BlobItem> blobs = null;
+            List<BlobItem> filteredBlobList = null;
 
-            if (string.IsNullOrEmpty(SingleMeasureAdHocFacility))
-                throw new InvalidOperationException("Facility ID must be set using UseSingleMeasureFacility() or UseMultiMeasureFacility().");
-
-            var url = $"{api_LinkAdminBffURL}/Submission/{SingleMeasureAdHocFacility}/{AdHocReportGuid}";
-            var response = await _client.GetAsync(url);
-            response.EnsureSuccessStatusCode();
-
-            byte[] zipBytes = await response.Content.ReadAsByteArrayAsync();
-
-            if (save && !string.IsNullOrEmpty(TestConfig.SmokeTestDownloadPath))
+            try
             {
-                if (!Directory.Exists(TestConfig.SmokeTestDownloadPath))
-                    Directory.CreateDirectory(TestConfig.SmokeTestDownloadPath);
+                blobContainerClient = new BlobContainerClient(azuriteConnectionString, "internal");
+                blobs = blobContainerClient.GetBlobs()
+                        .Where(b => b.Name.StartsWith(azuriteBaseDirectoryName, StringComparison.OrdinalIgnoreCase))
+                        .ToList();
+                
+                if (blobs.Any())
+                {   
+                    var latestBlob =  blobs.OrderByDescending(x => x.Properties.CreatedOn).ToList().FirstOrDefault();
+                    //get the id from the file name. split on '/' and take the first segment and then split on '_' and take the last segment
+                    var idFromFileName = latestBlob.Name.Split('/').FirstOrDefault()?.Split('_').LastOrDefault();
 
-                var downloadPath = Path.Combine(TestConfig.SmokeTestDownloadPath, "adhoc-reporting-smoke-test-submission.zip");
-                await File.WriteAllBytesAsync(downloadPath, zipBytes);
-                output.WriteLine($"Report downloaded to {downloadPath}");
+                    if (string.IsNullOrWhiteSpace(idFromFileName))
+                    {
+                        output.WriteLine($"🔴  [ERROR] Unable to extract report ID from blob name: {latestBlob.Name}");
+                        throw new Exception("Verification failed: Unable to extract report ID from blob name.");
+                    }
+
+                    //grab all files with the same id and created within 5 minutes of the latest file
+                    filteredBlobList = blobs.Where(b => b.Name.Contains(idFromFileName) && 
+                                            b.Properties.CreatedOn.HasValue && 
+                                            Math.Abs((b.Properties.CreatedOn.Value.UtcDateTime - latestBlob.Properties.CreatedOn.Value.UtcDateTime).TotalMinutes) <= 5)
+                                 .ToList();
+
+                    //log the filtered files
+                    output.WriteLine($"Found {filteredBlobList.Count} blobs related to report ID {idFromFileName}:");
+                    foreach (var blob in filteredBlobList)
+                    {
+                        output.WriteLine($" - {blob.Name}, CreatedOn: {blob.Properties.CreatedOn}");
+                    }
+
+                    foreach (var blob in blobs.OrderByDescending(x => x.Properties.CreatedOn).ToList())
+                    {
+                        //download the blob
+                        output.WriteLine($"Downloading blob: {blob.Name}, CreatedOn: {blob.Properties.CreatedOn}");
+                        var blobClient = blobContainerClient.GetBlobClient(blob.Name);
+                        var downloadInfo = await blobClient.DownloadAsync();
+                        using (var ms = new MemoryStream())
+                        {
+                            await downloadInfo.Value.Content.CopyToAsync(ms);
+                            _zipContents[Path.GetFileName(blob.Name)] = System.Text.Encoding.UTF8.GetString(ms.ToArray());
+
+                            if (save)
+                            {
+                                var localPath = Path.Combine(Directory.GetCurrentDirectory(), "DownloadedZips");
+                                if (!Directory.Exists(localPath))
+                                    Directory.CreateDirectory(localPath);
+                                var filePath = Path.Combine(localPath, Path.GetFileName(blob.Name));
+                                await File.WriteAllBytesAsync(filePath, ms.ToArray());
+                                output.WriteLine($"Saved blob to: {filePath}");
+                            }
+                        }
+                    }
+                }
+                else
+                {
+                    output.WriteLine($"🔴  [ERROR] No files found in azurite/internal!");
+                    throw new Exception($"Verification failed: Unable to connect to blob storage or no files are found.");
+                }
             }
-
-            using var zipStream = new MemoryStream(zipBytes);
-            using var archive = new ZipArchive(zipStream, ZipArchiveMode.Read);
-
-            foreach (var entry in archive.Entries)
+            catch (Exception ex)
             {
-                if (!entry.FullName.EndsWith(".json", StringComparison.OrdinalIgnoreCase))
-                    continue;
-
-                using var reader = new StreamReader(entry.Open());
-                string content = await reader.ReadToEndAsync();
-                _zipContents[entry.FullName] = content;
+                output.WriteLine($"🔴  [ERROR] Exception while accessing blobs: {ex.Message}\n\t{ex.StackTrace}");
+                throw;
             }
         }
 
@@ -135,22 +172,30 @@ namespace LantanaGroup.Link.Tests.BackendE2ETests.ApiRequests
             DateTime startTime = DateTime.Now;
             while ((DateTime.Now - startTime).TotalSeconds < timeoutSeconds)
             {
-                json = JObject.Parse(content);
-
-                actualCounts = new Dictionary<string, int>
+                //the content is ndjson, so we need to split it into lines and parse each line as JSON
+                foreach (var line in content.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries))
                 {
-                    { (string)json["resourceType"] ?? "null", 1 }
-                };
-                var entryCounts = json["entry"]?
-                    .GroupBy(e => (string)e["resource"]?["resourceType"])
-                    .ToDictionary(g => g.Key ?? "null", g => g.Count()) ?? new Dictionary<string, int>();
-
-                foreach (var kvp in entryCounts)
-                {
-                    if (actualCounts.ContainsKey(kvp.Key))
-                        actualCounts[kvp.Key] += kvp.Value;
+                    var lineJson = JObject.Parse(line);
+                    var resourceType = (string)lineJson["resourceType"] ?? "null";
+                    
+                    if (actualCounts == null)
+                        actualCounts = new Dictionary<string, int>();
+                    if (actualCounts.ContainsKey(resourceType))
+                        actualCounts[resourceType]++;
                     else
-                        actualCounts[kvp.Key] = kvp.Value;
+                        actualCounts[resourceType] = 1;
+
+                    var entryCounts = lineJson["entry"]?
+                        .GroupBy(e => (string)e["resource"]?["resourceType"])
+                        .ToDictionary(g => g.Key ?? "null", g => g.Count()) ?? new Dictionary<string, int>();
+
+                    foreach (var kvp in entryCounts)
+                    {
+                        if (actualCounts.ContainsKey(kvp.Key))
+                            actualCounts[kvp.Key] += kvp.Value;
+                        else
+                            actualCounts[kvp.Key] = kvp.Value;
+                    }
                 }
 
                 if (expectedResourceCounts.All(kvp =>
@@ -189,13 +234,21 @@ namespace LantanaGroup.Link.Tests.BackendE2ETests.ApiRequests
         }
         public void ValidateSingleMeasureAdHocAggregateACHMFile()
         {
-            string fileName = "aggregate-ACHM.json";
+            string fileName = "manfiest.ndjson";
 
             var entry = _zipContents.Keys.FirstOrDefault(name => name.EndsWith(fileName, StringComparison.OrdinalIgnoreCase));
             if (entry == null)
                 throw new Exception($"{fileName} is missing from the ZIP archive.");
             var content = _zipContents[entry];
-            JObject json = JObject.Parse(content);
+
+            //loop through each line and find the MeasureReport resource
+            var measureReportLine = content.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries)
+                                            .FirstOrDefault(line => line.Contains("\"resourceType\":\"MeasureReport\"", StringComparison.OrdinalIgnoreCase));
+
+            if (string.IsNullOrWhiteSpace(measureReportLine))
+                throw new Exception("Verification failed: MeasureReport resource is missing from manifest.ndjson.");
+
+            JObject json = JObject.Parse(measureReportLine);
             int actualCount = (int?)json["group"]?[0]?["population"]?[0]?["count"] ?? -1;
             if (actualCount != 8)
             {

--- a/Tests/BackendE2ETests/ApiRequests/SubmissionZipReader.cs
+++ b/Tests/BackendE2ETests/ApiRequests/SubmissionZipReader.cs
@@ -2,12 +2,14 @@
 using Newtonsoft.Json.Linq;
 using Xunit.Abstractions;
 using LantanaGroup.Link.Tests.E2ETests;
+using Azure.Storage.Blobs;
 
 
 namespace LantanaGroup.Link.Tests.BackendE2ETests.ApiRequests
 {
     public class SubmissionZipReader(ITestOutputHelper output)
     {
+        private static readonly string azuriteUrl = "http://127.0.0.1:10000/devstoreaccount1/internal"
         protected static readonly string api_LinkAdminBffURL = TestConfig.AdminBffBase;
         protected static readonly string fhirServerBaseUrl = TestConfig.InternalFhirServerBase;
         protected static readonly string SingleMeasureAdHocFacility = TestConfig.SingleMeasureAdHocFacility;
@@ -18,6 +20,9 @@ namespace LantanaGroup.Link.Tests.BackendE2ETests.ApiRequests
 
         public async Task DownloadAndExtractSingleMeasureZipAsync(bool save = false)
         {
+
+            var blobServiceClient = new BlobServiceClient("http://127.0.0.1:10000/devstoreaccount1/internal");
+
             if (string.IsNullOrEmpty(SingleMeasureAdHocFacility))
                 throw new InvalidOperationException("Facility ID must be set using UseSingleMeasureFacility() or UseMultiMeasureFacility().");
 
@@ -50,21 +55,18 @@ namespace LantanaGroup.Link.Tests.BackendE2ETests.ApiRequests
                 _zipContents[entry.FullName] = content;
             }
         }
+
         public void SingleMeasureAdHocValidateFilesAppear()
         {
             var expectedFiles = new List<string>
             {
-                "patient-list.json",
-                "sending-organization.json",
-                "sending-device.json",
-                "aggregate-ACHM.json",
-                "other-resources.json",
-                "patient-x25sJU80vVa51mxJ6vSDcjbNC3BcdCQujJbXQwqdppFOO.json",
-                "patient-MVLkMLWErl3gQGRCuA2mygtVuix7PMBFBh9WVayaCL7xM.json",
-                "patient-CYUcGIlSrpJxCBMeEml30YSmE0Ea7loNBPVZfhCUkv7A3.json",
-                "patient-VsZkAG8h9vkGcL528ZcJxVXynyj8X39GaDfjHbA9AnvyA.json",
-                "patient-jjMZxCVWUbZgLkPf2LTzvZIBOW76YLJdIGCw8JFaTPiZg.json",
-                "patient-6tZ8Wt8maJdDFLvEsDcKmAaCAcSOxjr0mB8RjEi5Szw7H.json"
+                "manifest.ndjson",
+                "patient-x25sJU80vVa51mxJ6vSDcjbNC3BcdCQujJbXQwqdppFOO.ndjson",
+                "patient-MVLkMLWErl3gQGRCuA2mygtVuix7PMBFBh9WVayaCL7xM.ndjson",
+                "patient-CYUcGIlSrpJxCBMeEml30YSmE0Ea7loNBPVZfhCUkv7A3.ndjson",
+                "patient-VsZkAG8h9vkGcL528ZcJxVXynyj8X39GaDfjHbA9AnvyA.ndjson",
+                "patient-jjMZxCVWUbZgLkPf2LTzvZIBOW76YLJdIGCw8JFaTPiZg.ndjson",
+                "patient-6tZ8Wt8maJdDFLvEsDcKmAaCAcSOxjr0mB8RjEi5Szw7H.ndjson"
             };
 
             var missingFiles = expectedFiles
@@ -85,10 +87,10 @@ namespace LantanaGroup.Link.Tests.BackendE2ETests.ApiRequests
         {
             var disallowedFiles = new List<string>
             {
-                "patient-jbbPDJeGWyEyudcf6EBKTgmeCLxB7jTgu5Ugm27JAO494.json",
-                "patient-DJxsHpmWuBezhV9hJNgEHT4szaKW3uP5vUNzXUCkltpXj.json",
-                "patient-9i6Xi6uG2WjuGxHTmpbin4ct2ZwevRwTWhIkJkRjVFZ4C.json",
-                "patient-5ieWogP3EGV24Kus8QsGh6rpmUaJBP5Hl0nCSJJXmh6TI.json"
+                "patient-jbbPDJeGWyEyudcf6EBKTgmeCLxB7jTgu5Ugm27JAO494.ndjson",
+                "patient-DJxsHpmWuBezhV9hJNgEHT4szaKW3uP5vUNzXUCkltpXj.ndjson",
+                "patient-9i6Xi6uG2WjuGxHTmpbin4ct2ZwevRwTWhIkJkRjVFZ4C.ndjson",
+                "patient-5ieWogP3EGV24Kus8QsGh6rpmUaJBP5Hl0nCSJJXmh6TI.ndjson"
             };
 
             var foundDisallowedFiles = disallowedFiles
@@ -106,7 +108,7 @@ namespace LantanaGroup.Link.Tests.BackendE2ETests.ApiRequests
         }
         public void ValidateSpecificPatientFileContents(int timeoutSeconds = 10, int pollIntervalMs = 1000)
         {
-            string fileName = "patient-x25sJU80vVa51mxJ6vSDcjbNC3BcdCQujJbXQwqdppFOO.json";
+            string fileName = "patient-x25sJU80vVa51mxJ6vSDcjbNC3BcdCQujJbXQwqdppFOO.ndjson";
 
             var entry = _zipContents.Keys.FirstOrDefault(name => name.EndsWith(fileName, StringComparison.OrdinalIgnoreCase));
             if (entry == null)

--- a/Tests/BackendE2ETests/BackendE2ETests.csproj
+++ b/Tests/BackendE2ETests/BackendE2ETests.csproj
@@ -16,6 +16,7 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <PackageReference Include="Azure.Storage.Blobs" Version="12.25.0" />
         <PackageReference Include="Hl7.Fhir.R4" Version="5.12.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.*" />
         <PackageReference Include="Moq.AutoMock" Version="*-*" />

--- a/Tests/BackendE2ETests/BackendE2ETests.csproj
+++ b/Tests/BackendE2ETests/BackendE2ETests.csproj
@@ -16,7 +16,6 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Azure.Storage.Blobs" Version="12.25.0" />
         <PackageReference Include="Hl7.Fhir.R4" Version="5.12.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.*" />
         <PackageReference Include="Moq.AutoMock" Version="*-*" />


### PR DESCRIPTION
### 🛠️ Description of Changes
Updated the Single Measure Adhoc Report Smoke Test to account for ABS changes and the presence of Azurite in the testing environment.

### 🧪 Testing Performed
Ran the Single Measure Adhoc Report Smoke Test to success.

### 🧑‍🔬 Unit Testing
- [X ] I have written or updated unit tests to cover my changes

### 📓 Documentation Updated
This only changes underlying functionality and not the configuration.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Support NDJSON outputs (manifest and patient files) with per-line parsing and validation.

- Refactor
  - Updated report retrieval and extraction to handle NDJSON entries inside retrieved archives and stream processing.

- Bug Fixes
  - Improved stability checks, longer default timeouts/polling for file availability, and clearer error messages when files or facility config are missing.

- Tests
  - E2E tests updated to validate NDJSON content and now log test duration on successful runs.

- Chores
  - Added cloud storage client dependency to the test project.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->