### PR TITLE
LNK-4176: Manifest file shows only partial patient entries for List

### DIFF
--- a/DotNet/Report/KafkaProducers/ReportManifestProducer.cs
+++ b/DotNet/Report/KafkaProducers/ReportManifestProducer.cs
@@ -94,6 +94,11 @@ namespace LantanaGroup.Link.Report.KafkaProducers
                 manifestResources.Add(operationOutcome);
             }
 
+            foreach (var resource in manifestResources)
+            {
+                resource.Id ??= Guid.NewGuid().ToString();
+            }
+
             Uri? payloadUri = await _blobStorageService.UploadManifestAsync(schedule, manifestResources);
 
             await _payloadSubmittedProducer.Produce(schedule, PayloadType.ReportSchedule, payloadUri: payloadUri?.ToString());

--- a/DotNet/Report/KafkaProducers/ReportManifestProducer.cs
+++ b/DotNet/Report/KafkaProducers/ReportManifestProducer.cs
@@ -48,13 +48,17 @@ namespace LantanaGroup.Link.Report.KafkaProducers
                 return false;
             }
 
-            var submissionEntries = await _database.SubmissionEntryRepository.FindAsync(x => x.ReportScheduleId == schedule.Id && x.Status != PatientSubmissionStatus.NotReportable);
+            var allSubmissionEntries = await _database.SubmissionEntryRepository.FindAsync(x => x.ReportScheduleId == schedule.Id);
+
+            var submissionEntries = allSubmissionEntries.Where(x => x.Status != PatientSubmissionStatus.NotReportable).ToList();
 
             var measureReports = submissionEntries
                         .Select(e => e.MeasureReport)
                         .Where(report => report != null).ToList();
 
-            var patientIds = submissionEntries.Where(s => s.Status == PatientSubmissionStatus.ValidationComplete).Select(s => s.PatientId).Distinct().ToList();
+            var allPatientIds = allSubmissionEntries.Select(s => s.PatientId).Distinct().ToList();
+
+            var patientIds = submissionEntries.Where(s => s.Status == PatientSubmissionStatus.ValidationComplete || s.Status == PatientSubmissionStatus.Submitted).Select(s => s.PatientId).Distinct().ToList();
 
             var failedEntries = submissionEntries.Where(s => s.ValidationStatus == ValidationStatus.Failed).ToList();
 
@@ -75,7 +79,7 @@ namespace LantanaGroup.Link.Report.KafkaProducers
             [
                 organization,
                 CreateDevice(),
-                CreatePatientList(patientIds, schedule.ReportStartDate, schedule.ReportEndDate),
+                CreatePatientList(allPatientIds, schedule.ReportStartDate, schedule.ReportEndDate),
             ];
 
             foreach (var aggregate in aggregates)


### PR DESCRIPTION
### 🛠️ Description of Changes
  - Include all POIs (even non-reportable) in manifest `List`
  - Handle `Submitted` status similarly to `ValidationComplete`

### 🧪 Testing Performed
N/A

### 🧑‍🔬 Unit Testing
N/A

### 📓 Documentation Updated
N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Expanded patient eligibility to include ValidationComplete and Submitted statuses when generating manifests.
  * Patient lists now derive from the full submission set for greater completeness.

* Bug Fixes
  * Ensures every manifest resource has an ID by auto-assigning one when missing.
  * Preserves operation outcome handling while preventing missing identifiers.

* Refactor
  * Adopted a two-step submission processing flow (gather all, then filter) and deferred ID assignment to post-processing for more predictable outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->