### PR TITLE
LNK-4548: Initial ABS work for Report

### DIFF
--- a/DotNet/Report/Application/Models/MeasureReportGeneratedValue.cs
+++ b/DotNet/Report/Application/Models/MeasureReportGeneratedValue.cs
@@ -1,0 +1,12 @@
+﻿namespace LantanaGroup.Link.Report.Application.Models
+{
+    public class MeasureReportGeneratedValue
+    {
+        public string FacilityId { get; set; } = string.Empty;
+        public string ReportTrackingId { get; set; } = string.Empty;
+        public string PatientId { get; set; } = string.Empty;
+        public string ReportType { get; set; } = string.Empty;
+        public string MeasureReportURI { get; set; } = string.Empty;
+        public bool IsReportable { get; set; }
+    }
+}

--- a/DotNet/Report/Application/Models/MeasureReportGeneratedValue.cs
+++ b/DotNet/Report/Application/Models/MeasureReportGeneratedValue.cs
@@ -7,6 +7,7 @@
         public string PatientId { get; set; } = string.Empty;
         public string ReportType { get; set; } = string.Empty;
         public string MeasureReportURI { get; set; } = string.Empty;
+        public string MeasureReportFileName { get; set; } = string.Empty;
         public bool IsReportable { get; set; }
     }
 }

--- a/DotNet/Report/Controllers/ReportController.cs
+++ b/DotNet/Report/Controllers/ReportController.cs
@@ -80,9 +80,8 @@ namespace LantanaGroup.Link.Report.Controllers
                     return BadRequest("Parameter reportScheduleId is null or whitespace");
                 }
 
-                var submission = await _patientReportSubmissionBundler.GenerateBundle(facilityId, patientId, reportScheduleId);
-
-                return Ok(submission);
+                await _patientReportSubmissionBundler.GenerateBundleToABS(patientId, reportScheduleId);
+                return Ok();
 
             }
             catch (Exception ex)

--- a/DotNet/Report/Core/PatientReportSubmissionBundler.cs
+++ b/DotNet/Report/Core/PatientReportSubmissionBundler.cs
@@ -180,35 +180,40 @@ namespace LantanaGroup.Link.Report.Core
             {
                 foreach (var entry in entries)
                 {
-                    Uri entry_uri = new Uri(entry.MeasureReportUri);
-
-                    BlockBlobClient blockReadBlobClient = _containerClient.GetBlockBlobClient(entry_uri.AbsolutePath);
-
-                    using (Stream read_stream = await blockReadBlobClient.OpenReadAsync(true))
-                    using (StreamReader reader = new StreamReader(read_stream))
+                    BlockBlobClient blockReadBlobClient = _containerClient.GetBlockBlobClient(entry.MeasureReportFileName);
+                    
+                    try
                     {
-                        while (reader.Peek() >= 0)
+                        using (Stream read_stream = await blockReadBlobClient.OpenReadAsync(true))
+                        using (StreamReader reader = new StreamReader(read_stream))
                         {
-                            string[] resource_and_id = reader.ReadLine().Split("_");
-
-                            if (resourcesAdded.ContainsKey(resource_and_id[1]) && resourcesAdded[resource_and_id[1]].Where(x => x == resource_and_id[0]).Any())
+                            while (reader.Peek() >= 0)
                             {
-                                //Skip FHIR Resource line
-                                reader.Read();
-                                continue;
-                            }
+                                string[] resource_and_id = reader.ReadLine().Split("_");
 
-                            if (resourcesAdded.ContainsKey(resource_and_id[1]))
-                            {
-                                resourcesAdded[resource_and_id[1]].Add(resource_and_id[0]);
-                            }
-                            else
-                            {
-                                resourcesAdded.Add(resource_and_id[1], new List<string>() { resource_and_id[0] });
-                            }
+                                if (resourcesAdded.ContainsKey(resource_and_id[1]) && resourcesAdded[resource_and_id[1]].Where(x => x == resource_and_id[0]).Any())
+                                {
+                                    //Skip FHIR Resource line
+                                    reader.Read();
+                                    continue;
+                                }
 
-                            writer.WriteLine(reader.ReadLine());
+                                if (resourcesAdded.ContainsKey(resource_and_id[1]))
+                                {
+                                    resourcesAdded[resource_and_id[1]].Add(resource_and_id[0]);
+                                }
+                                else
+                                {
+                                    resourcesAdded.Add(resource_and_id[1], new List<string>() { resource_and_id[0] });
+                                }
+
+                                writer.WriteLine(reader.ReadLine());
+                            }
                         }
+                    }
+                    catch (Exception ex) {
+                        //TODO: Do something with this catch
+                        throw ex;
                     }
                 }
             }

--- a/DotNet/Report/Core/PatientReportSubmissionBundler.cs
+++ b/DotNet/Report/Core/PatientReportSubmissionBundler.cs
@@ -171,7 +171,7 @@ namespace LantanaGroup.Link.Report.Core
             //TODO: Add missing entry check
 
             //The 'resourcesAdded' Dictionary will keep track of FHIR resource id's that have been added to the bundle to avoid adding duplicates across entries. The value of each dictionary entry will contain the associated FHIR types. It's a string List type in case there are different FHIR resources that share the same id. This is probably unlikely to happen, but is possible. 
-            Dictionary<string, List<string>> resourcesAdded = new Dictionary<string, List<string>>();
+            Dictionary<string, int> resourcesAdded = new Dictionary<string,int>();
 
             BlockBlobClient blockWriteBlobClient = _containerClient.GetBlockBlobClient("Patient_" + patientId + ".ndjson");
 
@@ -189,24 +189,16 @@ namespace LantanaGroup.Link.Report.Core
                         {
                             while (reader.Peek() >= 0)
                             {
-                                string[] resource_and_id = reader.ReadLine().Split("_");
+                                string resource_and_id = reader.ReadLine();
 
-                                if (resourcesAdded.ContainsKey(resource_and_id[1]) && resourcesAdded[resource_and_id[1]].Where(x => x == resource_and_id[0]).Any())
+                                if (resourcesAdded.ContainsKey(resource_and_id))
                                 {
                                     //Skip FHIR Resource line
                                     reader.Read();
                                     continue;
                                 }
 
-                                if (resourcesAdded.ContainsKey(resource_and_id[1]))
-                                {
-                                    resourcesAdded[resource_and_id[1]].Add(resource_and_id[0]);
-                                }
-                                else
-                                {
-                                    resourcesAdded.Add(resource_and_id[1], new List<string>() { resource_and_id[0] });
-                                }
-
+                                resourcesAdded.Add(resource_and_id, 1);
                                 writer.WriteLine(reader.ReadLine());
                             }
                         }

