### PR TITLE
LNK-4551: Enhance Admin UI Health screen with service meta-data (version, commit, build, swagger link)

### DIFF
--- a/DotNet/Admin.BFF/Infrastructure/Extensions/Security/CorsServiceExtension.cs
+++ b/DotNet/Admin.BFF/Infrastructure/Extensions/Security/CorsServiceExtension.cs
@@ -49,8 +49,15 @@ namespace LantanaGroup.Link.LinkAdmin.BFF.Infrastructure.Extensions.Security
 
                 options.AddPolicy(CorsConfig.DefaultCorsPolicyName, cpb.Build());
 
-                //add health check endpoint to cors policy
+                //add health check and api info endpoint to cors policy
                 options.AddPolicy("HealthCheckPolicy", policy =>
+                {
+                    policy.AllowAnyHeader();
+                    policy.AllowAnyMethod();
+                    policy.AllowAnyOrigin();
+                });
+                
+                options.AddPolicy("ApiInfoPolicy", policy =>
                 {
                     policy.AllowAnyHeader();
                     policy.AllowAnyMethod();

--- a/DotNet/Admin.BFF/Program.cs
+++ b/DotNet/Admin.BFF/Program.cs
@@ -454,46 +454,70 @@ static void SetupMiddleware(WebApplication app)
         var tasks = new List<Task<ServiceInformation?>>();
 
         if (!string.IsNullOrEmpty(serviceRegistry.AccountServiceApiUrl))
-            tasks.Add(ServiceInformation.GetServiceInformation(client, serviceRegistry.AccountServiceApiUrl + "/account/info", logger));
+            tasks.Add(ServiceInformation.GetServiceInformation(client, serviceRegistry.AccountServiceApiUrl, 
+                serviceRegistry.PublicAccountServiceUrl, 
+                "/account/info", logger));
 
         if (!string.IsNullOrEmpty(serviceRegistry.AuditServiceApiUrl))
-            tasks.Add(ServiceInformation.GetServiceInformation(client, serviceRegistry.AuditServiceApiUrl + "/audit/info", logger));
+            tasks.Add(ServiceInformation.GetServiceInformation(client, serviceRegistry.AuditServiceApiUrl, 
+                serviceRegistry.PublicAuditServiceUrl,  
+                "/audit/info", logger));
 
         if (!string.IsNullOrEmpty(serviceRegistry.CensusServiceApiUrl))
-            tasks.Add(ServiceInformation.GetServiceInformation(client, serviceRegistry.CensusServiceApiUrl + "/census/info", logger));
+            tasks.Add(ServiceInformation.GetServiceInformation(client, serviceRegistry.CensusServiceApiUrl, 
+                serviceRegistry.PublicCensusServiceUrl,  
+                "/census/info", logger));
 
         if (!string.IsNullOrEmpty(serviceRegistry.DataAcquisitionServiceApiUrl))
-            tasks.Add(ServiceInformation.GetServiceInformation(client, serviceRegistry.DataAcquisitionServiceApiUrl + "/data/info", logger));
+            tasks.Add(ServiceInformation.GetServiceInformation(client, serviceRegistry.DataAcquisitionServiceApiUrl, 
+                serviceRegistry.PublicDataAcquisitionServiceUrl,  
+                "/data/info", logger));
 
         if (!string.IsNullOrEmpty(serviceRegistry.MeasureServiceApiUrl))
-            tasks.Add(ServiceInformation.GetServiceInformation(client, serviceRegistry.MeasureServiceApiUrl + "/measure-definition/info", logger));
+            tasks.Add(ServiceInformation.GetServiceInformation(client, serviceRegistry.MeasureServiceApiUrl, 
+                serviceRegistry.PublicMeasureServiceUrl,  
+                "/measure-definition/info", logger));
 
         if (!string.IsNullOrEmpty(serviceRegistry.NormalizationServiceApiUrl))
-            tasks.Add(ServiceInformation.GetServiceInformation(client, serviceRegistry.NormalizationServiceApiUrl + "/normalization/info", logger));
+            tasks.Add(ServiceInformation.GetServiceInformation(client, serviceRegistry.NormalizationServiceApiUrl, 
+                serviceRegistry.PublicNormalizationServiceUrl, 
+                "/normalization/info", logger));
 
         if (!string.IsNullOrEmpty(serviceRegistry.QueryDispatchServiceApiUrl))
-            tasks.Add(ServiceInformation.GetServiceInformation(client, serviceRegistry.QueryDispatchServiceApiUrl + "/querydispatch/info", logger));
+            tasks.Add(ServiceInformation.GetServiceInformation(client, serviceRegistry.QueryDispatchServiceApiUrl, 
+                serviceRegistry.PublicQueryDispatchServiceUrl,  
+                "/querydispatch/info", logger));
 
         if (!string.IsNullOrEmpty(serviceRegistry.ReportServiceApiUrl))
-            tasks.Add(ServiceInformation.GetServiceInformation(client, serviceRegistry.ReportServiceApiUrl + "/report/info", logger));
+            tasks.Add(ServiceInformation.GetServiceInformation(client, serviceRegistry.ReportServiceApiUrl, 
+                serviceRegistry.PublicReportServiceUrl,  
+                "/report/info", logger));
 
         if (!string.IsNullOrEmpty(serviceRegistry.SubmissionServiceApiUrl))
-            tasks.Add(ServiceInformation.GetServiceInformation(client, serviceRegistry.SubmissionServiceApiUrl + "/submission/info", logger));
+            tasks.Add(ServiceInformation.GetServiceInformation(client, serviceRegistry.SubmissionServiceApiUrl, 
+                serviceRegistry.PublicSubmissionServiceUrl, 
+                "/submission/info", logger));
 
         if (!string.IsNullOrEmpty(serviceRegistry.TenantServiceApiUrl))
-            tasks.Add(ServiceInformation.GetServiceInformation(client, serviceRegistry.TenantServiceApiUrl + "/facility/info", logger));
+            tasks.Add(ServiceInformation.GetServiceInformation(client, serviceRegistry.TenantServiceApiUrl, 
+                serviceRegistry.TenantService.PublicTenantServiceUrl, 
+                "/facility/info", logger));
 
         if (!string.IsNullOrEmpty(serviceRegistry.ValidationServiceApiUrl))
-            tasks.Add(ServiceInformation.GetServiceInformation(client, serviceRegistry.ValidationServiceApiUrl + "/validation/info", logger));
+            tasks.Add(ServiceInformation.GetServiceInformation(client, serviceRegistry.ValidationServiceApiUrl, 
+                serviceRegistry.PublicValidationServiceUrl, 
+                "/validation/info", logger));
 
         if (!string.IsNullOrEmpty(serviceRegistry.TerminologyServiceApiUrl))
-            tasks.Add(ServiceInformation.GetServiceInformation(client, serviceRegistry.TerminologyServiceApiUrl + "/terminology/info", logger));
+            tasks.Add(ServiceInformation.GetServiceInformation(client, serviceRegistry.TerminologyServiceApiUrl, 
+                serviceRegistry.PublicTerminologyServiceUrl, 
+                "/terminology/info", logger));
 
         var results = await Task.WhenAll(tasks);
         serviceInfos.AddRange(results.Where(info => info != null)!);
 
         return serviceInfos;
-    });
+    }).RequireCors("ApiInfoPolicy");
 }
 
 #endregion

