### PR TITLE
LNK-4532:  Bundle Aggregation Optimization

### DIFF
--- a/DotNet/Report/Core/PatientReportSubmissionBundler.cs
+++ b/DotNet/Report/Core/PatientReportSubmissionBundler.cs
@@ -46,19 +46,16 @@ namespace LantanaGroup.Link.Report.Core
 
         public async Task<PatientSubmissionModel> GenerateBundle(string facilityId, string patientId, string reportScheduleId)
         {
-            var startBundleTime = Stopwatch.GetTimestamp();
-
             var schedule = await _reportScheduledManager.SingleOrDefaultAsync(s => s.Id == reportScheduleId) ?? throw new Exception($"No Measure Reports Scheduled for reportScheduleId of {reportScheduleId}");
 
             var entries = await _database.SubmissionEntryRepository.FindAsync(e =>
                 e.FacilityId == facilityId && e.PatientId == patientId &&
                 schedule.Id == e.ReportScheduleId);
 
-            // TODO: Return null if no entries found?
-
-            Dictionary<string, List<string>> resources_added = new Dictionary<string, List<string>>();
+            //The 'resourcesAdded' Dictionary will keep track of FHIR resource id's that have been added to the bundle to avoid adding duplicates across entries. The value of each dictionary entry will contain the associated FHIR types. It's a string List type in case there are different FHIR resources that share the same id. This is probably unlikely to happen, but is possible. 
+            Dictionary<string, List<string>> resourcesAdded = new Dictionary<string, List<string>>();
             Bundle bundle = CreateNewBundle();
-            
+
             foreach (var entry in entries)
             {
                 if (entry.MeasureReport == null) 
@@ -71,7 +68,15 @@ namespace LantanaGroup.Link.Report.Core
                 foreach (var r in entry.ContainedResources)
                 {
                     if (r.DocumentId == null)
+                    {
+                        //TODO: Log if this happens?
                         continue;
+                    }
+
+                    if (resourcesAdded.ContainsKey(r.ResourceId) && resourcesAdded[r.ResourceId].Where(x => x == r.ResourceType).Any())
+                    {
+                        continue;
+                    }
 
                     IFacilityResource facilityResource = null!;
                     
@@ -82,12 +87,21 @@ namespace LantanaGroup.Link.Report.Core
                         if (resourceTypeCategory == ResourceCategoryType.Patient)
                         {
                             facilityResource = await _database.PatientResourceRepository.GetAsync(r.DocumentId);
-                            AddResourceToBundle(bundle, facilityResource.GetResource(), resources_added);
+                            AddResourceToBundle(bundle, facilityResource.GetResource());
                         }
                         else
                         {
                             facilityResource = await _database.SharedResourceRepository.GetAsync(r.DocumentId);
-                            AddResourceToBundle(bundle, facilityResource.GetResource(), resources_added);
+                            AddResourceToBundle(bundle, facilityResource.GetResource());
+                        }
+
+                        if (resourcesAdded.ContainsKey(r.ResourceId))
+                        {
+                            resourcesAdded[r.ResourceId].Add(r.ResourceType);
+                        }
+                        else
+                        {
+                            resourcesAdded.Add(r.ResourceId, new List<string>() { r.ResourceType });
                         }
                     }
                     catch (Exception ex)
@@ -97,8 +111,7 @@ namespace LantanaGroup.Link.Report.Core
 
                         throw new Exception(message, ex);
                     }
-                }
-                
+                }                
 
                 // ensure we have an id to reference
                 if (string.IsNullOrEmpty(mr.Id))
@@ -113,7 +126,7 @@ namespace LantanaGroup.Link.Report.Core
                 // clean up resource
                 cleanupResource(mr);
 
-                AddResourceToBundle(bundle, mr, resources_added);
+                AddResourceToBundle(bundle, mr);
 
                 _metrics.IncrementReportGeneratedCounter(new List<KeyValuePair<string, object?>>() {
                     new KeyValuePair<string, object?>("facilityId", schedule.FacilityId),
@@ -131,10 +144,6 @@ namespace LantanaGroup.Link.Report.Core
                 EndDate = schedule.ReportEndDate,
                 Bundle = bundle
             };
-
-            var diffBundleTime = Stopwatch.GetElapsedTime(startBundleTime);
-
-            Console.WriteLine($"Total Bundling Time: Patient {patientId} - Duration: {diffBundleTime}");
 
             return patientSubmissionModel;
         }
@@ -206,18 +215,12 @@ namespace LantanaGroup.Link.Report.Core
         /// </summary>
         /// <param name="bundle"></param>
         /// <param name="resource"></param>