--- a/DotNet/Report/Core/PatientReportSubmissionBundler.cs
+++ b/DotNet/Report/Core/PatientReportSubmissionBundler.cs
@@ -1,12 +1,20 @@
-﻿using Hl7.Fhir.Model;
+﻿using Azure.Storage.Blobs;
+using Azure.Storage.Blobs.Specialized;
+using Google.Protobuf.WellKnownTypes;
+using Hl7.Fhir.Model;
 using Hl7.Fhir.Serialization;
 using LantanaGroup.Link.Report.Application.Interfaces;
+using LantanaGroup.Link.Report.Application.Options;
 using LantanaGroup.Link.Report.Application.ResourceCategories;
 using LantanaGroup.Link.Report.Domain;
 using LantanaGroup.Link.Report.Domain.Enums;
 using LantanaGroup.Link.Report.Domain.Managers;
+using LantanaGroup.Link.Report.Services;
 using LantanaGroup.Link.Report.Settings;
 using LantanaGroup.Link.Shared.Application.Models;
+using Microsoft.Extensions.Options;
+using System.Text;
+using System.Threading;
 
 namespace LantanaGroup.Link.Report.Core
 {
@@ -20,6 +28,9 @@ namespace LantanaGroup.Link.Report.Core
         private readonly IReportServiceMetrics _metrics;
         private readonly IDatabase _database;
         private readonly IReportScheduledManager _reportScheduledManager;
+        private readonly BlobStorageService _blobStorageService;
+        private readonly BlobContainerClient _containerClient;
+        private readonly BlobStorageSettings _settings;
 
         private readonly List<string> REMOVE_EXTENSIONS = new List<string> {
         "http://hl7.org/fhir/5.0/StructureDefinition/extension-MeasureReport.population.description",
@@ -33,12 +44,19 @@ namespace LantanaGroup.Link.Report.Core
         "http://open.epic.com/FHIR/StructureDefinition/extension/team-name",
         "https://open.epic.com/FHIR/StructureDefinition/extension/patient-merge-unmerge-instant"};
 
-        public PatientReportSubmissionBundler(ILogger<PatientReportSubmissionBundler> logger, IDatabase database, IReportServiceMetrics metrics, IReportScheduledManager reportScheduledManager)
+        public PatientReportSubmissionBundler(ILogger<PatientReportSubmissionBundler> logger, IDatabase database, IReportServiceMetrics metrics, IReportScheduledManager reportScheduledManager, BlobStorageService blobStorageService, IOptions<BlobStorageSettings> settings)
         {
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
             _metrics = metrics ?? throw new ArgumentException(nameof(metrics));
             _database = database ?? throw new ArgumentNullException(nameof(database));
             _reportScheduledManager = reportScheduledManager ?? throw new ArgumentNullException(nameof(reportScheduledManager));
+            _blobStorageService = blobStorageService;
+
+            _settings = settings.Value;
+            if (_settings.ConnectionString != null)
+            {
+                _containerClient = new BlobContainerClient(_settings.ConnectionString, _settings.BlobContainerName);
+            }
         }
 
 
@@ -144,6 +162,139 @@ namespace LantanaGroup.Link.Report.Core
             };
 
             return patientSubmissionModel;
+        }
+
+        public async Task<Uri> GenerateBundleToABS(string patientId, string reportScheduleId)
+        {
+            var entries = (await _database.ReportEntryStatusRepository.FindAsync(x => x.ReportScheduleId == reportScheduleId && x.PatientId == patientId)).ToList();
+
+            //TODO: Add missing entry check
+
+            //The 'resourcesAdded' Dictionary will keep track of FHIR resource id's that have been added to the bundle to avoid adding duplicates across entries. The value of each dictionary entry will contain the associated FHIR types. It's a string List type in case there are different FHIR resources that share the same id. This is probably unlikely to happen, but is possible. 
+            Dictionary<string, List<string>> resourcesAdded = new Dictionary<string, List<string>>();
+
+            BlockBlobClient blockWriteBlobClient = _containerClient.GetBlockBlobClient("Patient_" + patientId + ".ndjson");
+
+            using (Stream write_stream = await blockWriteBlobClient.OpenWriteAsync(true))
+            using (StreamWriter writer = new StreamWriter(write_stream))
+            {
+                foreach (var entry in entries)
+                {
+                    Uri entry_uri = new Uri(entry.MeasureReportUri);
+
+                    BlockBlobClient blockReadBlobClient = _containerClient.GetBlockBlobClient(entry_uri.AbsolutePath);
+
+                    using (Stream read_stream = await blockReadBlobClient.OpenReadAsync(true))
+                    using (StreamReader reader = new StreamReader(read_stream))
+                    {
+                        while (reader.Peek() >= 0)
+                        {
+                            string[] resource_and_id = reader.ReadLine().Split("_");
+
+                            if (resourcesAdded.ContainsKey(resource_and_id[1]) && resourcesAdded[resource_and_id[1]].Where(x => x == resource_and_id[0]).Any())
+                            {
+                                //Skip FHIR Resource line
+                                reader.Read();
+                                continue;
+                            }
+
+                            if (resourcesAdded.ContainsKey(resource_and_id[1]))
+                            {
+                                resourcesAdded[resource_and_id[1]].Add(resource_and_id[0]);
+                            }
+                            else
+                            {
+                                resourcesAdded.Add(resource_and_id[1], new List<string>() { resource_and_id[0] });
+                            }
+
+                            writer.WriteLine(reader.ReadLine());
+                        }
+                    }
+                }
+            }
+
+            return blockWriteBlobClient.Uri;
+        }
+
+        public async Task<bool> GenerateBundleFromABS()
+        {
+            //The 'resourcesAdded' Dictionary will keep track of FHIR resource id's that have been added to the bundle to avoid adding duplicates across entries. The value of each dictionary entry will contain the associated FHIR types. It's a string List type in case there are different FHIR resources that share the same id. This is probably unlikely to happen, but is possible. 
+            Dictionary<string, List<string>> resourcesAdded = new Dictionary<string, List<string>>();
+            BlockBlobClient blockReadBlobClient = _containerClient.GetBlockBlobClient("Patient_3f993147-8cd4-44c6-bbb5-9f25fe428517");
+            BlockBlobClient blockWriteBlobClient = _containerClient.GetBlockBlobClient("Patient_3f993147-8cd4-44c6-bbb5-9f25fe428517.ndjson");
+
+            using (Stream read_stream = await blockReadBlobClient.OpenReadAsync(true))
+            using (Stream write_stream = await blockWriteBlobClient.OpenWriteAsync(true))
+            using (StreamReader reader = new StreamReader(read_stream)) 
+            using (StreamWriter writer = new StreamWriter(write_stream))
+                
+            while (reader.Peek() >= 0)
+            {
+                string[] resource_and_id = reader.ReadLine().Split("_");
+
+                if (resourcesAdded.ContainsKey(resource_and_id[1]) && resourcesAdded[resource_and_id[1]].Where(x => x == resource_and_id[0]).Any())
+                {
+                    //Skip resource line
+                    reader.Read();
+                    continue;
+                }
+
+                if (resourcesAdded.ContainsKey(resource_and_id[1]))
+                {
+                    resourcesAdded[resource_and_id[1]].Add(resource_and_id[0]);
+                }
+                else
+                {
+                    resourcesAdded.Add(resource_and_id[1], new List<string>() { resource_and_id[0] });
+                }
+
+                writer.WriteLine(reader.ReadLine());        
+            }
+
+
+            return true;
+        }
+
+        public async Task<bool> GenerateBundleFromABSMulti()
+        {
+            //The 'resourcesAdded' Dictionary will keep track of FHIR resource id's that have been added to the bundle to avoid adding duplicates across entries. The value of each dictionary entry will contain the associated FHIR types. It's a string List type in case there are different FHIR resources that share the same id. This is probably unlikely to happen, but is possible. 
+            Dictionary<string, List<string>> resourcesAdded = new Dictionary<string, List<string>>();
+            
+            BlockBlobClient blockWriteBlobClient = _containerClient.GetBlockBlobClient("Patient_3f993147-8cd4-44c6-bbb5-9f25fe428517.ndjson");
+
+            using (Stream write_stream = await blockWriteBlobClient.OpenWriteAsync(true))
+            using (StreamWriter writer = new StreamWriter(write_stream))
+
+                for (int i = 0; i < 2; i++) {
+                    BlockBlobClient blockReadBlobClient = _containerClient.GetBlockBlobClient("Patient_3f993147-8cd4-44c6-bbb5-9f25fe428517_multi_" + (i + 1));
+                    using (Stream read_stream = await blockReadBlobClient.OpenReadAsync(true))
+                    using (StreamReader reader = new StreamReader(read_stream))
+
+                        while (reader.Peek() >= 0)
+                        {
+                            string[] resource_and_id = reader.ReadLine().Split("_");
+
+                            if (resourcesAdded.ContainsKey(resource_and_id[1]) && resourcesAdded[resource_and_id[1]].Where(x => x == resource_and_id[0]).Any())
+                            {
+                                //Skip resource line
+                                reader.Read();
+                                continue;
+                            }
+
+                            if (resourcesAdded.ContainsKey(resource_and_id[1]))
+                            {
+                                resourcesAdded[resource_and_id[1]].Add(resource_and_id[0]);
+                            }
+                            else
+                            {
+                                resourcesAdded.Add(resource_and_id[1], new List<string>() { resource_and_id[0] });
+                            }
+
+                            writer.WriteLine(reader.ReadLine());
+                        }
+                }
+
+            return true;
         }
 
         #region Bundling Options

