### PR TITLE
LNK-4485: Batching collection of patient/shared resources

### DIFF
--- a/Java/measureeval/src/main/java/com/lantanagroup/link/measureeval/repositories/AbstractResourceRepository.java
+++ b/Java/measureeval/src/main/java/com/lantanagroup/link/measureeval/repositories/AbstractResourceRepository.java
@@ -5,6 +5,8 @@ import com.lantanagroup.link.measureeval.entities.PatientReportingEvaluationStat
 import com.lantanagroup.link.measureeval.entities.PatientResource;
 import com.lantanagroup.link.measureeval.entities.SharedResource;
 import com.lantanagroup.link.measureeval.records.AbstractResourceRecord;
+import com.lantanagroup.link.shared.mongo.CustomAggregationOperation;
+import org.bson.Document;
 import org.hl7.fhir.r4.model.ResourceType;
 import org.springframework.data.mongodb.core.MongoOperations;
 import org.springframework.data.mongodb.core.aggregation.Aggregation;
@@ -123,9 +125,28 @@ public class AbstractResourceRepository {
                 .and("reports.reportTrackingId").in(reportIds)));
         pipeline.add(Aggregation.unwind("resources"));
         pipeline.add(Aggregation.match(Criteria.where("resources.normalizationStatus").is("NORMALIZED")));
-        pipeline.add(Aggregation.lookup("patientResource", "resources.resourceId", "resourceId", "matchedResources"));
+
+        Document lookupStage = new Document("$lookup",
+                new Document("from", "patientResource")
+                        .append("let", new Document("localResourceId", "$resources.resourceId")
+                                .append("localResourceType", "$resources.resourceType"))
+                        .append("pipeline", List.of(
+                                new Document("$match",
+                                        new Document("$expr",
+                                                new Document("$and", List.of(
+                                                        new Document("$eq", List.of("$resourceId", "$$localResourceId")),
+                                                        new Document("$eq", List.of("$resourceType", "$$localResourceType")),
+                                                        new Document("$eq", List.of("$facilityId", facilityId))
+                                                ))
+                                        )
+                                )
+                        ))
+                        .append("as", "matchedResources")
+        );
+
+        pipeline.add(new CustomAggregationOperation(lookupStage));
+
         pipeline.add(Aggregation.unwind("matchedResources"));
-        pipeline.add(Aggregation.match(Criteria.where("matchedResources.facilityId").is(facilityId)));
         pipeline.add(Aggregation.replaceRoot("matchedResources"));
 
         Aggregation aggregation = Aggregation.newAggregation(pipeline);

--- a/Java/measureeval/src/main/java/com/lantanagroup/link/measureeval/repositories/AbstractResourceRepository.java
+++ b/Java/measureeval/src/main/java/com/lantanagroup/link/measureeval/repositories/AbstractResourceRepository.java
@@ -7,9 +7,13 @@ import com.lantanagroup.link.measureeval.entities.SharedResource;
 import com.lantanagroup.link.measureeval.records.AbstractResourceRecord;
 import org.hl7.fhir.r4.model.ResourceType;
 import org.springframework.data.mongodb.core.MongoOperations;
+import org.springframework.data.mongodb.core.aggregation.Aggregation;
+import org.springframework.data.mongodb.core.aggregation.AggregationOperation;
 import org.springframework.data.mongodb.core.query.Criteria;
 import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.stereotype.Repository;
+
+import java.util.ArrayList;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -113,10 +117,20 @@ public class AbstractResourceRepository {
         return sharedResources;
     }
 
