### PR TITLE
LNK-4299: Release 0.3 

### DIFF
--- a/DotNet/Normalization/Application/Models/Operations/HttpModels/PostOperationModel.cs
+++ b/DotNet/Normalization/Application/Models/Operations/HttpModels/PostOperationModel.cs
@@ -2,11 +2,12 @@
 using System.ComponentModel.DataAnnotations;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.Serialization;
+using Hl7.Fhir.Model;
 
 namespace LantanaGroup.Link.Normalization.Application.Models.Operations.HttpModels
 {
     [ExcludeFromCodeCoverage]
-    public class PostOperationModel()
+    public class PostOperationModel
     {
         [Required, DataMember]
         public List<string> ResourceTypes { get; set; } = new List<string>();
@@ -15,6 +16,19 @@ namespace LantanaGroup.Link.Normalization.Application.Models.Operations.HttpMode
         [DataMember]
         public string? FacilityId { get; set; } = null;
         [DataMember(IsRequired = false)]
-        public List<Guid>? VendorIds { get; set; }   
+        public List<Guid>? VendorIds { get; set; }
+
+        public PostOperationModel(List<string> resourceTypes, IOperation operation, string? facilityId, List<Guid>? vendorIds)
+        {
+            ResourceTypes = resourceTypes ?? new List<string>();
+            Operation = operation;
+            FacilityId = facilityId;
+            VendorIds = vendorIds;
+
+            if (this.Operation.OperationType == OperationType.CopyLocation)
+            {
+                this.ResourceTypes.Add(ResourceType.Location.ToString());
+            }
+        }
     }
 }

--- a/DotNet/Normalization/Application/Models/Operations/HttpModels/PutOperationModel.cs
+++ b/DotNet/Normalization/Application/Models/Operations/HttpModels/PutOperationModel.cs
@@ -6,7 +6,7 @@ using System.Runtime.Serialization;
 namespace LantanaGroup.Link.Normalization.Application.Models.Operations.HttpModels
 {
     [ExcludeFromCodeCoverage]
-    public class PutOperationModel()
+    public class PutOperationModel
     {
         [Required, DataMember]
         public required Guid? Id { get; set; }
@@ -19,5 +19,19 @@ namespace LantanaGroup.Link.Normalization.Application.Models.Operations.HttpMode
         [DataMember]
         public string? FacilityId { get; set; }
         public List<Guid>? VendorIds { get; set; }
+        public PutOperationModel(Guid? id, List<string> resourceTypes, IOperation operation, bool isDisabled, string? facilityId, List<Guid>? vendorIds)
+        {
+            Id = id;
+            ResourceTypes = resourceTypes ?? new List<string>();
+            Operation = operation;
+            IsDisabled = isDisabled;
+            FacilityId = facilityId;
+            VendorIds = vendorIds;
+
+            if (this.Operation.OperationType == OperationType.CopyLocation)
+            {
+                this.ResourceTypes.Add("Location");
+            }
+        }
     }
 }

--- a/DotNet/Normalization/Application/Operations/CopyLocationOperation.cs
+++ b/DotNet/Normalization/Application/Operations/CopyLocationOperation.cs
@@ -1,0 +1,18 @@
+﻿using LantanaGroup.Link.Normalization.Application.Models.Operations;
+using Microsoft.Identity.Client;
+
+namespace LantanaGroup.Link.Normalization.Application.Operations
+{
+    public class CopyLocationOperation : IOperation
+    {
+        public OperationType OperationType => OperationType.CopyLocation;
+
+        public string Name { get; set; }
+        public string Description { get; set; }
+
+        public CopyLocationOperation() {
+            Name = "Copy Location Operation";
+            Description = "Copies each Location Identifier 'System' and 'Value' fields into Location.Type as a CodeableConcept";
+        }
+    }
+}

--- a/DotNet/Normalization/Application/Operations/OperationConverter.cs
+++ b/DotNet/Normalization/Application/Operations/OperationConverter.cs
@@ -23,6 +23,7 @@ public class OperationConverter : JsonConverter<IOperation>
                 "CopyProperty" => JsonSerializer.Deserialize<CopyPropertyOperation>(doc.RootElement.GetRawText(), options),
                 "CodeMap" => JsonSerializer.Deserialize<CodeMapOperation>(doc.RootElement.GetRawText(), options),
                 "ConditionalTransform" => JsonSerializer.Deserialize<ConditionalTransformOperation>(doc.RootElement.GetRawText(), options),
+                "CopyLocation" => JsonSerializer.Deserialize<CopyLocationOperation>(doc.RootElement.GetRawText(), options),
                 _ => throw new JsonException($"Unknown operationType: {operationType}")
             };
         }

