### PR TITLE
LNK-4477: Enable Add button only when user starts to enter data

### DIFF
--- a/DotNet/Shared/Application/Models/Kafka/PatientListMessage.cs
+++ b/DotNet/Shared/Application/Models/Kafka/PatientListMessage.cs
@@ -1,13 +1,11 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿
+using System.Text.Json.Serialization;
 
 namespace LantanaGroup.Link.Shared.Application.Models.Kafka
 {
     public class PatientListMessage
     {
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string? ReportTrackingId { get; set; }
         public List<PatientListItem> PatientLists { get; set; } = new();
     }

--- a/Web/Admin.UI/server/main.js
+++ b/Web/Admin.UI/server/main.js
@@ -11,7 +11,6 @@ const trustProxyValue = !isNaN(trustProxyEnv) ? Number(trustProxyEnv) : trustPro
 app.set('trust proxy', trustProxyValue);
 console.log(`Express trust proxy is set to: ${trustProxyValue}`);
 
-app.set('trust proxy', trustProxyValue);
 
 const port = process.env.PORT || 80;
 

--- a/Web/Admin.UI/src/app/components/testing/patient-listacquired-form/patient-listacquired-form.component.html
+++ b/Web/Admin.UI/src/app/components/testing/patient-listacquired-form/patient-listacquired-form.component.html
@@ -24,6 +24,7 @@
           type="button"
           class="custom-height-button"
           (click)="addPatients(idx)"
+          [disabled]="!patientForm.get('input_' + idx)?.value"
         >
           Add
         </button>


### PR DESCRIPTION
### 🛠️ Description of Changes
Enable Add button only when user starts to enter data 

### 🧪 Testing Performed
Tested locally

### 🧑‍🔬 Unit Testing
- [ ] I have written or updated unit tests to cover my changes

### 📓 Documentation Updated
Please update any relevant sections in the project documentation that were impacted by the changes in the PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Add button in patient list form now prevents submission when input is empty.

* **Chores**
  * Removed duplicate configuration setting.
  * Refined data serialization to omit empty values in API responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->