--- a/DotNet/Report/Domain/Database.cs
+++ b/DotNet/Report/Domain/Database.cs
@@ -12,6 +12,7 @@ namespace LantanaGroup.Link.Report.Domain
         IBaseEntityRepository<SharedResourceModel> SharedResourceRepository { get; set; }
         IBaseEntityRepository<ReportScheduleModel> ReportScheduledRepository { get; set; }
         IBaseEntityRepository<MeasureReportSubmissionEntryModel> SubmissionEntryRepository { get; set; }
+        IBaseEntityRepository<ReportEntryStatusModel> ReportEntryStatusRepository { get; set; }
     }
 
     public class Database : IDatabase
@@ -22,12 +23,14 @@ namespace LantanaGroup.Link.Report.Domain
         public IBaseEntityRepository<SharedResourceModel> SharedResourceRepository { get; set; }
         public IBaseEntityRepository<ReportScheduleModel> ReportScheduledRepository { get; set; }
         public IBaseEntityRepository<MeasureReportSubmissionEntryModel> SubmissionEntryRepository { get; set; }
+        public IBaseEntityRepository<ReportEntryStatusModel> ReportEntryStatusRepository { get; set; }
 
         public Database(IOptions<MongoConnection> mongoSettings,
             IBaseEntityRepository<PatientResourceModel> patientResourceRepository,
             IBaseEntityRepository<SharedResourceModel> sharedResourceRepository,
             IBaseEntityRepository<ReportScheduleModel> reportScheduledRepository,
-            IBaseEntityRepository<MeasureReportSubmissionEntryModel> submissionEntryRepository)
+            IBaseEntityRepository<MeasureReportSubmissionEntryModel> submissionEntryRepository,
+            IBaseEntityRepository<ReportEntryStatusModel> reportEntryStatusRepository)
         {
             var client = new MongoClient(mongoSettings.Value.ConnectionString);
             DbContext = client.GetDatabase(mongoSettings.Value.DatabaseName);
@@ -36,6 +39,7 @@ namespace LantanaGroup.Link.Report.Domain
             SharedResourceRepository = sharedResourceRepository;
             ReportScheduledRepository = reportScheduledRepository;
             SubmissionEntryRepository = submissionEntryRepository;
+            ReportEntryStatusRepository = reportEntryStatusRepository;
         }
     }
 }