--- a/DotNet/Normalization/Application/Operations/OperationHelper.cs
+++ b/DotNet/Normalization/Application/Operations/OperationHelper.cs
@@ -18,6 +18,7 @@ namespace LantanaGroup.Link.Normalization.Application.Operations
                 OperationType.CopyProperty => JsonSerializer.Deserialize<CopyPropertyOperation>(operationJson),
                 OperationType.CodeMap => JsonSerializer.Deserialize<CodeMapOperation>(operationJson),
                 OperationType.ConditionalTransform => JsonSerializer.Deserialize<ConditionalTransformOperation>(operationJson),
+                OperationType.CopyLocation => JsonSerializer.Deserialize<CopyLocationOperation>(operationJson),
                 _ => null
             };
 

--- a/DotNet/Normalization/Application/Operations/OperationType.cs
+++ b/DotNet/Normalization/Application/Operations/OperationType.cs
@@ -5,6 +5,7 @@
         None = 0,
         CopyProperty = 1,
         ConditionalTransform = 2,
-        CodeMap = 3
+        CodeMap = 3,
+        CopyLocation = 4
     }
 }

--- a/DotNet/Normalization/Application/Services/Operations/CopyLocationOperation.cs
+++ b/DotNet/Normalization/Application/Services/Operations/CopyLocationOperation.cs
@@ -1,0 +1,56 @@
+﻿using Google.Protobuf.Collections;
+using Hl7.Fhir.ElementModel;
+using Hl7.Fhir.Model;
+using Hl7.FhirPath;
+using LantanaGroup.Link.Normalization.Application.Models.Operations;
+using LantanaGroup.Link.Normalization.Application.Operations;
+using LantanaGroup.Link.Normalization.Application.Services.FhirPathValidation;
+using System.Collections;
+
+namespace LantanaGroup.Link.Normalization.Application.Services.Operations
+{
+    public class CopyLocationOperationService : BaseOperationService<CopyLocationOperation>
+    {
+        public CopyLocationOperationService(ILogger<CopyLocationOperationService> logger, TimeSpan? operationTimeout = null)
+            : base(logger, operationTimeout)
+        {
+        }
+
+        protected override async Task<OperationResult> ExecuteOperation(CopyLocationOperation operation, DomainResource resource)
+        {
+            if (resource is not Location) 
+            {
+                return OperationResult.Failure($"Resource must be a Location");
+            }
+
+            Location location = (Location)resource;
+
+            if (location.Type == null)
+            {
+                location.Type = new List<CodeableConcept>();
+            }
+
+            foreach (var identifier in location.Identifier) 
+            {
+                if (string.IsNullOrWhiteSpace(identifier.System) && string.IsNullOrWhiteSpace(identifier.Value)) 
+                {
+                    continue;
+                }
+
+                // de-dupe on (system, code)
+                var exists = location.Type.Any(cc =>
+                cc.Coding.Any(cd =>
+                string.Equals(cd.System, identifier.System, StringComparison.Ordinal) &&
+                string.Equals(cd.Code, identifier.Value, StringComparison.Ordinal)));
+                
+                if (exists) 
+                    continue;
+
+                CodeableConcept codeableConcept = new(identifier.System, identifier.Value);
+                location.Type.Add(codeableConcept);
+            }
+
+            return OperationResult.Success(location);
+        }
+    }
+}

--- a/DotNet/Normalization/Application/Services/Operations/OperationServiceHelper.cs
+++ b/DotNet/Normalization/Application/Services/Operations/OperationServiceHelper.cs
@@ -39,6 +39,7 @@ namespace LantanaGroup.Link.Normalization.Application.Services.Operations
                 OperationType.CopyProperty => (object)(CopyPropertyOperation)operation,
                 OperationType.CodeMap => (object)(CodeMapOperation)operation,
                 OperationType.ConditionalTransform => (object)(ConditionalTransformOperation)operation,
+                OperationType.CopyLocation => (object)(CopyLocationOperation)operation,
                 _ => null
             };
         }
@@ -704,7 +705,7 @@ namespace LantanaGroup.Link.Normalization.Application.Services.Operations
                 {
                     var op = (CopyPropertyOperation)operation;
                     StringBuilder builder = new StringBuilder();
-                    foreach(var resource in resources)
+                    foreach (var resource in resources)
                     {
                         var result = await FhirPathValidator.IsFhirPathValidForResourceType(op.SourceFhirPath, resource);
 
@@ -720,8 +721,8 @@ namespace LantanaGroup.Link.Normalization.Application.Services.Operations
                             builder.AppendLine($"TargetFhirPath {op.TargetFhirPath} is not a valid path for {resource}: {result.ErrorMessage}");
                         }
                     }
-                    
-                    if(builder.Length > 0)
+
+                    if (builder.Length > 0)
                     {
                         return (false, builder.ToString());
                     }
