### PR TITLE
LNK-4175: HTTP 414 for reference-based query with large number of resources

### DIFF
--- a/DotNet/DataAcquisition.Domain/Application/Managers/ReferenceResourcesManager.cs
+++ b/DotNet/DataAcquisition.Domain/Application/Managers/ReferenceResourcesManager.cs
@@ -27,7 +27,9 @@ public class ReferenceResourcesManager : IReferenceResourcesManager
     public async Task<ReferenceResources> AddAsync(ReferenceResources referenceResources,
         CancellationToken cancellationToken = default)
     {
-        return await _database.ReferenceResourcesRepository.AddAsync(referenceResources);
+        var result = await _database.ReferenceResourcesRepository.AddAsync(referenceResources);
+        await _database.ReferenceResourcesRepository.SaveChangesAsync();
+        return result;
     }
 
 

--- a/DotNet/DataAcquisition.Domain/Application/Services/PatientDataService.cs
+++ b/DotNet/DataAcquisition.Domain/Application/Services/PatientDataService.cs
@@ -255,8 +255,7 @@ public class PatientDataService : IPatientDataService
                     }
                     catch (Exception ex)
                     {
-                        var message = "Error creating log entry for facility {facilityId} and patient {patientId}";
-                        _logger.LogError(ex, message, request.FacilityId.Sanitize(), dataAcqRequested.PatientId);
+                        _logger.LogError(ex, "Error creating log entry for facility {facilityId} and patient {patientId}", request.FacilityId.Sanitize(), dataAcqRequested.PatientId);
 
                         throw;
                     }

