### PR TITLE
LNK-4458: fix race condition resourceAcquiredIds

### DIFF
--- a/DotNet/DataAcquisition.Domain/Application/Services/PatientDataService.cs
+++ b/DotNet/DataAcquisition.Domain/Application/Services/PatientDataService.cs
@@ -464,11 +464,13 @@ public class PatientDataService : IPatientDataService
                         {
                             var ids = await _fhirApiService.ExecuteRead(log, fhirQuery, resourceType, fhirQueryConfiguration, cancellationToken);
                             resourceIds.AddRange(ids);
+                            resourceIds.AddRange(ids ?? Array.Empty<string>());
                         }
                         else if (fhirQuery.QueryType == FhirQueryType.Search)
                         {
                             var ids = await _fhirApiService.ExecuteSearch(log, fhirQuery, fhirQueryConfiguration, resourceType, cancellationToken);
                             resourceIds.AddRange(ids);
+                            resourceIds.AddRange(ids ?? Array.Empty<string>());
                         }
                         else if (fhirQuery.QueryType == FhirQueryType.BulkDataRequest)
                         {

--- a/DotNet/DataAcquisition.Domain/Application/Services/PatientDataService.cs
+++ b/DotNet/DataAcquisition.Domain/Application/Services/PatientDataService.cs
@@ -321,6 +321,24 @@ public class PatientDataService : IPatientDataService
                     throw new ArgumentException($"Facility ID {request.facilityId} does not match log's facility ID {log.FacilityId}.");
                 }
 
+                //check if log has any FhirQuery objects
+                if (log.FhirQuery == null || !log.FhirQuery.Any())
+                {
+                    throw new ArgumentException($"Log with ID {log.Id} does not have any FHIR queries defined.");
+                }
+
+                //check if resource types are defined in all FhirQuery objects
+                if (log.FhirQuery.Any(x => x.ResourceTypes == null || !x.ResourceTypes.Any()))
+                {
+                    throw new ArgumentException($"Log with ID {log.Id} has a FHIR query with no resource types defined.");
+                }
+
+                //check if query type is search and there are no query parameters in FhirQuery
+                if (log.FhirQuery != null && log.FhirQuery.Any() && log.FhirQuery.Any(x => x.QueryType == FhirQueryType.Search && !x.QueryParameters.Any()))
+                {
+                    throw new ArgumentException($"Log with ID {log.Id} has a FHIR query of type 'Search' without any query parameters defined.");
+                }
+
                 //check if isCensus, if true, create scope for PatientCensusService and execute RetrieveListData
                 if (log.IsCensus)
                 {
@@ -407,24 +425,6 @@ public class PatientDataService : IPatientDataService
                     throw new ArgumentException($"Log with ID {log.Id} is not in a ready state. Current status: {log.Status}");
                 }
 
-                //check if log has any FhirQuery objects
-                if (log.FhirQuery == null || !log.FhirQuery.Any())
-                {
-                    throw new ArgumentException($"Log with ID {log.Id} does not have any FHIR queries defined.");
-                }
-
-                //check if resource types are defined in all FhirQuery objects
-                if (log.FhirQuery.Any(x => x.ResourceTypes == null || !x.ResourceTypes.Any()))
-                {
-                    throw new ArgumentException($"Log with ID {log.Id} has a FHIR query with no resource types defined.");
-                }
-
-                //check if query type is search and there are no query parameters in FhirQuery
-                if (log.FhirQuery != null && log.FhirQuery.Any() && log.FhirQuery.Any(x => x.QueryType == FhirQueryType.Search && !x.QueryParameters.Any()))
-                {
-                    throw new ArgumentException($"Log with ID {log.Id} has a FHIR query of type 'Search' without any query parameters defined.");
-                }
-
                 //2. set to "Processing"
                 log.Status = RequestStatus.Processing;
                 await _dataAcquisitionLogManager.UpdateAsync(new UpdateDataAcquisitionLogModel
@@ -464,12 +464,12 @@ public class PatientDataService : IPatientDataService
                         if (fhirQuery.QueryType == FhirQueryType.Read)
                         {
                             var ids = await _fhirApiService.ExecuteRead(log, fhirQuery, resourceType, fhirQueryConfiguration, cancellationToken);
-                            foreach (var id in ids) resourceIds.Add(id);
+                            if(ids != null) foreach (var id in ids) resourceIds.Add(id);
                         }
                         else if (fhirQuery.QueryType == FhirQueryType.Search)
                         {
                             var ids = await _fhirApiService.ExecuteSearch(log, fhirQuery, fhirQueryConfiguration, resourceType, cancellationToken);
-                            foreach (var id in ids) resourceIds.Add(id);
+                            if (ids != null) foreach (var id in ids) resourceIds.Add(id);
                         }
                         else if (fhirQuery.QueryType == FhirQueryType.BulkDataRequest)
                         {

--- a/DotNet/DataAcquisition.Domain/Application/Services/PatientDataService.cs
+++ b/DotNet/DataAcquisition.Domain/Application/Services/PatientDataService.cs
@@ -452,7 +452,8 @@ public class PatientDataService : IPatientDataService
                         $"No configuration for {log.FacilityId} exists.");
                 }
 