-    public List<PatientResource> findPatientResources(String facilityId, String patientId) {
-        Query query = new Query();
-        query.addCriteria(Criteria.where("facilityId").is(facilityId));
-        query.addCriteria(Criteria.where("patientId").is(patientId));
-        return mongoOperations.find(query, PatientResource.class);
+    public List<PatientResource> findPatientResources(String facilityId, String patientId, List<String> reportIds) {
+        List<AggregationOperation> pipeline = new ArrayList<>();
+
+        pipeline.add(Aggregation.match(Criteria.where("facilityId").is(facilityId)
+                .and("patientId").is(patientId)
+                .and("reports.reportTrackingId").in(reportIds)));
+        pipeline.add(Aggregation.unwind("resources"));
+        pipeline.add(Aggregation.match(Criteria.where("resources.normalizationStatus").is("NORMALIZED")));
+        pipeline.add(Aggregation.lookup("patientResource", "resources.resourceId", "resourceId", "matchedResources"));
+        pipeline.add(Aggregation.unwind("matchedResources"));
+        pipeline.add(Aggregation.match(Criteria.where("matchedResources.facilityId").is(facilityId)));
+        pipeline.add(Aggregation.replaceRoot("matchedResources"));
+
+        Aggregation aggregation = Aggregation.newAggregation(pipeline);
+        return mongoOperations.aggregate(aggregation, "patientReportingEvaluationStatus", PatientResource.class).getMappedResults();
     }
 }

--- a/Java/measureeval/src/main/java/com/lantanagroup/link/measureeval/repositories/AbstractResourceRepository.java
+++ b/Java/measureeval/src/main/java/com/lantanagroup/link/measureeval/repositories/AbstractResourceRepository.java
@@ -80,74 +80,34 @@ public class AbstractResourceRepository {
         return mongoOperations.find(query, entityType);
     }
 
-    public List<SharedResource> findSharedResources(String facilityId, List<PatientReportingEvaluationStatus.Resource> resources) {
-        List<SharedResource> sharedResources = new ArrayList<>();
-        if (resources == null || resources.isEmpty()) {
-            return sharedResources;
-        }
-
-        // Batch the searches so that it doesn't exceed mongo's query limitations
-        List<PatientReportingEvaluationStatus.Resource> remainingResources = new ArrayList<>(resources);
-        while (!remainingResources.isEmpty()) {
-            int characterCount = 0;
-            List<Criteria> batchCriteria = new ArrayList<>();
-
-            for (int i = remainingResources.size() - 1; i >= 0; i--) {
-                PatientReportingEvaluationStatus.Resource resource = remainingResources.get(i);
-                int resourceCharLength = resource.getResourceType().toString().length() + resource.getResourceId().length();
-
-                if (characterCount + resourceCharLength >= 10000) {
-                    break;
-                }
-
-                characterCount += resourceCharLength;
-                batchCriteria.add(Criteria.where("facilityId").is(facilityId)
-                        .and("resourceType").is(resource.getResourceType())
-                        .and("resourceId").is(resource.getResourceId()));
-                remainingResources.remove(i);
-            }
-
-            if (!batchCriteria.isEmpty()) {
-                Criteria combinedCriteria = new Criteria().orOperator(batchCriteria.toArray(new Criteria[0]));
-                Query query = new Query(combinedCriteria);
-                sharedResources.addAll(mongoOperations.find(query, SharedResource.class));
-            }
-        }
-
-        return sharedResources;
-    }
-
-    public List<PatientResource> findPatientResources(String facilityId, String patientId, List<String> reportIds) {
+    public List<PatientResource> findResources(boolean isShared, String facilityId, String correlationId) {
         List<AggregationOperation> pipeline = new ArrayList<>();
 
         pipeline.add(Aggregation.match(Criteria.where("facilityId").is(facilityId)
-                .and("patientId").is(patientId)
-                .and("reports.reportTrackingId").in(reportIds)));
+                .and("correlationId").is(correlationId)));
         pipeline.add(Aggregation.unwind("resources"));
-        pipeline.add(Aggregation.match(Criteria.where("resources.normalizationStatus").is("NORMALIZED")));
+        pipeline.add(Aggregation.replaceRoot("resources"));
+        pipeline.add(Aggregation.match(Criteria.where("isPatientResource").is(!isShared)
+                .and("normalizationStatus").is("NORMALIZED")));
 
         Document lookupStage = new Document("$lookup",
-                new Document("from", "patientResource")
-                        .append("let", new Document("localResourceId", "$resources.resourceId")
-                                .append("localResourceType", "$resources.resourceType"))
-                        .append("pipeline", List.of(
-                                new Document("$match",
-                                        new Document("$expr",
-                                                new Document("$and", List.of(
-                                                        new Document("$eq", List.of("$resourceId", "$$localResourceId")),
-                                                        new Document("$eq", List.of("$resourceType", "$$localResourceType")),
-                                                        new Document("$eq", List.of("$facilityId", facilityId))
-                                                ))
-                                        )
-                                )
-                        ))
-                        .append("as", "matchedResources")
-        );
+                new Document("from", isShared ? "sharedResource" : "patientResource")
+                        .append("localField", "resourceId")
+                        .append("foreignField", "resourceId")
+                        .append("as", "patientResources"));
 
         pipeline.add(new CustomAggregationOperation(lookupStage));