--- a/DotNet/Shared/Application/Models/Configs/ServiceRegistry.cs
+++ b/DotNet/Shared/Application/Models/Configs/ServiceRegistry.cs
@@ -7,18 +7,30 @@ namespace LantanaGroup.Link.Shared.Application.Models.Configs
         public static string ConfigSectionName = "ServiceRegistry";
 
         public string AccountServiceUrl { get; set; } = null!;
+        public string? PublicAccountServiceUrl { get; set; }
         public string AuditServiceUrl { get; set; } = null!;
+        public string? PublicAuditServiceUrl { get; set; }
         public string CensusServiceUrl { get; set; } = null!;
+        public string? PublicCensusServiceUrl { get; set; }
         public string DataAcquisitionServiceUrl { get; set; } = null!;
+        public string? PublicDataAcquisitionServiceUrl { get; set; }
         public string MeasureServiceUrl { get; set; } = null!;
+        public string? PublicMeasureServiceUrl { get; set; }
         public string NormalizationServiceUrl { get; set; } = null!;
+        public string? PublicNormalizationServiceUrl { get; set; }
         public string NotificationServiceUrl { get; set; } = null!;
+        public string? PublicNotificationServiceUrl { get; set; }
         public string QueryDispatchServiceUrl { get; set; } = null!;
+        public string? PublicQueryDispatchServiceUrl { get; set; }
         public string ReportServiceUrl { get; set; } = null!;
+        public string? PublicReportServiceUrl { get; set; }
         public string SubmissionServiceUrl { get; set; } = null!;
+        public string? PublicSubmissionServiceUrl { get; set; }
         public string ValidationServiceUrl { get; set; } = null!;
+        public string? PublicValidationServiceUrl { get; set; }
         public TenantServiceRegistration TenantService { get; set; } = null!;
         public string TerminologyServiceUrl { get; set; } = null!;