-                List<string> resourceIds = new List<string>();
+                //hashset to hold unique resource ids
+                var resourceIds = new HashSet<string>();
 
                 //4. call api
                 foreach (var fhirQuery in log.FhirQuery.ToList())
@@ -463,14 +464,12 @@ public class PatientDataService : IPatientDataService
                         if (fhirQuery.QueryType == FhirQueryType.Read)
                         {
                             var ids = await _fhirApiService.ExecuteRead(log, fhirQuery, resourceType, fhirQueryConfiguration, cancellationToken);
-                            resourceIds.AddRange(ids);
-                            resourceIds.AddRange(ids ?? Array.Empty<string>());
+                            foreach (var id in ids) resourceIds.Add(id);
                         }
                         else if (fhirQuery.QueryType == FhirQueryType.Search)
                         {
                             var ids = await _fhirApiService.ExecuteSearch(log, fhirQuery, fhirQueryConfiguration, resourceType, cancellationToken);
-                            resourceIds.AddRange(ids);
-                            resourceIds.AddRange(ids ?? Array.Empty<string>());
+                            foreach (var id in ids) resourceIds.Add(id);
                         }
                         else if (fhirQuery.QueryType == FhirQueryType.BulkDataRequest)
                         {
@@ -489,7 +488,7 @@ public class PatientDataService : IPatientDataService
                 log.CompletionTimeMilliseconds = stopwatch.ElapsedMilliseconds;
                 log.CompletionDate = System.DateTime.UtcNow;
                 log.Status = RequestStatus.Completed;
-                log.ResourceAcquiredIds = resourceIds;
+                log.ResourceAcquiredIds = resourceIds.ToList();
                 await _dataAcquisitionLogManager.UpdateAsync(new UpdateDataAcquisitionLogModel
                 {
                     Id = log.Id,

--- a/DotNet/DataAcquisition.Domain/Application/Services/PatientDataService.cs
+++ b/DotNet/DataAcquisition.Domain/Application/Services/PatientDataService.cs
@@ -462,11 +462,13 @@ public class PatientDataService : IPatientDataService
 
                         if (fhirQuery.QueryType == FhirQueryType.Read)
                         {
-                            resourceIds = await _fhirApiService.ExecuteRead(log, fhirQuery, resourceType, fhirQueryConfiguration, resourceIds, cancellationToken);
+                            var ids = await _fhirApiService.ExecuteRead(log, fhirQuery, resourceType, fhirQueryConfiguration, cancellationToken);
+                            resourceIds.AddRange(ids);
                         }
                         else if (fhirQuery.QueryType == FhirQueryType.Search)
                         {
-                            resourceIds = await _fhirApiService.ExecuteSearch(log, fhirQuery, fhirQueryConfiguration, resourceIds, resourceType, cancellationToken);
+                            var ids = await _fhirApiService.ExecuteSearch(log, fhirQuery, fhirQueryConfiguration, resourceType, cancellationToken);
+                            resourceIds.AddRange(ids);
                         }
                         else if (fhirQuery.QueryType == FhirQueryType.BulkDataRequest)
                         {

--- a/DotNet/ServiceTests/IntegrationTests/DataAcquisition/FhirApiServiceTests.cs
+++ b/DotNet/ServiceTests/IntegrationTests/DataAcquisition/FhirApiServiceTests.cs
@@ -155,7 +155,7 @@ public class FhirApiServiceTests
             .ThrowsAsync(exception);
 
         await Assert.ThrowsAsync<FhirOperationException>(async () =>
-            await service.ExecuteRead(log, fhirQuery, ResourceType.Patient, new FhirQueryConfigurationModel { FhirServerBaseUrl = "http://example.com/fhir" }, null!));
+            await service.ExecuteRead(log, fhirQuery, ResourceType.Patient, new FhirQueryConfigurationModel { FhirServerBaseUrl = "http://example.com/fhir" }));
         Assert.NotNull(log.Notes);
         Assert.NotEmpty(log.Notes);
         Assert.StartsWith("OperationOutcome", log.Notes[0]);
@@ -235,10 +235,8 @@ public class FhirApiServiceTests
             FhirServerBaseUrl = "http://example.com/fhir"
         };
 
-        var resourceIds = new List<string>();
-
         // Act
-        await service.ExecuteSearch(log, fhirQuery, fhirQueryConfig, resourceIds, Hl7.Fhir.Model.ResourceType.Location);
+        await service.ExecuteSearch(log, fhirQuery, fhirQueryConfig, Hl7.Fhir.Model.ResourceType.Location);
 
         // Assert: Kafka message was produced and PatientId is null
         Assert.NotNull(producedMessage);

--- a/DotNet/ServiceTests/IntegrationTests/DataAcquisition/PatientDataServiceTests.cs
+++ b/DotNet/ServiceTests/IntegrationTests/DataAcquisition/PatientDataServiceTests.cs
@@ -369,4 +369,115 @@ public class PatientDataServiceTests
         // Act & Assert
         await Assert.ThrowsAsync<ArgumentNullException>(() => _service.ExecuteLogRequest(request, cancellationToken));
     }
+
+    [Fact]
+    public async Task ExecuteLogRequest_ShouldAccumulateResourceIds_FromMultipleFhirQueries()
+    {
+        // Arrange
+        var request = new AcquisitionRequest(1, "facility-1");
+        var cancellationToken = CancellationToken.None;
+
+        var log = new DataAcquisitionLog
+        {
+            Id = 1,
+            FacilityId = "facility-1",
+            PatientId = "Patient/123",
+            Status = RequestStatus.Ready,
+            CorrelationId = "corr-1",
+            FhirQueries = new List<FhirQuery>
+        {
+            new FhirQuery
+            {
+                QueryType = FhirQueryType.Read,
+                FhirQueryResourceTypes = new List<FhirQueryResourceType>
+                {
+                    new() { ResourceType = ResourceType.Patient }
+                }
+            },
+            new FhirQuery
+            {
+                QueryType = FhirQueryType.Search,
+                FhirQueryResourceTypes = new List<FhirQueryResourceType>
+                {
+                    new() { ResourceType = ResourceType.Observation }
+                },
+                QueryParameters = new List<string> { "patient=Patient/123" }
+            },
+            new FhirQuery
+            {
+                QueryType = FhirQueryType.Read,
+                FhirQueryResourceTypes = new List<FhirQueryResourceType>
+                {
+                    new() { ResourceType = ResourceType.Encounter }
+                }
+            }
+        },
+            ScheduledReport = new ScheduledReport()
+        };
+
+        var model = DataAcquisitionLogModel.FromDomain(log);
+
+        _mockLogQueries
+            .Setup(q => q.GetAsync(1, cancellationToken))
+            .ReturnsAsync(model);
+
+        _mockFhirQueryQueries
+            .Setup(q => q.GetByFacilityIdAsync("facility-1", cancellationToken))
+            .ReturnsAsync(new FhirQueryConfigurationModel { FacilityId = "facility-1" });
+
+        // Mock three different queries returning different IDs
+        _mockFhirApiService
+            .Setup(x => x.ExecuteRead(
+                It.IsAny<DataAcquisitionLogModel>(),
+                It.Is<FhirQueryModel>(q => q.ResourceTypes.Contains(ResourceType.Patient)),
+                ResourceType.Patient,
+                It.IsAny<FhirQueryConfigurationModel>(),
+                cancellationToken))
+            .ReturnsAsync(new[] { "Patient/123" });
+
+        _mockFhirApiService
+            .Setup(x => x.ExecuteSearch(
+                It.IsAny<DataAcquisitionLogModel>(),
+                It.Is<FhirQueryModel>(q => q.ResourceTypes.Contains(ResourceType.Observation)),
+                It.IsAny<FhirQueryConfigurationModel>(),
+                ResourceType.Observation,
+                cancellationToken))
+            .ReturnsAsync(new[] { "Observation/obs1", "Observation/obs2" });
+
+        _mockFhirApiService
+            .Setup(x => x.ExecuteRead(
+                It.IsAny<DataAcquisitionLogModel>(),
+                It.Is<FhirQueryModel>(q => q.ResourceTypes.Contains(ResourceType.Encounter)),
+                ResourceType.Encounter,
+                It.IsAny<FhirQueryConfigurationModel>(),
+                cancellationToken))
+            .ReturnsAsync(new[] { "Encounter/enc1" });
+
+        _mockLogManager
+            .Setup(m => m.UpdateAsync(It.IsAny<UpdateDataAcquisitionLogModel>(), cancellationToken))
+            .ReturnsAsync(model)
+            .Callback<UpdateDataAcquisitionLogModel, CancellationToken>((updateModel, _) =>
+            {
+                // Capture the final log state
+                model.ResourceAcquiredIds = updateModel.ResourceAcquiredIds;
+                model.Status = updateModel.Status;
+            });
+
+        // Act
+        await _service.ExecuteLogRequest(request, cancellationToken);
+
+        // Assert - All IDs from all queries must be present
+        _mockLogManager.Verify(m => m.UpdateAsync(
+            It.Is<UpdateDataAcquisitionLogModel>(u =>
+                u.ResourceAcquiredIds != null &&
+                u.ResourceAcquiredIds.Count == 4 &&
+                u.ResourceAcquiredIds.Contains("Patient/123") &&
+                u.ResourceAcquiredIds.Contains("Observation/obs1") &&
+                u.ResourceAcquiredIds.Contains("Observation/obs2") &&
+                u.ResourceAcquiredIds.Contains("Encounter/enc1") &&
+                u.Status == RequestStatus.Completed
+            ),
+            cancellationToken),
+            Times.Once);
+    }
 }