+        pipeline.add(Aggregation.unwind("patientResources"));
 
-        pipeline.add(Aggregation.unwind("matchedResources"));
-        pipeline.add(Aggregation.replaceRoot("matchedResources"));
+        Document matchExpr = new Document("$match",
+                new Document("$expr",
+                        new Document("$and", List.of(
+                                new Document("$eq", List.of("$patientResources.facilityId", facilityId)),
+                                new Document("$eq", List.of("$patientResources.resourceType", "$resourceType"))
+                        ))));
+        pipeline.add(new CustomAggregationOperation(matchExpr));
+
+        pipeline.add(Aggregation.replaceRoot("patientResources"));
 
         Aggregation aggregation = Aggregation.newAggregation(pipeline);
         return mongoOperations.aggregate(aggregation, "patientReportingEvaluationStatus", PatientResource.class).getMappedResults();

--- a/Java/measureeval/src/main/java/com/lantanagroup/link/measureeval/repositories/AbstractResourceRepository.java
+++ b/Java/measureeval/src/main/java/com/lantanagroup/link/measureeval/repositories/AbstractResourceRepository.java
@@ -80,36 +80,45 @@ public class AbstractResourceRepository {
         return mongoOperations.find(query, entityType);
     }
 
-    public List<PatientResource> findResources(boolean isShared, String facilityId, String correlationId) {
-        List<AggregationOperation> pipeline = new ArrayList<>();
+    public List<AbstractResourceEntity> findResources(String facilityId, boolean isShared, List<PatientReportingEvaluationStatus.Resource> resourceReferences) {
+        List<AbstractResourceEntity> resources = new ArrayList<>();
+        if (resourceReferences == null || resourceReferences.isEmpty()) {
+            return resources;
+        }
 
-        pipeline.add(Aggregation.match(Criteria.where("facilityId").is(facilityId)
-                .and("correlationId").is(correlationId)));
-        pipeline.add(Aggregation.unwind("resources"));
-        pipeline.add(Aggregation.replaceRoot("resources"));
-        pipeline.add(Aggregation.match(Criteria.where("isPatientResource").is(!isShared)
-                .and("normalizationStatus").is("NORMALIZED")));
+        // Batch the searches so that it doesn't exceed mongo's query limitations
+        List<PatientReportingEvaluationStatus.Resource> remainingResources = new ArrayList<>(resourceReferences);
+        while (!remainingResources.isEmpty()) {
+            int characterCount = 0;
+            List<Criteria> batchCriteria = new ArrayList<>();
 
-        Document lookupStage = new Document("$lookup",
-                new Document("from", isShared ? "sharedResource" : "patientResource")
-                        .append("localField", "resourceId")
-                        .append("foreignField", "resourceId")
-                        .append("as", "patientResources"));
+            for (int i = remainingResources.size() - 1; i >= 0; i--) {
+                PatientReportingEvaluationStatus.Resource resource = remainingResources.get(i);
+                int resourceCharLength = resource.getResourceType().toString().length() + resource.getResourceId().length();
 
-        pipeline.add(new CustomAggregationOperation(lookupStage));
-        pipeline.add(Aggregation.unwind("patientResources"));
+                if (characterCount + resourceCharLength >= 10000) {
+                    break;
+                }
 
-        Document matchExpr = new Document("$match",
-                new Document("$expr",
-                        new Document("$and", List.of(
-                                new Document("$eq", List.of("$patientResources.facilityId", facilityId)),
-                                new Document("$eq", List.of("$patientResources.resourceType", "$resourceType"))
-                        ))));
-        pipeline.add(new CustomAggregationOperation(matchExpr));
+                characterCount += resourceCharLength;
+                batchCriteria.add(Criteria.where("facilityId").is(facilityId)
+                        .and("resourceType").is(resource.getResourceType())
+                        .and("resourceId").is(resource.getResourceId()));
+                remainingResources.remove(i);
+            }
 
-        pipeline.add(Aggregation.replaceRoot("patientResources"));
+            if (!batchCriteria.isEmpty()) {
+                Criteria combinedCriteria = new Criteria().orOperator(batchCriteria.toArray(new Criteria[0]));
+                Query query = new Query(combinedCriteria);
 
-        Aggregation aggregation = Aggregation.newAggregation(pipeline);
-        return mongoOperations.aggregate(aggregation, "patientReportingEvaluationStatus", PatientResource.class).getMappedResults();
+                if (isShared) {
+                    resources.addAll(mongoOperations.find(query, SharedResource.class));
+                } else {
+                    resources.addAll(mongoOperations.find(query, PatientResource.class));
+                }
+            }
+        }
+
+        return resources;
     }
 }