--- a/DotNet/DataAcquisition.Domain/Application/Services/PatientDataService.cs
+++ b/DotNet/DataAcquisition.Domain/Application/Services/PatientDataService.cs
@@ -255,7 +255,7 @@ public class PatientDataService : IPatientDataService
                     }
                     catch (Exception ex)
                     {
-                        var message = "Error creating log entry for facility {facilityId} and patient {patientId}\n{ex.Message}\n{innerException}";
+                        var message = "Error creating log entry for facility {facilityId} and patient {patientId}";
                         _logger.LogError(ex, message, request.FacilityId.Sanitize(), dataAcqRequested.PatientId);
 
                         throw;

--- a/DotNet/DataAcquisition.Domain/Application/Services/QueryListProcessor.cs
+++ b/DotNet/DataAcquisition.Domain/Application/Services/QueryListProcessor.cs
@@ -251,8 +251,17 @@ public class QueryListProcessor : IQueryListProcessor
 
             if (builtQuery.GetType() == typeof(ReferenceQueryFactoryResult))
             {
-                //do nothing, reference queries are handled separately
-                return;
+                var config = (ReferenceQueryConfig)queryConfig;
+                _logger.LogInformation("Resource: {resourceType}", config.ResourceType);
+                OperationType operationType = config.OperationType ?? OperationType.Search;
+                FhirQueryType fhirQueryType = FhirQueryTypeUtilities.ToDomain(operationType.ToString());
+                log.QueryType = fhirQueryType;
+                fhirQuery.QueryType = fhirQueryType;
+                fhirQuery.ResourceTypes = [Enum.Parse<ResourceType>(config.ResourceType)];
+                fhirQuery.QueryParameters = ["_id="];
+                fhirQuery.ResourceReferenceTypes = [];
+                fhirQuery.Paged = config.Paged;
+                fhirQuery.isReference = true;
             }
 
             log.FhirQuery.Add(fhirQuery);

--- a/DotNet/DataAcquisition.Domain/Application/Services/ReferenceResourceService.cs
+++ b/DotNet/DataAcquisition.Domain/Application/Services/ReferenceResourceService.cs
@@ -127,6 +127,11 @@ public class ReferenceResourceService : IReferenceResourceService
         foreach (var group in groupedIdentities)
         {
             var resourceType = group.Key;
+            if (string.IsNullOrEmpty(resourceType))
+            {
+                _logger.LogWarning("Skipping reference resources with no type for log with ID: {LodId}", log.Id);
+                continue;
+            }
             var referenceLog = await _dataAcquisitionLogQueries.GetLogByFacilityIdAndReportTrackingIdAndResourceType(log.FacilityId, log.ReportTrackingId, resourceType, log.CorrelationId, cancellationToken);
             if (referenceLog == null)
             {

--- a/DotNet/DataAcquisition.Domain/Application/Services/ReferenceResourceService.cs
+++ b/DotNet/DataAcquisition.Domain/Application/Services/ReferenceResourceService.cs
@@ -1,5 +1,6 @@
 ﻿using Confluent.Kafka;
 using Hl7.Fhir.Model;
+using Hl7.Fhir.Rest;
 using LantanaGroup.Link.DataAcquisition.Domain.Application.Interfaces;
 using LantanaGroup.Link.DataAcquisition.Domain.Application.Managers;
 using LantanaGroup.Link.DataAcquisition.Domain.Application.Models;
@@ -115,152 +116,35 @@ public class ReferenceResourceService : IReferenceResourceService
         if (log == null)
             throw new ArgumentNullException(nameof(log), "Data acquisition log cannot be null.");
 
-        //group refResources by type
-        var groupedRefResources = refResources.Where(r => r.Url != null).GroupBy(r => r.Url.ToString().Split('/')[0]).ToList();
+        var groupedIdentities = refResources.Select(rr => rr.Reference)
+            .Where(r => !string.IsNullOrEmpty(r))
+            .Select(r => new ResourceIdentity(r))
+            .GroupBy(i => i.ResourceType)
+            .ToList();
 
-        _logger.LogInformation("Processing {Count} reference resources for log with ID: {LogId}", groupedRefResources.Sum(g => g.Count()), log.Id);
+        _logger.LogInformation("Processing {Count} reference resources for log with ID: {LogId}", groupedIdentities.Sum(g => g.Count()), log.Id);
 
-        foreach (var refResourcesTypeGroup in groupedRefResources)
+        foreach (var group in groupedIdentities)
         {
-            var resourceType = refResourcesTypeGroup.Key;
-            var refResourcesListDeDuped = refResourcesTypeGroup.DistinctBy(x => x.Url?.ToString()).ToList();
-            // Get existing reference IDs async
-            var existingRefIds = new HashSet<string>();
-            foreach (var refResource in refResourcesListDeDuped)
+            var resourceType = group.Key;
+            var referenceLog = await _dataAcquisitionLogQueries.GetLogByFacilityIdAndReportTrackingIdAndResourceType(log.FacilityId, log.ReportTrackingId, resourceType, log.CorrelationId, cancellationToken);
+            if (referenceLog == null)
             {
-                var existing = await _referenceResourcesManager.GetByResourceIdAndFacilityId(refResource.Reference.SplitReference(), log.FacilityId, cancellationToken);
-                if (existing != null && existing.ReferenceResource != null)
-                {
-                    existingRefIds.Add(refResource.Reference.SplitReference());
-                }
+                throw new InvalidOperationException($"No data acquisition log for reference resource type: {resourceType}");
             }
-
-            var existingLog = await _dataAcquisitionLogQueries.GetLogByFacilityIdAndReportTrackingIdAndResourceType(log.FacilityId, log.ReportTrackingId, resourceType, log.CorrelationId, cancellationToken);
-
-            // Filter out references that already exist
-            var refResourceListForTypeFiltered = refResourcesListDeDuped.Where(x => !existingRefIds.Contains(x.Reference.SplitReference())).ToList();
-
-            for (int i = 0; i < refResourcesListDeDuped.Count; i += 100)
+            if (referenceLog.FhirQuery == null || referenceLog.FhirQuery.Count == 0)
             {
-                //take chunks of 100 
-                var chunk = refResourcesListDeDuped.Skip(i).Take(100).ToList();
-
-                //if no chunk, continue to next iteration
-                if (!chunk.Any()) continue;
-
-                //get valid ids and normalize
-                var idsList = string.Join(",", chunk.Select(x => x.Url.ToString().SplitReference()).Distinct());
-
-                //check for existing log before adding a new one
-                if (existingLog == null)
-                {
-                    var refResourcesTypes = //get all reference types from every log.FhirQuery and combine into 1 list
-                    log.FhirQuery.SelectMany(x => x.ResourceReferenceTypes)
-                        .Select(x => new ResourceReferenceType
-                        {
-                            ResourceType = x.ResourceType,
-                            FacilityId = log.FacilityId,
-                            QueryPhase = log.QueryPhase.Value,
-                        })
-                        .DistinctBy(x => x.ResourceType)
-                        .ToList();
-
-                    var newFhirQueries = new List<FhirQuery>
-                        {
-                            new FhirQuery
-                            {
-                                QueryType = FhirQueryType.Search,
-                                FacilityId = log.FacilityId,
-                                ResourceReferenceTypes = refResourcesTypes,
-                                MeasureId = log.ScheduledReport?.ReportTypes.FirstOrDefault(),
-                                ResourceTypes = new List<ResourceType> { Enum.Parse<ResourceType>(refResourcesTypeGroup.Key) },
-                                QueryParameters = new List<string>
-                                {
-                                    $"_id={idsList}"
-                                },
-                            }
-                        };
-
-                    existingLog = CreateDataAcquisitionLog(log, refResourcesTypeGroup.Key, refResourcesTypes, newFhirQueries);
-
-                    //add the log entry
-                    await _dataAcquisitionLogManager.CreateAsync(existingLog, cancellationToken);
-                }
-                else
-                {
-                    //update existing log.FhirQUery with new parameters
-                    var existingFhirQuery = existingLog.FhirQuery.FirstOrDefault(x => x.QueryType == FhirQueryType.Search && x.ResourceTypes.Contains(Enum.Parse<ResourceType>(refResourcesTypeGroup.Key)));
-                    if (existingFhirQuery != null)
-                    {
-                        existingFhirQuery.QueryParameters = existingFhirQuery.QueryParameters.Union(new List<string> { $"_id={idsList}" }).ToList();
-                        await _fhirQueryMananger.UpdateAsync(existingFhirQuery, cancellationToken);
-                    }
-                    else
-                    {
-                        //if no existing query, create a new one
-                        var fhirQuery = new FhirQuery
-                        {
-                            QueryType = FhirQueryType.Search,
-                            ResourceTypes = new List<ResourceType> { Enum.Parse<ResourceType>(refResourcesTypeGroup.Key) },
-                            QueryParameters = new List<string> { $"_id={idsList}" },
-                            MeasureId = log.ScheduledReport?.ReportTypes.FirstOrDefault(),
-                            FacilityId = log.FacilityId,
-                            DataAcquisitionLogId = log.Id,
-                            ResourceReferenceTypes = new List<ResourceReferenceType>
-                            {
-                                new ResourceReferenceType
-                                {
-                                    FacilityId = log.FacilityId,
-                                    QueryPhase = log.QueryPhase.Value,
-                                    ResourceType = refResourcesTypeGroup.Key,
-                                }
-                            }
-                        };
-
-                        await _fhirQueryMananger.AddAsync(fhirQuery, cancellationToken);
-                    }
-                }
+                throw new InvalidOperationException($"No FHIR query for reference resource type: {resourceType}");
             }
-
-            //save reference resources to db
-            foreach (var refResource in refResourceListForTypeFiltered)
+            if (referenceLog.FhirQuery.Count > 1)
             {
-                var parsedResourceType = refResource.Url.ToString().Split('/')[0];
-
-                var referenceResource = new ReferenceResources
-                {
-                    ResourceId = refResource.Reference.SplitReference(),
-                    ResourceType = parsedResourceType,
-                    FacilityId = log.FacilityId,
-                    DataAcquisitionLogId = log.Id,
-                };
-                await _referenceResourcesManager.AddAsync(referenceResource, cancellationToken);
+                throw new InvalidOperationException($"Multiple FHIR queries for reference resource type: {resourceType}");
             }
+            FhirQuery fhirQuery = referenceLog.FhirQuery.First();
+            fhirQuery.IdQueryParameterValues = fhirQuery.IdQueryParameterValues.ToList()
+                .Concat(group.Select(i => i.Id))
+                .Distinct();
+            await _fhirQueryMananger.UpdateAsync(fhirQuery, cancellationToken);
         }
     }
-
-    private DataAcquisitionLog CreateDataAcquisitionLog(DataAcquisitionLog log, string resourceType, List<ResourceReferenceType> refResourcesTypes, List<FhirQuery> fhirQueries)
-    {
-        return new DataAcquisitionLog
-        {
-            FacilityId = log.FacilityId,
-            Priority = log.Priority,
-            PatientId = log.PatientId,
-            CorrelationId = log.CorrelationId,
-            ReportTrackingId = log.ReportTrackingId,
-            ReportStartDate = log.ReportStartDate,
-            ReportEndDate = log.ReportEndDate,
-            ReportableEvent = log.ReportableEvent,
-            FhirVersion = log.FhirVersion,
-            QueryPhase = log.QueryPhase,
-            QueryType = FhirQueryType.Search,
-            Status = RequestStatus.Pending,
-            TimeZone = log.TimeZone,
-            ScheduledReport = log.ScheduledReport,
-            ExecutionDate = DateTime.UtcNow,
-            FhirQuery = fhirQueries,
-            TraceId = log.TraceId
-        };
-    }
-
 }

--- a/DotNet/DataAcquisition.Domain/Infrastructure/Entities/FhirQuery.cs
+++ b/DotNet/DataAcquisition.Domain/Infrastructure/Entities/FhirQuery.cs
@@ -33,7 +33,7 @@ public class FhirQuery : BaseEntityExtended
         {
             string prefix = "_id=";
             QueryParameters = (QueryParameters ?? []).Where(p => !p.StartsWith(prefix))
-                .Append($"{prefix}{string.Join(',', value)}")
+                .Append($"{prefix}{string.Join(',', (value ?? []))}")
                 .ToList();
         }
     }

