### PR TITLE
TECH_DEBT: Remove EF CORE generation from CD pipelines

### DIFF
--- a/Azure_Pipelines/azure-pipelines.census.cd.yaml
+++ b/Azure_Pipelines/azure-pipelines.census.cd.yaml
@@ -97,28 +97,6 @@ steps:
         $(MyTag)
       buildContext: '$(Build.Repository.LocalPath)'
 
-  - task: DotNetCoreCLI@2
-    displayName: Install dotnet-ef
-    inputs:
-      command: 'custom'
-      custom: 'tool'
-      arguments: 'install --global dotnet-ef'
-
-  # - script: |
-  #    dotnet ef migrations script \
-  #    --idempotent \
-  #    --verbose \
-  #    -c CensusContext \
-  #    -s $(build.sourcesdirectory)/$(project) \
-  #    -p $(build.sourcesdirectory)/$(project) \
-  #    -o $(build.artifactstagingdirectory)/DotNet/Census/Scripts/censusDb.sql
-  #   displayName: Generate SQL Script
-
-  # - task: PublishPipelineArtifact@1
-  #   inputs:
-  #     targetPath: '$(Build.ArtifactStagingDirectory)'
-  #     artifact: 'manifest'
-
   - task: PublishBuildArtifacts@1
     inputs:
       PathtoPublish: '$(Build.ArtifactStagingDirectory)'

--- a/Azure_Pipelines/azure-pipelines.dataacquisition-worker.cd.yaml
+++ b/Azure_Pipelines/azure-pipelines.dataacquisition-worker.cd.yaml
@@ -110,21 +110,6 @@ steps:
       custom: 'tool'
       arguments: 'install --global dotnet-ef'
 
-  # - script: |
-  #    dotnet ef migrations script \
-  #    --idempotent \
-  #    --verbose \
-  #    -c DataAcquisition-workerDbContext \
-  #    -s $(build.sourcesdirectory)/$(project) \
-  #    -p $(build.sourcesdirectory)/$(domainProject) \
-  #    -o $(build.artifactstagingdirectory)/sqlMigrations/Scripts/dataAcqDb.sql
-  #   displayName: Generate SQL Script
-
-  # - task: PublishPipelineArtifact@1
-  #   inputs:
-  #     targetPath: '$(Build.ArtifactStagingDirectory)'
-  #     artifact: 'manifest'
-
   - task: PublishBuildArtifacts@1
     inputs:
       PathtoPublish: '$(Build.ArtifactStagingDirectory)'

--- a/Azure_Pipelines/azure-pipelines.dataacquisition.cd.yaml
+++ b/Azure_Pipelines/azure-pipelines.dataacquisition.cd.yaml
@@ -102,27 +102,6 @@ steps:
         $(tags1)
         $(MyTag)
       buildContext: '$(Build.Repository.LocalPath)'
-  - task: DotNetCoreCLI@2
-    displayName: Install dotnet-ef
-    inputs:
-      command: 'custom'
-      custom: 'tool'
-      arguments: 'install --global dotnet-ef'
-
-  - script: |
-     dotnet ef migrations script \
-     --idempotent \
-     --verbose \
-     -c DataAcquisitionDbContext \
-     -s $(build.sourcesdirectory)/$(project) \
-     -p $(build.sourcesdirectory)/$(domainProject) \
-     -o $(build.artifactstagingdirectory)/sqlMigrations/Scripts/dataAcqDb.sql
-    displayName: Generate SQL Script
-
-  # - task: PublishPipelineArtifact@1
-  #   inputs:
-  #     targetPath: '$(Build.ArtifactStagingDirectory)'
-  #     artifact: 'manifest'
 
   - task: PublishBuildArtifacts@1
     inputs:


### PR DESCRIPTION
### 🛠️ Description of Changes
Remove ef core lines from CD for DAW, DA, Census. DB script generation has moved to another pipeline.

### 🧪 Testing Performed
azure pipelines

### 🧑‍🔬 Unit Testing
- [ ] I have written or updated unit tests to cover my changes

### 📓 Documentation Updated
n.a


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined Azure Pipelines configurations to optimize artifact publishing workflows across deployment pipelines
  * Removed legacy pipeline steps and simplified build process configuration for improved maintainability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->