### PR TITLE
LNK-4659: add link admin to roles - measure

### DIFF
--- a/Java/measureeval/src/main/java/com/lantanagroup/link/measureeval/controllers/MeasureDefinitionController.java
+++ b/Java/measureeval/src/main/java/com/lantanagroup/link/measureeval/controllers/MeasureDefinitionController.java
@@ -31,7 +31,7 @@ import java.util.List;
 
 @RestController
 @RequestMapping("/api/measureeval/measure-definition")
-@PreAuthorize("hasRole('LinkUser')")
+@PreAuthorize("hasAnyRole('LinkUser', 'LinkAdministrator')")
 public class MeasureDefinitionController {
 
     private final Logger _logger = LoggerFactory.getLogger(MeasureDefinitionController.class);

--- a/Java/measureeval/src/main/java/com/lantanagroup/link/measureeval/controllers/PatientController.java
+++ b/Java/measureeval/src/main/java/com/lantanagroup/link/measureeval/controllers/PatientController.java
@@ -13,7 +13,7 @@ import org.springframework.web.server.ResponseStatusException;
 
 @RestController
 @RequestMapping("/api/measureeval/patient")
-@PreAuthorize("hasRole('LinkUser')")
+@PreAuthorize("hasAnyRole('LinkUser', 'LinkAdministrator')")
 public class PatientController {
     private final PatientReportingEvaluationStatusRepository patientReportingEvaluationStatusRepository;
     private final PatientStatusBundler patientStatusBundler;


### PR DESCRIPTION
### 🛠️ Description of Changes
Update allowable roles in measure def controllers.

### 🧪 Testing Performed
Will test in cloud where auth is enabled.

### 🧑‍🔬 Unit Testing
- [ ] I have written or updated unit tests to cover my changes

### 📓 Documentation Updated
none.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded access controls across API controllers to permit LinkAdministrator role users the same level of access as LinkUser role holders, enhancing administrative capabilities for system resource management.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->