@@ -734,7 +735,7 @@ namespace LantanaGroup.Link.Normalization.Application.Services.Operations
 
                     foreach (var map in op.CodeSystemMaps)
                     {
-                        if(string.IsNullOrEmpty(map.SourceSystem))
+                        if (string.IsNullOrEmpty(map.SourceSystem))
                         {
                             builder.AppendLine($"CodeSystemMap.SourceSystem cannot be null or empty.");
                         }
@@ -754,7 +755,7 @@ namespace LantanaGroup.Link.Normalization.Application.Services.Operations
                         }
                         else
                         {
-                            foreach(var codeMap in map.CodeMaps)
+                            foreach (var codeMap in map.CodeMaps)
                             {
                                 if (string.IsNullOrEmpty(codeMap.Key))
                                 {
@@ -805,7 +806,7 @@ namespace LantanaGroup.Link.Normalization.Application.Services.Operations
                             builder.AppendLine($"TargetFhirPath {op.TargetFhirPath} is not a valid path for {resource}: {result.ErrorMessage}");
                         }
 
-                        foreach(var condition in op.Conditions)
+                        foreach (var condition in op.Conditions)
                         {
                             var condResult = await FhirPathValidator.IsFhirPathValidForResourceType(condition.FhirPathSource, resource);
 
@@ -820,6 +821,9 @@ namespace LantanaGroup.Link.Normalization.Application.Services.Operations
                     {
                         return (false, builder.ToString());
                     }
+                }
+                else if (operation is CopyLocationOperation) { 
+                    //No validation needed for CopyLocationOperation
                 }
                 else
                 {

--- a/DotNet/Normalization/Controllers/OperationsController.cs
+++ b/DotNet/Normalization/Controllers/OperationsController.cs
@@ -31,8 +31,9 @@ namespace LantanaGroup.Link.Normalization.Controllers
         private readonly CopyPropertyOperationService _copyPropertyOperationService;
         private readonly CodeMapOperationService _codeMapOperationService;
         private readonly ConditionalTransformOperationService _conditionalTransformOperationService;
+        private readonly CopyLocationOperationService _copyLocationOperationService;
 
-        public OperationsController(IOperationManager operationManager, IOperationQueries operationQueries, IVendorQueries vendorQueries, ITenantApiService tenantApiService, CopyPropertyOperationService copyPropertyService, CodeMapOperationService codeMapOperationService, ConditionalTransformOperationService conditionalTransformOperationService)
+        public OperationsController(IOperationManager operationManager, IOperationQueries operationQueries, IVendorQueries vendorQueries, ITenantApiService tenantApiService, CopyPropertyOperationService copyPropertyService, CodeMapOperationService codeMapOperationService, ConditionalTransformOperationService conditionalTransformOperationService, CopyLocationOperationService copyLocationOperationService)
         {
             _operationManager = operationManager;
             _operationQueries = operationQueries;
@@ -41,6 +42,7 @@ namespace LantanaGroup.Link.Normalization.Controllers
             _copyPropertyOperationService = copyPropertyService;
             _codeMapOperationService = codeMapOperationService;
             _conditionalTransformOperationService = conditionalTransformOperationService;
+            _copyLocationOperationService = copyLocationOperationService;
         }
 
         [HttpGet("")]
@@ -361,6 +363,7 @@ namespace LantanaGroup.Link.Normalization.Controllers
                     OperationType.CopyProperty => await _copyPropertyOperationService.EnqueueOperationAsync((CopyPropertyOperation)operationImplementation, domainResource),
                     OperationType.CodeMap => await _codeMapOperationService.EnqueueOperationAsync((CodeMapOperation)operationImplementation, domainResource),
                     OperationType.ConditionalTransform => await _conditionalTransformOperationService.EnqueueOperationAsync((ConditionalTransformOperation)operationImplementation, domainResource),
+                    OperationType.CopyLocation => await _copyLocationOperationService.EnqueueOperationAsync((CopyLocationOperation)operationImplementation, domainResource),
                     _ => null
                 };
 
@@ -407,6 +410,7 @@ namespace LantanaGroup.Link.Normalization.Controllers
                     OperationType.CopyProperty => await _copyPropertyOperationService.EnqueueOperationAsync((CopyPropertyOperation)operation, domainResource),
                     OperationType.CodeMap => await _codeMapOperationService.EnqueueOperationAsync((CodeMapOperation)operation, domainResource),
                     OperationType.ConditionalTransform => await _conditionalTransformOperationService.EnqueueOperationAsync((ConditionalTransformOperation)operation, domainResource),
+                    OperationType.CopyLocation => await _copyLocationOperationService.EnqueueOperationAsync((CopyLocationOperation)operation, domainResource),
                     _ => null
                 };
 

--- a/DotNet/Normalization/Listeners/ResourceAcquiredListener.cs
+++ b/DotNet/Normalization/Listeners/ResourceAcquiredListener.cs
@@ -40,6 +40,7 @@ public class ResourceAcquiredListener : BackgroundService
     private readonly CopyPropertyOperationService _copyPropertyOperationService;
     private readonly CodeMapOperationService _codeMapOperationService;
     private readonly ConditionalTransformOperationService _conditionalTransformOperationService;
+    private readonly CopyLocationOperationService _copyLocationOperationService;
 
     public ResourceAcquiredListener(
         ILogger<ResourceAcquiredListener> logger,
@@ -53,7 +54,8 @@ public class ResourceAcquiredListener : BackgroundService
         IProducer<string, ResourceNormalizedMessage> producer,
         CopyPropertyOperationService copyPropertyOperationService,
         CodeMapOperationService codeMapOperationService,
-        ConditionalTransformOperationService conditionalTransformOperationService)
+        ConditionalTransformOperationService conditionalTransformOperationService,
+        CopyLocationOperationService copyLocationOperationService)
     {
         this._logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _consumerFactory = consumerFactory ?? throw new ArgumentNullException(nameof(consumerFactory));
@@ -72,8 +74,9 @@ public class ResourceAcquiredListener : BackgroundService
         _producer = producer ?? throw new ArgumentNullException(nameof(producer));
 
         _copyPropertyOperationService = copyPropertyOperationService;
-        _codeMapOperationService = codeMapOperationService ?? throw new ArgumentNullException( nameof(codeMapOperationService));
+        _codeMapOperationService = codeMapOperationService ?? throw new ArgumentNullException(nameof(codeMapOperationService));
         _conditionalTransformOperationService = conditionalTransformOperationService ?? throw new ArgumentNullException(nameof(conditionalTransformOperationService));
+        _copyLocationOperationService = copyLocationOperationService ?? throw new ArgumentNullException(nameof(copyLocationOperationService));
     }
 
     protected override async Task ExecuteAsync(CancellationToken cancellationToken)