-        /// <param name="resourcesAdded"></param>
         /// <returns></returns>
-        protected void AddResourceToBundle(Bundle bundle, Resource resource, Dictionary<string, List<string>> resourcesAdded)
+        protected void AddResourceToBundle(Bundle bundle, Resource resource)
         {
             var fullUrl = GetFullUrl(resource);
 
-            if (resourcesAdded.ContainsKey(fullUrl) && resourcesAdded[fullUrl].Where(x => x == resource.TypeName).Any()) {
-                return;
-            }
-
             bundle.AddResourceEntry(resource, fullUrl);
-            resourcesAdded.Add(resource.Id, new List<string>() { resource.TypeName });
         }
 
         #endregion

--- a/DotNet/Report/Core/PatientReportSubmissionBundler.cs
+++ b/DotNet/Report/Core/PatientReportSubmissionBundler.cs
@@ -1,4 +1,5 @@
-﻿using Hl7.Fhir.Model;
+﻿using Google.Protobuf.WellKnownTypes;
+using Hl7.Fhir.Model;
 using Hl7.Fhir.Serialization;
 using LantanaGroup.Link.Report.Application.Interfaces;
 using LantanaGroup.Link.Report.Application.ResourceCategories;
@@ -7,6 +8,7 @@ using LantanaGroup.Link.Report.Domain.Enums;
 using LantanaGroup.Link.Report.Domain.Managers;
 using LantanaGroup.Link.Report.Settings;
 using LantanaGroup.Link.Shared.Application.Models;
