### PR TITLE
LNK-4607: Ensure 409 is returned when an entity already exists

### DIFF
--- a/DotNet/DataAcquisition/Controllers/QueryListController.cs
+++ b/DotNet/DataAcquisition/Controllers/QueryListController.cs
@@ -94,7 +94,7 @@ public class QueryListController : Controller
             }
             catch (EntityAlreadyExistsException ex)
             {
-                return BadRequest(ex.Message);
+                return Conflict(ex.Message);
             }
             catch (MissingFacilityConfigurationException ex)
             {


### PR DESCRIPTION
### 🛠️ Description of Changes
Ensure 409 is returned when an entity already exists

### 🧪 Testing Performed
Please describe the testing that was performed on the changes included in this PR.

### 🧑‍🔬 Unit Testing
- [ ] I have written or updated unit tests to cover my changes

### 📓 Documentation Updated
Please update any relevant sections in the project documentation that were impacted by the changes in the PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed HTTP status code response when attempting to create a FHIR configuration that already exists. Now returns 409 Conflict instead of 400 Bad Request for improved API compliance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->