--- a/DotNet/Report/Domain/Managers/ReportEntryStatusManager.cs
+++ b/DotNet/Report/Domain/Managers/ReportEntryStatusManager.cs
@@ -10,7 +10,7 @@ namespace LantanaGroup.Link.Report.Domain.Managers
 {
     public interface IReportEntryStatusManager 
     {
-        Task<ReportEntryStatusModel?> GetPatientEntry(string reportId, string patientId, CancellationToken cancellationToken = default);
+        Task<ReportEntryStatusModel?> GetPatientEntry(string reportId, string reportType, string patientId, CancellationToken cancellationToken = default);
 
         Task<ReportEntryStatusModel> UpdateAsync(ReportEntryStatusModel entry,
             CancellationToken cancellationToken);
@@ -45,9 +45,9 @@ namespace LantanaGroup.Link.Report.Domain.Managers
             return await _database.ReportEntryStatusRepository.FindAsync(predicate, cancellationToken);
         }
 
-        public async Task<ReportEntryStatusModel?> GetPatientEntry(string reportId, string patientId, CancellationToken cancellationToken = default)
+        public async Task<ReportEntryStatusModel?> GetPatientEntry(string reportId, string reportType, string patientId, CancellationToken cancellationToken = default)
         {
-            return (await _database.ReportEntryStatusRepository.FindAsync(r => r.ReportScheduleId == reportId && r.PatientId == patientId, cancellationToken)).SingleOrDefault();
+            return (await _database.ReportEntryStatusRepository.FindAsync(r => r.ReportScheduleId == reportId && r.PatientId == patientId && r.ReportType == reportType, cancellationToken)).SingleOrDefault();
         }
 
         public async Task<ReportEntryStatusModel?> SingleOrDefaultAsync(Expression<Func<ReportEntryStatusModel, bool>> predicate, CancellationToken cancellationToken = default)

--- a/DotNet/Report/Domain/Managers/ReportEntryStatusManager.cs
+++ b/DotNet/Report/Domain/Managers/ReportEntryStatusManager.cs
@@ -1,0 +1,63 @@
+﻿using AngleSharp.Dom;
+using Hl7.Fhir.Model;
+using LantanaGroup.Link.Report.Application.Factory;
+using LantanaGroup.Link.Report.Entities;
+using LantanaGroup.Link.Shared.Application.Models.Report;
+using LantanaGroup.Link.Shared.Application.Models.Responses;
+using System.Linq.Expressions;
+
+namespace LantanaGroup.Link.Report.Domain.Managers
+{
+    public interface IReportEntryStatusManager 
+    {
+        Task<ReportEntryStatusModel?> GetPatientEntry(string reportId, string patientId, CancellationToken cancellationToken = default);
+
+        Task<ReportEntryStatusModel> UpdateAsync(ReportEntryStatusModel entry,
+            CancellationToken cancellationToken);
+
+        Task<ReportEntryStatusModel> AddAsync(ReportEntryStatusModel entry,
+            CancellationToken cancellationToken);
+
+        Task<List<ReportEntryStatusModel>> FindAsync(Expression<Func<ReportEntryStatusModel, bool>> predicate,
+            CancellationToken cancellationToken = default);
+
+        Task<ReportEntryStatusModel?> SingleOrDefaultAsync(
+            Expression<Func<ReportEntryStatusModel, bool>> predicate,
+            CancellationToken cancellationToken = default);
+    }
+
+    public class ReportEntryStatusManager : IReportEntryStatusManager
+    {
+        private readonly IDatabase _database;
+
+        public ReportEntryStatusManager(IDatabase database)
+        {
+            _database = database;
+        }
+
+        public async Task<ReportEntryStatusModel> AddAsync(ReportEntryStatusModel entry, CancellationToken cancellationToken)
+        {
+            return await _database.ReportEntryStatusRepository.AddAsync(entry, cancellationToken);
+        }
+
+        public async Task<List<ReportEntryStatusModel>> FindAsync(Expression<Func<ReportEntryStatusModel, bool>> predicate, CancellationToken cancellationToken = default)
+        {
+            return await _database.ReportEntryStatusRepository.FindAsync(predicate, cancellationToken);
+        }
+
+        public async Task<ReportEntryStatusModel?> GetPatientEntry(string reportId, string patientId, CancellationToken cancellationToken = default)
+        {
+            return (await _database.ReportEntryStatusRepository.FindAsync(r => r.ReportScheduleId == reportId && r.PatientId == patientId, cancellationToken)).SingleOrDefault();
+        }
+
+        public async Task<ReportEntryStatusModel?> SingleOrDefaultAsync(Expression<Func<ReportEntryStatusModel, bool>> predicate, CancellationToken cancellationToken = default)
+        {
+            return await _database.ReportEntryStatusRepository.SingleOrDefaultAsync(predicate, cancellationToken);
+        }
+
+        public async Task<ReportEntryStatusModel> UpdateAsync(ReportEntryStatusModel entry, CancellationToken cancellationToken)
+        {
+            return await _database.ReportEntryStatusRepository.UpdateAsync(entry, cancellationToken);
+        }
+    }
+}

--- a/DotNet/Report/Entities/ReportEntryStatusModel.cs
+++ b/DotNet/Report/Entities/ReportEntryStatusModel.cs
@@ -16,6 +16,7 @@ namespace LantanaGroup.Link.Report.Entities
         public PatientSubmissionStatus Status { get; set; } = PatientSubmissionStatus.PendingEvaluation;
         public ValidationStatus ValidationStatus { get; set; } = ValidationStatus.Pending;
         public string MeasureReportUri { get; set; } = string.Empty;
+        public string MeasureReportFileName { get; set; } = string.Empty;
         public string AggregateReportUri { get; set; } = string.Empty;
     }
 }

--- a/DotNet/Report/Entities/ReportEntryStatusModel.cs
+++ b/DotNet/Report/Entities/ReportEntryStatusModel.cs
@@ -18,5 +18,6 @@ namespace LantanaGroup.Link.Report.Entities
         public string MeasureReportUri { get; set; } = string.Empty;
         public string MeasureReportFileName { get; set; } = string.Empty;
         public string AggregateReportUri { get; set; } = string.Empty;
+        public string AggregateReportFileName { get; set; } = string.Empty;
     }
 }

--- a/DotNet/Report/Entities/ReportEntryStatusModel.cs
+++ b/DotNet/Report/Entities/ReportEntryStatusModel.cs
@@ -1,0 +1,21 @@
+﻿using LantanaGroup.Link.Report.Domain.Enums;
+using LantanaGroup.Link.Shared.Domain.Attributes;
+using LantanaGroup.Link.Shared.Domain.Entities;
+using MongoDB.Bson.Serialization.Attributes;
+
+namespace LantanaGroup.Link.Report.Entities
+{
+    [BsonCollection("reportEntryStatus")]
+    [BsonIgnoreExtraElements]
+    public class ReportEntryStatusModel : BaseEntityExtended
+    {
+        public string FacilityId { get; set; } = string.Empty;
+        public string ReportScheduleId { get; set; } = string.Empty;
+        public string PatientId { get; set; } = string.Empty;
+        public string ReportType { get; set; } = string.Empty;
+        public PatientSubmissionStatus Status { get; set; } = PatientSubmissionStatus.PendingEvaluation;
+        public ValidationStatus ValidationStatus { get; set; } = ValidationStatus.Pending;
+        public string MeasureReportUri { get; set; } = string.Empty;
+        public string AggregateReportUri { get; set; } = string.Empty;
+    }
+}

