### PR TITLE
LNK-4274: Remove FacilityId check DEV

### DIFF
--- a/DotNet/DataAcquisition.Domain/Application/Models/Http/LogSearchParameters.cs
+++ b/DotNet/DataAcquisition.Domain/Application/Models/Http/LogSearchParameters.cs
@@ -5,7 +5,7 @@ using System.ComponentModel.DataAnnotations;
 namespace LantanaGroup.Link.DataAcquisition.Domain.Application.Models.Http;
 public class LogSearchParameters : GenericLogSearchParameters
 {
-    public string FacilityId { get; set; }
+    public string? FacilityId { get; set; }
     public string? PatientId { get; set; }
     public string? ReportId { get; set; }
     public string? ResourceId { get; set; }

--- a/DotNet/DataAcquisition.Domain/Application/Models/Http/LogSearchParameters.cs
+++ b/DotNet/DataAcquisition.Domain/Application/Models/Http/LogSearchParameters.cs
@@ -5,8 +5,7 @@ using System.ComponentModel.DataAnnotations;
 namespace LantanaGroup.Link.DataAcquisition.Domain.Application.Models.Http;
 public class LogSearchParameters : GenericLogSearchParameters
 {
-    [Required]
-    public required string FacilityId { get; set; }
+    public string FacilityId { get; set; }
     public string? PatientId { get; set; }
     public string? ReportId { get; set; }
     public string? ResourceId { get; set; }


### PR DESCRIPTION
Remove facility id check from LogController.Search() to allow UI to pull log records with no parameters.

🛠️ Description of Changes
Remove facility id check from LogController.Search() to allow UI to pull log records with no parameters.

🧪 Testing Performed
Local Testing.

🧑‍🔬 Unit Testing
[X ] I have written or updated unit tests to cover my changes

📓 Documentation Updated
No documentation to update.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Log search no longer requires a Facility ID, allowing searches without specifying a facility.
  * Enables broader or cross-facility queries where supported.

* **Bug Fixes**
  * Reduced unnecessary validation failures by making Facility ID optional during search requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->