--- a/Java/measureeval/src/main/java/com/lantanagroup/link/measureeval/services/PatientStatusBundler.java
+++ b/Java/measureeval/src/main/java/com/lantanagroup/link/measureeval/services/PatientStatusBundler.java
@@ -39,19 +39,15 @@ public class PatientStatusBundler {
             logger.debug("Retrieving resources");
         }
 
-        var patientResourcesRefs = patientStatus.getResources().stream()
-                .filter(resource -> resource.getNormalizationStatus() == NormalizationStatus.NORMALIZED)
-                .filter(PatientReportingEvaluationStatus.Resource::getIsPatientResource)
-                .toList();
         var sharedResourcesRefs = patientStatus.getResources().stream()
                 .filter(resource -> resource.getNormalizationStatus() == NormalizationStatus.NORMALIZED)
                 .filter(resource -> !resource.getIsPatientResource())
                 .toList();
 
-        logger.debug("Collecting {} patient resources and {} shared resources from the database", patientResourcesRefs.size(), sharedResourcesRefs.size());
+        logger.debug("Collecting patient resources for patient {} and {} shared resources from the database", patientStatus.getPatientId(), sharedResourcesRefs.size());
 
-        var patientResources = resourceRepository.findAll(patientStatus.getFacilityId(), patientResourcesRefs, PatientResource.class);
-        var sharedResources = resourceRepository.findAll(patientStatus.getFacilityId(), sharedResourcesRefs, SharedResource.class);
+        var patientResources = resourceRepository.findPatientResources(patientStatus.getFacilityId(), patientStatus.getPatientId());
+        var sharedResources = resourceRepository.findSharedResources(patientStatus.getFacilityId(), sharedResourcesRefs);
 
         logger.debug("Retrieved {} patient resources and {} shared resources from the database", patientResources.size(), sharedResources.size());
 

--- a/Java/measureeval/src/main/java/com/lantanagroup/link/measureeval/services/PatientStatusBundler.java
+++ b/Java/measureeval/src/main/java/com/lantanagroup/link/measureeval/services/PatientStatusBundler.java
@@ -29,11 +29,11 @@ public class PatientStatusBundler {
         }
         Bundle bundle = new Bundle();
         bundle.setType(Bundle.BundleType.COLLECTION);
-        bundle.setTotal(patientStatus.getResources().size());
         retrieveResources(patientStatus).stream()
                 .map(AbstractResourceEntity::getResource)
                 .map(Resource.class::cast)
                 .forEachOrdered(resource -> bundle.addEntry().setResource(resource));
+        bundle.setTotal(patientStatus.getResources().size());
         return bundle;
     }
 

