### PR TITLE
LNK-3834: Sftp acquisition log table

### DIFF
--- a/DotNet/DataAcquisition.Domain/Application/Managers/SftpAcquisitionLogManager.cs
+++ b/DotNet/DataAcquisition.Domain/Application/Managers/SftpAcquisitionLogManager.cs
@@ -65,11 +65,11 @@ public class SftpAcquisitionLogManager(ILogger<SftpAcquisitionLogManager> logger
         using var activity = Activity.Current?.Source.StartActivity();
         activity?.SetTag(DiagnosticNames.FacilityId, model.FacilityId);
         
-        if(model.Id <= 0)
+        if(model.ExternalId is not null && model.ExternalId != Guid.Empty)
         {
-            activity?.SetStatus(ActivityStatusCode.Error, "Log ID cannot be zero or null");
-            logger.LogError("Sftp Acquisition Log Id cannot be zero or null");
-            throw new ArgumentException("SftpAcquisitionLog Id must be greater than zero for update operation.");
+            activity?.SetStatus(ActivityStatusCode.Error, "Invalid log id");
+            logger.LogError("Sftp Acquisition Log Id cannot be null or empty for update operation.");
+            throw new ArgumentException("SftpAcquisitionLog Id cannot be null or empty for update operation.");
         }
 
         if (string.IsNullOrEmpty(model.FacilityId))
@@ -79,13 +79,12 @@ public class SftpAcquisitionLogManager(ILogger<SftpAcquisitionLogManager> logger
             throw new MissingFacilityIdException(nameof(model.FacilityId));
         }
 
-        var existingLog = await database.SftpAcquisitionLogRepository.GetAsync(model.Id, cancellationToken);
+        var existingLog = await database.SftpAcquisitionLogRepository.FirstOrDefaultAsync(x => x.ExternalId == model.ExternalId, cancellationToken);
         
-        //TODO: should update the interface to allow a nullable return from GetAsync
         if (existingLog is null)
         {
             activity?.SetStatus(ActivityStatusCode.Error, "SFTP Acquisition log not found");
-            throw new DomainEntityNotFoundException($"SFTP Acquisition log with ID {model.Id} not found.");
+            throw new DomainEntityNotFoundException($"SFTP Acquisition log with ID {model.ExternalId} not found.");
         }
 
         try
@@ -132,7 +131,7 @@ public class SftpAcquisitionLogManager(ILogger<SftpAcquisitionLogManager> logger
         if (existingLog is null)
         {
             activity?.SetStatus(ActivityStatusCode.Error, "SFTP Acquisition log not found");
-            throw new DomainEntityNotFoundException($"SFTP Acquisition log with ID {model.Id} not found.");
+            throw new DomainEntityNotFoundException($"SFTP Acquisition log with ID {model.ExternalId} not found.");
         }
         
         try

--- a/DotNet/DataAcquisition.Domain/Application/Managers/SftpAcquisitionLogManager.cs
+++ b/DotNet/DataAcquisition.Domain/Application/Managers/SftpAcquisitionLogManager.cs
@@ -30,7 +30,7 @@ public class SftpAcquisitionLogManager(ILogger<SftpAcquisitionLogManager> logger
         activity?.AddTag(DiagnosticNames.FacilityId, model.FacilityId);
 
         // Ensure the process date is set sometime in the future
-        if (model.ProcessDate <= DateTime.Now)
+        if (model.ProcessDate.ToUniversalTime() <= DateTime.UtcNow)
         {
             activity?.SetStatus(ActivityStatusCode.Error, "ProcessDate cannot be in the past.");
             activity?.AddTag("sftp.acquisition.log", JsonSerializer.Serialize(model, LinkFhirSerializerOptions.ActivityTagging));
@@ -40,6 +40,8 @@ public class SftpAcquisitionLogManager(ILogger<SftpAcquisitionLogManager> logger
         try
         {
             var entity = model.ToDomain();
+            
+            entity.ProcessDate = model.ProcessDate.ToUniversalTime();
             
             // There should not be any counts yet as it has not been run
             entity.EncounterCount = 0;
@@ -87,13 +89,21 @@ public class SftpAcquisitionLogManager(ILogger<SftpAcquisitionLogManager> logger
             activity?.SetStatus(ActivityStatusCode.Error, "SFTP Acquisition log not found");
             throw new DomainEntityNotFoundException($"SFTP Acquisition log with ID {model.ExternalId} not found.");
         }
+        
+        // Ensure the process date is set sometime in the future
+        if (model.ProcessDate.ToUniversalTime() <= DateTime.UtcNow)
+        {
+            activity?.SetStatus(ActivityStatusCode.Error, "ProcessDate cannot be in the past.");
+            activity?.AddTag("sftp.acquisition.log", JsonSerializer.Serialize(model, LinkFhirSerializerOptions.ActivityTagging));
+            throw new ArgumentException("ProcessDate cannot be in the past.");
+        }
 
         try
         {
             // Update existing log entry
             existingLog.EncounterCount = model.EncounterCount;
             existingLog.PatientCount = model.PatientCount;
-            existingLog.ProcessDate = model.ProcessDate;
+            existingLog.ProcessDate = model.ProcessDate.ToUniversalTime();
         
             await database.SaveChangesAsync();
         
@@ -114,7 +124,7 @@ public class SftpAcquisitionLogManager(ILogger<SftpAcquisitionLogManager> logger
         using var activity = Activity.Current?.Source.StartActivity();
         activity?.SetTag(DiagnosticNames.FacilityId, model.ExternalId);
 
-        if (model.ProcessDate <= DateTime.Now)
+        if (model.ProcessDate.ToUniversalTime() <= DateTime.UtcNow)
         {
             activity?.SetStatus(ActivityStatusCode.Error, "ProcessDate cannot be in the past.");
             activity?.AddTag("sftp.log.process.date", model.ProcessDate);
@@ -146,7 +156,7 @@ public class SftpAcquisitionLogManager(ILogger<SftpAcquisitionLogManager> logger
         {
             // Update existing log entry
             existingLog.FileName = model.FileName;
-            existingLog.ProcessDate = model.ProcessDate;
+            existingLog.ProcessDate = model.ProcessDate.ToUniversalTime();
         
             await database.SaveChangesAsync();
         

--- a/DotNet/DataAcquisition.Domain/Application/Managers/SftpAcquisitionLogManager.cs
+++ b/DotNet/DataAcquisition.Domain/Application/Managers/SftpAcquisitionLogManager.cs
@@ -15,7 +15,7 @@ public interface ISftpAcquisitionLogManager
     Task<SftpAcquisitionLogModel> CreateAsync(SftpAcquisitionLogModel model, CancellationToken cancellationToken);
     Task<SftpAcquisitionLogModel> UpdateAsync(SftpAcquisitionLogModel model, CancellationToken cancellationToken);
 
-    Task<SftpAcquisitionLogModel> UpdateProcessDateAsync(SftpAcquisitionLogModel model,
+    Task<SftpAcquisitionLogModel> UserUpdateAsync(SftpAcquisitionLogModel model,
         CancellationToken cancellationToken);
     Task DeleteAsync(long id, CancellationToken cancellationToken);
 }
@@ -47,7 +47,7 @@ public class SftpAcquisitionLogManager(ILogger<SftpAcquisitionLogManager> logger
             await database.SftpAcquisitionLogRepository.AddAsync(entity, cancellationToken);
             await database.SaveChangesAsync();
             
-            logger.LogInformation("Created SFTP Acquisition Log for FacilityId: {FacilityId}, FacilityName: {FacilityName}", model.FacilityId, model.FacilityName);
+            logger.LogInformation("Created SFTP Acquisition Log for FacilityId: {FacilityId}, FileName: {FileName}", model.FacilityId, model.FileName);
         
             return entity.ToModel();
         }
@@ -55,7 +55,7 @@ public class SftpAcquisitionLogManager(ILogger<SftpAcquisitionLogManager> logger
         {
             activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
             activity?.AddTag(DiagnosticNames.StackTrace, ex.StackTrace);
-            logger.LogError(ex, "Error creating SFTP Acquisition Log for FacilityId: {FacilityId}, FacilityName: {FacilityName}", model.FacilityId, model.FacilityName);
+            logger.LogError(ex, "Error creating SFTP Acquisition Log for FacilityId: {FacilityId}, FileName: {FileName}", model.FacilityId, model.FileName);
             throw;
         }
     }
@@ -103,12 +103,12 @@ public class SftpAcquisitionLogManager(ILogger<SftpAcquisitionLogManager> logger
             activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
             activity?.SetTag("SftpAcquisitionLog", JsonSerializer.Serialize(model, LinkFhirSerializerOptions.ActivityTagging));
             activity?.AddTag(DiagnosticNames.StackTrace, ex.StackTrace);
-            logger.LogError(ex, "Error updating SFTP Acquisition Log for FacilityId: {FacilityId}, FacilityName: {FacilityName}", model.FacilityId, model.FacilityName);
+            logger.LogError(ex, "Error updating SFTP Acquisition Log for FacilityId: {FacilityId}, FileName: {FileName}", model.FacilityId, model.FileName);
             throw;
         }
     }
     
-    public async Task<SftpAcquisitionLogModel> UpdateProcessDateAsync(SftpAcquisitionLogModel model, CancellationToken cancellationToken = default)
+    public async Task<SftpAcquisitionLogModel> UserUpdateAsync(SftpAcquisitionLogModel model, CancellationToken cancellationToken = default)
     {
         using var activity = Activity.Current?.Source.StartActivity();
         activity?.SetTag(DiagnosticNames.FacilityId, model.ExternalId);
@@ -126,6 +126,13 @@ public class SftpAcquisitionLogManager(ILogger<SftpAcquisitionLogManager> logger
             throw new ArgumentNullException(nameof(model.ExternalId));
         }
 
+        // TODO: Consider adding file type restrictions
+        if (string.IsNullOrEmpty(model.FileName))
+        {
+            activity?.SetStatus(ActivityStatusCode.Error, "FileName cannot be null or empty");
+            throw new ArgumentNullException(nameof(model.FileName));
+        }
+
         var existingLog = await database.SftpAcquisitionLogRepository.FirstOrDefaultAsync(x => x.ExternalId == model.ExternalId, cancellationToken);
         
         if (existingLog is null)
@@ -137,6 +144,7 @@ public class SftpAcquisitionLogManager(ILogger<SftpAcquisitionLogManager> logger
         try
         {
             // Update existing log entry
+            existingLog.FileName = model.FileName;
             existingLog.ProcessDate = model.ProcessDate;
         
             await database.SaveChangesAsync();
@@ -148,7 +156,7 @@ public class SftpAcquisitionLogManager(ILogger<SftpAcquisitionLogManager> logger
             activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
             activity?.SetTag("SftpAcquisitionLog", JsonSerializer.Serialize(model, LinkFhirSerializerOptions.ActivityTagging));
             activity?.AddTag(DiagnosticNames.StackTrace, ex.StackTrace);
-            logger.LogError(ex, "Error updating SFTP Acquisition Log for FacilityId: {FacilityId}, FacilityName: {FacilityName}", model.FacilityId, model.FacilityName);
+            logger.LogError(ex, "Error updating SFTP Acquisition Log for FacilityId: {FacilityId}, FileName: {FileName}", model.FacilityId, model.FileName);
             throw;
         }
     }

--- a/DotNet/DataAcquisition.Domain/Application/Managers/SftpAcquisitionLogManager.cs
+++ b/DotNet/DataAcquisition.Domain/Application/Managers/SftpAcquisitionLogManager.cs
@@ -1,0 +1,125 @@
+using System.Diagnostics;
+using System.Text.Json;
+using LantanaGroup.Link.DataAcquisition.Domain.Application.Models.Api.QueryLog;
+using LantanaGroup.Link.DataAcquisition.Domain.Application.Models.Exceptions;
+using LantanaGroup.Link.DataAcquisition.Domain.Infrastructure;
+using LantanaGroup.Link.Shared.Application.Models.Telemetry;
+using LantanaGroup.Link.Shared.Application.SerDes;
+using Microsoft.Extensions.Logging;
+
+namespace LantanaGroup.Link.DataAcquisition.Domain.Application.Managers;
+
+public interface ISftpAcquisitionLogManager
+{
+    Task<SftpAcquisitionLogModel> CreateAsync(SftpAcquisitionLogModel model, CancellationToken cancellationToken);
+    Task<SftpAcquisitionLogModel> UpdateAsync(SftpAcquisitionLogModel model, CancellationToken cancellationToken);
+    Task DeleteAsync(long id, CancellationToken cancellationToken);
+}
+
+
+public class SftpAcquisitionLogManager(ILogger<SftpAcquisitionLogManager> logger, IDatabase database) : ISftpAcquisitionLogManager
+{
+    public async Task<SftpAcquisitionLogModel> CreateAsync(SftpAcquisitionLogModel model, CancellationToken cancellationToken = default)
+    {
+        using var activity = Activity.Current?.Source.StartActivity();
+        activity?.AddTag(DiagnosticNames.FacilityId, model.FacilityId);
+
+        try
+        {
+            var entity = model.ToDomain();
+        
+            await database.SftpAcquisitionLogRepository.AddAsync(entity, cancellationToken);
+            await database.SaveChangesAsync();
+            
+            logger.LogInformation("Created SFTP Acquisition Log for FacilityId: {FacilityId}, FacilityName: {FacilityName}", model.FacilityId, model.FacilityName);
+        
+            return entity.ToModel();
+        }
+        catch (Exception ex)
+        {
+            activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
+            activity?.AddTag(DiagnosticNames.StackTrace, ex.StackTrace);
+            logger.LogError(ex, "Error creating SFTP Acquisition Log for FacilityId: {FacilityId}, FacilityName: {FacilityName}", model.FacilityId, model.FacilityName);
+            throw;
+        }
+    }
+
+    public async Task<SftpAcquisitionLogModel> UpdateAsync(SftpAcquisitionLogModel model, CancellationToken cancellationToken = default)
+    {
+        using var activity = Activity.Current?.Source.StartActivity();
+        activity?.SetTag(DiagnosticNames.FacilityId, model.FacilityId);
+        
+        if(model.Id <= 0)
+        {
+            activity?.SetStatus(ActivityStatusCode.Error, "Log ID cannot be zero or null");
+            logger.LogError("Sftp Acquisition Log Id cannot be zero or null");
+            throw new ArgumentException("SftpAcquisitionLog Id must be greater than zero for update operation.");
+        }
+
+        if (string.IsNullOrEmpty(model.FacilityId))
+        {
+            activity?.SetStatus(ActivityStatusCode.Error, "FacilityId cannot be empty or null");
+            logger.LogError("Sftp Acquisition Log FacilityId cannot be empty or null");
+            throw new MissingFacilityIdException(nameof(model.FacilityId));
+        }
+
+        var existingLog = await database.SftpAcquisitionLogRepository.GetAsync(model.Id, cancellationToken);
+        
+        //TODO: should update the interface to allow a nullable return from GetAsync
+        if (existingLog is null)
+        {
+            activity?.SetStatus(ActivityStatusCode.Error, "SFTP Acquisition log not found");
+            throw new NotFoundException($"SFTP Acquisition log with ID {model.Id} not found.");
+        }
+
+        try
+        {
+            // Update existing log entry
+            existingLog.EncounterCount = model.EncounterCount;
+            existingLog.PatientCount = model.PatientCount;
+            existingLog.ProcessDate = model.ProcessDate;
+        
+            await database.SaveChangesAsync();
+        
+            return existingLog.ToModel();
+        }
+        catch (Exception ex)
+        {
+            activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
+            activity?.SetTag("SftpAcquisitionLog", JsonSerializer.Serialize(model, LinkFhirSerializerOptions.ActivityTagging));
+            activity?.AddTag(DiagnosticNames.StackTrace, ex.StackTrace);
+            logger.LogError(ex, "Error updating SFTP Acquisition Log for FacilityId: {FacilityId}, FacilityName: {FacilityName}", model.FacilityId, model.FacilityName);
+            throw;
+        }
+
+        
+    }
+
+    public async Task DeleteAsync(long id, CancellationToken cancellationToken = default)
+    {
+        using var activity = Activity.Current?.Source.StartActivity();
+        activity?.SetTag(DiagnosticNames.EntityId, id);
+        
+        // Check if log exists
+        var existingLog = await database.SftpAcquisitionLogRepository.GetAsync(id, cancellationToken);
+        
+        if (existingLog is null)
+        {
+            activity?.SetStatus(ActivityStatusCode.Error, "SFTP Acquisition log not found");
+            throw new NotFoundException($"SFTP Acquisition log with ID {id} not found.");
+        }
+
+        try
+        {
+            database.SftpAcquisitionLogRepository.Remove(existingLog);
+            await database.SaveChangesAsync();
+        }
+        catch (Exception ex)
+        {
+            activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
+            activity?.AddTag(DiagnosticNames.StackTrace, ex.StackTrace);
+            logger.LogError(ex, "Error deleting SFTP Acquisition Log with ID: {Id}", id);
+            throw;
+        }
+    }
+}

--- a/DotNet/DataAcquisition.Domain/Application/Managers/SftpAcquisitionLogManager.cs
+++ b/DotNet/DataAcquisition.Domain/Application/Managers/SftpAcquisitionLogManager.cs
@@ -3,6 +3,7 @@ using System.Text.Json;
 using LantanaGroup.Link.DataAcquisition.Domain.Application.Models.Api.QueryLog;
 using LantanaGroup.Link.DataAcquisition.Domain.Application.Models.Exceptions;
 using LantanaGroup.Link.DataAcquisition.Domain.Infrastructure;
+using LantanaGroup.Link.DataAcquisition.Domain.Infrastructure.Models.Exceptions;
 using LantanaGroup.Link.Shared.Application.Models.Telemetry;
 using LantanaGroup.Link.Shared.Application.SerDes;
 using Microsoft.Extensions.Logging;
@@ -13,6 +14,9 @@ public interface ISftpAcquisitionLogManager
 {
     Task<SftpAcquisitionLogModel> CreateAsync(SftpAcquisitionLogModel model, CancellationToken cancellationToken);
     Task<SftpAcquisitionLogModel> UpdateAsync(SftpAcquisitionLogModel model, CancellationToken cancellationToken);
+
+    Task<SftpAcquisitionLogModel> UpdateProcessDateAsync(SftpAcquisitionLogModel model,
+        CancellationToken cancellationToken);
     Task DeleteAsync(long id, CancellationToken cancellationToken);
 }
 
@@ -24,9 +28,21 @@ public class SftpAcquisitionLogManager(ILogger<SftpAcquisitionLogManager> logger
         using var activity = Activity.Current?.Source.StartActivity();
         activity?.AddTag(DiagnosticNames.FacilityId, model.FacilityId);
 
+        // Ensure the process date is set sometime in the future
+        if (model.ProcessDate <= DateTime.Now)
+        {
+            activity?.SetStatus(ActivityStatusCode.Error, "ProcessDate cannot be in the past.");
+            activity?.AddTag("sftp.acquisition.log", JsonSerializer.Serialize(model, LinkFhirSerializerOptions.ActivityTagging));
+            throw new ArgumentException("ProcessDate cannot be in the past.");
+        }
+
         try
         {
             var entity = model.ToDomain();
+            
+            // There should not be any counts yet as it has not been run
+            entity.EncounterCount = 0;
+            entity.PatientCount = 0;
         
             await database.SftpAcquisitionLogRepository.AddAsync(entity, cancellationToken);
             await database.SaveChangesAsync();
@@ -69,7 +85,7 @@ public class SftpAcquisitionLogManager(ILogger<SftpAcquisitionLogManager> logger
         if (existingLog is null)
         {
             activity?.SetStatus(ActivityStatusCode.Error, "SFTP Acquisition log not found");
-            throw new NotFoundException($"SFTP Acquisition log with ID {model.Id} not found.");
+            throw new DomainEntityNotFoundException($"SFTP Acquisition log with ID {model.Id} not found.");
         }
 
         try
@@ -91,8 +107,51 @@ public class SftpAcquisitionLogManager(ILogger<SftpAcquisitionLogManager> logger
             logger.LogError(ex, "Error updating SFTP Acquisition Log for FacilityId: {FacilityId}, FacilityName: {FacilityName}", model.FacilityId, model.FacilityName);
             throw;
         }
+    }
+    
+    public async Task<SftpAcquisitionLogModel> UpdateProcessDateAsync(SftpAcquisitionLogModel model, CancellationToken cancellationToken = default)
+    {
+        using var activity = Activity.Current?.Source.StartActivity();
+        activity?.SetTag(DiagnosticNames.FacilityId, model.ExternalId);
 
+        if (model.ProcessDate <= DateTime.Now)
+        {
+            activity?.SetStatus(ActivityStatusCode.Error, "ProcessDate cannot be in the past.");
+            activity?.AddTag("sftp.log.process.date", model.ProcessDate);
+            throw new ArgumentException("ProcessDate cannot be in the past.");
+        }
+
+        if (model.ExternalId is null || model.ExternalId == Guid.Empty)
+        {
+            activity?.SetStatus(ActivityStatusCode.Error, "ExternalId cannot be null");
+            throw new ArgumentNullException(nameof(model.ExternalId));
+        }
+
+        var existingLog = await database.SftpAcquisitionLogRepository.FirstOrDefaultAsync(x => x.ExternalId == model.ExternalId, cancellationToken);
         
+        if (existingLog is null)
+        {
+            activity?.SetStatus(ActivityStatusCode.Error, "SFTP Acquisition log not found");
+            throw new DomainEntityNotFoundException($"SFTP Acquisition log with ID {model.Id} not found.");
+        }
+        
+        try
+        {
+            // Update existing log entry
+            existingLog.ProcessDate = model.ProcessDate;
+        
+            await database.SaveChangesAsync();
+        
+            return existingLog.ToModel();
+        }
+        catch (Exception ex)
+        {
+            activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
+            activity?.SetTag("SftpAcquisitionLog", JsonSerializer.Serialize(model, LinkFhirSerializerOptions.ActivityTagging));
+            activity?.AddTag(DiagnosticNames.StackTrace, ex.StackTrace);
+            logger.LogError(ex, "Error updating SFTP Acquisition Log for FacilityId: {FacilityId}, FacilityName: {FacilityName}", model.FacilityId, model.FacilityName);
+            throw;
+        }
     }
 
     public async Task DeleteAsync(long id, CancellationToken cancellationToken = default)

--- a/DotNet/DataAcquisition.Domain/Application/Managers/SftpAcquisitionLogManager.cs
+++ b/DotNet/DataAcquisition.Domain/Application/Managers/SftpAcquisitionLogManager.cs
@@ -6,6 +6,7 @@ using LantanaGroup.Link.DataAcquisition.Domain.Infrastructure;
 using LantanaGroup.Link.DataAcquisition.Domain.Infrastructure.Models.Exceptions;
 using LantanaGroup.Link.Shared.Application.Models.Telemetry;
 using LantanaGroup.Link.Shared.Application.SerDes;
+using LantanaGroup.Link.Shared.Application.Services.Security;
 using Microsoft.Extensions.Logging;
 
 namespace LantanaGroup.Link.DataAcquisition.Domain.Application.Managers;
@@ -47,7 +48,7 @@ public class SftpAcquisitionLogManager(ILogger<SftpAcquisitionLogManager> logger
             await database.SftpAcquisitionLogRepository.AddAsync(entity, cancellationToken);
             await database.SaveChangesAsync();
             
-            logger.LogInformation("Created SFTP Acquisition Log for FacilityId: {FacilityId}, FileName: {FileName}", model.FacilityId, model.FileName);
+            logger.LogInformation("Created SFTP Acquisition Log for FacilityId: {FacilityId}, FileName: {FileName}", model.FacilityId.Sanitize(), model.FileName.Sanitize());
         
             return entity.ToModel();
         }
@@ -55,7 +56,7 @@ public class SftpAcquisitionLogManager(ILogger<SftpAcquisitionLogManager> logger
         {
             activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
             activity?.AddTag(DiagnosticNames.StackTrace, ex.StackTrace);
-            logger.LogError(ex, "Error creating SFTP Acquisition Log for FacilityId: {FacilityId}, FileName: {FileName}", model.FacilityId, model.FileName);
+            logger.LogError(ex, "Error creating SFTP Acquisition Log for FacilityId: {FacilityId}, FileName: {FileName}", model.FacilityId.Sanitize(), model.FileName.Sanitize());
             throw;
         }
     }
@@ -156,7 +157,7 @@ public class SftpAcquisitionLogManager(ILogger<SftpAcquisitionLogManager> logger
             activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
             activity?.SetTag("SftpAcquisitionLog", JsonSerializer.Serialize(model, LinkFhirSerializerOptions.ActivityTagging));
             activity?.AddTag(DiagnosticNames.StackTrace, ex.StackTrace);
-            logger.LogError(ex, "Error updating SFTP Acquisition Log for FacilityId: {FacilityId}, FileName: {FileName}", model.FacilityId, model.FileName);
+            logger.LogError(ex, "Error updating SFTP Acquisition Log for FacilityId: {FacilityId}, FileName: {FileName}", model.FacilityId.Sanitize(), model.FileName.Sanitize());
             throw;
         }
     }

--- a/DotNet/DataAcquisition.Domain/Application/Models/Api/QueryLog/SftpAcquisitionLogModel.cs
+++ b/DotNet/DataAcquisition.Domain/Application/Models/Api/QueryLog/SftpAcquisitionLogModel.cs
@@ -19,6 +19,10 @@ public record PagedSftpAcquisitionLogModel : IPagedModel<SftpAcquisitionLogModel
     public PaginationMetadata Metadata { get; set; }
 }
 
+public record CreateSftpLogRequest(string FacilityId, string FacilityName, DateTime ProcessDate);
+
+public record UpdateSftpLogRequest(Guid ExternalId, DateTime ProcessDate);
+
 public static class SftpAcquisitionLogModelExtensions
 {
 
@@ -41,5 +45,25 @@ public static class SftpAcquisitionLogModelExtensions
         EncounterCount = model.EncounterCount,
         ProcessDate = model.ProcessDate
     };
+    
+    public static SftpAcquisitionLogModel ToModel(this CreateSftpLogRequest req) => new(
+    
+        Id: 0,
+        ExternalId: Guid.NewGuid(),
+        FacilityId: req.FacilityId,
+        FacilityName: req.FacilityName,
+        PatientCount: 0,
+        EncounterCount: 0,
+        ProcessDate: req.ProcessDate
+    );
 
+    public static SftpAcquisitionLogModel ToModel(this UpdateSftpLogRequest req) => new(
+        Id: 0,
+        ExternalId: req.ExternalId,
+        FacilityId: string.Empty,
+        FacilityName: string.Empty,
+        PatientCount: 0,
+        EncounterCount: 0,
+        ProcessDate: req.ProcessDate
+    );
 }

--- a/DotNet/DataAcquisition.Domain/Application/Models/Api/QueryLog/SftpAcquisitionLogModel.cs
+++ b/DotNet/DataAcquisition.Domain/Application/Models/Api/QueryLog/SftpAcquisitionLogModel.cs
@@ -1,0 +1,38 @@
+using LantanaGroup.Link.DataAcquisition.Domain.Infrastructure.Entities;
+
+namespace LantanaGroup.Link.DataAcquisition.Domain.Application.Models.Api.QueryLog;
+
+public record SftpAcquisitionLogModel(
+    long Id, 
+    Guid? ExternalId, 
+    string FacilityId, 
+    string FacilityName, 
+    int PatientCount, 
+    int EncounterCount, 
+    DateTime? ProcessDate);
+
+
+public static class SftpAcquisitionLogModelExtensions
+{
+
+    public static SftpAcquisitionLogModel ToModel(this SftpAcquisitionLog entity) => new(
+        entity.Id,
+        entity.ExternalId,
+        entity.FacilityId,
+        entity.FacilityName,
+        entity.PatientCount,
+        entity.EncounterCount,
+        entity.ProcessDate
+    );
+    
+    public static SftpAcquisitionLog ToDomain(this SftpAcquisitionLogModel model) => new()
+    {
+        ExternalId = model.ExternalId ?? Guid.NewGuid(),
+        FacilityId = model.FacilityId,
+        FacilityName = model.FacilityName,
+        PatientCount = model.PatientCount,
+        EncounterCount = model.EncounterCount,
+        ProcessDate = model.ProcessDate ?? DateTime.UtcNow
+    };
+
+}

--- a/DotNet/DataAcquisition.Domain/Application/Models/Api/QueryLog/SftpAcquisitionLogModel.cs
+++ b/DotNet/DataAcquisition.Domain/Application/Models/Api/QueryLog/SftpAcquisitionLogModel.cs
@@ -1,4 +1,6 @@
 using LantanaGroup.Link.DataAcquisition.Domain.Infrastructure.Entities;
+using LantanaGroup.Link.Shared.Application.Interfaces.Models;
+using LantanaGroup.Link.Shared.Application.Models.Responses;
 
 namespace LantanaGroup.Link.DataAcquisition.Domain.Application.Models.Api.QueryLog;
 
@@ -11,6 +13,11 @@ public record SftpAcquisitionLogModel(
     int EncounterCount, 
     DateTime ProcessDate);
 
+public record PagedSftpAcquisitionLogModel : IPagedModel<SftpAcquisitionLogModel>
+{
+    public List<SftpAcquisitionLogModel> Records { get; set; }
+    public PaginationMetadata Metadata { get; set; }
+}
 
 public static class SftpAcquisitionLogModelExtensions
 {

--- a/DotNet/DataAcquisition.Domain/Application/Models/Api/QueryLog/SftpAcquisitionLogModel.cs
+++ b/DotNet/DataAcquisition.Domain/Application/Models/Api/QueryLog/SftpAcquisitionLogModel.cs
@@ -9,7 +9,7 @@ public record SftpAcquisitionLogModel(
     string FacilityName, 
     int PatientCount, 
     int EncounterCount, 
-    DateTime? ProcessDate);
+    DateTime ProcessDate);
 
 
 public static class SftpAcquisitionLogModelExtensions
@@ -32,7 +32,7 @@ public static class SftpAcquisitionLogModelExtensions
         FacilityName = model.FacilityName,
         PatientCount = model.PatientCount,
         EncounterCount = model.EncounterCount,
-        ProcessDate = model.ProcessDate ?? DateTime.UtcNow
+        ProcessDate = model.ProcessDate
     };
 
 }

--- a/DotNet/DataAcquisition.Domain/Application/Models/Api/QueryLog/SftpAcquisitionLogModel.cs
+++ b/DotNet/DataAcquisition.Domain/Application/Models/Api/QueryLog/SftpAcquisitionLogModel.cs
@@ -5,7 +5,6 @@ using LantanaGroup.Link.Shared.Application.Models.Responses;
 namespace LantanaGroup.Link.DataAcquisition.Domain.Application.Models.Api.QueryLog;
 
 public record SftpAcquisitionLogModel(
-    long Id, 
     Guid? ExternalId, 
     string FacilityId, 
     string FacilityName, 
@@ -27,7 +26,6 @@ public static class SftpAcquisitionLogModelExtensions
 {
 
     public static SftpAcquisitionLogModel ToModel(this SftpAcquisitionLog entity) => new(
-        entity.Id,
         entity.ExternalId,
         entity.FacilityId,
         entity.FacilityName,
@@ -47,8 +45,6 @@ public static class SftpAcquisitionLogModelExtensions
     };
     
     public static SftpAcquisitionLogModel ToModel(this CreateSftpLogRequest req) => new(
-    
-        Id: 0,
         ExternalId: Guid.NewGuid(),
         FacilityId: req.FacilityId,
         FacilityName: req.FacilityName,
@@ -58,7 +54,6 @@ public static class SftpAcquisitionLogModelExtensions
     );
 
     public static SftpAcquisitionLogModel ToModel(this UpdateSftpLogRequest req) => new(
-        Id: 0,
         ExternalId: req.ExternalId,
         FacilityId: string.Empty,
         FacilityName: string.Empty,

--- a/DotNet/DataAcquisition.Domain/Application/Models/Api/QueryLog/SftpAcquisitionLogModel.cs
+++ b/DotNet/DataAcquisition.Domain/Application/Models/Api/QueryLog/SftpAcquisitionLogModel.cs
@@ -31,7 +31,7 @@ public static class SftpAcquisitionLogModelExtensions
         entity.FileName,
         entity.PatientCount,
         entity.EncounterCount,
-        entity.ProcessDate
+        DateTime.SpecifyKind(entity.ProcessDate, DateTimeKind.Utc)
     );
     
     public static SftpAcquisitionLog ToDomain(this SftpAcquisitionLogModel model) => new()

--- a/DotNet/DataAcquisition.Domain/Application/Models/Api/QueryLog/SftpAcquisitionLogModel.cs
+++ b/DotNet/DataAcquisition.Domain/Application/Models/Api/QueryLog/SftpAcquisitionLogModel.cs
@@ -7,7 +7,7 @@ namespace LantanaGroup.Link.DataAcquisition.Domain.Application.Models.Api.QueryL
 public record SftpAcquisitionLogModel(
     Guid? ExternalId, 
     string FacilityId, 
-    string FacilityName, 
+    string FileName, 
     int PatientCount, 
     int EncounterCount, 
     DateTime ProcessDate);
@@ -18,9 +18,9 @@ public record PagedSftpAcquisitionLogModel : IPagedModel<SftpAcquisitionLogModel
     public PaginationMetadata Metadata { get; set; }
 }
 
-public record CreateSftpLogRequest(string FacilityId, string FacilityName, DateTime ProcessDate);
+public record CreateSftpLogRequest(string FacilityId, string FileName, DateTime ProcessDate);
 
-public record UpdateSftpLogRequest(Guid ExternalId, DateTime ProcessDate);
+public record UpdateSftpLogRequest(Guid ExternalId, string FileName, DateTime ProcessDate);
 
 public static class SftpAcquisitionLogModelExtensions
 {
@@ -28,7 +28,7 @@ public static class SftpAcquisitionLogModelExtensions
     public static SftpAcquisitionLogModel ToModel(this SftpAcquisitionLog entity) => new(
         entity.ExternalId,
         entity.FacilityId,
-        entity.FacilityName,
+        entity.FileName,
         entity.PatientCount,
         entity.EncounterCount,
         entity.ProcessDate
@@ -38,7 +38,7 @@ public static class SftpAcquisitionLogModelExtensions
     {
         ExternalId = model.ExternalId ?? Guid.NewGuid(),
         FacilityId = model.FacilityId,
-        FacilityName = model.FacilityName,
+        FileName = model.FileName,
         PatientCount = model.PatientCount,
         EncounterCount = model.EncounterCount,
         ProcessDate = model.ProcessDate
@@ -47,7 +47,7 @@ public static class SftpAcquisitionLogModelExtensions
     public static SftpAcquisitionLogModel ToModel(this CreateSftpLogRequest req) => new(
         ExternalId: Guid.NewGuid(),
         FacilityId: req.FacilityId,
-        FacilityName: req.FacilityName,
+        FileName: req.FileName,
         PatientCount: 0,
         EncounterCount: 0,
         ProcessDate: req.ProcessDate
@@ -56,7 +56,7 @@ public static class SftpAcquisitionLogModelExtensions
     public static SftpAcquisitionLogModel ToModel(this UpdateSftpLogRequest req) => new(
         ExternalId: req.ExternalId,
         FacilityId: string.Empty,
-        FacilityName: string.Empty,
+        FileName: req.FileName,
         PatientCount: 0,
         EncounterCount: 0,
         ProcessDate: req.ProcessDate

--- a/DotNet/DataAcquisition.Domain/Application/Models/Http/LogSearchParameters.cs
+++ b/DotNet/DataAcquisition.Domain/Application/Models/Http/LogSearchParameters.cs
@@ -15,6 +15,11 @@ public class LogSearchParameters : GenericLogSearchParameters
     public AcquisitionPriority? Priority { get; set; }
 }
 
+public class SftpLogSearchParameters : GenericLogSearchParameters
+{
+    public string? FacilityId { get; set; }
+}
+
 public class GenericLogSearchParameters
 {
     [Range(1, int.MaxValue, ErrorMessage = "PageNumber must be greater than 0")]

--- a/DotNet/DataAcquisition.Domain/Application/Queries/SftpAcquisitionLogQueries.cs
+++ b/DotNet/DataAcquisition.Domain/Application/Queries/SftpAcquisitionLogQueries.cs
@@ -1,0 +1,117 @@
+using System.Diagnostics;
+using System.Linq.Expressions;
+using System.Reflection;
+using System.Text.Json;
+using LantanaGroup.Link.DataAcquisition.Domain.Application.Models.Api.QueryLog;
+using LantanaGroup.Link.DataAcquisition.Domain.Application.Models.Http;
+using LantanaGroup.Link.DataAcquisition.Domain.Infrastructure.Context;
+using LantanaGroup.Link.DataAcquisition.Domain.Infrastructure.Entities;
+using LantanaGroup.Link.Shared.Application.Enums;
+using LantanaGroup.Link.Shared.Application.Models.Responses;
+using LantanaGroup.Link.Shared.Application.Models.Telemetry;
+using LantanaGroup.Link.Shared.Application.SerDes;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace LantanaGroup.Link.DataAcquisition.Domain.Application.Queries;
+
+public interface ISftpAcquisitionLogQueries
+{
+    Task<SftpAcquisitionLog?> GetByIdAsync(long id, CancellationToken cancellationToken);
+    Task<PagedSftpAcquisitionLogModel> SearchAsync(SftpLogSearchParameters queryParameters,
+        CancellationToken cancellationToken);
+}
+
+public class SftpAcquisitionLogQueries(
+    ILogger<SftpAcquisitionLogQueries> logger, 
+    DataAcquisitionDbContext dbContext) : ISftpAcquisitionLogQueries
+{
+    public async Task<SftpAcquisitionLog?> GetByIdAsync(long id, CancellationToken cancellationToken)
+    {
+        using var activity = Activity.Current?.Source.StartActivity();
+        activity?.SetTag(DiagnosticNames.EntityId, id);
+        
+        try
+        {
+            var sftpLog = await dbContext.SftpAcquisitionLogs.FirstOrDefaultAsync(x => x.Id == id, cancellationToken: cancellationToken);
+            return sftpLog;
+        }
+        catch (Exception ex)
+        {
+            activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
+            logger.LogError(ex, "Error retrieving SFTP Acquisition Log with Id: {Id}", id);
+            throw;
+        }
+        
+    }
+
+    public async Task<PagedSftpAcquisitionLogModel> SearchAsync(SftpLogSearchParameters queryParameters, CancellationToken cancellationToken)
+    {
+        using var activity = Activity.Current?.Source.StartActivity();
+        activity?.AddTag(DiagnosticNames.SearchParameters,
+            JsonSerializer.Serialize(queryParameters, LinkFhirSerializerOptions.ActivityTagging));
+
+        try
+        {
+            var query = dbContext.SftpAcquisitionLogs
+                .AsNoTracking()
+                .AsQueryable();
+            
+            if(!string.IsNullOrEmpty(queryParameters.FacilityId))
+                query = query.Where(x => x.FacilityId == queryParameters.FacilityId);
+            
+            query = queryParameters.SortOrder switch
+            {
+                SortOrder.Ascending => query.OrderBy(SetSortBy<SftpAcquisitionLog>(queryParameters.SortBy)),
+                SortOrder.Descending => query.OrderByDescending(SetSortBy<SftpAcquisitionLog>(queryParameters.SortBy)),
+                _ => query
+            };
+                
+            var total = await query.CountAsync(cancellationToken);
+            
+            var logs = await query
+                .Skip((queryParameters.PageNumber - 1) * queryParameters.PageSize)
+                .Take(queryParameters.PageSize)
+                .ToListAsync(cancellationToken);
+
+            return new PagedSftpAcquisitionLogModel
+            {
+                Metadata = new PaginationMetadata
+                {
+                    PageNumber = queryParameters.PageNumber,
+                    PageSize = queryParameters.PageSize,
+                    TotalCount = total,
+                    TotalPages = (long)Math.Ceiling(total / (double)queryParameters.PageSize)
+                },
+                Records = logs.Select(x => x.ToModel()).ToList()
+            };
+        }
+        catch (Exception ex)
+        {
+            activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
+            logger.LogError(ex, "Error retrieving SFTP Acquisition Logs");
+            throw;
+        }
+    }
+    
+    private Expression<Func<T, object>> SetSortBy<T>(string? sortBy)
+    {
+        var type = typeof(T);
+        var inputSortBy = sortBy?.Trim();
+        var sortKey = "ProcessDate"; // default
+
+        if (!string.IsNullOrEmpty(inputSortBy))
+        {
+            var prop = type.GetProperty(inputSortBy, BindingFlags.Public | BindingFlags.Instance | BindingFlags.IgnoreCase);
+            if (prop != null)
+            {
+                sortKey = prop.Name;
+            }
+        }
+
+        var parameter = Expression.Parameter(type, "p");
+        var property = Expression.Property(parameter, sortKey);
+        var converted = Expression.Convert(property, typeof(object));
+        return Expression.Lambda<Func<T, object>>(converted, parameter);
+    }
+}

--- a/DotNet/DataAcquisition.Domain/Application/Queries/SftpAcquisitionLogQueries.cs
+++ b/DotNet/DataAcquisition.Domain/Application/Queries/SftpAcquisitionLogQueries.cs
@@ -18,6 +18,7 @@ namespace LantanaGroup.Link.DataAcquisition.Domain.Application.Queries;
 public interface ISftpAcquisitionLogQueries
 {
     Task<SftpAcquisitionLog?> GetByIdAsync(long id, CancellationToken cancellationToken);
+    Task<SftpAcquisitionLog?> GetByExternalIdAsync(Guid id, CancellationToken cancellationToken);
     Task<PagedSftpAcquisitionLogModel> SearchAsync(SftpLogSearchParameters queryParameters,
         CancellationToken cancellationToken);
 }
@@ -34,6 +35,25 @@ public class SftpAcquisitionLogQueries(
         try
         {
             var sftpLog = await dbContext.SftpAcquisitionLogs.FirstOrDefaultAsync(x => x.Id == id, cancellationToken: cancellationToken);
+            return sftpLog;
+        }
+        catch (Exception ex)
+        {
+            activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
+            logger.LogError(ex, "Error retrieving SFTP Acquisition Log with Id: {Id}", id);
+            throw;
+        }
+        
+    }
+    
+    public async Task<SftpAcquisitionLog?> GetByExternalIdAsync(Guid id, CancellationToken cancellationToken)
+    {
+        using var activity = Activity.Current?.Source.StartActivity();
+        activity?.SetTag(DiagnosticNames.EntityId, id);
+        
+        try
+        {
+            var sftpLog = await dbContext.SftpAcquisitionLogs.FirstOrDefaultAsync(x => x.ExternalId == id, cancellationToken: cancellationToken);
             return sftpLog;
         }
         catch (Exception ex)

--- a/DotNet/DataAcquisition.Domain/Extensions/GeneralStartupExtensions.cs
+++ b/DotNet/DataAcquisition.Domain/Extensions/GeneralStartupExtensions.cs
@@ -204,6 +204,7 @@ public static class GeneralStartupExtensions
         services.AddTransient<IEntityRepository<FhirQuery>, EntityRepository<FhirQuery, DataAcquisitionDbContext>>();
         services.AddTransient<IEntityRepository<DataAcquisitionLog>, EntityRepository<DataAcquisitionLog, DataAcquisitionDbContext>>();
         services.AddTransient<IEntityRepository<FhirQueryResourceType>, EntityRepository<FhirQueryResourceType, DataAcquisitionDbContext>>();
+        services.AddTransient<IEntityRepository<SftpAcquisitionLog>, EntityRepository<SftpAcquisitionLog, DataAcquisitionDbContext>>();
 
         //Database
         services.AddTransient<IDatabase, Database>();
@@ -213,6 +214,7 @@ public static class GeneralStartupExtensions
     {
         //Queries
         services.AddTransient<IDataAcquisitionLogQueries, DataAcquisitionLogQueries>();
+        services.AddTransient<ISftpAcquisitionLogQueries, SftpAcquisitionLogQueries>();
         services.AddTransient<IFhirQueryConfigurationQueries, FhirQueryConfigurationQueries>();
         services.AddTransient<IFhirQueryListConfigurationQueries, FhirQueryListConfigurationQueries>();
         services.AddTransient<IFhirQueryQueries, FhirQueryQueries>();
@@ -226,6 +228,7 @@ public static class GeneralStartupExtensions
         services.AddTransient<IReferenceResourcesManager, ReferenceResourcesManager>();
         services.AddTransient<IFhirQueryManager, FhirQueryManager>();
         services.AddTransient<IDataAcquisitionLogManager, DataAcquisitionLogManager>();
+        services.AddTransient<ISftpAcquisitionLogManager, SftpAcquisitionLogManager>();
     }
 
     public static void RegisterServices(this IServiceCollection services)

--- a/DotNet/DataAcquisition.Domain/Infrastructure/Context/DataAcquisitionDbContext.cs
+++ b/DotNet/DataAcquisition.Domain/Infrastructure/Context/DataAcquisitionDbContext.cs
@@ -191,7 +191,7 @@ public class DataAcquisitionDbContext : DbContext
                 .IsRequired()
                 .HasMaxLength(DataAcquisitionConstants.DatabaseSettings.MaxFacilityIdLength);
             
-            entity.Property(e => e.FacilityName)
+            entity.Property(e => e.FileName)
                 .HasMaxLength(DataAcquisitionConstants.DatabaseSettings.MaxFacilityNameLength);
 
             entity.HasIndex(i => i.FacilityId)

--- a/DotNet/DataAcquisition.Domain/Infrastructure/Context/DataAcquisitionDbContext.cs
+++ b/DotNet/DataAcquisition.Domain/Infrastructure/Context/DataAcquisitionDbContext.cs
@@ -12,6 +12,7 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Microsoft.Extensions.Configuration;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using LantanaGroup.Link.DataAcquisition.Domain.Settings;
 using RequestStatus = LantanaGroup.Link.DataAcquisition.Domain.Infrastructure.Models.Enums.RequestStatus;
 using ScheduledReport = LantanaGroup.Link.Shared.Application.Models.ScheduledReport;
 
@@ -30,6 +31,7 @@ public class DataAcquisitionDbContext : DbContext
     public DbSet<FhirQuery> FhirQueries { get; set; }
     public virtual DbSet<FhirQueryResourceType> FhirQueryResourceTypes { get; set; }
     public DbSet<DataAcquisitionLog> DataAcquisitionLogs { get; set; }
+    public DbSet<SftpAcquisitionLog> SftpAcquisitionLogs { get; set; }
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
@@ -152,7 +154,6 @@ public class DataAcquisitionDbContext : DbContext
 
             entity.HasIndex(e => new { e.ExecutionDate, e.Id })
                 .IsDescending()
-                .IsDescending()
                 .HasDatabaseName("IX_DataAcquisitionLogs_Paging_Default")
                 .IncludeProperties(
                     nameof(DataAcquisitionLog.Priority),
@@ -180,6 +181,22 @@ public class DataAcquisitionDbContext : DbContext
         modelBuilder.Entity<ResourceReferenceType>()
             .Property(b => b.QueryPhase)
             .HasConversion(new EnumToStringConverter<QueryPhase>());
+        
+        //-------------------SftpAcquisitionLog-------------------
+        modelBuilder.Entity<SftpAcquisitionLog>(entity =>
+        {
+            entity.Property(e => e.Id).ValueGeneratedOnAdd();
+
+            entity.Property(e => e.FacilityId)
+                .IsRequired()
+                .HasMaxLength(DataAcquisitionConstants.DatabaseSettings.MaxFacilityIdLength);
+            
+            entity.Property(e => e.FacilityName)
+                .HasMaxLength(DataAcquisitionConstants.DatabaseSettings.MaxFacilityNameLength);
+
+            entity.HasIndex(i => i.FacilityId)
+                .HasDatabaseName("IX_SftpAcquisitionLog_FacilityId");
+        });
 
         // Prefix and schema can be passed as parameters
         // Adds Quartz.NET SqlServer schema to EntityFrameworkCore

--- a/DotNet/DataAcquisition.Domain/Infrastructure/Database.cs
+++ b/DotNet/DataAcquisition.Domain/Infrastructure/Database.cs
@@ -14,6 +14,7 @@ namespace LantanaGroup.Link.DataAcquisition.Domain.Infrastructure
         IEntityRepository<ResourceReferenceType> ResourceReferenceTypeRepository { get; set; }
         IEntityRepository<FhirQueryResourceType> FhirQueryResourceTypeRepository { get; set; }
         IEntityRepository<DataAcquisitionLog> DataAcquisitionLogRepository { get; set; }
+        IEntityRepository<SftpAcquisitionLog> SftpAcquisitionLogRepository { get; set; }
         Task SaveChangesAsync();
     }
     public class Database : IDatabase
@@ -27,6 +28,7 @@ namespace LantanaGroup.Link.DataAcquisition.Domain.Infrastructure
         public IEntityRepository<ReferenceResources> ReferenceResourcesRepository { get; set; }
         public IEntityRepository<FhirQueryResourceType> FhirQueryResourceTypeRepository { get; set; }
         public IEntityRepository<DataAcquisitionLog> DataAcquisitionLogRepository { get; set; }
+        public IEntityRepository<SftpAcquisitionLog> SftpAcquisitionLogRepository { get; set; }
 
         public Database(
             DataAcquisitionDbContext context,
@@ -37,7 +39,8 @@ namespace LantanaGroup.Link.DataAcquisition.Domain.Infrastructure
             IEntityRepository<QueryPlan> queryPlans,
             IEntityRepository<DataAcquisitionLog> dataAcquisitionLogRepository,
             IEntityRepository<ResourceReferenceType> resourceReferenceTypeRepository,
-            IEntityRepository<FhirQueryResourceType> fhirQueryResourceTypeRepository)
+            IEntityRepository<FhirQueryResourceType> fhirQueryResourceTypeRepository,
+            IEntityRepository<SftpAcquisitionLog> sftpAcquisitionLogRepository)
         {
             _context = context;
             QueryPlanRepository = queryPlans;
@@ -48,6 +51,7 @@ namespace LantanaGroup.Link.DataAcquisition.Domain.Infrastructure
             DataAcquisitionLogRepository = dataAcquisitionLogRepository;
             ResourceReferenceTypeRepository = resourceReferenceTypeRepository;
             FhirQueryResourceTypeRepository = fhirQueryResourceTypeRepository;
+            SftpAcquisitionLogRepository = sftpAcquisitionLogRepository;
         }
 
         public async Task SaveChangesAsync()

--- a/DotNet/DataAcquisition.Domain/Infrastructure/Entities/SftpAcquisitionLog.cs
+++ b/DotNet/DataAcquisition.Domain/Infrastructure/Entities/SftpAcquisitionLog.cs
@@ -1,0 +1,23 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace LantanaGroup.Link.DataAcquisition.Domain.Infrastructure.Entities;
+
+[Table("SftpAcquisitionLog")]
+public class SftpAcquisitionLog
+{
+    [Key]
+    public long Id { get; set; }
+    
+    public Guid ExternalId { get; set; }
+    
+    public string FacilityId { get; set; } = string.Empty;
+    
+    public string FacilityName { get; set; } = string.Empty;
+    
+    public int PatientCount { get; set; }
+    
+    public int EncounterCount { get; set; }
+    
+    public DateTime ProcessDate { get; set; } = DateTime.UtcNow;
+}

--- a/DotNet/DataAcquisition.Domain/Infrastructure/Entities/SftpAcquisitionLog.cs
+++ b/DotNet/DataAcquisition.Domain/Infrastructure/Entities/SftpAcquisitionLog.cs
@@ -13,7 +13,7 @@ public class SftpAcquisitionLog
     
     public string FacilityId { get; set; } = string.Empty;
     
-    public string FacilityName { get; set; } = string.Empty;
+    public string FileName { get; set; } = string.Empty;
     
     public int PatientCount { get; set; }
     

--- a/DotNet/DataAcquisition.Domain/Migrations/20251218150340_AddSftpAcquisitionLog.Designer.cs
+++ b/DotNet/DataAcquisition.Domain/Migrations/20251218150340_AddSftpAcquisitionLog.Designer.cs
@@ -4,6 +4,7 @@ using LantanaGroup.Link.DataAcquisition.Domain.Infrastructure.Context;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace DataAcquisition.Domain.Migrations
 {
     [DbContext(typeof(DataAcquisitionDbContext))]
-    partial class DataAcquisitionDbContextModelSnapshot : ModelSnapshot
+    [Migration("20251218150340_AddSftpAcquisitionLog")]
+    partial class AddSftpAcquisitionLog
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/DotNet/DataAcquisition.Domain/Migrations/20251218150340_AddSftpAcquisitionLog.cs
+++ b/DotNet/DataAcquisition.Domain/Migrations/20251218150340_AddSftpAcquisitionLog.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace DataAcquisition.Domain.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddSftpAcquisitionLog : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "SftpAcquisitionLog",
+                columns: table => new
+                {
+                    Id = table.Column<long>(type: "bigint", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    ExternalId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    FacilityId = table.Column<string>(type: "nvarchar(250)", maxLength: 250, nullable: false),
+                    FacilityName = table.Column<string>(type: "nvarchar(1000)", maxLength: 1000, nullable: false),
+                    PatientCount = table.Column<int>(type: "int", nullable: false),
+                    EncounterCount = table.Column<int>(type: "int", nullable: false),
+                    ProcessDate = table.Column<DateTime>(type: "datetime2", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_SftpAcquisitionLog", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_SftpAcquisitionLog_FacilityId",
+                table: "SftpAcquisitionLog",
+                column: "FacilityId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "SftpAcquisitionLog");
+        }
+    }
+}

--- a/DotNet/DataAcquisition.Domain/Migrations/20251218150340_AddSftpAcquisitionLog.cs
+++ b/DotNet/DataAcquisition.Domain/Migrations/20251218150340_AddSftpAcquisitionLog.cs
@@ -19,7 +19,7 @@ namespace DataAcquisition.Domain.Migrations
                         .Annotation("SqlServer:Identity", "1, 1"),
                     ExternalId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
                     FacilityId = table.Column<string>(type: "nvarchar(250)", maxLength: 250, nullable: false),
-                    FacilityName = table.Column<string>(type: "nvarchar(1000)", maxLength: 1000, nullable: false),
+                    FileName = table.Column<string>(type: "nvarchar(1000)", maxLength: 1000, nullable: false),
                     PatientCount = table.Column<int>(type: "int", nullable: false),
                     EncounterCount = table.Column<int>(type: "int", nullable: false),
                     ProcessDate = table.Column<DateTime>(type: "datetime2", nullable: false)

--- a/DotNet/DataAcquisition.Domain/Settings/DataAcquisitionConstants.cs
+++ b/DotNet/DataAcquisition.Domain/Settings/DataAcquisitionConstants.cs
@@ -43,4 +43,10 @@ public static class DataAcquisitionConstants
         //public const string Basic = "basic";
         //public const string FormUrlEncoded = "application/x-www-form-urlencoded";
     }
+
+    public static class DatabaseSettings
+    {
+        public const int MaxFacilityIdLength = 250;
+        public const int MaxFacilityNameLength = 1000;
+    }
 }

--- a/DotNet/DataAcquisition/Controllers/SftpLogController.cs
+++ b/DotNet/DataAcquisition/Controllers/SftpLogController.cs
@@ -1,6 +1,5 @@
 using LantanaGroup.Link.DataAcquisition.Domain.Application.Managers;
 using LantanaGroup.Link.DataAcquisition.Domain.Application.Models.Api.QueryLog;
-using LantanaGroup.Link.DataAcquisition.Domain.Application.Models.Exceptions;
 using LantanaGroup.Link.DataAcquisition.Domain.Application.Models.Http;
 using LantanaGroup.Link.DataAcquisition.Domain.Application.Queries;
 using LantanaGroup.Link.DataAcquisition.Domain.Infrastructure.Models.Exceptions;
@@ -12,7 +11,7 @@ using Microsoft.AspNetCore.Mvc;
 namespace LantanaGroup.Link.DataAcquisition.Controllers;
 
 
-[Microsoft.AspNetCore.Components.Route("api/data/sftp-logs")]
+[Route("api/data/sftp-logs")]
 [Authorize(Policy = PolicyNames.IsLinkAdmin)]
 [ApiController]
 public class SftpLogController : ControllerBase
@@ -32,46 +31,6 @@ public class SftpLogController : ControllerBase
     }
     
     /// <summary>
-    /// Get SFTP log by ID
-    /// </summary>
-    /// <param name="id"></param>
-    /// <param name="cancellationToken"></param>
-    /// <returns></returns>
-    [HttpGet("{id}")]
-    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(SftpAcquisitionLogModel))]
-    [ProducesResponseType(StatusCodes.Status400BadRequest)]
-    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
-    [ProducesResponseType(StatusCodes.Status403Forbidden)]
-    [ProducesResponseType(StatusCodes.Status404NotFound)]
-    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-    public async Task<ActionResult<SftpAcquisitionLogModel>> GetSftpLogById(long id, CancellationToken cancellationToken = default)
-    {
-        // Validate log ID
-        if (id <= 0)
-            return BadRequest("Invalid log ID.");
-        
-        // Store httpContext so that it is not lost during processing
-        var httpContext = HttpContext;
-
-        try
-        {
-            var log = await _queries.GetByIdAsync(id, cancellationToken);
-        
-            if (log is null)
-                return NotFound();
-        
-            return Ok(log.ToModel());
-        }
-        catch (Exception)
-        {
-            return Problem(
-                title: "An error occurred while processing your request.",
-                detail: $"An unexpected error occurred while processing your request, please see the logs for more details. TraceId: {httpContext.TraceIdentifier}",
-                statusCode: StatusCodes.Status500InternalServerError);
-        }
-    }
-
-    /// <summary>
     /// Search SFTP logs
     /// </summary>
     /// <param name="queryParameters"></param>
@@ -83,7 +42,7 @@ public class SftpLogController : ControllerBase
     [ProducesResponseType(StatusCodes.Status403Forbidden)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     public async Task<ActionResult<IPagedModel<SftpAcquisitionLogModel>>> Search(
-        SftpLogSearchParameters? queryParameters, CancellationToken cancellationToken = default)
+        [FromQuery] SftpLogSearchParameters? queryParameters, CancellationToken cancellationToken = default)
     {
         // If no query parameters are specified, use default values
         queryParameters ??= new SftpLogSearchParameters
@@ -100,6 +59,48 @@ public class SftpLogController : ControllerBase
             var searchResults = await _queries.SearchAsync(queryParameters, cancellationToken);
             
             return Ok(searchResults);
+        }
+        catch (Exception)
+        {
+            return Problem(
+                title: "An error occurred while processing your request.",
+                detail: $"An unexpected error occurred while processing your request, please see the logs for more details. TraceId: {httpContext.TraceIdentifier}",
+                statusCode: StatusCodes.Status500InternalServerError);
+        }
+    }
+    
+    /// <summary>
+    /// Get SFTP log by external ID
+    /// </summary>
+    /// <param name="logId"></param>
+    /// <param name="cancellationToken"></param>
+    /// <returns></returns>
+    [HttpGet("{logId}")]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(SftpAcquisitionLogModel))]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+    public async Task<ActionResult<SftpAcquisitionLogModel>> GetSftpLogByExternalId(string logId, CancellationToken cancellationToken = default)
+    {
+        // Validate log ID
+        if (string.IsNullOrWhiteSpace(logId) || !Guid.TryParse(logId, out var id))
+        {
+            return BadRequest("Invalid log ID.");
+        }
+        
+        // Store httpContext so that it is not lost during processing
+        var httpContext = HttpContext;
+
+        try
+        {
+            var log = await _queries.GetByExternalIdAsync(id, cancellationToken);
+        
+            if (log is null)
+                return NotFound();
+        
+            return Ok(log.ToModel());
         }
         catch (Exception)
         {
@@ -131,7 +132,7 @@ public class SftpLogController : ControllerBase
         {
             var createdLog = await _manager.CreateAsync(req.ToModel(), cancellationToken);
 
-            return Created($"/api/data/sftp-logs/{createdLog.Id}", createdLog);
+            return Created($"/api/data/sftp-logs/{createdLog.ExternalId}", createdLog);
 
         }
         catch (ArgumentException ex)
@@ -152,23 +153,29 @@ public class SftpLogController : ControllerBase
     /// <summary>
     /// Update Process Date of SFTP log
     /// </summary>
-    /// <param name="externalId"></param>
+    /// <param name="logId"></param>
     /// <param name="req"></param>
     /// <param name="cancellationToken"></param>
     /// <returns></returns>
-    [HttpPut("{id}")]
+    [HttpPut("{logId}")]
     [ProducesResponseType(StatusCodes.Status201Created, Type = typeof(SftpAcquisitionLogModel))]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
     [ProducesResponseType(StatusCodes.Status403Forbidden)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-    public async Task<ActionResult> UpdateSftpLogProcessDate(Guid? externalId, UpdateSftpLogRequest req, CancellationToken cancellationToken = default)
+    public async Task<ActionResult> UpdateSftpLogProcessDate(string logId, UpdateSftpLogRequest req, CancellationToken cancellationToken = default)
     {
-        // Validate the request model id matches the id in the url
-        if (req.ExternalId != externalId)
+        // Validate log ID
+        if (string.IsNullOrWhiteSpace(logId) || !Guid.TryParse(logId, out var id))
         {
-            _logger.LogWarning("Sftp Log id in the request body ({RequestExternalId}) does not match the id in the url ({ExternalId}).", req.ExternalId, externalId);
+            return BadRequest("Invalid log ID.");
+        }
+        
+        // Validate the request model id matches the id in the url
+        if (req.ExternalId != id)
+        {
+            _logger.LogWarning("Sftp Log id in the request body ({RequestExternalId}) does not match the id in the url ({ExternalId}).", req.ExternalId, logId);
             return BadRequest("The ids in the request body and url do not match.");
         }
         

--- a/DotNet/DataAcquisition/Controllers/SftpLogController.cs
+++ b/DotNet/DataAcquisition/Controllers/SftpLogController.cs
@@ -184,7 +184,7 @@ public class SftpLogController : ControllerBase
 
         try
         {
-            var updatedLog = await _manager.UpdateProcessDateAsync(req.ToModel(), cancellationToken);
+            var updatedLog = await _manager.UserUpdateAsync(req.ToModel(), cancellationToken);
 
             return Accepted(updatedLog);
         }

--- a/DotNet/DataAcquisition/Controllers/SftpLogController.cs
+++ b/DotNet/DataAcquisition/Controllers/SftpLogController.cs
@@ -1,7 +1,9 @@
 using LantanaGroup.Link.DataAcquisition.Domain.Application.Managers;
 using LantanaGroup.Link.DataAcquisition.Domain.Application.Models.Api.QueryLog;
+using LantanaGroup.Link.DataAcquisition.Domain.Application.Models.Exceptions;
 using LantanaGroup.Link.DataAcquisition.Domain.Application.Models.Http;
 using LantanaGroup.Link.DataAcquisition.Domain.Application.Queries;
+using LantanaGroup.Link.DataAcquisition.Domain.Infrastructure.Models.Exceptions;
 using LantanaGroup.Link.Shared.Application.Interfaces.Models;
 using Link.Authorization.Policies;
 using Microsoft.AspNetCore.Authorization;
@@ -75,7 +77,7 @@ public class SftpLogController : ControllerBase
     /// <param name="queryParameters"></param>
     /// <param name="cancellationToken"></param>
     /// <returns></returns>
-    [HttpGet()]
+    [HttpGet]
     [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(IPagedModel<SftpAcquisitionLogModel>))]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
     [ProducesResponseType(StatusCodes.Status403Forbidden)]
@@ -106,8 +108,95 @@ public class SftpLogController : ControllerBase
                 detail: $"An unexpected error occurred while processing your request, please see the logs for more details. TraceId: {httpContext.TraceIdentifier}",
                 statusCode: StatusCodes.Status500InternalServerError);
         }
+    }
+    
+    /// <summary>
+    /// Create SFTP log
+    /// </summary>
+    /// <param name="req"></param>
+    /// <param name="cancellationToken"></param>
+    /// <returns></returns>
+    [HttpPost]
+    [ProducesResponseType(StatusCodes.Status201Created, Type = typeof(SftpAcquisitionLogModel))]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+    public async Task<ActionResult> CreateSftpLog(CreateSftpLogRequest req, CancellationToken cancellationToken = default)
+    {
+        // Store httpContext so that it is not lost during processing
+        var httpContext = HttpContext;
 
+        try
+        {
+            var createdLog = await _manager.CreateAsync(req.ToModel(), cancellationToken);
 
-        return Ok();
+            return Created($"/api/data/sftp-logs/{createdLog.Id}", createdLog);
+
+        }
+        catch (ArgumentException ex)
+        {
+            return BadRequest(ex.Message);
+        }
+        catch (Exception)
+        {
+            return Problem(
+                title: "An error occurred while processing your request.",
+                detail:
+                $"An unexpected error occurred while processing your request, please see the logs for more details. TraceId: {httpContext.TraceIdentifier}",
+                statusCode: StatusCodes.Status500InternalServerError
+            );
+        }
+    }
+
+    /// <summary>
+    /// Update Process Date of SFTP log
+    /// </summary>
+    /// <param name="externalId"></param>
+    /// <param name="req"></param>
+    /// <param name="cancellationToken"></param>
+    /// <returns></returns>
+    [HttpPut("{id}")]
+    [ProducesResponseType(StatusCodes.Status201Created, Type = typeof(SftpAcquisitionLogModel))]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+    public async Task<ActionResult> UpdateSftpLogProcessDate(Guid? externalId, UpdateSftpLogRequest req, CancellationToken cancellationToken = default)
+    {
+        // Validate the request model id matches the id in the url
+        if (req.ExternalId != externalId)
+        {
+            _logger.LogWarning("Sftp Log id in the request body ({RequestExternalId}) does not match the id in the url ({ExternalId}).", req.ExternalId, externalId);
+            return BadRequest("The ids in the request body and url do not match.");
+        }
+        
+        // Store httpContext so that it is not lost during processing
+        var httpContext = HttpContext;
+
+        try
+        {
+            var updatedLog = await _manager.UpdateProcessDateAsync(req.ToModel(), cancellationToken);
+
+            return Accepted(updatedLog);
+        }
+        catch (ArgumentException ex)
+        {
+            return BadRequest(ex.Message);
+        }
+        catch (DomainEntityNotFoundException ex)
+        {
+            return NotFound(ex.Message);
+        }
+        catch (Exception)
+        {
+            return Problem(
+                title: "An error occurred while processing your request.",
+                detail:
+                $"An unexpected error occurred while processing your request, please see the logs for more details. TraceId: {httpContext.TraceIdentifier}",
+                statusCode: StatusCodes.Status500InternalServerError
+            );
+        }
     }
 }

--- a/DotNet/DataAcquisition/Controllers/SftpLogController.cs
+++ b/DotNet/DataAcquisition/Controllers/SftpLogController.cs
@@ -4,6 +4,7 @@ using LantanaGroup.Link.DataAcquisition.Domain.Application.Models.Http;
 using LantanaGroup.Link.DataAcquisition.Domain.Application.Queries;
 using LantanaGroup.Link.DataAcquisition.Domain.Infrastructure.Models.Exceptions;
 using LantanaGroup.Link.Shared.Application.Interfaces.Models;
+using LantanaGroup.Link.Shared.Application.Services.Security;
 using Link.Authorization.Policies;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -175,7 +176,7 @@ public class SftpLogController : ControllerBase
         // Validate the request model id matches the id in the url
         if (req.ExternalId != id)
         {
-            _logger.LogWarning("Sftp Log id in the request body ({RequestExternalId}) does not match the id in the url ({ExternalId}).", req.ExternalId, logId);
+            _logger.LogWarning("Sftp Log id in the request body ({RequestExternalId}) does not match the id in the url ({ExternalId}).", req.ExternalId, logId.Sanitize());
             return BadRequest("The ids in the request body and url do not match.");
         }
         

--- a/DotNet/DataAcquisition/Controllers/SftpLogController.cs
+++ b/DotNet/DataAcquisition/Controllers/SftpLogController.cs
@@ -1,0 +1,113 @@
+using LantanaGroup.Link.DataAcquisition.Domain.Application.Managers;
+using LantanaGroup.Link.DataAcquisition.Domain.Application.Models.Api.QueryLog;
+using LantanaGroup.Link.DataAcquisition.Domain.Application.Models.Http;
+using LantanaGroup.Link.DataAcquisition.Domain.Application.Queries;
+using LantanaGroup.Link.Shared.Application.Interfaces.Models;
+using Link.Authorization.Policies;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace LantanaGroup.Link.DataAcquisition.Controllers;
+
+
+[Microsoft.AspNetCore.Components.Route("api/data/sftp-logs")]
+[Authorize(Policy = PolicyNames.IsLinkAdmin)]
+[ApiController]
+public class SftpLogController : ControllerBase
+{
+    private readonly ILogger<SftpLogController> _logger;
+    private readonly ISftpAcquisitionLogManager _manager;
+    private readonly ISftpAcquisitionLogQueries _queries;
+
+    private const int DefaultLogPageSize = 20;
+    private const string DefaultSortBy = "ProcessDate";
+    
+    public SftpLogController(ILogger<SftpLogController> logger, ISftpAcquisitionLogManager manager, ISftpAcquisitionLogQueries queries)
+    {
+        _logger = logger;
+        _manager = manager;
+        _queries = queries;
+    }
+    
+    /// <summary>
+    /// Get SFTP log by ID
+    /// </summary>
+    /// <param name="id"></param>
+    /// <param name="cancellationToken"></param>
+    /// <returns></returns>
+    [HttpGet("{id}")]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(SftpAcquisitionLogModel))]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+    public async Task<ActionResult<SftpAcquisitionLogModel>> GetSftpLogById(long id, CancellationToken cancellationToken = default)
+    {
+        // Validate log ID
+        if (id <= 0)
+            return BadRequest("Invalid log ID.");
+        
+        // Store httpContext so that it is not lost during processing
+        var httpContext = HttpContext;
+
+        try
+        {
+            var log = await _queries.GetByIdAsync(id, cancellationToken);
+        
+            if (log is null)
+                return NotFound();
+        
+            return Ok(log.ToModel());
+        }
+        catch (Exception)
+        {
+            return Problem(
+                title: "An error occurred while processing your request.",
+                detail: $"An unexpected error occurred while processing your request, please see the logs for more details. TraceId: {httpContext.TraceIdentifier}",
+                statusCode: StatusCodes.Status500InternalServerError);
+        }
+    }
+
+    /// <summary>
+    /// Search SFTP logs
+    /// </summary>
+    /// <param name="queryParameters"></param>
+    /// <param name="cancellationToken"></param>
+    /// <returns></returns>
+    [HttpGet()]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(IPagedModel<SftpAcquisitionLogModel>))]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+    public async Task<ActionResult<IPagedModel<SftpAcquisitionLogModel>>> Search(
+        SftpLogSearchParameters? queryParameters, CancellationToken cancellationToken = default)
+    {
+        // If no query parameters are specified, use default values
+        queryParameters ??= new SftpLogSearchParameters
+        {
+            SortBy = DefaultSortBy,
+            PageSize = DefaultLogPageSize
+        };
+        
+        // Store httpContext so that it is not lost during processing
+        var httpContext = HttpContext;
+
+        try
+        {
+            var searchResults = await _queries.SearchAsync(queryParameters, cancellationToken);
+            
+            return Ok(searchResults);
+        }
+        catch (Exception)
+        {
+            return Problem(
+                title: "An error occurred while processing your request.",
+                detail: $"An unexpected error occurred while processing your request, please see the logs for more details. TraceId: {httpContext.TraceIdentifier}",
+                statusCode: StatusCodes.Status500InternalServerError);
+        }
+
+
+        return Ok();
+    }
+}

--- a/DotNet/DataAcquisition/Program.cs
+++ b/DotNet/DataAcquisition/Program.cs
@@ -20,7 +20,6 @@ using LantanaGroup.Link.Shared.Application.Models.Configs;
 using LantanaGroup.Link.Shared.Settings;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Diagnostics.HealthChecks;
-using Microsoft.EntityFrameworkCore;
 using Microsoft.OpenApi.Models;
 using System.Reflection;
 using System.Text.Json.Serialization;

--- a/DotNet/Shared/Application/Models/Telemetry/DiagnosticNames.cs
+++ b/DotNet/Shared/Application/Models/Telemetry/DiagnosticNames.cs
@@ -45,6 +45,7 @@
 
         //Diagnostic tags Searching
         public const string SearchText = "search.text";
+        public const string SearchParameters = "search.parameters";
         public const string FacilityFilter = "facility.filter";
         public const string CorrelationFilter = "correlation.filter";
         public const string ServiceFilter = "service.filter";

--- a/DotNet/Shared/Application/Models/Telemetry/DiagnosticNames.cs
+++ b/DotNet/Shared/Application/Models/Telemetry/DiagnosticNames.cs
@@ -6,6 +6,7 @@
         public const string StackTrace = "stack.trace";
         public const string Service = "service";
         public const string CorrelationId = "correlation.id";
+        public const string EntityId = "entity.id";
         public const string ReportId = "report.id";
         public const string ReportTrackingId = "report.tracking.id";
         public const string ReportScheduledId = "report.scheduled.id";

--- a/DotNet/Shared/Application/SerDes/LinkFhirSerializerOptions.cs
+++ b/DotNet/Shared/Application/SerDes/LinkFhirSerializerOptions.cs
@@ -54,5 +54,15 @@ namespace LantanaGroup.Link.Shared.Application.SerDes
                     }                                  
             } 
         }
