### PR TITLE
LNK-4293: Cherry Pick from #1120

### DIFF
--- a/DotNet/DataAcquisition.Domain/Application/Models/Http/DeleteQueryPlanParameters.cs
+++ b/DotNet/DataAcquisition.Domain/Application/Models/Http/DeleteQueryPlanParameters.cs
@@ -1,9 +1,11 @@
 ﻿using LantanaGroup.Link.Shared.Application.Models;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
 using System.ComponentModel.DataAnnotations;
 
 namespace LantanaGroup.Link.DataAcquisition.Domain.Application.Models.Http;
 public class DeleteQueryPlanParameters
 {
+    [BindRequired]
     [Required]
     public Frequency? Type { get; set; }
 }

--- a/DotNet/DataAcquisition.Domain/Application/Models/Http/GetQueryPlanParameters.cs
+++ b/DotNet/DataAcquisition.Domain/Application/Models/Http/GetQueryPlanParameters.cs
@@ -1,9 +1,11 @@
 ﻿using LantanaGroup.Link.Shared.Application.Models;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
 using System.ComponentModel.DataAnnotations;
 
 namespace LantanaGroup.Link.DataAcquisition.Domain.Application.Models.Http;
 public class GetQueryPlanParameters
 {
+    [BindRequired]
     [Required]
     public Frequency? Type { get; set; }
 }

--- a/DotNet/DataAcquisition/Controllers/QueryPlanConfigController.cs
+++ b/DotNet/DataAcquisition/Controllers/QueryPlanConfigController.cs
@@ -49,6 +49,11 @@ public class QueryPlanConfigController : Controller
         [FromQuery] GetQueryPlanParameters queryParameters,
         CancellationToken cancellationToken)
     {
+        if(!ModelState.IsValid)
+        {
+            return BadRequest(ModelState);
+        }
+
         try
         {
             if (string.IsNullOrWhiteSpace(facilityId))
@@ -307,6 +312,10 @@ public class QueryPlanConfigController : Controller
         [FromQuery] DeleteQueryPlanParameters parameters,
         CancellationToken cancellationToken)
     {
+        if (!ModelState.IsValid)
+        {
+            return BadRequest(ModelState);
+        }
 
         try
         {

--- a/DotNet/Normalization/Application/Models/Operations/HttpModels/TestOperationModel.cs
+++ b/DotNet/Normalization/Application/Models/Operations/HttpModels/TestOperationModel.cs
@@ -1,5 +1,6 @@
 ﻿using Hl7.Fhir.Model;
 using LantanaGroup.Link.Normalization.Application.Operations;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
 using System.ComponentModel.DataAnnotations;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.Serialization;
@@ -9,8 +10,11 @@ namespace LantanaGroup.Link.Normalization.Application.Models.Operations.HttpMode
     [ExcludeFromCodeCoverage]
     public class TestOperationModel()
     {
+        [BindRequired]
         [Required, DataMember]
         public required IOperation Operation { get; set; }
+
+        [BindRequired]
         [Required, DataMember]
         public DomainResource? Resource { get; set; }
 

--- a/DotNet/Normalization/appsettings.json
+++ b/DotNet/Normalization/appsettings.json
@@ -1,6 +1,9 @@
 {  
   "ServiceInformation": {
-    "ServiceName": "Link Normalization Service"
+    "Name": "Link Normalization Service",
+    "ServiceName": "Link Normalization Service",
+    "Version": "0.1.1-dev",
+    "GitCommit": "git_value"
   },
   "EnableSwagger": false,
   "Logging": {


### PR DESCRIPTION
* LNK-4293: Insecure Binding Configuration Fixes

* address Binding attributein DeleteQueryPlanParameters
* address Binding attributein GetQueryPlanParameters
* add ModelState validation in QueryPlanConfigController
* add BindRequired attribute in TestOperationModel

* LNK-4284: Pipeline updates to inject service info in all services (#1121)

* Fixing broken appsettings.json file in DA so that it can be parsed

* Creating new script that can be run on either dotnet or java services to set service information in the appsetttings.json or application.yml files. Updating pipelines to use new script

* Outputting contents of settings files after they are updated in set_service_info.py script

* Fixing bad JSON format for Admin.BFF and Normalization services' appsettings.json files Updating set_service_info.py to include more debugging information/functionality

* Removing duplicate /api/info endpoint from Admin.BFF, removing ServiceInformation.Version/Commit information from code for services, and correcting ServiceInformation.Name to ServiceInformation.ServiceName where appropriate.

* Adding option for "build" to set_service_info.py Updating pipelines to set build number to pipeline's Build.BuildNumber

---------

### 🛠️ Description of Changes
Cherry pick commit back into dev from https://github.com/lantanagroup/link-cloud/pull/1120

### 🧪 Testing Performed
n/a

### 🧑‍🔬 Unit Testing
- [ ] I have written or updated unit tests to cover my changes

### 📓 Documentation Updated
n/a


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enforced required request fields for query plan (get/delete) and normalization test operations.
  * APIs now return 400 Bad Request with clear validation messages when required parameters are missing or invalid.

* **Chores**
  * Updated normalization service metadata in configuration (name, version, commit) for clearer service identification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->