--- a/DotNet/DataAcquisition.Domain/Infrastructure/Entities/FhirQuery.cs
+++ b/DotNet/DataAcquisition.Domain/Infrastructure/Entities/FhirQuery.cs
@@ -24,7 +24,7 @@ public class FhirQuery : BaseEntityExtended
         get
         {
             string prefix = "_id=";
-            return QueryParameters.Where(p => p.StartsWith(prefix))
+            return (QueryParameters ?? []).Where(p => p.StartsWith(prefix))
                 .Select(p => p.Substring(prefix.Length))
                 .SelectMany(p => p.Split(','))
                 .Where(id => id != "");
@@ -32,7 +32,7 @@ public class FhirQuery : BaseEntityExtended
         set
         {
             string prefix = "_id=";
-            QueryParameters = QueryParameters.Where(p => !p.StartsWith(prefix))
+            QueryParameters = (QueryParameters ?? []).Where(p => !p.StartsWith(prefix))
                 .Append($"{prefix}{string.Join(',', value)}")
                 .ToList();
         }

--- a/DotNet/DataAcquisition.Domain/Infrastructure/Entities/FhirQuery.cs
+++ b/DotNet/DataAcquisition.Domain/Infrastructure/Entities/FhirQuery.cs
@@ -18,4 +18,23 @@ public class FhirQuery : BaseEntityExtended
     public DataAcquisitionLog DataAcquisitionLog { get; set; }
     public long DataAcquisitionLogId { get; set; }
 
+    [NotMapped]
+    public IEnumerable<string> IdQueryParameterValues
+    {
+        get
+        {
+            string prefix = "_id=";
+            return QueryParameters.Where(p => p.StartsWith(prefix))
+                .Select(p => p.Substring(prefix.Length))
+                .SelectMany(p => p.Split(','))
+                .Where(id => id != "");
+        }
+        set
+        {
+            string prefix = "_id=";
+            QueryParameters = QueryParameters.Where(p => !p.StartsWith(prefix))
+                .Append($"{prefix}{string.Join(',', value)}")
+                .ToList();
+        }
+    }
 }