+        
+        public static JsonSerializerOptions ActivityTagging { get; } = new()
+        {
+            ReferenceHandler = System.Text.Json.Serialization.ReferenceHandler.Preserve,
+            WriteIndented =  true,
+            Converters =
+            {
+                new System.Text.Json.Serialization.JsonStringEnumConverter()
+            }
+        };
     }
 }


### PR DESCRIPTION
### 🛠️ Description of Changes
This feature introduces a new acquisition log for SFTP-based patient census capture. The SFTP Acquisition Log captures key metrics about data acquisition operations, including facility information, patient counts, encounter counts, and processing timestamps.

### 🧪 Testing Performed
1. **ProcessDate Validation**:
   - On Create: ProcessDate MUST be in the future (greater than DateTime.Now)
   - On Update (ProcessDate): ProcessDate MUST be in the future

2. **Count Initialization**:
   - PatientCount and EncounterCount are always set to 0 on creation (ignoring any provided values)
   - These fields are only updated through the UpdateAsync method (not exposed via API yet)

3. **ExternalId Handling**:
   - Auto-generated as new GUID on creation
   - Used as the primary identifier in API endpoints (not the internal Id)
   - Update operations use ExternalId to locate records

4. **Update Operations**:
   - Full update (UpdateAsync): Updates PatientCount, EncounterCount, and ProcessDate by ExternalId
   - Partial update (UpdateProcessDateAsync): Only updates ProcessDate by ExternalId

### 🧑‍🔬 Unit Testing
- [ ] I have written or updated unit tests to cover my changes

### 📓 Documentation Updated
Please update any relevant sections in the project documentation that were impacted by the changes in the PR.