--- a/Java/measureeval/src/main/java/com/lantanagroup/link/measureeval/services/PatientStatusBundler.java
+++ b/Java/measureeval/src/main/java/com/lantanagroup/link/measureeval/services/PatientStatusBundler.java
@@ -50,9 +50,8 @@ public class PatientStatusBundler {
         logger.debug("Collecting patient resources for patient {} and {} shared resources from the database", patientStatus.getPatientId(), sharedResourcesRefs.size());
 
         try (Timer timer = Timer.start()) {
-            List<String> reportIds = patientStatus.getReports().stream().map(PatientReportingEvaluationStatus.Report::getReportTrackingId).toList();
-            var patientResources = resourceRepository.findPatientResources(patientStatus.getFacilityId(), patientStatus.getPatientId(), reportIds);
-            var sharedResources = resourceRepository.findSharedResources(patientStatus.getFacilityId(), sharedResourcesRefs);
+            var patientResources = resourceRepository.findResources(false, patientStatus.getFacilityId(), patientStatus.getCorrelationId());
+            var sharedResources = resourceRepository.findResources(true, patientStatus.getFacilityId(), patientStatus.getCorrelationId());
 
             logger.debug("Retrieved {} patient resources and {} shared resources from the database in {} seconds", patientResources.size(), sharedResources.size(), timer.getSeconds());
 

--- a/Java/measureeval/src/main/java/com/lantanagroup/link/measureeval/services/PatientStatusBundler.java
+++ b/Java/measureeval/src/main/java/com/lantanagroup/link/measureeval/services/PatientStatusBundler.java
@@ -46,12 +46,16 @@ public class PatientStatusBundler {
                 .filter(resource -> resource.getNormalizationStatus() == NormalizationStatus.NORMALIZED)
                 .filter(resource -> !resource.getIsPatientResource())
                 .toList();
+        var patientResourcesRefs = patientStatus.getResources().stream()
+                .filter(resource -> resource.getNormalizationStatus() == NormalizationStatus.NORMALIZED)
+                .filter(PatientReportingEvaluationStatus.Resource::getIsPatientResource)
+                .toList();
 
         logger.debug("Collecting patient resources for patient {} and {} shared resources from the database", patientStatus.getPatientId(), sharedResourcesRefs.size());
 
         try (Timer timer = Timer.start()) {
-            var patientResources = resourceRepository.findResources(false, patientStatus.getFacilityId(), patientStatus.getCorrelationId());
-            var sharedResources = resourceRepository.findResources(true, patientStatus.getFacilityId(), patientStatus.getCorrelationId());
+            var patientResources = resourceRepository.findResources(patientStatus.getFacilityId(), true, patientResourcesRefs);
+            var sharedResources = resourceRepository.findResources(patientStatus.getFacilityId(), false, sharedResourcesRefs);
 
             logger.debug("Retrieved {} patient resources and {} shared resources from the database in {} seconds", patientResources.size(), sharedResources.size(), timer.getSeconds());
 

--- a/Java/shared/src/main/java/com/lantanagroup/link/shared/mongo/CustomAggregationOperation.java
+++ b/Java/shared/src/main/java/com/lantanagroup/link/shared/mongo/CustomAggregationOperation.java
@@ -1,0 +1,17 @@
+package com.lantanagroup.link.shared.mongo;
+
+import org.bson.Document;
+import org.springframework.data.mongodb.core.aggregation.AggregationOperation;
+
+public class CustomAggregationOperation implements AggregationOperation {
+    private final Document operation;
+
+    public CustomAggregationOperation(Document operation) {
+        this.operation = operation;
+    }
+
+    @Override
+    public Document toDocument(org.springframework.data.mongodb.core.aggregation.AggregationOperationContext context) {
+        return context.getMappedObject(operation);
+    }
+}


### PR DESCRIPTION
### 🛠️ Description of Changes

Changing strategy to bundling process so that it batches the resources for shared and patient resource references, rather than attempting to use an aggregate pipeline. The aggregate pipeline's $lookup operation has similar problems to performing the lookup in code, where eventually the query is so big that it reaches the maximum query size.

### 🧪 Testing Performed

Ensure smoke test continues to succeed.
Working with QA to identify a mega-patient to test with.

### 🧑‍🔬 Unit Testing
- [ ] I have written or updated unit tests to cover my changes

### 📓 Documentation Updated
N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated resource retrieval mechanism to use batch processing with resource references instead of correlation ID-based queries
  * Modified repository query strategy from single aggregation pipeline to targeted multi-find operations
  * Changed resource entity return types for improved data handling consistency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->