### PR TITLE
LNK-4493: ResourceAcquired message for shared resources - No PatientId populated

### DIFF
--- a/DotNet/DataAcquisition.Domain/Application/Services/FhirApi/FhirApiService.cs
+++ b/DotNet/DataAcquisition.Domain/Application/Services/FhirApi/FhirApiService.cs
@@ -102,7 +102,7 @@ public class FhirApiService : IFhirApiService
             {
                 Resource = resource,
                 ScheduledReports = new List<Shared.Application.Models.ScheduledReport> { log.ScheduledReport },
-                PatientId = log.PatientId,
+                PatientId = !fhirQuery.IsReference ?? false ? log.PatientId : null,
                 QueryType = log.QueryPhase.ToString(),
                 ReportableEvent = log.ReportableEvent ?? throw new ArgumentNullException(nameof(log.ReportableEvent)),
             }, log.FacilityId, log.CorrelationId, cancellationToken);
@@ -192,7 +192,7 @@ public class FhirApiService : IFhirApiService
                     {
                         Resource = resource,
                         ScheduledReports = new List<Shared.Application.Models.ScheduledReport> { log.ScheduledReport },
-                        PatientId = log.PatientId,
+                        PatientId = !fhirQuery.IsReference ?? false ? log.PatientId : null,
                         QueryType = log.QueryPhase.ToString(),
                         ReportableEvent = log.ReportableEvent ?? throw new ArgumentNullException(nameof(log.ReportableEvent)),
                     }, log.FacilityId, log.CorrelationId, cancellationToken);

--- a/DotNet/DataAcquisition.Domain/Application/Services/PatientDataService.cs
+++ b/DotNet/DataAcquisition.Domain/Application/Services/PatientDataService.cs
@@ -49,9 +49,7 @@ public class PatientDataService : IPatientDataService
     private readonly IDatabase _database;
 
     private readonly ILogger<PatientDataService> _logger;
-    private readonly IFhirQueryConfigurationManager _fhirQueryManager;
     private readonly IFhirQueryConfigurationQueries _fhirQueryQueries;
-    private readonly IQueryPlanManager _queryPlanManager;
     private readonly IQueryPlanQueries _queryPlanQueries;
     private readonly IQueryListProcessor _queryListProcessor;
     private readonly ProducerConfig _producerConfig;
@@ -65,9 +63,7 @@ public class PatientDataService : IPatientDataService
     public PatientDataService(
         IDatabase database,
         ILogger<PatientDataService> logger,
-        IFhirQueryConfigurationManager fhirQueryManager,
         IFhirQueryConfigurationQueries fhirQueryQueries,
-        IQueryPlanManager queryPlanManager,
         IQueryPlanQueries queryPlanQueries,
         IQueryListProcessor queryListProcessor,
         IReadFhirCommand readFhirCommand,
@@ -80,9 +76,7 @@ public class PatientDataService : IPatientDataService
     {
         _database = database ?? throw new ArgumentNullException(nameof(database));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
-        _fhirQueryManager = fhirQueryManager;
         _fhirQueryQueries = fhirQueryQueries;
-        _queryPlanManager = queryPlanManager;
         _queryPlanQueries = queryPlanQueries;
 
         _producerConfig = new ProducerConfig();
@@ -456,7 +450,6 @@ public class PatientDataService : IPatientDataService
                 }
 
                 List<string> resourceIds = new List<string>();
-
 
                 //4. call api
                 foreach (var fhirQuery in log.FhirQuery.ToList())

--- a/DotNet/ServiceTests/IntegrationTests/DataAcquisition/PatientDataServiceTests.cs
+++ b/DotNet/ServiceTests/IntegrationTests/DataAcquisition/PatientDataServiceTests.cs
@@ -91,9 +91,7 @@ public class PatientDataServiceTests
         _service = new PatientDataService(
             _mockDatabase.Object,
             _mockLogger.Object,
-            _mockFhirQueryManager.Object,
             _mockFhirQueryQueries.Object,
-            _mockQueryPlanManager.Object,
             _mockQueryPlanQueries.Object,
             _mockQueryListProcessor.Object,
             _mockReadFhirCommand.Object,

--- a/docs/domains/DataAccess/services/DataAcquisitionWorkerService/index.mdx
+++ b/docs/domains/DataAccess/services/DataAcquisitionWorkerService/index.mdx
@@ -14,6 +14,13 @@ receives:
 
 sends:
   - id: ResourceAcquired
+    model:
+      AcquisitionComplete: boolean
+      PatientId: string
+      QueryType: string
+      Resource: Resource
+      ScheduledReports: List<ScheduledReport>
+      ReportableEvent: ReportableEvent
 
 specifications:
   openapiPath: openapi.yml

--- a/docs/domains/Tenant/services/CensusService/index.mdx
+++ b/docs/domains/Tenant/services/CensusService/index.mdx
@@ -226,8 +226,8 @@ Gets the admitted patients for a facility within a date range. Returns a FHIR Li
 
 **Parameters:**
 - `facilityId` (path, required): The unique identifier of the facility.
-- `startDate` (query, optional): Start date for the date range filter. If not provided, defaults to retrieving all active patients.
-- `endDate` (query, optional): End date for the date range filter.
+- `startDate` (query, required): Start date for the date range filter.
+- `endDate` (query, required): End date for the date range filter.
 
 **Response:**
 - `200 OK`: Returns a FHIR List resource with admitted patients.


### PR DESCRIPTION
### 🛠️ Description of Changes
Remove population of PatientId field for ResourceAcquired messages when that resource is "shared" (i.e. Location, Medication, etc.).

### 🧪 Testing Performed
Local E2E testing, wrote new test for this scenario.,

### 🧑‍🔬 Unit Testing
- [x] I have written or updated unit tests to cover my changes

### 📓 Documentation Updated
update service spec to reflect true ResourceAcquired message structure.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected how patient identifiers are assigned to reference resources in data messages. Reference resources now properly indicate when patient context is not applicable by using null values instead of inherited identifiers.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->