### PR TITLE
LNK-4485: Performance problem with db query in measureeval during bundling

### DIFF
--- a/Java/measureeval/src/main/java/com/lantanagroup/link/measureeval/services/PatientStatusBundler.java
+++ b/Java/measureeval/src/main/java/com/lantanagroup/link/measureeval/services/PatientStatusBundler.java
@@ -39,19 +39,15 @@ public class PatientStatusBundler {
             logger.debug("Retrieving resources");
         }
 
-        var patientResourcesRefs = patientStatus.getResources().stream()
-                .filter(resource -> resource.getNormalizationStatus() == NormalizationStatus.NORMALIZED)
-                .filter(PatientReportingEvaluationStatus.Resource::getIsPatientResource)
-                .toList();
         var sharedResourcesRefs = patientStatus.getResources().stream()
                 .filter(resource -> resource.getNormalizationStatus() == NormalizationStatus.NORMALIZED)
                 .filter(resource -> !resource.getIsPatientResource())
                 .toList();
 
-        logger.debug("Collecting {} patient resources and {} shared resources from the database", patientResourcesRefs.size(), sharedResourcesRefs.size());
+        logger.debug("Collecting patient resources for patient {} and {} shared resources from the database", patientStatus.getPatientId(), sharedResourcesRefs.size());
 
-        var patientResources = resourceRepository.findAll(patientStatus.getFacilityId(), patientResourcesRefs, PatientResource.class);
-        var sharedResources = resourceRepository.findAll(patientStatus.getFacilityId(), sharedResourcesRefs, SharedResource.class);
+        var patientResources = resourceRepository.findPatientResources(patientStatus.getFacilityId(), patientStatus.getPatientId());
+        var sharedResources = resourceRepository.findSharedResources(patientStatus.getFacilityId(), sharedResourcesRefs);
 
         logger.debug("Retrieved {} patient resources and {} shared resources from the database", patientResources.size(), sharedResources.size());
 


### PR DESCRIPTION
### 🛠️ Description of Changes

Improving the performance of the two queries needed for bundling:
* Shared resources - still uses individual resourceIds and resourceTypes, but batches the requests
* Patient resources - a single select to the database by patientId rather than for individual resources

### 🧪 Testing Performed

Ensured that Smoke Test runs successfully

### 🧑‍🔬 Unit Testing

- [ ] I have written or updated unit tests to cover my changes

### 📓 Documentation Updated

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized backend resource retrieval with improved batch processing and query efficiency to enhance overall system performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->