### PR TITLE
LNK-4370: Static Scan Results 10/08/25 - ASP.NET MVC Bad Practices

### DIFF
--- a/DotNet/DataAcquisition.Domain/Application/Models/UpdateDataAcquisitionLogModel.cs
+++ b/DotNet/DataAcquisition.Domain/Application/Models/UpdateDataAcquisitionLogModel.cs
@@ -1,12 +1,11 @@
-using System.ComponentModel.DataAnnotations;
 using System.Runtime.Serialization;
 
 namespace LantanaGroup.Link.DataAcquisition.Domain.Application.Models
 {
     public class UpdateDataAcquisitionLogModel
     {
-        [Required, DataMember]
-        public required long Id { get; set; }
+        [DataMember]
+        public long Id { get; set; }
         public DateTime? ScheduledExecutionDate { get; set; }
         public RequestStatusModel? Status { get; set; }
     }


### PR DESCRIPTION
### 🛠️ Description of Changes
Removed the required attribute/modifier on the DAL update model's ID.  This should resolve the "Model With Required Non-Nullable Property" vulnerability.  Validation that the ID was set (i.e., is nonzero) is performed in `DataAcquisitionLogManager.UpdateAsync`.

### 🧪 Testing Performed
N/A (no change to functionality)

### 🧑‍🔬 Unit Testing
N/A

### 📓 Documentation Updated
N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed required validation constraint on the ID field for data acquisition log updates, allowing updates to proceed without explicitly providing this identifier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->