@@ -184,6 +187,7 @@ public class ResourceAcquiredListener : BackgroundService
                                     OperationType.CopyProperty => await _copyPropertyOperationService.EnqueueOperationAsync((CopyPropertyOperation)operation, resource),
                                     OperationType.CodeMap => await _codeMapOperationService.EnqueueOperationAsync((CodeMapOperation)operation, resource),
                                     OperationType.ConditionalTransform => await _conditionalTransformOperationService.EnqueueOperationAsync((ConditionalTransformOperation)operation, resource),
+                                    OperationType.CopyLocation => await _copyLocationOperationService.EnqueueOperationAsync((CopyLocationOperation)operation, resource),
                                     _ => null
                                 };
 

--- a/DotNet/Normalization/Program.cs
+++ b/DotNet/Normalization/Program.cs
@@ -226,6 +226,9 @@ static void RegisterServices(WebApplicationBuilder builder)
     builder.Services.AddSingleton<ConditionalTransformOperationService>();
     builder.Services.AddHostedService(provider => provider.GetRequiredService<ConditionalTransformOperationService>());
 
+    builder.Services.AddSingleton<CopyLocationOperationService>();
+    builder.Services.AddHostedService(provider => provider.GetRequiredService<CopyLocationOperationService>());
+
     if (consumerSettings != null && !consumerSettings.DisableConsumer)
     {
          builder.Services.AddHostedService<ResourceAcquiredListener>();

--- a/DotNet/ServiceTests/IntegrationTests/Normalization/NormalizationIntegrationTestFixture.cs
+++ b/DotNet/ServiceTests/IntegrationTests/Normalization/NormalizationIntegrationTestFixture.cs
@@ -41,6 +41,9 @@ namespace IntegrationTests.Normalization
                     services.AddSingleton<CopyPropertyOperationService>();
                     services.AddHostedService(provider => provider.GetRequiredService<CopyPropertyOperationService>());
 
+                    services.AddSingleton<CopyLocationOperationService>();
+                    services.AddHostedService(provider => provider.GetRequiredService<CopyLocationOperationService>());
+
                     services.AddSingleton<CodeMapOperationService>();
                     services.AddHostedService(provider => provider.GetRequiredService<CodeMapOperationService>());
 


### PR DESCRIPTION
* Initial Checkin. Added most of the code needed to accept the new operation. Added functionality to POST the new operation via REST. Added initial copy Location operation logic

* Updated Put model to support Copy Location operation. Added Copy Location operation to the Rest operations/{id}/test endpoint

* Updated listener to support the new Copy Location operation

* Added copy location integration test

* Casted location to variable to simplify readability of the operation

* Added a check to see if Location.identifier has a null system and value prior to adding to Location.type

* DOC: Removed unused Normalization requests. Updated GET operation params

* Updated Normalization openapi.yml

* Used FHIR Location enum when adding Location resource to resource types when the operation is CopyLocation