+        public string? PublicTerminologyServiceUrl { get; set; }
 
         public string? TerminologyServiceApiUrl
         {
@@ -159,6 +171,138 @@ namespace LantanaGroup.Link.Shared.Application.Models.Configs
             {
                 if (!string.IsNullOrEmpty(this.ValidationServiceUrl))
                     return this.ValidationServiceUrl.TrimEnd('/') + "/api";
+
+                return null;
+            }
+        }
+
+        public string? PublicAccountServiceApiUrl
+        {
+            get
+            {
+                if (!string.IsNullOrEmpty(this.PublicAccountServiceUrl))
+                    return this.PublicAccountServiceUrl.TrimEnd('/') + "/api";
+
+                return null;
+            }
+        }
+
+        public string? PublicAuditServiceApiUrl
+        {
+            get
+            {
+                if (!string.IsNullOrEmpty(this.PublicAuditServiceUrl))
+                    return this.PublicAuditServiceUrl.TrimEnd('/') + "/api";
+
+                return null;
+            }
+        }
+
+        public string? PublicCensusServiceApiUrl
+        {
+            get
+            {
+                if (!string.IsNullOrEmpty(this.PublicCensusServiceUrl))
+                    return this.PublicCensusServiceUrl.TrimEnd('/') + "/api";
+
+                return null;
+            }
+        }
+
+        public string? PublicDataAcquisitionServiceApiUrl
+        {
+            get
+            {
+                if (!string.IsNullOrEmpty(this.PublicDataAcquisitionServiceUrl))
+                    return this.PublicDataAcquisitionServiceUrl.TrimEnd('/') + "/api";
+
+                return null;
+            }
+        }
+
+        public string? PublicMeasureServiceApiUrl
+        {
+            get
+            {
+                if (!string.IsNullOrEmpty(this.PublicMeasureServiceUrl))
+                    return this.PublicMeasureServiceUrl.TrimEnd('/') + "/api";
+
+                return null;
+            }
+        }
+
+        public string? PublicNormalizationServiceApiUrl
+        {
+            get
+            {
+                if (!string.IsNullOrEmpty(this.PublicNormalizationServiceUrl))
+                    return this.PublicNormalizationServiceUrl.TrimEnd('/') + "/api";
+
+                return null;
+            }
+        }
+
+        public string? PublicNotificationServiceApiUrl
+        {
+            get
+            {
+                if (!string.IsNullOrEmpty(this.PublicNotificationServiceUrl))
+                    return this.PublicNotificationServiceUrl.TrimEnd('/') + "/api";
+
+                return null;
+            }
+        }
+
+        public string? PublicQueryDispatchServiceApiUrl
+        {
+            get
+            {
+                if (!string.IsNullOrEmpty(this.PublicQueryDispatchServiceUrl))
+                    return this.PublicQueryDispatchServiceUrl.TrimEnd('/') + "/api";
+
+                return null;
+            }
+        }
+
+        public string? PublicReportServiceApiUrl
+        {
+            get
+            {
+                if (!string.IsNullOrEmpty(this.PublicReportServiceUrl))
+                    return this.PublicReportServiceUrl.TrimEnd('/') + "/api";
+
+                return null;
+            }
+        }
+
+        public string? PublicSubmissionServiceApiUrl
+        {
+            get
+            {
+                if (!string.IsNullOrEmpty(this.PublicSubmissionServiceUrl))
+                    return this.PublicSubmissionServiceUrl.TrimEnd('/') + "/api";
+
+                return null;
+            }
+        }
+
+        public string? PublicValidationServiceApiUrl
+        {
+            get
+            {
+                if (!string.IsNullOrEmpty(this.PublicValidationServiceUrl))
+                    return this.PublicValidationServiceUrl.TrimEnd('/') + "/api";
+
+                return null;
+            }
+        }
+
+        public string? PublicTerminologyServiceApiUrl
+        {
+            get
+            {
+                if (!string.IsNullOrEmpty(this.PublicTerminologyServiceUrl))
+                    return this.PublicTerminologyServiceUrl.TrimEnd('/') + "/api";
 
                 return null;
             }

--- a/DotNet/Shared/Application/Models/Configs/TenantServiceRegistration.cs
+++ b/DotNet/Shared/Application/Models/Configs/TenantServiceRegistration.cs
@@ -3,7 +3,18 @@
 public class TenantServiceRegistration
 {
     public string? TenantServiceUrl { get; set; }
+    public string? PublicTenantServiceUrl { get; set; }
     public bool CheckIfTenantExists { get; set; }
     public string? GetTenantRelativeEndpoint { get; set; }
+    
+    public string? PublicTenantServiceApiUrl
+    {
+        get
+        {
+            if (!string.IsNullOrEmpty(this.PublicTenantServiceUrl))
+                return this.PublicTenantServiceUrl.TrimEnd('/') + "/api";
 
+            return null;
+        }
+    }
 }

--- a/DotNet/Shared/Application/Models/ServiceInformation.cs
+++ b/DotNet/Shared/Application/Models/ServiceInformation.cs
@@ -15,6 +15,7 @@ public class ServiceInformation
     public string ProductVersion { get; init; } = string.Empty;
     public string Commit { get; init; } = string.Empty;
     public string Build { get; init; } = string.Empty;
+    public string SwaggerUrl { get; set; } = string.Empty;
 
     public static ServiceInformation GetServiceInformation(Assembly assembly, IConfiguration configuration)
     {
@@ -25,6 +26,11 @@ public class ServiceInformation
         
         if (string.IsNullOrEmpty(serviceInformation.Version))
             serviceInformation.Version = assemblyVersion;
+        
+        var enableSwagger = configuration.GetValue<bool>("EnableSwagger");
+
+        if (enableSwagger)
+            serviceInformation.SwaggerUrl = "/swagger/index.html";
 
         return serviceInformation;
     }
@@ -32,10 +38,13 @@ public class ServiceInformation
     /**
      * Gets service information for a given service at its base URL.
      */
-    public static async Task<ServiceInformation?> GetServiceInformation(HttpClient client, string? serviceInfoEndpoint, ILogger logger)
+    public static async Task<ServiceInformation?> GetServiceInformation(HttpClient client, string? internalBaseUrl, string? externalBaseUrl, string? serviceInfoPath, ILogger logger)
     {
-        if (string.IsNullOrEmpty(serviceInfoEndpoint))
+        if (string.IsNullOrEmpty(internalBaseUrl) || string.IsNullOrEmpty(serviceInfoPath))
             return null;
+
+        string serviceInfoEndpoint =
+            internalBaseUrl + (serviceInfoPath.StartsWith("/") ? serviceInfoPath : "/" + serviceInfoPath);
         
         try
         {
@@ -46,9 +55,28 @@ public class ServiceInformation
                 return null;
             }
             var content = await response.Content.ReadAsStringAsync();
-            JsonSerializerOptions options = new JsonSerializerOptions();
-            options.PropertyNameCaseInsensitive = true;
-            return JsonSerializer.Deserialize<ServiceInformation>(content, options);
+            JsonSerializerOptions options = new JsonSerializerOptions
+            {
+                PropertyNameCaseInsensitive = true
+            };
+            ServiceInformation? serviceInfo = JsonSerializer.Deserialize<ServiceInformation>(content, options);
+
+            if (serviceInfo != null && !string.IsNullOrEmpty(serviceInfo.SwaggerUrl) &&
+                serviceInfo.SwaggerUrl.StartsWith("/"))
+            {
+                string baseUrl = externalBaseUrl ?? internalBaseUrl;
+                
+                logger.LogDebug("Service information Swagger URL is relative, using base URL {BaseUrl}", baseUrl);
+                
+                if (baseUrl.EndsWith("/"))
+                    baseUrl = baseUrl.Substring(0, baseUrl.Length - 1);
+                
+                serviceInfo.SwaggerUrl = baseUrl + serviceInfo.SwaggerUrl;
+                
+                logger.LogDebug("Service information Swagger URL is now {SwaggerUrl}", serviceInfo.SwaggerUrl);
+            }
+
+            return serviceInfo;
         }
         catch (Exception ex)
         {

--- a/Java/shared/src/main/java/com/lantanagroup/link/shared/config/ServiceInformationConfig.java
+++ b/Java/shared/src/main/java/com/lantanagroup/link/shared/config/ServiceInformationConfig.java
@@ -5,6 +5,7 @@ import jakarta.annotation.PostConstruct;
 import lombok.Getter;
 import lombok.Setter;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.info.BuildProperties;
 
@@ -17,15 +18,23 @@ public class ServiceInformationConfig {
     private String productVersion;
     private String build;
     private String commit;
+    private String swaggerUrl;
+
+    @Value("${springdoc.swagger-ui.enabled:false}")
+    private boolean swaggerUiEnabled;
 
     @Autowired(required = false)
     @JsonIgnore
     private BuildProperties buildProperties;
 
     @PostConstruct
-    public void initializeVersion() {
+    public void initialize() {
         if (this.version == null || this.version.isEmpty()) {
             this.version = buildProperties != null ? buildProperties.getVersion() : "UNKNOWN";
+        }
+
+        if (this.swaggerUiEnabled) {
+            this.swaggerUrl = "/swagger-ui.html";
         }
     }
 }

--- a/Web/Admin.UI/Dockerfile
+++ b/Web/Admin.UI/Dockerfile
@@ -2,7 +2,7 @@
 FROM node:23-alpine AS build
 WORKDIR /app
 COPY . .
-RUN npm install
+RUN npm ci
 RUN npm run build
 
 # Runtime Stage: Node.js Server

--- a/Web/Admin.UI/src/app/components/monitor/link-health-check/link-health-check.component.html
+++ b/Web/Admin.UI/src/app/components/monitor/link-health-check/link-health-check.component.html
@@ -1,9 +1,76 @@
+
+@if (!initializeServiceInfos) {
+  <div class="content">
+    <p>
+      <mat-toolbar class="page-header-bar" color="primary">
+        <span>Service Meta Data</span>
+        <button mat-mini-fab aria-label="Refresh" matTooltip="Refresh health summary" (click)="getServiceInfos()">
+          <mat-icon>refresh</mat-icon>
+        </button>
+      </mat-toolbar>
+    </p>
+    @if (serviceInfos.length > 0) {
+      <div class="table-container">
+        <table mat-table [dataSource]="serviceInfos">
+          <ng-container matColumnDef="serviceName" class="service-name-column">
+            <th mat-header-cell [ngStyle]="{'border-right': '1px solid lightgray'}" *matHeaderCellDef> Service</th>
+            <td mat-cell [ngStyle]="{'border-right': '1px solid lightgray'}" *matCellDef="let info">
+              @if (info.swaggerUrl) {
+                <a [href]="info.swaggerUrl" target="_blank">{{ info.serviceName }}</a>
+              } @else {
+                {{ info.serviceName }}
+              }
+            </td>
+          </ng-container>
+          <ng-container matColumnDef="version">
+            <th mat-header-cell [ngStyle]="{'border-right': '1px solid lightgray'}" *matHeaderCellDef> Version</th>
+            <td mat-cell [ngStyle]="{'border-right': '1px solid lightgray'}"
+                *matCellDef="let info"> {{ info.version || 'N/A' }}
+            </td>
+          </ng-container>
+          <ng-container matColumnDef="productVersion">
+            <th mat-header-cell [ngStyle]="{'border-right': '1px solid lightgray'}" *matHeaderCellDef> Product Version
+            </th>
+            <td mat-cell [ngStyle]="{'border-right': '1px solid lightgray'}"
+                *matCellDef="let info"> {{ info.productVersion || 'N/A' }}
+            </td>
+          </ng-container>
+          <ng-container matColumnDef="commit">
+            <th mat-header-cell [ngStyle]="{'border-right': '1px solid lightgray'}" *matHeaderCellDef> Commit</th>
+            <td mat-cell [ngStyle]="{'border-right': '1px solid lightgray'}"
+                *matCellDef="let info"> {{ info.commit || 'N/A' }}
+            </td>
+          </ng-container>
+          <ng-container matColumnDef="build">
+            <th mat-header-cell [ngStyle]="{'border-right': '1px solid lightgray'}" *matHeaderCellDef> Build</th>
+            <td mat-cell [ngStyle]="{'border-right': '1px solid lightgray'}"
+                *matCellDef="let info"> {{ info.build || 'N/A' }}
+            </td>
+          </ng-container>
+          <tr mat-header-row *matHeaderRowDef="serviceInfosDisplayColumns"></tr>
+          <tr mat-row *matRowDef="let row; columns: serviceInfosDisplayColumns;"></tr>
+        </table>
+      </div>
+    } @else {
+      <div class="no-results-found-container">
+        <span>No service information found.</span>
+      </div>
+    }
+  </div>
+} @else {
+  <div class="content">
+    <div class="no-results-found-container">
+      <span>Loading link services information.</span>
+    </div>
+  </div>
+}
+
 @if (!initializeSummaries) {
   <div class="content">
     <p>
       <mat-toolbar class="page-header-bar" color="primary">
-        <span>Link Health Status</span>
-        <button mat-mini-fab aria-label="Refresh" matTooltip="Refresh health summary" (click)="onRefresh()">
+        <span>Service Health Status</span>
+        <button mat-mini-fab aria-label="Refresh" matTooltip="Refresh health summary" (click)="getHealthSummary()">
           <mat-icon>refresh</mat-icon>
         </button>
       </mat-toolbar>
@@ -62,8 +129,8 @@
               </mat-chip>
             </td>
           </ng-container>
-          <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
-          <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
+          <tr mat-header-row *matHeaderRowDef="healthDisplayColumns"></tr>
+          <tr mat-row *matRowDef="let row; columns: healthDisplayColumns;"></tr>
         </table>
       </div>
     } @else {

--- a/Web/Admin.UI/src/app/components/monitor/link-health-check/link-health-check.component.ts
+++ b/Web/Admin.UI/src/app/components/monitor/link-health-check/link-health-check.component.ts
@@ -5,6 +5,7 @@ import { ILinkServiceHealthSummary } from './link-service-health-summary.interfa
 import { MatToolbarModule } from '@angular/material/toolbar';
 import { CommonModule } from '@angular/common';
 import { MatIconModule } from '@angular/material/icon';
+import {IServiceInfoModel, ServiceInfoService} from "../service-info.service";
 
 @Component({
   selector: 'app-link-health-check',
@@ -12,40 +13,58 @@ import { MatIconModule } from '@angular/material/icon';
     CommonModule,
     MatToolbarModule,
     MatTableModule,
-    MatIconModule   
+    MatIconModule
   ],
   templateUrl: './link-health-check.component.html',
   styleUrl: './link-health-check.component.scss'
 })
 export class LinkHealthCheckComponent implements OnInit {
-  dataSource!: MatTableDataSource<ILinkServiceHealthSummary>;
+  healthDataSource!: MatTableDataSource<ILinkServiceHealthSummary>;
+  serviceInfosDataSource!: MatTableDataSource<IServiceInfoModel>;
   healthSummary: ILinkServiceHealthSummary[] = [];
-  displayedColumns: string[] = ['ServiceName', 'ServiceHealthStatus', 'KafkaConnection', 'DatabaseConnection', 'CacheConnection'];
+  serviceInfos: IServiceInfoModel[] = [];
+  healthDisplayColumns: string[] = ['ServiceName', 'ServiceHealthStatus', 'KafkaConnection', 'DatabaseConnection', 'CacheConnection'];
+  serviceInfosDisplayColumns: string[] = ['serviceName', 'version', 'productVersion', 'commit', 'build'];
 
   initializeSummaries = true;
+  initializeServiceInfos = true;
 
-  constructor(private monitorService: MonitorService) { }
+  constructor(private monitorService: MonitorService, private serviceInfoService: ServiceInfoService) { }
 
   ngOnInit(): void {
-    this.dataSource = new MatTableDataSource<ILinkServiceHealthSummary>();
-    this.getLinkHealthSummary();    
+    this.healthDataSource = new MatTableDataSource<ILinkServiceHealthSummary>();
+    this.getHealthSummary();
+    this.getServiceInfos();
   }
 
-  getLinkHealthSummary(): void {
+  getHealthSummary(): void {
     this.monitorService.getLinkHealthCheck().subscribe({
       next: (response: ILinkServiceHealthSummary[]) => {
         this.healthSummary = response;
-        this.dataSource.data = this.healthSummary;
-        this.initializeSummaries = false;
+        this.healthDataSource.data = this.healthSummary;
       },
       error: (error) => {
         console.error('Error fetching link health summary:', error);
-      } 
+      },
+      complete: () => {
+        this.initializeSummaries = false;
+      }
     })
   }
 
-  onRefresh(): void {
-    this.getLinkHealthSummary();
+  getServiceInfos(): void {
+    this.serviceInfoService.getServiceInfos().subscribe({
+      next: (response: IServiceInfoModel[]) => {
+        this.serviceInfos = response;
+        this.serviceInfosDataSource.data = this.serviceInfos;
+      },
+      error: (error) => {
+        console.error('Error fetching service infos:', error);
+      },
+      complete: () => {
+        this.initializeServiceInfos = false;
+      }
+    })
   }
 
 }

--- a/Web/Admin.UI/src/app/components/monitor/service-info.service.ts
+++ b/Web/Admin.UI/src/app/components/monitor/service-info.service.ts
@@ -1,0 +1,37 @@
+﻿import { HttpClient, HttpErrorResponse } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import {AppConfigService} from '../../services/app-config.service';
+import { ErrorHandlingService } from 'src/app/services/error-handling.service';
+import { catchError, map, Observable } from 'rxjs';
+
+export interface IServiceInfoModel {
+  serviceName: string;
+  version?: string;
+  productVersion?: string;
+  commit?: string;
+  build?: string;
+  swaggerUrl?: string;
+}
+
+@Injectable({
+  providedIn: 'root'
+})
+export class ServiceInfoService {
+  baseApiPath: string = `${this.appConfigService.config?.baseApiUrl}`;
+
+  constructor(private http: HttpClient, private errorHandler: ErrorHandlingService, public appConfigService: AppConfigService) { }
+
+  getServiceInfos(): Observable<IServiceInfoModel[]> {
+    return this.http.get<IServiceInfoModel[]>(`${this.baseApiPath}/info`)
+      .pipe(
+        map((response: IServiceInfoModel[]) => {
+          return response;
+        }),
+        catchError(this.handleError.bind(this))
+      );
+  }
+
+  private handleError(err: HttpErrorResponse) {
+    return this.errorHandler.handleError(err);
+  }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -496,16 +496,29 @@ services:
       CORS__AllowedMethods__4: OPTIONS
       CORS__AllowedHeaders__0: "*"
       ServiceRegistry__TenantService__TenantServiceURL: http://tenant:8074
+      ServiceRegistry__TenantService__PublicTenantServiceUrl: http://localhost:8074
       ServiceRegistry__AccountServiceUrl: http://account:8060
+      ServiceRegistry__PublicAccountServiceUrl: http://localhost:8060
       ServiceRegistry__AuditServiceUrl: http://audit:8062
+      ServiceRegistry__PublicAuditServiceUrl: http://localhost:8062
       ServiceRegistry__CensusServiceUrl: http://census:8064
+      ServiceRegistry__PublicCensusServiceUrl: http://localhost:8064
       ServiceRegistry__DataAcquisitionServiceUrl: http://dataacquisition:8065
+      ServiceRegistry__PublicDataAcquisitionServiceUrl: http://localhost:8065
       ServiceRegistry__MeasureServiceUrl: http://measureeval:8067
+      ServiceRegistry__PublicMeasureServiceUrl: http://localhost:8067
       ServiceRegistry__NormalizationServiceUrl: http://normalization:8068
+      ServiceRegistry__PublicNormalizationServiceUrl: http://localhost:8068
       ServiceRegistry__ReportServiceUrl: http://report:8072
+      ServiceRegistry__PublicReportServiceUrl: http://localhost:8072
       ServiceRegistry__SubmissionServiceUrl: http://submission:8073
+      ServiceRegistry__PublicSubmissionServiceUrl: http://localhost:8073
       ServiceRegistry__QueryDispatchServiceUrl: http://querydispatch:8071
+      ServiceRegistry__PublicQueryDispatchServiceUrl: http://localhost:8071
+      ServiceRegistry__ValidationServiceUrl: http://validation:8075
+      ServiceRegistry__PublicValidationServiceUrl: http://localhost:8075
       ServiceRegistry__TerminologyServiceUrl: http://terminology:8076
+      ServiceRegistry__PublicTerminologyServiceUrl: http://localhost:8076
       ReverseProxy__Clusters__AccountService__Destinations__destination1__Address: http://account:8060
       ReverseProxy__Clusters__AuditService__Destinations__destination1__Address: http://audit:8062
       ReverseProxy__Clusters__CensusService__Destinations__destination1__Address: http://census:8064

--- a/docs/docs/config/dotnet.mdx
+++ b/docs/docs/config/dotnet.mdx
@@ -131,39 +131,59 @@ Not all services use every URL. The configuration is provided for completeness a
 
 ## Service URLs
 
-| Property                                   | Description                               |
-|--------------------------------------------|-------------------------------------------|
-| ServiceRegistry__AccountServiceUrl         | Base URL for the Account service          |
-| ServiceRegistry__AuditServiceUrl           | Base URL for the Audit service            |
-| ServiceRegistry__CensusServiceUrl          | Base URL for the Census service           |
-| ServiceRegistry__DataAcquisitionServiceUrl | Base URL for the Data Acquisition service |
-| ServiceRegistry__MeasureServiceUrl         | Base URL for the Measure service          |
-| ServiceRegistry__NormalizationServiceUrl   | Base URL for the Normalization service    |
-| ServiceRegistry__NotificationServiceUrl    | Base URL for the Notification service     |
-| ServiceRegistry__QueryDispatchServiceUrl   | Base URL for the Query Dispatch service   |
-| ServiceRegistry__ReportServiceUrl          | Base URL for the Report service           |
-| ServiceRegistry__SubmissionServiceUrl      | Base URL for the Submission service       |
+| Property                                                  | Required | Description                                                                                              |
+|-----------------------------------------------------------|:---------|----------------------------------------------------------------------------------------------------------|
+| ServiceRegistry__AccountServiceUrl                        | Yes      | Base URL for the Account service                                                                         |
+| ServiceRegistry__PublicAccountServiceUrl                  | No       | Public base URL for the Account service                                                                  |
+| ServiceRegistry__AuditServiceUrl                          | Yes      | Base URL for the Audit service                                                                           |
+| ServiceRegistry__PublicAuditServiceUrl                    | No       | Public base URL for the Audit service                                                                    |
+| ServiceRegistry__CensusServiceUrl                         | Yes      | Base URL for the Census service                                                                          |
+| ServiceRegistry__PublicCensusServiceUrl                   | No       | Public base URL for the Census service                                                                   |
+| ServiceRegistry__DataAcquisitionServiceUrl                | Yes      | Base URL for the Data Acquisition service                                                                |
+| ServiceRegistry__PublicDataAcquisitionServiceUrl          | No       | Public base URL for the Data Acquisition service                                                         |
+| ServiceRegistry__MeasureServiceUrl                        | Yes      | Base URL for the Measure service                                                                         |
+| ServiceRegistry__PublicMeasureServiceUrl                  | No       | Public base URL for the Measure service                                                                  |
+| ServiceRegistry__NormalizationServiceUrl                  | Yes      | Base URL for the Normalization service                                                                   |
+| ServiceRegistry__PublicNormalizationServiceUrl            | No       | Public base URL for the Normalization service                                                            |
+| ServiceRegistry__NotificationServiceUrl                   | Yes      | Base URL for the Notification service                                                                    |
+| ServiceRegistry__PublicNotificationServiceUrl             | No       | Public base URL for the Notification service                                                             |
+| ServiceRegistry__QueryDispatchServiceUrl                  | Yes      | Base URL for the Query Dispatch service                                                                  |
+| ServiceRegistry__PublicQueryDispatchServiceUrl            | No       | Public base URL for the Query Dispatch service                                                           |
+| ServiceRegistry__ReportServiceUrl                         | Yes      | Base URL for the Report service                                                                          |
+| ServiceRegistry__PublicReportServiceUrl                   | No       | Public base URL for the Report service                                                                   |
+| ServiceRegistry__SubmissionServiceUrl                     | Yes      | Base URL for the Submission service                                                                      |
+| ServiceRegistry__PublicSubmissionServiceUrl               | No       | Public base URL for the Submission service                                                               |
+| ServiceRegistry__ValidationServiceUrl                     | Yes      | Base URL for the Validation service                                                                      |
+| ServiceRegistry__PublicValidationServiceUrl               | No       | Public base URL for the Validation service                                                               |
+| ServiceRegistry__TerminologyServiceUrl                    | Yes      | Base URL for the Terminology service                                                                     |
+| ServiceRegistry__PublicTerminologyServiceUrl              | No       | Public base URL for the Terminology service                                                              |
+| ServiceRegistry__TenantService__TenantServiceUrl          | Yes      | Base URL for the Tenant service                                                                          |
+| ServiceRegistry__TenantService__PublicTenantServiceUrl    | No       | Public base URL for the Tenant service                                                                   |
+| ServiceRegistry__TenantService__CheckIfTenantExists       | No       | Whether to validate tenant's existence in other services such as Data Acquisition                        |
+| ServiceRegistry__TenantService__GetTenantRelativeEndpoint | No       | Relative endpoint path for tenant retrieval in other services such as Data Acquisition; excluding "/api" |
 
 ### Example Configuration in JSON
 
 ```json
 {
   "ServiceRegistry": {
-    "AccountServiceUrl": "https://localhost:7001",
-    "AuditServiceUrl": "https://localhost:7334",
-    "CensusServiceUrl": "https://localhost:7234",
-    "DataAcquisitionServiceUrl": "https://localhost:7194",
-    "MeasureServiceUrl": "https://localhost:7135",
-    "NormalizationServiceUrl": "https://localhost:7038",
-    "NotificationServiceUrl": "https://localhost:7434",
-    "QueryDispatchServiceUrl": "https://localhost:7534",
-    "ReportServiceUrl": "https://localhost:7110",
-    "SubmissionServiceUrl": "https://localhost:7046",
+    "AccountServiceUrl": "http://localhost:8060",
+    "AuditServiceUrl": "http://localhost:8062",
+    "CensusServiceUrl": "http://localhost:8064",
+    "DataAcquisitionServiceUrl": "http://localhost:8065",
+    "MeasureServiceUrl": "http://localhost:8067",
+    "NormalizationServiceUrl": "http://localhost:8068",
+    "NotificationServiceUrl": "http://localhost:7434",
+    "QueryDispatchServiceUrl": "http://localhost:8071",
+    "ReportServiceUrl": "http://localhost:8072",
+    "SubmissionServiceUrl": "http://localhost:8073",
     "TenantService": {
-      "TenantServiceUrl": "https://localhost:7332",
+      "TenantServiceUrl": "http://localhost:8074",
       "CheckIfTenantExists": true,
       "GetTenantRelativeEndpoint": "facility/"
-    }
+    },
+    "ValidationServiceUrl": "http://localhost:8075",
+    "TerminologyServiceUrl": "http://localhost:8076"
   }
 }
 ```


### PR DESCRIPTION
### 🛠️ Description of Changes

Adding support for Swagger URLs and public service URLs across multiple services, extending `ServiceRegistry` and related components to handle public API URLs, and updating the UI to display service metadata.

### 🧪 Testing Performed

Ran with Docker Compose, confirmed that the UI shows correctly.

### 🧑‍🔬 Unit Testing

N/A as most of the changes were UI or configuration related; and we aren't unit testing either of those.

### 📓 Documentation Updated

Updated config documentation to make note of new ServiceRegistry entries.