--- a/DotNet/Report/Listeners/MeasureReportGeneratedListener.cs
+++ b/DotNet/Report/Listeners/MeasureReportGeneratedListener.cs
@@ -118,23 +118,36 @@ namespace LantanaGroup.Link.Report.Listeners
 
                             var correlationId = Encoding.UTF8.GetString(headerValue);
 
-                            var reportEntry = await _reportEntryManager.GetPatientEntry(result.Value.ReportTrackingId, result.Value.PatientId);
+                            var reportEntry = await _reportEntryManager.GetPatientEntry(result.Value.ReportTrackingId, result.Value.ReportType, result.Value.PatientId);
 
                             //TODO: Add null check 
 
-                            if (result.Value.IsReportable) {
+                            reportEntry.MeasureReportFileName = result.Value.MeasureReportFileName;
+                            reportEntry.MeasureReportUri = result.Value.MeasureReportURI;
+
+                            if (result.Value.IsReportable)
+                            {
+                                reportEntry.Status = PatientSubmissionStatus.ReadyForValidation;
+                            }
+                            else 
+                            {
                                 reportEntry.Status = PatientSubmissionStatus.NotReportable;
                                 reportEntry.ValidationStatus = ValidationStatus.NotReportable;
-
-                                await _reportEntryManager.UpdateAsync(reportEntry, cancellationToken);
                             }
+
+                            await _reportEntryManager.UpdateAsync(reportEntry, cancellationToken);
 
                             var entries = await _reportEntryManager.FindAsync(x => x.PatientId == result.Value.PatientId && x.FacilityId == result.Value.FacilityId && x.ReportScheduleId == result.Value.ReportTrackingId);
 
-                            var readyForValidation = entries.All(e => e.Status == PatientSubmissionStatus.NotReportable || e.Status == PatientSubmissionStatus.ReadyForValidation) && entries.Any(e => e.Status == PatientSubmissionStatus.ReadyForValidation);
+                           var readyForValidation = entries.All(e =>
+                                e.Status == PatientSubmissionStatus.NotReportable ||
+                                e.Status == PatientSubmissionStatus.ReadyForValidation) &&
+                                entries.Any(e => e.Status == PatientSubmissionStatus.ReadyForValidation);
+
 
                             var schedule = await _reportScheduledManager.GetReportSchedule(result.Value.FacilityId, result.Value.ReportTrackingId, cancellationToken);
 
+                            //TODO: Follow up on this logic
                             if (!readyForValidation)
                             {
                                 await _reportManifestProducer.Produce(schedule, correlationId);
@@ -145,7 +158,8 @@ namespace LantanaGroup.Link.Report.Listeners
 
                             foreach (var ent in entries.Where(s => s.Status == PatientSubmissionStatus.ReadyForValidation))
                             {
-                                ent.AggregateReportUri = ndjson_blob_uri.AbsolutePath;
+                                ent.AggregateReportUri = ndjson_blob_uri.AbsoluteUri;
+                                //TODO: Add AggregateFileName
                                 ent.ModifyDate = DateTime.UtcNow;
                                 await _reportEntryManager.UpdateAsync(ent, cancellationToken);
                             }

--- a/DotNet/Report/Listeners/MeasureReportGeneratedListener.cs
+++ b/DotNet/Report/Listeners/MeasureReportGeneratedListener.cs
@@ -1,0 +1,182 @@
+﻿using Confluent.Kafka;
+using Confluent.Kafka.Extensions.Diagnostics;
+using Google.Protobuf.WellKnownTypes;
+using Hl7.Fhir.Model;
+using Hl7.Fhir.Serialization;
+using LantanaGroup.Link.Report.Application.Interfaces;
+using LantanaGroup.Link.Report.Application.Models;
+using LantanaGroup.Link.Report.Core;
+using LantanaGroup.Link.Report.Domain.Enums;
+using LantanaGroup.Link.Report.Domain.Managers;
+using LantanaGroup.Link.Report.Entities;
+using LantanaGroup.Link.Report.KafkaProducers;
+using LantanaGroup.Link.Report.Services;
+using LantanaGroup.Link.Report.Services.ResourceMerger;
+using LantanaGroup.Link.Report.Services.ResourceMerger.Strategies;
+using LantanaGroup.Link.Report.Settings;
+using LantanaGroup.Link.Shared.Application.Error.Exceptions;
+using LantanaGroup.Link.Shared.Application.Error.Interfaces;
+using LantanaGroup.Link.Shared.Application.Interfaces;
+using LantanaGroup.Link.Shared.Application.Models;
+using LantanaGroup.Link.Shared.Application.Models.Kafka;
+using LantanaGroup.Link.Shared.Settings;
+using OpenTelemetry.Trace;
+using System.Diagnostics;
+using System.Reflection.Metadata.Ecma335;
+using System.Text;
+using System.Text.Json;
+using Task = System.Threading.Tasks.Task;
+
+namespace LantanaGroup.Link.Report.Listeners
+{
+    public class MeasureReportGeneratedListener : BackgroundService
+    {
+        private readonly ILogger<MeasureReportGeneratedListener> _logger;
+        private readonly IKafkaConsumerFactory<Null, MeasureReportGeneratedValue> _kafkaConsumerFactory;
+
+        private readonly IServiceScopeFactory _serviceScopeFactory;
+
+        private readonly ITransientExceptionHandler<Null, MeasureReportGeneratedValue> _transientExceptionHandler;
+        private readonly IDeadLetterExceptionHandler<Null, MeasureReportGeneratedValue> _deadLetterExceptionHandler;
+
+        private readonly PatientReportSubmissionBundler _patientReportSubmissionBundler;
+        private readonly BlobStorageService _blobStorageService;
+        private readonly ReadyForValidationProducer _readyForValidationProducer;
+        private readonly ReportManifestProducer _reportManifestProducer;
+        private readonly AuditableEventOccurredProducer _auditableEventOccurredProducer;
+        private readonly IReportEntryStatusManager _reportEntryManager;
+        private readonly IReportScheduledManager _reportScheduledManager;
+
+        private string Name => this.GetType().Name;
+
+        public MeasureReportGeneratedListener(
+            ILogger<MeasureReportGeneratedListener> logger,
+            IKafkaConsumerFactory<Null, MeasureReportGeneratedValue> kafkaConsumerFactory,
+            ITransientExceptionHandler<Null, MeasureReportGeneratedValue> transientExceptionHandler,
+            IDeadLetterExceptionHandler<Null, MeasureReportGeneratedValue> deadLetterExceptionHandler,
+            IServiceScopeFactory serviceScopeFactory,
+            PatientReportSubmissionBundler patientReportSubmissionBundler,
+            BlobStorageService blobStorageService,
+            ReadyForValidationProducer readyForValidationProducer,
+            ReportManifestProducer reportManifestProducer,
+            AuditableEventOccurredProducer auditableEventOccurredProducer, 
+            IReportEntryStatusManager reportEntryManager,
+            IReportScheduledManager reportScheduledManager)
+        {
+
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+            _kafkaConsumerFactory = kafkaConsumerFactory ?? throw new ArgumentException(nameof(kafkaConsumerFactory));
+
+            _serviceScopeFactory = serviceScopeFactory;
+
+            _transientExceptionHandler = transientExceptionHandler ?? throw new ArgumentException(nameof(transientExceptionHandler));
+            _deadLetterExceptionHandler = deadLetterExceptionHandler ?? throw new ArgumentException(nameof(deadLetterExceptionHandler));
+
+            _transientExceptionHandler.ServiceName = ReportConstants.ServiceName;
+            _transientExceptionHandler.Topic = nameof(KafkaTopic.MeasureReportGenerated) + "-Retry";
+
+            _deadLetterExceptionHandler.ServiceName = ReportConstants.ServiceName;
+            _deadLetterExceptionHandler.Topic = nameof(KafkaTopic.MeasureReportGenerated) + "-Error";
+            _patientReportSubmissionBundler = patientReportSubmissionBundler;
+            _blobStorageService = blobStorageService;
+            _readyForValidationProducer = readyForValidationProducer;
+            _reportManifestProducer = reportManifestProducer;
+            _auditableEventOccurredProducer = auditableEventOccurredProducer;
+            _reportEntryManager = reportEntryManager;
+            _reportScheduledManager = reportScheduledManager;
+        }
+
+        protected override Task ExecuteAsync(CancellationToken stoppingToken)
+        {
+            return Task.Run(() => StartConsumerLoop(stoppingToken), stoppingToken);
+        }
+
+        private async Task StartConsumerLoop(CancellationToken cancellationToken)
+        {
+            var consumerConfig = new ConsumerConfig()
+            {
+                GroupId = ReportConstants.ServiceName,
+                EnableAutoCommit = false
+            };
+
+            using var consumer = _kafkaConsumerFactory.CreateConsumer(consumerConfig);
+            try
+            {
+                consumer.Subscribe(nameof(KafkaTopic.MeasureReportGenerated));
+                _logger.LogInformation("Started MeasureReportGenerated consumer on {date} for topic '{MeasureReportGeneratedName}'", DateTime.UtcNow, nameof(KafkaTopic.MeasureReportGenerated));
+
+                while (!cancellationToken.IsCancellationRequested)
+                {
+                    try
+                    {
+                        await consumer.ConsumeWithInstrumentation(async (result, consumeCancellationToken) =>
+                        {
+                            if (!result.Message.Headers.TryGetLastBytes("X-Correlation-Id", out var headerValue)) 
+                            { 
+                                //TODO: Add error
+                            }
+
+                            var correlationId = Encoding.UTF8.GetString(headerValue);
+
+                            var reportEntry = await _reportEntryManager.GetPatientEntry(result.Value.ReportTrackingId, result.Value.PatientId);
+
+                            //TODO: Add null check 
+
+                            if (result.Value.IsReportable) {
+                                reportEntry.Status = PatientSubmissionStatus.NotReportable;
+                                reportEntry.ValidationStatus = ValidationStatus.NotReportable;
+
+                                await _reportEntryManager.UpdateAsync(reportEntry, cancellationToken);
+                            }
+
+                            var entries = await _reportEntryManager.FindAsync(x => x.PatientId == result.Value.PatientId && x.FacilityId == result.Value.FacilityId && x.ReportScheduleId == result.Value.ReportTrackingId);
+
+                            var readyForValidation = entries.All(e => e.Status == PatientSubmissionStatus.NotReportable || e.Status == PatientSubmissionStatus.ReadyForValidation) && entries.Any(e => e.Status == PatientSubmissionStatus.ReadyForValidation);
+
+                            var schedule = await _reportScheduledManager.GetReportSchedule(result.Value.FacilityId, result.Value.ReportTrackingId, cancellationToken);
+
+                            if (!readyForValidation)
+                            {
+                                await _reportManifestProducer.Produce(schedule, correlationId);
+                                return;
+                            }
+
+                            Uri ndjson_blob_uri = await _patientReportSubmissionBundler.GenerateBundleToABS(result.Value.PatientId, result.Value.ReportTrackingId);
+
+                            foreach (var ent in entries.Where(s => s.Status == PatientSubmissionStatus.ReadyForValidation))
+                            {
+                                ent.AggregateReportUri = ndjson_blob_uri.AbsolutePath;
+                                ent.ModifyDate = DateTime.UtcNow;
+                                await _reportEntryManager.UpdateAsync(ent, cancellationToken);
+                            }
+
+                            try
+                            {
+                                await _readyForValidationProducer.Produce(schedule.Id, schedule.ReportTypes, schedule.FacilityId, result.Value.PatientId, ndjson_blob_uri.AbsolutePath, correlationId);
+                            }
+                            catch (ProduceException<ReadyForValidationKey, ReadyForValidationValue> ex)
+                            {
+                                //TODO: Add logic
+                            }           
+                        }, cancellationToken);
+                    }
+                    catch (ConsumeException ex)
+                    {
+
+                    }
+                    catch (OperationCanceledException oce)
+                    {
+
+                    }
+                    catch (Exception ex)
+                    {
+
+                    }
+                }
+            }
+            catch (OperationCanceledException oce)
+            {
+            }
+        }
+    }
+}

--- a/DotNet/Report/Listeners/PatientListsAcquiredListener.cs
+++ b/DotNet/Report/Listeners/PatientListsAcquiredListener.cs
@@ -23,13 +23,13 @@ namespace LantanaGroup.Link.Report.Listeners
         private readonly ITransientExceptionHandler<string, PatientListMessage> _transientExceptionHandler;
         private readonly IDeadLetterExceptionHandler<string, PatientListMessage> _deadLetterExceptionHandler;
         private readonly IServiceScopeFactory _serviceScopeFactory;
-        private readonly ISubmissionEntryManager _submissionEntryManager;
+        private readonly IReportEntryStatusManager _reportEntryStatusManager;
         private string Name => this.GetType().Name;
 
         public PatientListsAcquiredListener(
             ILogger<PatientListsAcquiredListener> logger, 
             IKafkaConsumerFactory<string, PatientListMessage> kafkaConsumerFactory,
-            ISubmissionEntryManager submissionEntryManager,
+            IReportEntryStatusManager reportEntryStatusManager,
             ITransientExceptionHandler<string, PatientListMessage> transientExceptionHandler,
             IDeadLetterExceptionHandler<string, PatientListMessage> deadLetterExceptionHandler, 
             IServiceScopeFactory serviceScopeFactory)
@@ -38,7 +38,7 @@ namespace LantanaGroup.Link.Report.Listeners
             _kafkaConsumerFactory = kafkaConsumerFactory ?? throw new ArgumentException(nameof(kafkaConsumerFactory));
             _serviceScopeFactory = serviceScopeFactory;
 
-            _submissionEntryManager = submissionEntryManager;
+            _reportEntryStatusManager = reportEntryStatusManager;
 
             _transientExceptionHandler = transientExceptionHandler ?? throw new ArgumentException(nameof(transientExceptionHandler));
             _deadLetterExceptionHandler = deadLetterExceptionHandler ?? throw new ArgumentException(nameof(deadLetterExceptionHandler));
@@ -118,14 +118,14 @@ namespace LantanaGroup.Link.Report.Listeners
                                             {
                                                 var patientId = pId.Split('/').Last();
 
-                                                var entry = await _submissionEntryManager.SingleOrDefaultAsync(e =>
+                                                var entry = await _reportEntryStatusManager.SingleOrDefaultAsync(e =>
                                                            e.ReportScheduleId == scheduledReport.Id
                                                            && e.PatientId == patientId
                                                            && e.ReportType == reportType, consumeCancellationToken);
 
                                                 if (entry == null)
                                                 {
-                                                    await _submissionEntryManager.AddAsync(new MeasureReportSubmissionEntryModel()
+                                                    await _reportEntryStatusManager.AddAsync(new ReportEntryStatusModel()
                                                     {
                                                         PatientId = patientId,
                                                         Status = PatientSubmissionStatus.PendingEvaluation,
@@ -133,12 +133,12 @@ namespace LantanaGroup.Link.Report.Listeners
                                                         FacilityId = scheduledReport.FacilityId,
                                                         ReportType = reportType,
                                                         CreateDate = DateTime.UtcNow,
-                                                    });
+                                                    }, cancellationToken);
                                                 }
                                                 else
                                                 {
                                                     entry.Status = PatientSubmissionStatus.PendingEvaluation;
-                                                    await _submissionEntryManager.UpdateAsync(entry);
+                                                    await _reportEntryStatusManager.UpdateAsync(entry, cancellationToken);
                                                 } 
                                             }
                                         }

--- a/DotNet/Report/Program.cs
+++ b/DotNet/Report/Program.cs
@@ -1,4 +1,5 @@
 using Azure.Identity;
+using Confluent.Kafka;
 using HealthChecks.UI.Client;
 using Hl7.Fhir.Serialization;
 using LantanaGroup.Link.Report.Application.Extensions;
@@ -105,6 +106,7 @@ static void RegisterServices(WebApplicationBuilder builder)
     builder.Services.AddTransient<MeasureReportSummaryFactory>();
     builder.Services.AddTransient<ResourceSummaryFactory>();
 
+
     builder.Services.AddTransient<IKafkaConsumerFactory<string, GenerateReportValue>, KafkaConsumerFactory<string, GenerateReportValue>>();
     builder.Services.AddTransient<IKafkaConsumerFactory<string, ReportScheduledValue>, KafkaConsumerFactory<string, ReportScheduledValue>>();
     builder.Services.AddTransient<IKafkaConsumerFactory<string, string>, KafkaConsumerFactory<string, string>>();
@@ -112,6 +114,7 @@ static void RegisterServices(WebApplicationBuilder builder)
     builder.Services.AddTransient<IKafkaConsumerFactory<string, PatientListMessage>, KafkaConsumerFactory<string, PatientListMessage>>();
     builder.Services.AddTransient<IKafkaConsumerFactory<string, ValidationCompleteValue>, KafkaConsumerFactory<string, ValidationCompleteValue>>();
     builder.Services.AddTransient<IKafkaConsumerFactory<PayloadSubmittedKey, PayloadSubmittedValue>, KafkaConsumerFactory<PayloadSubmittedKey, PayloadSubmittedValue>>();
+    builder.Services.AddTransient<IKafkaConsumerFactory<Null, MeasureReportGeneratedValue>, KafkaConsumerFactory<Null, MeasureReportGeneratedValue>>();
 
     builder.Services.AddTransient<IRetryModelFactory, RetryModelFactory>();
 
@@ -126,6 +129,7 @@ static void RegisterServices(WebApplicationBuilder builder)
     builder.Services.AddTransient<IKafkaProducerFactory<string, ValidationCompleteValue>, KafkaProducerFactory<string, ValidationCompleteValue>>();
     builder.Services.AddTransient<IKafkaProducerFactory<PayloadSubmittedKey, PayloadSubmittedValue>, KafkaProducerFactory<PayloadSubmittedKey, PayloadSubmittedValue>>();
     builder.Services.AddTransient<IKafkaProducerFactory<string, AuditEventMessage>, KafkaProducerFactory<string, AuditEventMessage>>();
+    builder.Services.AddTransient<IKafkaProducerFactory<Null, MeasureReportGeneratedValue>, KafkaProducerFactory<Null, MeasureReportGeneratedValue>>();
 
     // Add repositories
     builder.Services.AddTransient<IBaseEntityRepository<ReportScheduleModel>, MongoEntityRepository<ReportScheduleModel>>();
@@ -133,12 +137,14 @@ static void RegisterServices(WebApplicationBuilder builder)
     builder.Services.AddTransient<IBaseEntityRepository<ReportModel>, MongoEntityRepository<ReportModel>>();
     builder.Services.AddTransient<IBaseEntityRepository<SharedResourceModel>, MongoEntityRepository<SharedResourceModel>>();
     builder.Services.AddTransient<IBaseEntityRepository<PatientResourceModel>, MongoEntityRepository<PatientResourceModel>>();
+    builder.Services.AddTransient<IBaseEntityRepository<ReportEntryStatusModel>, MongoEntityRepository<ReportEntryStatusModel>>();
     builder.Services.AddTransient<IDatabase, Database>();
 
     // Add Managers
     builder.Services.AddTransient<IReportScheduledManager, ReportScheduledManager>();
     builder.Services.AddTransient<ISubmissionEntryManager, SubmissionEntryManager>();
     builder.Services.AddTransient<IResourceManager, ResourceManager>();
+    builder.Services.AddTransient<IReportEntryStatusManager, ReportEntryStatusManager>();
 
     // Add Link Security
     bool allowAnonymousAccess = builder.Configuration.GetValue<bool>("Authentication:EnableAnonymousAccess");
@@ -235,7 +241,7 @@ static void RegisterServices(WebApplicationBuilder builder)
     builder.Services.AddHostedService<RetryScheduleService>();
     builder.Services.AddHostedService<MeasureReportScheduleService>();
 
-    // Register listeners
+    //Register listeners
     builder.Services.AddSingleton(new RetryListenerSettings(ReportConstants.ServiceName, [
         KafkaTopic.ReportScheduledRetry.GetStringValue(),
         KafkaTopic.ResourceEvaluatedRetry.GetStringValue(),
@@ -249,6 +255,7 @@ static void RegisterServices(WebApplicationBuilder builder)
     builder.Services.AddHostedService<PatientListsAcquiredListener>();
     builder.Services.AddHostedService<ValidationCompleteListener>();
     builder.Services.AddHostedService<PayloadSubmittedListener>();
+    builder.Services.AddHostedService<MeasureReportGeneratedListener>();
 
     builder.Services.AddSingleton(new RetryListenerSettings(ReportConstants.ServiceName, [KafkaTopic.ReportScheduledRetry.GetStringValue(), KafkaTopic.ResourceEvaluatedRetry.GetStringValue(), KafkaTopic.PatientListsAcquiredRetry.GetStringValue(), KafkaTopic.DataAcquisitionRequestedRetry.GetStringValue()]));
     builder.Services.AddHostedService<RetryListener>();
@@ -277,9 +284,14 @@ static void RegisterServices(WebApplicationBuilder builder)
     
     builder.Services.AddTransient<IDeadLetterExceptionHandler<string, ReportScheduledValue>, DeadLetterExceptionHandler<string, ReportScheduledValue>>();
     builder.Services.AddTransient<ITransientExceptionHandler<string, ReportScheduledValue>, TransientExceptionHandler<string, ReportScheduledValue>>();
-    
+
+    builder.Services.AddTransient<IDeadLetterExceptionHandler<Null, MeasureReportGeneratedValue>, DeadLetterExceptionHandler<Null, MeasureReportGeneratedValue>>();
+
+    builder.Services.AddTransient<ITransientExceptionHandler<Null, MeasureReportGeneratedValue>, TransientExceptionHandler<Null, MeasureReportGeneratedValue>>();
+
     builder.Services.AddTransient<IDeadLetterExceptionHandler<ResourceEvaluatedKey, ResourceEvaluatedValue>, DeadLetterExceptionHandler<ResourceEvaluatedKey, ResourceEvaluatedValue>>();
     builder.Services.AddTransient<ITransientExceptionHandler<ResourceEvaluatedKey, ResourceEvaluatedValue>, TransientExceptionHandler<ResourceEvaluatedKey, ResourceEvaluatedValue>>();
+
     
     builder.Services.AddTransient<IDeadLetterExceptionHandler<string, string>, DeadLetterExceptionHandler<string, string>>();
 

--- a/DotNet/ServiceTests/IntegrationTests/Report/ReportIntegrationTestFixture.cs
+++ b/DotNet/ServiceTests/IntegrationTests/Report/ReportIntegrationTestFixture.cs
@@ -233,6 +233,7 @@ namespace IntegrationTests.Report
         public IBaseEntityRepository<SharedResourceModel> SharedResourceRepository { get; set; } = new InMemoryEntityRepository<SharedResourceModel>();
         public IBaseEntityRepository<ReportScheduleModel> ReportScheduledRepository { get; set; } = new InMemoryEntityRepository<ReportScheduleModel>();
         public IBaseEntityRepository<MeasureReportSubmissionEntryModel> SubmissionEntryRepository { get; set; } = new InMemoryEntityRepository<MeasureReportSubmissionEntryModel>();
+        public IBaseEntityRepository<ReportEntryStatusModel> ReportEntryStatusRepository { get; set; } = new InMemoryEntityRepository<ReportEntryStatusModel>();
     }
 
     public class InMemoryEntityRepository<T> : IBaseEntityRepository<T> where T : class, new()

--- a/DotNet/Shared/Application/Models/KafkaTopic.cs
+++ b/DotNet/Shared/Application/Models/KafkaTopic.cs
@@ -69,5 +69,6 @@ public enum KafkaTopic
     ValidationCompleteRetry,
     SubmitPayload,
     [StringValue("SubmitPayload-Retry")]
-    SubmitPayloadRetry
+    SubmitPayloadRetry,
+    MeasureReportGenerated
 }


### PR DESCRIPTION
DotMemory profiles for previous Report optimizations made in [LNK-4532](https://lantana.atlassian.net/browse/LNK-4532) showed that there were significant amounts of allocation being made when making requests to MongoDB and serializing the JSON resources. The work done here was to experiment ways in which we can remove as much allocations as possible and avoid any JSON serialization when performing Report consumer and aggregation logic. To accomplish this, it’s proposed that Measure Eval writes to Azure Blob Storage single MeasureReport blobs for each measure a patient is evaluated for. This will remove the need for Report to manage patient resources in Mongo. The format of the blob is similar to the current .ndjson format downstream services use with one important difference. Below is an example of how the blob I tested with is structured:

`MeasureReport_ed9058a5-c4f5-4674-a4af-a0b76a6776ef
{ ** MeasureReport Resource Here ** }
DiagnosticReport_VLgwkgT575UJhRIeJ108g8NYyAw0Qqr2BkGPbceSFm42x
{ ** DiagnosticReport Resource Here ** }
DiagnosticReport_gKoH5Ji6MjX1yiP1HBv5UlLbbzn603LPnevrIznW0ul7V
{ ** DiagnosticReport Resource Here ** }
ServiceRequest_Fcutd1ptl66cFgI2JrBb85ge521OzlncHp1hQPXPicKDd
{ ** ServiceRequest Resource Here ** }`

The idea is that by prefixing each resource with <ResourceType>_<ResourceId>, the Report service no longer needs to serialize each FHIR resource to find the Id and Type needed to determine if it should be added to the aggregate file. This significantly reduces the amount of memory that’s allocated when performing the aggregation logic. Additionally, the consumer logic becomes much simpler to manage. 

Below are some test results before and after the changes were made. These tests were all done against the mega patient provided by QA:

Before Changes (Mega Patient: ~8k resources) 
Allocated: ~1.2 GB
GC Time: 1.3 minutes

After Changes (Mega Patient: ~8k resources) 
Allocated: ~59.36 MB
GC Time: <1ms 

[LNK-4532]: https://lantana.atlassian.net/browse/LNK-4532?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