### PR TITLE
LNK-3457: Admin BFF respond with an array of service info

### DIFF
--- a/DotNet/Admin.BFF/Program.cs
+++ b/DotNet/Admin.BFF/Program.cs
@@ -25,6 +25,7 @@ using LantanaGroup.Link.LinkAdmin.BFF.Infrastructure.Extensions.Telemetry;
 using LantanaGroup.Link.Shared.Application.Extensions;
 using LantanaGroup.Link.Shared.Settings;
 using LantanaGroup.Link.LinkAdmin.BFF.Application.Interfaces.Infrastructure;
+using LantanaGroup.Link.LinkAdmin.BFF.Application.Models.Health;
 using LantanaGroup.Link.LinkAdmin.BFF.Infrastructure.Telemetry;
 using LantanaGroup.Link.Shared.Application.Middleware;
 using LantanaGroup.Link.Shared.Application.Extensions.ExternalServices;
@@ -441,7 +442,40 @@ static void SetupMiddleware(WebApplication app)
     {
         ResponseWriter = UIResponseWriter.WriteHealthCheckUIResponse
     }).RequireCors("HealthCheckPolicy");
-    app.MapInfo(Assembly.GetExecutingAssembly(), app.Configuration);
+    
+    app.MapGet("/api/info", async () =>
+    {
+        var logger = app.Services.GetRequiredService<ILogger<ServiceInformation>>();
+        List<ServiceInformation> serviceInfos = 
+            [ServiceInformation.GetServiceInformation(Assembly.GetExecutingAssembly(), app.Configuration)];
+        
+        ServiceRegistry? serviceRegistry = app.Configuration.GetSection(ServiceRegistry.ConfigSectionName).Get<ServiceRegistry>();
+
+        if (serviceRegistry == null)
+            return serviceInfos;
+        
+        using var client = new HttpClient();
+        
+        var tasks = new List<Task<ServiceInformation?>>
+        {
+            ServiceInformation.GetServiceInformation(client, serviceRegistry.AccountServiceApiUrl + "/account/info", logger),
+            ServiceInformation.GetServiceInformation(client, serviceRegistry.AuditServiceApiUrl + "/audit/info", logger),
+            ServiceInformation.GetServiceInformation(client, serviceRegistry.CensusServiceApiUrl + "/census/info", logger),
+            ServiceInformation.GetServiceInformation(client, serviceRegistry.DataAcquisitionServiceApiUrl + "/data/info", logger),
+            ServiceInformation.GetServiceInformation(client, serviceRegistry.MeasureServiceApiUrl + "/measure-definition/info", logger),
+            ServiceInformation.GetServiceInformation(client, serviceRegistry.NormalizationServiceApiUrl + "/normalization/info", logger),
+            ServiceInformation.GetServiceInformation(client, serviceRegistry.QueryDispatchServiceApiUrl + "/querydispatch/info", logger),
+            ServiceInformation.GetServiceInformation(client, serviceRegistry.ReportServiceApiUrl + "/report/info", logger),
+            ServiceInformation.GetServiceInformation(client, serviceRegistry.SubmissionServiceApiUrl + "/submission/info", logger),
+            ServiceInformation.GetServiceInformation(client, serviceRegistry.TenantServiceApiUrl + "/facility/info", logger),
+            ServiceInformation.GetServiceInformation(client, serviceRegistry.ValidationServiceApiUrl + "/validation/info", logger)
+        };
+
+        var results = await Task.WhenAll(tasks);
+        serviceInfos.AddRange(results.Where(info => info != null)!);
+
+        return serviceInfos;
+    });
 }
 
 #endregion

--- a/DotNet/Admin.BFF/Program.cs
+++ b/DotNet/Admin.BFF/Program.cs
@@ -456,20 +456,40 @@ static void SetupMiddleware(WebApplication app)
         
         using var client = new HttpClient();
         