--- a/DotNet/ServiceTests/IntegrationTests/DataAcquisition/PatientDataServiceTests.cs
+++ b/DotNet/ServiceTests/IntegrationTests/DataAcquisition/PatientDataServiceTests.cs
@@ -314,15 +314,18 @@ public class PatientDataServiceTests
             FacilityId = "facilityId",
             Status = RequestStatus.Ready,
             FhirQueries = new List<FhirQuery>
+        {
+            new FhirQuery
             {
-                new FhirQuery
+                QueryType = FhirQueryType.Read,
+                FhirQueryResourceTypes = new List<FhirQueryResourceType>
                 {
-                    QueryType = FhirQueryType.Read,
-                    FhirQueryResourceTypes = new List<FhirQueryResourceType> {  new FhirQueryResourceType() { ResourceType = Hl7.Fhir.Model.ResourceType.Patient } },
-                    QueryParameters = new List<string>(),
-                    ResourceReferenceTypes = new List<ResourceReferenceType>()
-                }
-            },
+                    new FhirQueryResourceType() { ResourceType = Hl7.Fhir.Model.ResourceType.Patient }
+                },
+                QueryParameters = new List<string>(),
+                ResourceReferenceTypes = new List<ResourceReferenceType>()
+            }
+        },
             ScheduledReport = new ScheduledReport(),
             PatientId = "patient-1",
             CorrelationId = "corr-1"
