### PR TITLE
LNK-4291: Added security headers including CSP

### DIFF
--- a/Java/shared/src/main/java/com/lantanagroup/link/shared/security/SecurityHelper.java
+++ b/Java/shared/src/main/java/com/lantanagroup/link/shared/security/SecurityHelper.java
@@ -50,17 +50,37 @@ public class SecurityHelper {
             .requestMatchers(HttpMethod.GET, "/swagger-ui/**").permitAll()
             //requestMatchers("/api/**").access("hasRole('LinkUser') and hasAuthority('IsLinkAdmin')").and().exceptionHandling(ex -> ex.authenticationEntryPoint(point)  - done in the specific end points using annotations for more granular control
             .requestMatchers("/api/**").authenticated().and().exceptionHandling(ex -> ex.authenticationEntryPoint(point))
-            .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
+            .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+            .headers(headers -> headers
+                  .contentSecurityPolicy(csp -> csp
+                          .policyDirectives(
+                          "default-src 'self'; " +
+                          "script-src 'self'; " +
+                          "style-src 'self' 'unsafe-inline'; " +
+                          "img-src 'self' data:;" +
+                          "connect-src 'self';"
+                          )
+                  )
+            );
     return http.build();
   }
 
 
-    public static SecurityFilterChain buildAnonymous(HttpSecurity http) throws Exception {
+  public static SecurityFilterChain buildAnonymous(HttpSecurity http) throws Exception {
         return http
                 .csrf(AbstractHttpConfigurer::disable)
-                .authorizeHttpRequests(authorizeRequests -> {
-                    authorizeRequests.anyRequest().permitAll();
-                })
+                .authorizeHttpRequests(authorizeRequests -> authorizeRequests.anyRequest().permitAll())
+                .headers(headers -> headers
+                        .contentSecurityPolicy(csp -> csp
+                                .policyDirectives(
+                                    "default-src 'self'; " +
+                                    "script-src 'self'; " +
+                                    "style-src 'self' 'unsafe-inline'; " +
+                                    "img-src 'self' data:;" +
+                                    "connect-src 'self';"
+                                )
+                        )
+                )
                 .build();
     }
 }


### PR DESCRIPTION
### 🛠️ Description of Changes
Added security headers including CSP

### 🧪 Testing Performed
Tested in CDC

### 🧑‍🔬 Unit Testing
- [ ] I have written or updated unit tests to cover my changes

### 📓 Documentation Updated
Please update any relevant sections in the project documentation that were impacted by the changes in the PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added Content Security Policy (CSP) headers to all endpoints, enhancing protection against XSS and unauthorized content loading.
- Chores
  - Standardized security headers across authenticated and anonymous flows: default sources restricted to self, images from self/data, scripts/styles from self (styles allow inline), and connections to self.
  - Maintained existing stateless session behavior with no functional changes to authentication flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->