-        var tasks = new List<Task<ServiceInformation?>>
-        {
-            ServiceInformation.GetServiceInformation(client, serviceRegistry.AccountServiceApiUrl + "/account/info", logger),
-            ServiceInformation.GetServiceInformation(client, serviceRegistry.AuditServiceApiUrl + "/audit/info", logger),
-            ServiceInformation.GetServiceInformation(client, serviceRegistry.CensusServiceApiUrl + "/census/info", logger),
-            ServiceInformation.GetServiceInformation(client, serviceRegistry.DataAcquisitionServiceApiUrl + "/data/info", logger),
-            ServiceInformation.GetServiceInformation(client, serviceRegistry.MeasureServiceApiUrl + "/measure-definition/info", logger),
-            ServiceInformation.GetServiceInformation(client, serviceRegistry.NormalizationServiceApiUrl + "/normalization/info", logger),
-            ServiceInformation.GetServiceInformation(client, serviceRegistry.QueryDispatchServiceApiUrl + "/querydispatch/info", logger),
-            ServiceInformation.GetServiceInformation(client, serviceRegistry.ReportServiceApiUrl + "/report/info", logger),
-            ServiceInformation.GetServiceInformation(client, serviceRegistry.SubmissionServiceApiUrl + "/submission/info", logger),
-            ServiceInformation.GetServiceInformation(client, serviceRegistry.TenantServiceApiUrl + "/facility/info", logger),
-            ServiceInformation.GetServiceInformation(client, serviceRegistry.ValidationServiceApiUrl + "/validation/info", logger)
-        };
+        var tasks = new List<Task<ServiceInformation?>>();
+
+        if (!string.IsNullOrEmpty(serviceRegistry.AccountServiceApiUrl))
+            tasks.Add(ServiceInformation.GetServiceInformation(client, serviceRegistry.AccountServiceApiUrl + "/account/info", logger));
+
+        if (!string.IsNullOrEmpty(serviceRegistry.AuditServiceApiUrl))
+            tasks.Add(ServiceInformation.GetServiceInformation(client, serviceRegistry.AuditServiceApiUrl + "/audit/info", logger));
+
+        if (!string.IsNullOrEmpty(serviceRegistry.CensusServiceApiUrl))
+            tasks.Add(ServiceInformation.GetServiceInformation(client, serviceRegistry.CensusServiceApiUrl + "/census/info", logger));
+
+        if (!string.IsNullOrEmpty(serviceRegistry.DataAcquisitionServiceApiUrl))
+            tasks.Add(ServiceInformation.GetServiceInformation(client, serviceRegistry.DataAcquisitionServiceApiUrl + "/data/info", logger));
+
+        if (!string.IsNullOrEmpty(serviceRegistry.MeasureServiceApiUrl))
+            tasks.Add(ServiceInformation.GetServiceInformation(client, serviceRegistry.MeasureServiceApiUrl + "/measure-definition/info", logger));
+
+        if (!string.IsNullOrEmpty(serviceRegistry.NormalizationServiceApiUrl))
+            tasks.Add(ServiceInformation.GetServiceInformation(client, serviceRegistry.NormalizationServiceApiUrl + "/normalization/info", logger));
+
+        if (!string.IsNullOrEmpty(serviceRegistry.QueryDispatchServiceApiUrl))
+            tasks.Add(ServiceInformation.GetServiceInformation(client, serviceRegistry.QueryDispatchServiceApiUrl + "/querydispatch/info", logger));
+
+        if (!string.IsNullOrEmpty(serviceRegistry.ReportServiceApiUrl))
+            tasks.Add(ServiceInformation.GetServiceInformation(client, serviceRegistry.ReportServiceApiUrl + "/report/info", logger));
+
+        if (!string.IsNullOrEmpty(serviceRegistry.SubmissionServiceApiUrl))
+            tasks.Add(ServiceInformation.GetServiceInformation(client, serviceRegistry.SubmissionServiceApiUrl + "/submission/info", logger));
+
+        if (!string.IsNullOrEmpty(serviceRegistry.TenantServiceApiUrl))
+            tasks.Add(ServiceInformation.GetServiceInformation(client, serviceRegistry.TenantServiceApiUrl + "/facility/info", logger));
+
+        if (!string.IsNullOrEmpty(serviceRegistry.ValidationServiceApiUrl))
+            tasks.Add(ServiceInformation.GetServiceInformation(client, serviceRegistry.ValidationServiceApiUrl + "/validation/info", logger));
 
         var results = await Task.WhenAll(tasks);
         serviceInfos.AddRange(results.Where(info => info != null)!);

--- a/DotNet/Shared/Application/Models/Configs/ServiceRegistry.cs
+++ b/DotNet/Shared/Application/Models/Configs/ServiceRegistry.cs
@@ -141,5 +141,16 @@ namespace LantanaGroup.Link.Shared.Application.Models.Configs
                 return null;
             }
         }
+
+        public string ValidationServiceApiUrl
+        {
+            get
+            {
+                if (this.ValidationServiceUrl != null)
+                    return this.ValidationServiceUrl.TrimEnd('/') + "/api";
+
+                return null;
+            }
+        }
     }
 }

--- a/DotNet/Shared/Application/Models/ServiceInformation.cs
+++ b/DotNet/Shared/Application/Models/ServiceInformation.cs
@@ -1,10 +1,15 @@
 ﻿using System.Reflection;
 using Microsoft.Extensions.Configuration;
+using System.Net.Http;
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
 
 namespace LantanaGroup.Link.Shared.Application.Models;
 
 public class ServiceInformation
 {
+    private static readonly ILogger _logger;
+
     public static string SectionName = "ServiceInformation";
     public string ServiceName { get; init; } = string.Empty;
     public string Version { get; set; } = string.Empty;
@@ -23,5 +28,33 @@ public class ServiceInformation
             serviceInformation.Version = assemblyVersion;
 
         return serviceInformation;
+    }
+
+    /**
+     * Gets service information for a given service at its base URL.
+     */
+    public static async Task<ServiceInformation?> GetServiceInformation(HttpClient client, string? serviceInfoEndpoint, ILogger logger)
+    {
+        if (string.IsNullOrEmpty(serviceInfoEndpoint))
+            return null;
+        
+        try
+        {
+            var response = await client.GetAsync(serviceInfoEndpoint);
+            if (!response.IsSuccessStatusCode)
+            {
+                logger.LogWarning("Failed to retrieve service information from endpoint {Endpoint} due to status code {StatusCode}", serviceInfoEndpoint, response.StatusCode);
+                return null;
+            }
+            var content = await response.Content.ReadAsStringAsync();
+            JsonSerializerOptions options = new JsonSerializerOptions();
+            options.PropertyNameCaseInsensitive = true;
+            return JsonSerializer.Deserialize<ServiceInformation>(content, options);
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning("Failed to retrieve service information from endpoint {Endpoint}: {Message}", serviceInfoEndpoint, ex.Message);
+            return null;
+        }
     }
 }


### PR DESCRIPTION
### 🛠️ Description of Changes

Having the Admin BFF respond with an array of service info for each of the services in the service registry.

### 🧪 Testing Performed

Ran with docker-compose and confirmed that admin bff responds with an array of all services' information in the service registry configured in the admin bff. Also tested that when services are down, the admin bff doesn't crash and handles the error appropriately.

### 🧑‍🔬 Unit Testing

N/A

### 📓 Documentation Updated

N/A