@@ -348,9 +351,15 @@ public class PatientDataServiceTests
             .Setup(m => m.GetByFacilityIdAsync("facilityId", cancellationToken))
             .ReturnsAsync(fhirQueryConfig);
 
-        _mockReadFhirCommand
-            .Setup(cmd => cmd.ExecuteAsync(It.IsAny<ReadFhirCommandRequest>(), cancellationToken))
-            .ReturnsAsync(new Patient { Id = "patient-1" });
+        // ADD THIS SETUP - Mock the ExecuteRead method to return a list of IDs
+        _mockFhirApiService
+            .Setup(x => x.ExecuteRead(
+                It.IsAny<DataAcquisitionLogModel>(),
+                It.IsAny<FhirQueryModel>(),
+                It.IsAny<Hl7.Fhir.Model.ResourceType>(),
+                It.IsAny<FhirQueryConfigurationModel>(),
+                cancellationToken))
+            .ReturnsAsync(new[] { "Patient/patient-1" });
 
         // Act
         await _service.ExecuteLogRequest(request, cancellationToken);


### PR DESCRIPTION
### 🛠️ Description of Changes
* fix api search/reads by returning a new list of ids acquired and then compiling that after the fact to avoid race conditions with that list.
* add new integration test for regression of this issue.

### 🧪 Testing Performed
local testing, integration tests

ResourceAcquiredIds property being properly populated:
<img width="1237" height="482" alt="image" src="https://github.com/user-attachments/assets/245178ab-2580-4f41-bc56-56d25b53e854" />

ResourceTypeCounts and totalResourceAcquired being properly populated:
<img width="858" height="1027" alt="image" src="https://github.com/user-attachments/assets/5248e59e-13f2-40a8-91be-d44933277074" />


### 🧑‍🔬 Unit Testing
- [x] I have written or updated unit tests to cover my changes

### 📓 Documentation Updated
n.a


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal data handling for API result aggregation to enhance maintainability and consistency.

* **Tests**
  * Updated test coverage to validate proper accumulation of data across multiple operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->