+using System.Diagnostics;
 
 namespace LantanaGroup.Link.Report.Core
 {
@@ -44,6 +46,8 @@ namespace LantanaGroup.Link.Report.Core
 
         public async Task<PatientSubmissionModel> GenerateBundle(string facilityId, string patientId, string reportScheduleId)
         {
+            var startBundleTime = Stopwatch.GetTimestamp();
+
             var schedule = await _reportScheduledManager.SingleOrDefaultAsync(s => s.Id == reportScheduleId) ?? throw new Exception($"No Measure Reports Scheduled for reportScheduleId of {reportScheduleId}");
 
             var entries = await _database.SubmissionEntryRepository.FindAsync(e =>
@@ -52,7 +56,9 @@ namespace LantanaGroup.Link.Report.Core
 
             // TODO: Return null if no entries found?
 
+            Dictionary<string, List<string>> resources_added = new Dictionary<string, List<string>>();
             Bundle bundle = CreateNewBundle();
+            
             foreach (var entry in entries)
             {
                 if (entry.MeasureReport == null) 
@@ -62,7 +68,7 @@ namespace LantanaGroup.Link.Report.Core
 
                 MeasureReport mr = entry.MeasureReport;
 
-                foreach(var r in entry.ContainedResources)
+                foreach (var r in entry.ContainedResources)
                 {
                     if (r.DocumentId == null)
                         continue;
@@ -71,27 +77,23 @@ namespace LantanaGroup.Link.Report.Core
                     
                     var resourceTypeCategory = ResourceCategory.GetResourceCategoryByType(r.ResourceType);
 
-                    Resource resource = null;
-
                     try
                     {
                         if (resourceTypeCategory == ResourceCategoryType.Patient)
                         {
                             facilityResource = await _database.PatientResourceRepository.GetAsync(r.DocumentId);
-                            resource = facilityResource.GetResource();
-                            AddResourceToBundle(bundle, resource);
+                            AddResourceToBundle(bundle, facilityResource.GetResource(), resources_added);
                         }
                         else
                         {
                             facilityResource = await _database.SharedResourceRepository.GetAsync(r.DocumentId);
-                            resource = facilityResource.GetResource();
-                            AddResourceToBundle(bundle, resource);
+                            AddResourceToBundle(bundle, facilityResource.GetResource(), resources_added);
                         }
                     }
                     catch (Exception ex)
                     {
                         var message = "Contained resource could not be parsed into a valid Resource.";
-                        _logger.LogError(ex, "{ResourceTypeName} with ID {ResourceId} contained resource could not be parsed into a valid Resource.", resource.TypeName, resource?.Id);
+                        _logger.LogError(ex, "{ResourceTypeName} with ID {ResourceId} contained resource could not be parsed into a valid Resource.", facilityResource.GetResource().TypeName, facilityResource.GetResource()?.Id);
 
                         throw new Exception(message, ex);
                     }
@@ -111,7 +113,7 @@ namespace LantanaGroup.Link.Report.Core
                 // clean up resource
                 cleanupResource(mr);
 
-                AddResourceToBundle(bundle, mr);
+                AddResourceToBundle(bundle, mr, resources_added);
 
                 _metrics.IncrementReportGeneratedCounter(new List<KeyValuePair<string, object?>>() {
                     new KeyValuePair<string, object?>("facilityId", schedule.FacilityId),
@@ -129,6 +131,10 @@ namespace LantanaGroup.Link.Report.Core
                 EndDate = schedule.ReportEndDate,
                 Bundle = bundle
             };
+
+            var diffBundleTime = Stopwatch.GetElapsedTime(startBundleTime);
+
+            Console.WriteLine($"Total Bundling Time: Patient {patientId} - Duration: {diffBundleTime}");
 
             return patientSubmissionModel;
         }
@@ -200,16 +206,20 @@ namespace LantanaGroup.Link.Report.Core
         /// </summary>
         /// <param name="bundle"></param>
         /// <param name="resource"></param>
+        /// <param name="resourcesAdded"></param>
         /// <returns></returns>
-        protected Bundle.EntryComponent AddResourceToBundle(Bundle bundle, Resource resource)
+        protected void AddResourceToBundle(Bundle bundle, Resource resource, Dictionary<string, List<string>> resourcesAdded)
         {
             var fullUrl = GetFullUrl(resource);
-            var existingEntry = bundle.FindEntry(fullUrl).FirstOrDefault();
-            return existingEntry ?? bundle.AddResourceEntry(resource, fullUrl);
+
+            if (resourcesAdded.ContainsKey(fullUrl) && resourcesAdded[fullUrl].Where(x => x == resource.TypeName).Any()) {
+                return;
+            }
+
+            bundle.AddResourceEntry(resource, fullUrl);
+            resourcesAdded.Add(resource.Id, new List<string>() { resource.TypeName });
         }
 
         #endregion
-
     }
-
 }

--- a/DotNet/Report/Core/PatientReportSubmissionBundler.cs
+++ b/DotNet/Report/Core/PatientReportSubmissionBundler.cs
@@ -1,5 +1,4 @@
-﻿using Google.Protobuf.WellKnownTypes;
-using Hl7.Fhir.Model;
+﻿using Hl7.Fhir.Model;
 using Hl7.Fhir.Serialization;
 using LantanaGroup.Link.Report.Application.Interfaces;
 using LantanaGroup.Link.Report.Application.ResourceCategories;
@@ -8,7 +7,6 @@ using LantanaGroup.Link.Report.Domain.Enums;
 using LantanaGroup.Link.Report.Domain.Managers;
 using LantanaGroup.Link.Report.Settings;
 using LantanaGroup.Link.Shared.Application.Models;
-using System.Diagnostics;
 
 namespace LantanaGroup.Link.Report.Core
 {
@@ -107,7 +105,7 @@ namespace LantanaGroup.Link.Report.Core
                     catch (Exception ex)
                     {
                         var message = "Contained resource could not be parsed into a valid Resource.";
-                        _logger.LogError(ex, "{ResourceTypeName} with ID {ResourceId} contained resource could not be parsed into a valid Resource.", facilityResource.GetResource().TypeName, facilityResource.GetResource()?.Id);
+                        _logger.LogError(ex, "{ResourceTypeName} with ID {ResourceId} contained resource could not be parsed into a valid Resource.", r.ResourceType, r.ResourceId);
 
                         throw new Exception(message, ex);
                     }


### PR DESCRIPTION
When profiling the bundling logic that the Report service performs on patient MeasureReports, I found that more than half of the processing time was being spent on the garbage collector. The cause of the problem was a FirstOrDefault() check being made against the generated bundle each time a resource was being added. A Dictionary now replaces this logic to manage which resources have been added to the bundle. Prior to making any DB calls, Report will check to see if the contained resource already exists in the patient bundle through the dictionary. 
**Local Results**

The following are locally run before and after bundling results made against the mega patient (8326 FHIR resources):

Before changes:
| Run | Time |
|---- | ---- |
| 1   | 4.34 |
| 2   | 5.08 |
| 3   | 4.27 | 
| 4   | 4.50 | 

After changes:
| Run | Time |
| --- | ---- |
| 1   | 1.23 |
| 2   | 0.48 |
| 3   | 0.47 |
| 4   | 0.44 |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Eliminated duplicate resources appearing in patient report submissions, improving data accuracy
  * Enhanced error diagnostics with detailed information for report processing failures

* **Improvements**
  * Strengthened resource metadata handling and validation to ensure complete, valid patient report submissions

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->