--- a/DotNet/ServiceTests/IntegrationTests/DataAcquisition/FhirApiServiceTests.cs
+++ b/DotNet/ServiceTests/IntegrationTests/DataAcquisition/FhirApiServiceTests.cs
@@ -156,6 +156,10 @@ public class FhirApiServiceTests
             PatientId = "the-patient",
             ResourceId = "the-patient"
         };
+        var fhirQuery = new FhirQuery
+        {
+            isReference = false
+        };
 
         var outcome = new OperationOutcome();
         outcome.AddIssue("Something went horribly wrong.", Issue.PROCESSING_CATASTROPHIC_FAILURE);
@@ -168,7 +172,7 @@ public class FhirApiServiceTests
         //    .Throws(exception);
 
         await Assert.ThrowsAsync<FhirOperationException>(async () =>
-            await service.ExecuteRead(log, null!, ResourceType.Patient, new FhirQueryConfiguration { FhirServerBaseUrl = "http://example.com/fhir" }, null!));
+            await service.ExecuteRead(log, fhirQuery, ResourceType.Patient, new FhirQueryConfiguration { FhirServerBaseUrl = "http://example.com/fhir" }, null!));
         Assert.NotNull(log.Notes);
         Assert.NotEmpty(log.Notes);
         Assert.StartsWith("OperationOutcome", log.Notes[0]);


### PR DESCRIPTION
### 🛠️ Description of Changes
The main change here is to move the work of creating DALs/FQs for referenced resources from `ReferenceResourceService` to `QueryListProcessor`.  I.e., create them "up front" alongside non-referenced resources, rather than waiting until the acquisition of a referencing resource.

  - `QueryListProcessor.Process`: Create a DAL and FQ for each query.
  - `ReferenceResourceService.ProcessReferences`: Assume an existing DAL and FQ; aggregate referenced IDs into a single parameter.
  - `FhirApiService.ExecuteRead`: If the FQ is reference, execute one read per ID and ignore HTTP 404s/410s.
  - `FhirApiService.ExecuteSearch`: If the FQ is reference, batch and search for IDs, respecting the query plan's page size.

### 🧪 Testing Performed
Tested locally on a data set that triggered an HTTP 414 on preexisting code.

### 🧑‍🔬 Unit Testing
N/A

### 📓 Documentation Updated
N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Reference-aware reads and searches with batching/paging for large ID sets.
  - Automatic persistence of reference resources discovered during reads/searches.
  - Emission of “Resource Acquired” events per resource for improved downstream visibility.

- Improvements
  - More reliable data writes with explicit save on add.
  - Enhanced query handling for ID-based searches.
  - Streamlined logging messages.

- Bug Fixes
  - Graceful handling of missing or retired reference resources (NotFound/Gone) to avoid unnecessary failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->