### PR TITLE
LNK-4705: Resource queries not populated with all parameters

### DIFF
--- a/DotNet/DataAcquisition.Domain/Application/Factories/ParameterFactories/ILiteralParameterFactory.cs
+++ b/DotNet/DataAcquisition.Domain/Application/Factories/ParameterFactories/ILiteralParameterFactory.cs
@@ -1,0 +1,9 @@
+﻿using LantanaGroup.Link.DataAcquisition.Domain.Application.Models.Factory.ParameterQuery;
+using LantanaGroup.Link.DataAcquisition.Domain.Infrastructure.Models.QueryConfig.Parameter;
+
+namespace LantanaGroup.Link.DataAcquisition.Domain.Application.Factories.ParameterFactories;
+
+public interface ILiteralParameterFactory
+{
+    ParameterFactoryResult? Build(LiteralParameter parameter);
+}

--- a/DotNet/DataAcquisition.Domain/Application/Factories/ParameterFactories/IResourceIdParameterFactory.cs
+++ b/DotNet/DataAcquisition.Domain/Application/Factories/ParameterFactories/IResourceIdParameterFactory.cs
@@ -1,0 +1,11 @@
+﻿using LantanaGroup.Link.DataAcquisition.Domain.Application.Models.Api.Requests;
+using LantanaGroup.Link.DataAcquisition.Domain.Application.Models.Factory.ParameterQuery;
+using LantanaGroup.Link.DataAcquisition.Domain.Application.Queries;
+using LantanaGroup.Link.DataAcquisition.Domain.Infrastructure.Models.QueryConfig.Parameter;
+
+namespace LantanaGroup.Link.DataAcquisition.Domain.Application.Factories.ParameterFactories;
+
+public interface IResourceIdParameterFactory
+{
+    Task<ParameterFactoryResult?> Build(ResourceIdsParameter parameter, GetPatientDataRequest request, IDataAcquisitionLogQueries dataAcquisitionLogQueries);
+}

--- a/DotNet/DataAcquisition.Domain/Application/Factories/ParameterFactories/IVariableParameterFactory.cs
+++ b/DotNet/DataAcquisition.Domain/Application/Factories/ParameterFactories/IVariableParameterFactory.cs
@@ -1,0 +1,11 @@
+﻿using LantanaGroup.Link.DataAcquisition.Domain.Application.Models.Api.Requests;
+using LantanaGroup.Link.DataAcquisition.Domain.Application.Models.Factory.ParameterQuery;
+using LantanaGroup.Link.DataAcquisition.Domain.Infrastructure.Models.QueryConfig.Parameter;
+using LantanaGroup.Link.Shared.Application.Models;
+
+namespace LantanaGroup.Link.DataAcquisition.Domain.Application.Factories.ParameterFactories;
+
+public interface IVariableParameterFactory
+{
+    ParameterFactoryResult? Build(VariableParameter parameter, GetPatientDataRequest request, ScheduledReport scheduledReport, string lookback);
+}

--- a/DotNet/DataAcquisition.Domain/Application/Factories/ParameterFactories/LiteralParameterFactory.cs
+++ b/DotNet/DataAcquisition.Domain/Application/Factories/ParameterFactories/LiteralParameterFactory.cs
@@ -1,14 +1,26 @@
 ﻿using LantanaGroup.Link.DataAcquisition.Domain.Application.Models.Factory.ParameterQuery;
 using LantanaGroup.Link.DataAcquisition.Domain.Infrastructure.Models.QueryConfig.Parameter;
+using Microsoft.Extensions.Logging;
 
 namespace LantanaGroup.Link.DataAcquisition.Domain.Application.Factories.ParameterFactories;
 
 public class LiteralParameterFactory
 {
-    public static ParameterFactoryResult Build(LiteralParameter parameter)
+    private static readonly ILogger<LiteralParameterFactory> _logger;
+
+    static LiteralParameterFactory()
+    {
+        using var loggerFactory = LoggerFactory.Create(builder => builder.AddConsole());
+        _logger = loggerFactory.CreateLogger<LiteralParameterFactory>();
+    }
+
+    public static ParameterFactoryResult? Build(LiteralParameter parameter)
     {
         if (string.IsNullOrWhiteSpace(parameter.Name) || string.IsNullOrWhiteSpace(parameter.Literal))
+        {
+            _logger.LogWarning("LiteralParameter validation failed: Name or Literal is null or whitespace. Name: {Name}, Literal: {Literal}", parameter.Name, parameter.Literal);
             return null;
+        }
 
         return new ParameterFactoryResult(parameter.Name, parameter.Literal);
     }

--- a/DotNet/DataAcquisition.Domain/Application/Factories/ParameterFactories/LiteralParameterFactory.cs
+++ b/DotNet/DataAcquisition.Domain/Application/Factories/ParameterFactories/LiteralParameterFactory.cs
@@ -4,17 +4,16 @@ using Microsoft.Extensions.Logging;
 
 namespace LantanaGroup.Link.DataAcquisition.Domain.Application.Factories.ParameterFactories;
 
-public class LiteralParameterFactory
+public class LiteralParameterFactory : ILiteralParameterFactory
 {
-    private static readonly ILogger<LiteralParameterFactory> _logger;
+    private readonly ILogger<LiteralParameterFactory> _logger;
 
-    static LiteralParameterFactory()
+    public LiteralParameterFactory(ILogger<LiteralParameterFactory> logger)
     {
-        using var loggerFactory = LoggerFactory.Create(builder => builder.AddConsole());
-        _logger = loggerFactory.CreateLogger<LiteralParameterFactory>();
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
-    public static ParameterFactoryResult? Build(LiteralParameter parameter)
+    public ParameterFactoryResult? Build(LiteralParameter parameter)
     {
         if (string.IsNullOrWhiteSpace(parameter.Name) || string.IsNullOrWhiteSpace(parameter.Literal))
         {

--- a/DotNet/DataAcquisition.Domain/Application/Factories/ParameterFactories/ResourceIdParameterFactory.cs
+++ b/DotNet/DataAcquisition.Domain/Application/Factories/ParameterFactories/ResourceIdParameterFactory.cs
@@ -6,16 +6,15 @@ using Microsoft.Extensions.Logging;
 
 namespace LantanaGroup.Link.DataAcquisition.Domain.Application.Factories.ParameterFactories;
 
-public class ResourceIdParameterFactory
+public class ResourceIdParameterFactory : IResourceIdParameterFactory
 {
-    private static readonly ILogger<ResourceIdParameterFactory> _logger;
+    private readonly ILogger<ResourceIdParameterFactory> _logger;
 
-    static ResourceIdParameterFactory()
+    public ResourceIdParameterFactory(ILogger<ResourceIdParameterFactory> logger)
     {
-        using var loggerFactory = LoggerFactory.Create(builder => builder.AddConsole());
-        _logger = loggerFactory.CreateLogger<ResourceIdParameterFactory>();
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
-    public static async Task<ParameterFactoryResult?> Build(ResourceIdsParameter parameter, GetPatientDataRequest request, IDataAcquisitionLogQueries dataAcquisitionLogQueries)
+    public async Task<ParameterFactoryResult?> Build(ResourceIdsParameter parameter, GetPatientDataRequest request, IDataAcquisitionLogQueries dataAcquisitionLogQueries)
     {
         List<string> resourceIds = await
             dataAcquisitionLogQueries.GetResourceIdsForReportPatient(request.CorrelationId, request.FacilityId, parameter.Resource);

--- a/DotNet/DataAcquisition.Domain/Application/Factories/ParameterFactories/ResourceIdParameterFactory.cs
+++ b/DotNet/DataAcquisition.Domain/Application/Factories/ParameterFactories/ResourceIdParameterFactory.cs
@@ -1,26 +1,36 @@
 ﻿using LantanaGroup.Link.DataAcquisition.Domain.Application.Models.Api.Requests;
 using LantanaGroup.Link.DataAcquisition.Domain.Application.Models.Factory.ParameterQuery;
+using LantanaGroup.Link.DataAcquisition.Domain.Application.Queries;
 using LantanaGroup.Link.DataAcquisition.Domain.Infrastructure.Models.QueryConfig.Parameter;
+using Microsoft.Extensions.Logging;
 
 namespace LantanaGroup.Link.DataAcquisition.Domain.Application.Factories.ParameterFactories;
 
 public class ResourceIdParameterFactory
 {
-    public static ParameterFactoryResult Build(ResourceIdsParameter parameter, GetPatientDataRequest request, List<string> resourceIds)
+    private static readonly ILogger<ResourceIdParameterFactory> _logger;
+
+    static ResourceIdParameterFactory()
     {
+        using var loggerFactory = LoggerFactory.Create(builder => builder.AddConsole());
+        _logger = loggerFactory.CreateLogger<ResourceIdParameterFactory>();
+    }
+    public static async Task<ParameterFactoryResult?> Build(ResourceIdsParameter parameter, GetPatientDataRequest request, IDataAcquisitionLogQueries dataAcquisitionLogQueries)
+    {
+        List<string> resourceIds = await
+            dataAcquisitionLogQueries.GetResourceIdsForReportPatient(request.CorrelationId, request.FacilityId, parameter.Resource);
+        
         if (resourceIds == null || !resourceIds.Any())
         {
+            _logger.LogWarning("ResourceIdsParameter validation failed: resourceIds is null or empty. Parameter Name: {Name}", parameter.Name);
             return null;
         }
+        
+        Int32.TryParse(parameter.Paged, out int pageSize);
 
-        if (string.IsNullOrWhiteSpace(parameter.Paged))
+        if (!string.IsNullOrWhiteSpace(parameter.Paged) && pageSize > 0 && resourceIds.Count > pageSize)
         {
-            int pageSize = int.Parse(parameter.Paged);
             var pagedEntries = resourceIds.Chunk(pageSize).ToList();
-
-            if (!pagedEntries.Any())
-                return null;
-
             return new ParameterFactoryResult(parameter.Name, null, true, pagedEntries);
         }
 

--- a/DotNet/DataAcquisition.Domain/Application/Factories/ParameterFactories/VariableParameterFactory.cs
+++ b/DotNet/DataAcquisition.Domain/Application/Factories/ParameterFactories/VariableParameterFactory.cs
@@ -8,17 +8,16 @@ using Microsoft.Extensions.Logging;
 
 namespace LantanaGroup.Link.DataAcquisition.Domain.Application.Factories.ParameterFactories;
 
-public class VariableParameterFactory
+public class VariableParameterFactory : IVariableParameterFactory
 {
-    private static readonly ILogger<VariableParameterFactory> _logger;
+    private readonly ILogger<VariableParameterFactory> _logger;
 
-    static VariableParameterFactory()
+    public VariableParameterFactory(ILogger<VariableParameterFactory> logger)
     {
-        using var loggerFactory = LoggerFactory.Create(builder => builder.AddConsole());
-        _logger = loggerFactory.CreateLogger<VariableParameterFactory>();
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
-    public static ParameterFactoryResult? Build(VariableParameter parameter, GetPatientDataRequest request, ScheduledReport scheduledReport, string lookback)
+    public ParameterFactoryResult? Build(VariableParameter parameter, GetPatientDataRequest request, ScheduledReport scheduledReport, string lookback)
     {
         ParameterFactoryResult parameterFactoryResult = parameter.Variable switch
         {

--- a/DotNet/DataAcquisition.Domain/Application/Factories/ParameterFactories/VariableParameterFactory.cs
+++ b/DotNet/DataAcquisition.Domain/Application/Factories/ParameterFactories/VariableParameterFactory.cs
@@ -1,15 +1,24 @@
-﻿using LantanaGroup.Link.DataAcquisition.Domain.Application.Models.Api.Requests;
+﻿using System.Globalization;
+using System.Xml;
+using LantanaGroup.Link.DataAcquisition.Domain.Application.Models.Api.Requests;
 using LantanaGroup.Link.DataAcquisition.Domain.Application.Models.Factory.ParameterQuery;
 using LantanaGroup.Link.DataAcquisition.Domain.Infrastructure.Models.QueryConfig.Parameter;
 using LantanaGroup.Link.Shared.Application.Models;
-using System.Globalization;
-using System.Xml;
+using Microsoft.Extensions.Logging;
 
 namespace LantanaGroup.Link.DataAcquisition.Domain.Application.Factories.ParameterFactories;
 
 public class VariableParameterFactory
 {
-    public static ParameterFactoryResult Build(VariableParameter parameter, GetPatientDataRequest request, ScheduledReport scheduledReport, string lookback)
+    private static readonly ILogger<VariableParameterFactory> _logger;
+
+    static VariableParameterFactory()
+    {
+        using var loggerFactory = LoggerFactory.Create(builder => builder.AddConsole());
+        _logger = loggerFactory.CreateLogger<VariableParameterFactory>();
+    }
+
+    public static ParameterFactoryResult? Build(VariableParameter parameter, GetPatientDataRequest request, ScheduledReport scheduledReport, string lookback)
     {
         ParameterFactoryResult parameterFactoryResult = parameter.Variable switch
         {
@@ -23,7 +32,14 @@ public class VariableParameterFactory
         if (string.IsNullOrWhiteSpace(parameterFactoryResult.key)
             || (string.IsNullOrWhiteSpace(parameterFactoryResult.value)
             || (parameterFactoryResult.paged && parameterFactoryResult.values?.Count == 0)))
+        {
+            _logger.LogWarning("VariableParameter validation failed: Key is null/whitespace, Value is null/whitespace, or Paged with empty values. Key: {Key}, Value: {Value}, Paged: {Paged}, ValuesCount: {ValuesCount}", 
+                parameterFactoryResult.key, 
+                parameterFactoryResult.value, 
+                parameterFactoryResult.paged, 
+                parameterFactoryResult.values?.Count);
             return null;
+        }
 
         return parameterFactoryResult;
     }

--- a/DotNet/DataAcquisition.Domain/Application/Factories/QueryFactories/IParameterQueryFactory.cs
+++ b/DotNet/DataAcquisition.Domain/Application/Factories/QueryFactories/IParameterQueryFactory.cs
@@ -1,0 +1,12 @@
+﻿using LantanaGroup.Link.DataAcquisition.Domain.Application.Models.Api.Requests;
+using LantanaGroup.Link.DataAcquisition.Domain.Application.Models.Factory.ParameterQuery;
+using LantanaGroup.Link.DataAcquisition.Domain.Application.Queries;
+using LantanaGroup.Link.DataAcquisition.Domain.Infrastructure.Models.QueryConfig;
+using LantanaGroup.Link.Shared.Application.Models;
+
+namespace LantanaGroup.Link.DataAcquisition.Domain.Application.Factories.QueryFactories;
+
+public interface IParameterQueryFactory
+{
+    Task<ParameterQueryFactoryResult> Build(ParameterQueryConfig config, GetPatientDataRequest request, ScheduledReport scheduledReport, string lookback, IDataAcquisitionLogQueries dataAcquisitionLogQueries);
+}

--- a/DotNet/DataAcquisition.Domain/Application/Factories/QueryFactories/ParameterQueryFactory.cs
+++ b/DotNet/DataAcquisition.Domain/Application/Factories/QueryFactories/ParameterQueryFactory.cs
@@ -10,17 +10,22 @@ using OperationType = LantanaGroup.Link.DataAcquisition.Domain.Infrastructure.Mo
 
 namespace LantanaGroup.Link.DataAcquisition.Domain.Application.Factories.QueryFactories;
 
-public class ParameterQueryFactory
+public class ParameterQueryFactory : IParameterQueryFactory
 {
-    private static readonly ILogger<ParameterQueryFactory> _logger;
+    private readonly ILogger<ParameterQueryFactory> _logger;
+    private readonly ILiteralParameterFactory _literalParameterFactory;
+    private readonly IVariableParameterFactory _variableParameterFactory;
+    private readonly IResourceIdParameterFactory _resourceIdParameterFactory;
 
-    static ParameterQueryFactory()
+    public ParameterQueryFactory(ILogger<ParameterQueryFactory> logger, ILiteralParameterFactory literalParameterFactory, IVariableParameterFactory variableParameterFactory, IResourceIdParameterFactory resourceIdParameterFactory)
     {
-        using var loggerFactory = LoggerFactory.Create(builder => builder.AddConsole());
-        _logger = loggerFactory.CreateLogger<ParameterQueryFactory>();
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _literalParameterFactory = literalParameterFactory ?? throw new ArgumentNullException(nameof(literalParameterFactory));
+        _variableParameterFactory = variableParameterFactory ?? throw new ArgumentNullException(nameof(variableParameterFactory));
+        _resourceIdParameterFactory = resourceIdParameterFactory ?? throw new ArgumentNullException(nameof(resourceIdParameterFactory));
     }
 
-    public static async Task<ParameterQueryFactoryResult> Build(ParameterQueryConfig config, GetPatientDataRequest request, ScheduledReport scheduledReport, string lookback, IDataAcquisitionLogQueries dataAcquisitionLogQueries)
+    public async Task<ParameterQueryFactoryResult> Build(ParameterQueryConfig config, GetPatientDataRequest request, ScheduledReport scheduledReport, string lookback, IDataAcquisitionLogQueries dataAcquisitionLogQueries)
     {
         var isPaged = false;
         var searchParams = new List<KeyValuePair<string, string>>();
@@ -30,9 +35,9 @@ public class ParameterQueryFactory
         {
             ParameterFactoryResult? searchParam = parameter switch
             {
-                LiteralParameter literalParameter => LiteralParameterFactory.Build(literalParameter),
-                VariableParameter variableParameter => VariableParameterFactory.Build(variableParameter, request, scheduledReport, lookback),
-                ResourceIdsParameter idsParameter => await ResourceIdParameterFactory.Build(idsParameter, request, dataAcquisitionLogQueries),
+                LiteralParameter literalParameter => _literalParameterFactory.Build(literalParameter),
+                VariableParameter variableParameter => _variableParameterFactory.Build(variableParameter, request, scheduledReport, lookback),
+                ResourceIdsParameter idsParameter => await _resourceIdParameterFactory.Build(idsParameter, request, dataAcquisitionLogQueries),
                 _ => throw new Exception("Unable to determine parameter type."),
             };
 

--- a/DotNet/DataAcquisition.Domain/Application/Factories/QueryFactories/ParameterQueryFactory.cs
+++ b/DotNet/DataAcquisition.Domain/Application/Factories/QueryFactories/ParameterQueryFactory.cs
@@ -1,50 +1,81 @@
-﻿using LantanaGroup.Link.DataAcquisition.Domain.Infrastructure.Models.QueryConfig;
-using Hl7.Fhir.Rest;
-using LantanaGroup.Link.DataAcquisition.Domain.Application.Factories.ParameterFactories;
-using LantanaGroup.Link.DataAcquisition.Domain.Application.Models.Factory.ParameterQuery;
-using OperationType = LantanaGroup.Link.DataAcquisition.Domain.Infrastructure.Models.QueryConfig.OperationType;
-using LantanaGroup.Link.Shared.Application.Models;
-using LantanaGroup.Link.DataAcquisition.Domain.Infrastructure.Models.QueryConfig.Parameter;
+﻿using LantanaGroup.Link.DataAcquisition.Domain.Application.Factories.ParameterFactories;
 using LantanaGroup.Link.DataAcquisition.Domain.Application.Models.Api.Requests;
+using LantanaGroup.Link.DataAcquisition.Domain.Application.Models.Factory.ParameterQuery;
+using LantanaGroup.Link.DataAcquisition.Domain.Application.Queries;
+using LantanaGroup.Link.DataAcquisition.Domain.Infrastructure.Models.QueryConfig;
+using LantanaGroup.Link.DataAcquisition.Domain.Infrastructure.Models.QueryConfig.Parameter;
+using LantanaGroup.Link.Shared.Application.Models;
+using Microsoft.Extensions.Logging;
+using OperationType = LantanaGroup.Link.DataAcquisition.Domain.Infrastructure.Models.QueryConfig.OperationType;
 
 namespace LantanaGroup.Link.DataAcquisition.Domain.Application.Factories.QueryFactories;
 
 public class ParameterQueryFactory
 {
-    public static ParameterQueryFactoryResult Build(ParameterQueryConfig config, GetPatientDataRequest request, ScheduledReport scheduledReport, string lookback, List<string> resourceIds = null)
+    private static readonly ILogger<ParameterQueryFactory> _logger;
+
+    static ParameterQueryFactory()
+    {
+        using var loggerFactory = LoggerFactory.Create(builder => builder.AddConsole());
+        _logger = loggerFactory.CreateLogger<ParameterQueryFactory>();
+    }
+
+    public static async Task<ParameterQueryFactoryResult> Build(ParameterQueryConfig config, GetPatientDataRequest request, ScheduledReport scheduledReport, string lookback, IDataAcquisitionLogQueries dataAcquisitionLogQueries)
     {
         var isPaged = false;
-        var searchParams = new SearchParams();
-        List<SearchParams> searchParamList = new List<SearchParams>();
+        var searchParams = new List<KeyValuePair<string, string>>();
+        List<List<KeyValuePair<string, string>>> searchParamList = new List<List<KeyValuePair<string, string>>>();
 
         foreach (var parameter in config.Parameters)
         {
-            ParameterFactoryResult searchParam = parameter switch
+            ParameterFactoryResult? searchParam = parameter switch
             {
-                LiteralParameter => LiteralParameterFactory.Build((LiteralParameter)parameter),
-                VariableParameter => VariableParameterFactory.Build((VariableParameter)parameter, request, scheduledReport, lookback),
-                ResourceIdsParameter => ResourceIdParameterFactory.Build((ResourceIdsParameter)parameter, request, resourceIds),
+                LiteralParameter literalParameter => LiteralParameterFactory.Build(literalParameter),
+                VariableParameter variableParameter => VariableParameterFactory.Build(variableParameter, request, scheduledReport, lookback),
+                ResourceIdsParameter idsParameter => await ResourceIdParameterFactory.Build(idsParameter, request, dataAcquisitionLogQueries),
                 _ => throw new Exception("Unable to determine parameter type."),
             };
 
-            if(searchParam == null)
-            {
+            if (searchParam == null)
                 continue;
-            }
 
             if (searchParam.paged)
             {
-                isPaged = true;
-                foreach(var idList in searchParam.values)
+                if (isPaged)
                 {
-                    var searchParamsCopy = searchParams;
-                    searchParamsCopy.Add(searchParam.key, string.Join(",",idList));
-                    searchParamList.Add(searchParamsCopy);
+                    _logger.LogError("Query plan cannot have multiple paged parameters per resource type: {ResourceType}", config.ResourceType);
+                    return null;
+                }
+                
+                isPaged = true;
+
+                if (searchParam.values != null)
+                {
+                    foreach (var idList in searchParam.values)
+                    {
+                        var searchParamsCopy = new List<KeyValuePair<string, string>>(searchParams);
+                        searchParamsCopy.Add(new KeyValuePair<string, string>(searchParam.key, string.Join(",", idList)));
+                        searchParamList.Add(searchParamsCopy);
+                    }
                 }
             }
             else
             {
-                searchParams.Add(searchParam.key, searchParam.value);
+                if (string.IsNullOrEmpty(searchParam.value))
+                {
+                    _logger.LogWarning("Parameter value is null or empty. Parameter Key: {Key} for {ResourceType} on CorrelationId {CorrelationId}", searchParam.key, config.ResourceType, request.CorrelationId);
+                    continue;
+                }
+                
+                // If another parameter previously made this a paged query, add the search param to all of the pages of the query
+                if (isPaged)
+                {
+                    searchParamList.ForEach(x => x.Add(new KeyValuePair<string, string>(searchParam.key, searchParam.value)));
+                }
+                else
+                {
+                    searchParams.Add(new KeyValuePair<string, string>(searchParam.key, searchParam.value));
+                }
             }   
         }
 

--- a/DotNet/DataAcquisition.Domain/Application/Models/Factory/ParameterQuery/PagedParameterQueryFactoryResult.cs
+++ b/DotNet/DataAcquisition.Domain/Application/Models/Factory/ParameterQuery/PagedParameterQueryFactoryResult.cs
@@ -1,6 +1,5 @@
-﻿using Hl7.Fhir.Rest;
-using LantanaGroup.Link.DataAcquisition.Domain.Infrastructure.Models.QueryConfig;
+﻿using LantanaGroup.Link.DataAcquisition.Domain.Infrastructure.Models.QueryConfig;
 
 namespace LantanaGroup.Link.DataAcquisition.Domain.Application.Models.Factory.ParameterQuery;
 
-public record PagedParameterQueryFactoryResult(OperationType opType, List<SearchParams> SearchParamsList) : ParameterQueryFactoryResult(opType);
+public record PagedParameterQueryFactoryResult(OperationType opType, List<List<KeyValuePair<string, string>>> SearchParamsList) : ParameterQueryFactoryResult(opType);

--- a/DotNet/DataAcquisition.Domain/Application/Models/Factory/ParameterQuery/ParameterFactoryResult.cs
+++ b/DotNet/DataAcquisition.Domain/Application/Models/Factory/ParameterQuery/ParameterFactoryResult.cs
@@ -1,4 +1,4 @@
 ﻿namespace LantanaGroup.Link.DataAcquisition.Domain.Application.Models.Factory.ParameterQuery;
 
-public record ParameterFactoryResult(string key, string value, bool paged = false, List<string[]>? values = null);
+public record ParameterFactoryResult(string key, string? value, bool paged = false, List<string[]>? values = null);
 

--- a/DotNet/DataAcquisition.Domain/Application/Models/Factory/ParameterQuery/SingularParameterQueryFactoryResult.cs
+++ b/DotNet/DataAcquisition.Domain/Application/Models/Factory/ParameterQuery/SingularParameterQueryFactoryResult.cs
@@ -1,6 +1,5 @@
-﻿using Hl7.Fhir.Rest;
-using LantanaGroup.Link.DataAcquisition.Domain.Infrastructure.Models.QueryConfig;
+﻿using LantanaGroup.Link.DataAcquisition.Domain.Infrastructure.Models.QueryConfig;
 
 namespace LantanaGroup.Link.DataAcquisition.Domain.Application.Models.Factory.ParameterQuery;
 
-public record SingularParameterQueryFactoryResult(OperationType opType, SearchParams? SearchParams = null, string? ResourceId = null) : ParameterQueryFactoryResult(opType);
+public record SingularParameterQueryFactoryResult(OperationType opType, List<KeyValuePair<string, string>>? SearchParams = null, string? ResourceId = null) : ParameterQueryFactoryResult(opType);

--- a/DotNet/DataAcquisition.Domain/Application/Queries/DataAcquisitionLogQueries.cs
+++ b/DotNet/DataAcquisition.Domain/Application/Queries/DataAcquisitionLogQueries.cs
@@ -1,6 +1,5 @@
 using System.Linq.Expressions;
 using System.Reflection;
-using System.Text.Json;
 using DataAcquisition.Domain.Application.Models;
 using LantanaGroup.Link.DataAcquisition.Domain.Application.Models.Api.Configuration;
 using LantanaGroup.Link.DataAcquisition.Domain.Application.Models.Api.QueryLog;
@@ -107,21 +106,14 @@ public class DataAcquisitionLogQueries : IDataAcquisitionLogQueries
 
         foreach (var resourceReferences in logsWithResources)
         {
-            try
+            if (resourceReferences != null)
             {
-                if (resourceReferences != null)
-                {
-                    var filteredIds = resourceReferences
-                        .Where(r => r.StartsWith(resourceTypePrefix, StringComparison.OrdinalIgnoreCase))
-                        .Select(r => r.Substring(resourceTypePrefix.Length))
-                        .ToList();
+                var filteredIds = resourceReferences
+                    .Where(r => r.StartsWith(resourceTypePrefix, StringComparison.OrdinalIgnoreCase))
+                    .Select(r => r.Substring(resourceTypePrefix.Length))
+                    .ToList();
 
-                    result.AddRange(filteredIds);
-                }
-            }
-            catch (JsonException ex)
-            {
-                _logger.LogError(ex, "Failed to deserialize ResourceAcquiredIds JSON: {Json}", resourceReferences);
+                result.AddRange(filteredIds);
             }
         }
 

--- a/DotNet/DataAcquisition.Domain/Application/Queries/DataAcquisitionLogQueries.cs
+++ b/DotNet/DataAcquisition.Domain/Application/Queries/DataAcquisitionLogQueries.cs
@@ -1,3 +1,6 @@
+using System.Linq.Expressions;
+using System.Reflection;
+using System.Text.Json;
 using DataAcquisition.Domain.Application.Models;
 using LantanaGroup.Link.DataAcquisition.Domain.Application.Models.Api.Configuration;
 using LantanaGroup.Link.DataAcquisition.Domain.Application.Models.Api.QueryLog;
@@ -15,12 +18,10 @@ using LantanaGroup.Link.Shared.Application.Models.Responses;
 using LantanaGroup.Link.Shared.Application.Services.Security;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
-using MongoDB.Driver;
-using System.Linq.Expressions;
-using System.Reflection;
 using Expression = System.Linq.Expressions.Expression;
 using IDatabase = LantanaGroup.Link.DataAcquisition.Domain.Infrastructure.IDatabase;
 using RequestStatus = LantanaGroup.Link.DataAcquisition.Domain.Infrastructure.Models.Enums.RequestStatus;
+using ResourceType = Hl7.Fhir.Model.ResourceType;
 
 namespace LantanaGroup.Link.DataAcquisition.Domain.Application.Queries;
 
@@ -68,6 +69,8 @@ public interface IDataAcquisitionLogQueries
     Task<List<string>> GetFacilitiesWithPendingAndRetryableFailedRequests(CancellationToken cancellationToken = default);
 
     Task<List<DataAcquisitionLogModel>> GetNextEligibleBatchForFacility(string facilityId, long? lastId, int batchSize, CancellationToken cancellationToken = default);
+
+    Task<List<string>> GetResourceIdsForReportPatient(string correlationId, string facilityId, string resourceType, CancellationToken cancellationToken = default);
 }
 
 public class DataAcquisitionLogQueries : IDataAcquisitionLogQueries
@@ -81,6 +84,43 @@ public class DataAcquisitionLogQueries : IDataAcquisitionLogQueries
         _database = database ?? throw new ArgumentNullException(nameof(database));
         _dbContext = dbContext ?? throw new ArgumentNullException(nameof(dbContext));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<List<string>> GetResourceIdsForReportPatient(string correlationId, string facilityId, string resourceType, CancellationToken cancellationToken = default)
+    {
+        var parsedResourceType = (ResourceType)Enum.Parse(typeof(ResourceType), resourceType);
+        var logsWithResources = await (from log in _dbContext.DataAcquisitionLogs
+                                     join query in _dbContext.FhirQueries on log.Id equals query.DataAcquisitionLogId
+                                     join resourceTypeEntry in _dbContext.FhirQueryResourceTypes on query.Id equals resourceTypeEntry.FhirQueryId
+                                     where query.FacilityId == facilityId
+                                           && log.CorrelationId == correlationId
+                                           && resourceTypeEntry.ResourceType == parsedResourceType
+                                     select log.ResourceAcquiredIds).ToListAsync(cancellationToken);
+
+        var result = new List<string>();
+        var resourceTypePrefix = $"{resourceType}/";
+
+        foreach (var resourceReferences in logsWithResources)
+        {
+            try
+            {
+                if (resourceReferences != null)
+                {
+                    var filteredIds = resourceReferences
+                        .Where(r => r.StartsWith(resourceTypePrefix, StringComparison.OrdinalIgnoreCase))
+                        .Select(r => r.Substring(resourceTypePrefix.Length))
+                        .ToList();
+
+                    result.AddRange(filteredIds);
+                }
+            }
+            catch (JsonException ex)
+            {
+                _logger.LogError(ex, "Failed to deserialize ResourceAcquiredIds JSON: {Json}", resourceReferences);
+            }
+        }
+
+        return result;
     }
 
     public async Task<DataAcquisitionLogModel?> GetAsync(long id, CancellationToken cancellationToken = default)
@@ -296,7 +336,7 @@ public class DataAcquisitionLogQueries : IDataAcquisitionLogQueries
 
         if (!string.IsNullOrEmpty(model.ResourceType))
         {
-            var resourceType = (Hl7.Fhir.Model.ResourceType)Enum.Parse(typeof(Hl7.Fhir.Model.ResourceType), model.ResourceType);    
+            var resourceType = (ResourceType)Enum.Parse(typeof(ResourceType), model.ResourceType);    
             query = (from l in query
                      join q in _dbContext.FhirQueries on l.Id equals q.DataAcquisitionLogId
                      where q.FhirQueryResourceTypes.Any(r => r.ResourceType == resourceType)

--- a/DotNet/DataAcquisition.Domain/Application/Queries/DataAcquisitionLogQueries.cs
+++ b/DotNet/DataAcquisition.Domain/Application/Queries/DataAcquisitionLogQueries.cs
@@ -88,7 +88,12 @@ public class DataAcquisitionLogQueries : IDataAcquisitionLogQueries
 
     public async Task<List<string>> GetResourceIdsForReportPatient(string correlationId, string facilityId, string resourceType, CancellationToken cancellationToken = default)
     {
-        var parsedResourceType = (ResourceType)Enum.Parse(typeof(ResourceType), resourceType);
+        if (!Enum.TryParse<ResourceType>(resourceType, out var parsedResourceType))
+        {
+            _logger.LogError("Failed to parse resource type: {ResourceType}", resourceType);
+            return new List<string>();
+        }
+
         var logsWithResources = await (from log in _dbContext.DataAcquisitionLogs
                                      join query in _dbContext.FhirQueries on log.Id equals query.DataAcquisitionLogId
                                      join resourceTypeEntry in _dbContext.FhirQueryResourceTypes on query.Id equals resourceTypeEntry.FhirQueryId

--- a/DotNet/DataAcquisition.Domain/Application/Services/QueryListProcessor.cs
+++ b/DotNet/DataAcquisition.Domain/Application/Services/QueryListProcessor.cs
@@ -72,7 +72,7 @@ public class QueryListProcessor : IQueryListProcessor
         _kafkaProducer = kafkaProducer ?? throw new ArgumentNullException(nameof(kafkaProducer));
         _referenceResourceService = referenceResourceService ?? throw new ArgumentNullException(nameof(referenceResourceService));
         _dataAcquisitionLogManager = dataAcquisitionLogManager ?? throw new ArgumentNullException(nameof(dataAcquisitionLogManager));
-        _dataAcquisitionLogQueries = dataAcquisitionLogQueries;
+        _dataAcquisitionLogQueries = dataAcquisitionLogQueries ?? throw new ArgumentNullException(nameof(dataAcquisitionLogQueries));
         _parameterQueryFactory = parameterQueryFactory ?? throw new ArgumentNullException(nameof(parameterQueryFactory));
 
         _producerConfig = new ProducerConfig();

--- a/DotNet/DataAcquisition.Domain/Application/Services/QueryListProcessor.cs
+++ b/DotNet/DataAcquisition.Domain/Application/Services/QueryListProcessor.cs
@@ -56,6 +56,7 @@ public class QueryListProcessor : IQueryListProcessor
     private readonly ProducerConfig _producerConfig;
     private readonly IDataAcquisitionLogManager _dataAcquisitionLogManager;
     private readonly IDataAcquisitionLogQueries _dataAcquisitionLogQueries;
+    private readonly IParameterQueryFactory _parameterQueryFactory;
 
     public QueryListProcessor(
         ILogger<QueryListProcessor> logger,
@@ -63,7 +64,8 @@ public class QueryListProcessor : IQueryListProcessor
         IProducer<string, ResourceAcquired> kafkaProducer,
         IReferenceResourceService referenceResourceService,
         IDataAcquisitionLogManager dataAcquisitionLogManager,
-        IDataAcquisitionLogQueries dataAcquisitionLogQueries)
+        IDataAcquisitionLogQueries dataAcquisitionLogQueries,
+        IParameterQueryFactory parameterQueryFactory)
     {
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _fhirRepo = fhirRepo ?? throw new ArgumentNullException(nameof(fhirRepo));
@@ -71,6 +73,7 @@ public class QueryListProcessor : IQueryListProcessor
         _referenceResourceService = referenceResourceService ?? throw new ArgumentNullException(nameof(referenceResourceService));
         _dataAcquisitionLogManager = dataAcquisitionLogManager ?? throw new ArgumentNullException(nameof(dataAcquisitionLogManager));
         _dataAcquisitionLogQueries = dataAcquisitionLogQueries;
+        _parameterQueryFactory = parameterQueryFactory ?? throw new ArgumentNullException(nameof(parameterQueryFactory));
 
         _producerConfig = new ProducerConfig();
         _producerConfig.CompressionType = CompressionType.Zstd;
@@ -136,7 +139,7 @@ public class QueryListProcessor : IQueryListProcessor
 
             QueryFactoryResult builtQuery = queryConfig switch
             {
-                ParameterQueryConfig config => await ParameterQueryFactory.Build(config, request, scheduledReport, queryPlan.LookBack, _dataAcquisitionLogQueries),
+                ParameterQueryConfig config => await _parameterQueryFactory.Build(config, request, scheduledReport, queryPlan.LookBack, _dataAcquisitionLogQueries),
                 ReferenceQueryConfig config => ReferenceQueryFactory.Build(config, new List<ResourceReference>()),
                 _ => throw new Exception("Unable to identify type for query operation."),
             };

--- a/DotNet/DataAcquisition.Domain/Application/Services/QueryListProcessor.cs
+++ b/DotNet/DataAcquisition.Domain/Application/Services/QueryListProcessor.cs
@@ -1,4 +1,5 @@
-﻿using Confluent.Kafka;
+﻿using System.Diagnostics;
+using Confluent.Kafka;
 using DataAcquisition.Domain.Application.Models;
 using Hl7.Fhir.Model;
 using LantanaGroup.Link.DataAcquisition.Domain.Application.Factories.QueryFactories;
@@ -9,15 +10,14 @@ using LantanaGroup.Link.DataAcquisition.Domain.Application.Models.Factory;
 using LantanaGroup.Link.DataAcquisition.Domain.Application.Models.Factory.ParameterQuery;
 using LantanaGroup.Link.DataAcquisition.Domain.Application.Models.Factory.ReferenceQuery;
 using LantanaGroup.Link.DataAcquisition.Domain.Application.Models.Kafka;
+using LantanaGroup.Link.DataAcquisition.Domain.Application.Queries;
 using LantanaGroup.Link.DataAcquisition.Domain.Application.Services.FhirApi;
 using LantanaGroup.Link.DataAcquisition.Domain.Infrastructure.Entities;
 using LantanaGroup.Link.DataAcquisition.Domain.Infrastructure.Interfaces;
 using LantanaGroup.Link.DataAcquisition.Domain.Infrastructure.Models.Enums;
 using LantanaGroup.Link.DataAcquisition.Domain.Infrastructure.Models.QueryConfig;
 using LantanaGroup.Link.Shared.Application.Models;
-using LantanaGroup.Link.Shared.Application.Utilities;
 using Microsoft.Extensions.Logging;
-using System.Diagnostics;
 using RequestStatus = LantanaGroup.Link.DataAcquisition.Domain.Infrastructure.Models.Enums.RequestStatus;
 using ResourceType = Hl7.Fhir.Model.ResourceType;
 using Task = System.Threading.Tasks.Task;
@@ -55,19 +55,22 @@ public class QueryListProcessor : IQueryListProcessor
     private readonly IReferenceResourceService _referenceResourceService;
     private readonly ProducerConfig _producerConfig;
     private readonly IDataAcquisitionLogManager _dataAcquisitionLogManager;
+    private readonly IDataAcquisitionLogQueries _dataAcquisitionLogQueries;
 
     public QueryListProcessor(
         ILogger<QueryListProcessor> logger,
         IFhirApiService fhirRepo,
         IProducer<string, ResourceAcquired> kafkaProducer,
         IReferenceResourceService referenceResourceService,
-        IDataAcquisitionLogManager dataAcquisitionLogManager)
+        IDataAcquisitionLogManager dataAcquisitionLogManager,
+        IDataAcquisitionLogQueries dataAcquisitionLogQueries)
     {
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _fhirRepo = fhirRepo ?? throw new ArgumentNullException(nameof(fhirRepo));
         _kafkaProducer = kafkaProducer ?? throw new ArgumentNullException(nameof(kafkaProducer));
         _referenceResourceService = referenceResourceService ?? throw new ArgumentNullException(nameof(referenceResourceService));
         _dataAcquisitionLogManager = dataAcquisitionLogManager ?? throw new ArgumentNullException(nameof(dataAcquisitionLogManager));
+        _dataAcquisitionLogQueries = dataAcquisitionLogQueries;
 
         _producerConfig = new ProducerConfig();
         _producerConfig.CompressionType = CompressionType.Zstd;
@@ -129,17 +132,16 @@ public class QueryListProcessor : IQueryListProcessor
         foreach (var query in queryList)
         {
             var queryConfig = query.Value;
+            List<string> resourceIds = null;
 
             QueryFactoryResult builtQuery = queryConfig switch
             {
-                ParameterQueryConfig => ParameterQueryFactory.Build((ParameterQueryConfig)queryConfig, request, scheduledReport, queryPlan.LookBack),
-                ReferenceQueryConfig => ReferenceQueryFactory.Build((ReferenceQueryConfig)queryConfig, new List<ResourceReference>()),
+                ParameterQueryConfig config => await ParameterQueryFactory.Build(config, request, scheduledReport, queryPlan.LookBack, _dataAcquisitionLogQueries),
+                ReferenceQueryConfig config => ReferenceQueryFactory.Build(config, new List<ResourceReference>()),
                 _ => throw new Exception("Unable to identify type for query operation."),
             };
 
-            _logger.LogInformation("Processing Query for:");
-
-            var fhirQueryType = FhirQueryType.Read;
+            _logger.LogDebug("Processing Query for:");
 
             var fhirQuery = new CreateFhirQueryModel
             {
@@ -151,65 +153,99 @@ public class QueryListProcessor : IQueryListProcessor
             if (builtQuery is SingularParameterQueryFactoryResult)
             {
                 var queryInfo = (ParameterQueryConfig)queryConfig;
-                _logger.LogInformation("Resource: {resourceType}", queryInfo.ResourceType);
+                _logger.LogDebug("Resource: {resourceType}", queryInfo.ResourceType);
 
                 var factoryResult = (SingularParameterQueryFactoryResult)builtQuery;
-                var config = (ParameterQueryConfig)queryConfig;
-
                 var resourceType = Enum.Parse<ResourceType>(queryInfo.ResourceType);
 
-                fhirQueryType = FhirQueryTypeUtilities.ToDomain(factoryResult.opType.ToString());
-                fhirQuery.ResourceTypes = new List<ResourceType> { resourceType };
-                fhirQuery.QueryParameters = factoryResult.SearchParams.Parameters.Select(x => $"{x.Item1}={x.Item2}").ToList();
+                fhirQuery.ResourceTypes = [resourceType];
+                fhirQuery.QueryParameters = factoryResult.SearchParams?.Select(x => $"{x.Key}={x.Value}").ToList() ?? [];
                 fhirQuery.QueryType = FhirQueryTypeUtilities.ToDomain(factoryResult.opType.ToString());
                 fhirQuery.MeasureId = scheduledReport.ReportTypes.FirstOrDefault();
-            }
 
-            if (builtQuery is PagedParameterQueryFactoryResult)
+                await CreateDataAcquisitionLogAsync(
+                    request,
+                    FhirQueryTypeUtilities.ToDomain(factoryResult.opType.ToString()),
+                    scheduledReport,
+                    fhirQuery,
+                    traceAndSpanDelimited,
+                    cancellationToken);
+            }
+            else if (builtQuery is PagedParameterQueryFactoryResult)
             {
                 var queryInfo = (ParameterQueryConfig)queryConfig;
-                _logger.LogInformation("Resource: {resourceType}", queryInfo.ResourceType);
+                _logger.LogDebug("Resource: {resourceType}", queryInfo.ResourceType);
 
                 var factoryResult = (PagedParameterQueryFactoryResult)builtQuery;
-                var config = (ParameterQueryConfig)queryConfig;
 
-                fhirQueryType = FhirQueryTypeUtilities.ToDomain(factoryResult.opType.ToString());
-                fhirQuery.ResourceTypes = new List<ResourceType> { Enum.Parse<ResourceType>(queryInfo.ResourceType) };
-                fhirQuery.QueryParameters = factoryResult.SearchParamsList.SelectMany(y => y.Parameters.Select(x => $"{x.Item1}={x.Item2}")).ToList();
-                fhirQuery.QueryType = FhirQueryTypeUtilities.ToDomain(factoryResult.opType.ToString());
+                foreach (var searchParams in factoryResult.SearchParamsList)
+                {
+                    var pagedFhirQuery = new CreateFhirQueryModel
+                    {
+                        FacilityId = request.FacilityId,
+                        ResourceReferenceTypes = referenceTypes.Select(x => new CreateResourceReferenceTypeModel { FacilityId = x.FacilityId, QueryPhase = x.QueryPhase, ResourceType = x.ResourceType }).ToList(),
+                        MeasureId = scheduledReport.ReportTypes.FirstOrDefault(),
+                        ResourceTypes = new List<ResourceType> { Enum.Parse<ResourceType>(queryInfo.ResourceType) },
+                        QueryParameters = searchParams.Select(x => $"{x.Key}={x.Value}").ToList(),
+                        QueryType = FhirQueryTypeUtilities.ToDomain(factoryResult.opType.ToString())
+                    };
 
+                    await CreateDataAcquisitionLogAsync(
+                        request,
+                        FhirQueryTypeUtilities.ToDomain(factoryResult.opType.ToString()),
+                        scheduledReport,
+                        pagedFhirQuery,
+                        traceAndSpanDelimited,
+                        cancellationToken);
+                }
             }
-
-            if (builtQuery is ReferenceQueryFactoryResult)
+            else if (builtQuery is ReferenceQueryFactoryResult)
             {
                 var config = (ReferenceQueryConfig)queryConfig;
-                _logger.LogInformation("Resource: {resourceType}", config.ResourceType);
+                _logger.LogDebug("Resource: {resourceType}", config.ResourceType);
 
-                fhirQueryType = FhirQueryTypeUtilities.ToDomain(config.OperationType.ToString());
+                var fhirQueryType = FhirQueryTypeUtilities.ToDomain(config.OperationType.ToString());
                 fhirQuery.QueryType = fhirQueryType;
                 fhirQuery.ResourceTypes = [Enum.Parse<ResourceType>(config.ResourceType)];
                 fhirQuery.QueryParameters = ["_id="];
                 fhirQuery.ResourceReferenceTypes = [];
                 fhirQuery.Paged = config.Paged;
                 fhirQuery.IsReference = true;
-            }
 
-            await _dataAcquisitionLogManager.CreateAsync(new CreateDataAcquisitionLogModel
-            {
-                FacilityId = request.FacilityId,
-                QueryType = fhirQueryType,
-                Priority = AcquisitionPriority.Normal,
-                PatientId = request.ConsumeResult.Value.PatientId,
-                CorrelationId = request.CorrelationId,
-                ReportableEvent = request.ConsumeResult.Value.ReportableEvent,
-                FhirVersion = "R4",
-                QueryPhase = QueryPhaseUtilities.ToDomain(request.QueryPlanType.ToString()),
-                Status = RequestStatus.Pending,
-                ScheduledReport = scheduledReport,
-                ExecutionDate = DateTime.UtcNow,
-                FhirQuery = new List<CreateFhirQueryModel>() { fhirQuery },
-                TraceId = traceAndSpanDelimited ?? string.Empty,
-            }, cancellationToken);
+                await CreateDataAcquisitionLogAsync(
+                    request,
+                    fhirQueryType,
+                    scheduledReport,
+                    fhirQuery,
+                    traceAndSpanDelimited,
+                    cancellationToken);
+            }
         }
+    }
+
+    private async Task CreateDataAcquisitionLogAsync(
+        GetPatientDataRequest request,
+        FhirQueryType fhirQueryType,
+        ScheduledReport scheduledReport,
+        CreateFhirQueryModel fhirQuery,
+        string traceAndSpanDelimited,
+        CancellationToken cancellationToken)
+    {
+        await _dataAcquisitionLogManager.CreateAsync(new CreateDataAcquisitionLogModel
+        {
+            FacilityId = request.FacilityId,
+            QueryType = fhirQueryType,
+            Priority = AcquisitionPriority.Normal,
+            PatientId = request.ConsumeResult.Message.Value.PatientId,
+            CorrelationId = request.CorrelationId,
+            ReportableEvent = request.ConsumeResult.Message.Value.ReportableEvent,
+            FhirVersion = "R4",
+            QueryPhase = QueryPhaseUtilities.ToDomain(request.QueryPlanType.ToString()),
+            Status = RequestStatus.Pending,
+            ScheduledReport = scheduledReport,
+            ExecutionDate = DateTime.UtcNow,
+            FhirQuery = [fhirQuery],
+            TraceId = traceAndSpanDelimited ?? string.Empty,
+        }, cancellationToken);
     }
 }

--- a/DotNet/DataAcquisition.Domain/Extensions/GeneralStartupExtensions.cs
+++ b/DotNet/DataAcquisition.Domain/Extensions/GeneralStartupExtensions.cs
@@ -1,9 +1,12 @@
-﻿using Azure.Identity;
+﻿using System.Diagnostics;
+using System.Net;
+using Confluent.Kafka;
 using DataAcquisition.Domain.Application.Queries;
 using FluentValidation;
+using LantanaGroup.Link.DataAcquisition.Domain.Application.Factories.ParameterFactories;
+using LantanaGroup.Link.DataAcquisition.Domain.Application.Factories.QueryFactories;
 using LantanaGroup.Link.DataAcquisition.Domain.Application.Interfaces;
 using LantanaGroup.Link.DataAcquisition.Domain.Application.Managers;
-using LantanaGroup.Link.DataAcquisition.Domain.Application.Models.Domain;
 using LantanaGroup.Link.DataAcquisition.Domain.Application.Models.Kafka;
 using LantanaGroup.Link.DataAcquisition.Domain.Application.Queries;
 using LantanaGroup.Link.DataAcquisition.Domain.Application.Serializers;
@@ -34,16 +37,14 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.Configuration.AzureAppConfiguration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
-using OpenTelemetry.Trace;
 using Serilog;
 using Serilog.Enrichers.Span;
 using Serilog.Settings.Configuration;
-using System.Diagnostics;
-using System.Net;
+using Serilog.Sinks.SystemConsole.Themes;
+using IHostingEnvironment = Microsoft.Extensions.Hosting.IHostingEnvironment;
 
 namespace LantanaGroup.Link.DataAcquisition.Domain.Extensions;
 public static class GeneralStartupExtensions
@@ -74,7 +75,7 @@ public static class GeneralStartupExtensions
         builder.Services.RegisterServices();
         builder.Services.RegisterFactories(builder.Configuration);
         builder.Services.RegisterTelemetry(builder.Configuration, builder.Environment, serviceName);
-        builder.Services.RegisterProblemDetails((Microsoft.Extensions.Hosting.IHostingEnvironment)builder.Environment);
+        builder.Services.RegisterProblemDetails((IHostingEnvironment)builder.Environment);
     }
 
     public static void RegisterMonitoring(this IConfigurationManager configuration, ILoggingBuilder logging, IServiceCollection services)
@@ -96,7 +97,7 @@ public static class GeneralStartupExtensions
         {
             serilogConfig.WriteTo.Console(
                 outputTemplate: "[{Timestamp:HH:mm:ss} {Level:u3}] {Message:lj}{NewLine}{Exception}",
-                theme: Serilog.Sinks.SystemConsole.Themes.AnsiConsoleTheme.Code  // Colorful output like default console
+                theme: AnsiConsoleTheme.Code  // Colorful output like default console
             );
         }
         else
@@ -278,7 +279,7 @@ public static class GeneralStartupExtensions
 
         //Factories - Producer
         var kafkaConnection = configuration.GetRequiredSection(KafkaConstants.SectionName).Get<KafkaConnection>() ?? throw new Exception("Missing Kafka Connection Settings");
-        var producerConfig = new Confluent.Kafka.ProducerConfig { CompressionType = Confluent.Kafka.CompressionType.Zstd };
+        var producerConfig = new ProducerConfig { CompressionType = CompressionType.Zstd };
         
         services.RegisterKafkaProducer<string, object>(kafkaConnection, producerConfig);
         services.RegisterKafkaProducer<string, string>(kafkaConnection, producerConfig);
@@ -297,6 +298,12 @@ public static class GeneralStartupExtensions
         services.AddTransient<IKafkaProducerFactory<string, ResourceAcquired>, KafkaProducerFactory<string, ResourceAcquired>>();
         services.AddTransient<IKafkaProducerFactory<string, PatientListMessage>, KafkaProducerFactory<string, PatientListMessage>>();
         services.AddTransient<IKafkaProducerFactory<long, ReadyToAcquire>, KafkaProducerFactory<long, ReadyToAcquire>>();
+
+        //Factories - Application
+        services.AddTransient<IParameterQueryFactory, ParameterQueryFactory>();
+        services.AddTransient<ILiteralParameterFactory, LiteralParameterFactory>();
+        services.AddTransient<IVariableParameterFactory, VariableParameterFactory>();
+        services.AddTransient<IResourceIdParameterFactory, ResourceIdParameterFactory>();
     }
 
     public static void RegisterTelemetry(this IServiceCollection services, IConfigurationManager configuration, IWebHostEnvironment environment, string serviceName)
@@ -311,7 +318,7 @@ public static class GeneralStartupExtensions
         });
     }
 
-    public static void RegisterProblemDetails(this IServiceCollection services, Microsoft.Extensions.Hosting.IHostingEnvironment environment)
+    public static void RegisterProblemDetails(this IServiceCollection services, IHostingEnvironment environment)
     {
         services.AddProblemDetails(options => {
             options.CustomizeProblemDetails = ctx =>

--- a/DotNet/ServiceTests/IntegrationTests/DataAcquisition/Factories/ParameterQueryFactoryTests.cs
+++ b/DotNet/ServiceTests/IntegrationTests/DataAcquisition/Factories/ParameterQueryFactoryTests.cs
@@ -1,10 +1,12 @@
-﻿using LantanaGroup.Link.DataAcquisition.Domain.Application.Factories.QueryFactories;
+﻿using LantanaGroup.Link.DataAcquisition.Domain.Application.Factories.ParameterFactories;
+using LantanaGroup.Link.DataAcquisition.Domain.Application.Factories.QueryFactories;
 using LantanaGroup.Link.DataAcquisition.Domain.Application.Models.Api.Requests;
 using LantanaGroup.Link.DataAcquisition.Domain.Application.Models.Factory.ParameterQuery;
 using LantanaGroup.Link.DataAcquisition.Domain.Application.Queries;
 using LantanaGroup.Link.DataAcquisition.Domain.Infrastructure.Interfaces;
 using LantanaGroup.Link.DataAcquisition.Domain.Infrastructure.Models.QueryConfig;
 using LantanaGroup.Link.DataAcquisition.Domain.Infrastructure.Models.QueryConfig.Parameter;
+using Microsoft.Extensions.Logging;
 using Moq;
 using Task = System.Threading.Tasks.Task;
 
@@ -13,10 +15,22 @@ namespace IntegrationTests.DataAcquisition.Factories
     public class ParameterQueryFactoryTests
     {
         private readonly Mock<IDataAcquisitionLogQueries> _dataAcquisitionLogQueriesMock;
+        private readonly IParameterQueryFactory _parameterQueryFactory;
 
         public ParameterQueryFactoryTests()
         {
             _dataAcquisitionLogQueriesMock = new Mock<IDataAcquisitionLogQueries>();
+
+            var logger = new Mock<ILogger<ParameterQueryFactory>>().Object;
+            var literalLogger = new Mock<ILogger<LiteralParameterFactory>>().Object;
+            var variableLogger = new Mock<ILogger<VariableParameterFactory>>().Object;
+            var resourceIdLogger = new Mock<ILogger<ResourceIdParameterFactory>>().Object;
+
+            var literalFactory = new LiteralParameterFactory(literalLogger);
+            var variableFactory = new VariableParameterFactory(variableLogger);
+            var resourceIdFactory = new ResourceIdParameterFactory(resourceIdLogger);
+
+            _parameterQueryFactory = new ParameterQueryFactory(logger, literalFactory, variableFactory, resourceIdFactory);
         }
 
         [Fact]
@@ -35,7 +49,7 @@ namespace IntegrationTests.DataAcquisition.Factories
             var request = new GetPatientDataRequest { CorrelationId = "corr1", FacilityId = "fac1" };
 
             // Act
-            var result = await ParameterQueryFactory.Build(config, request, null, null, _dataAcquisitionLogQueriesMock.Object);
+            var result = await _parameterQueryFactory.Build(config, request, null, null, _dataAcquisitionLogQueriesMock.Object);
 
             // Assert
             var singularResult = Assert.IsType<SingularParameterQueryFactoryResult>(result);
@@ -65,7 +79,7 @@ namespace IntegrationTests.DataAcquisition.Factories
                 .ReturnsAsync(resourceIds);
 
             // Act
-            var result = await ParameterQueryFactory.Build(config, request, null, null, _dataAcquisitionLogQueriesMock.Object);
+            var result = await _parameterQueryFactory.Build(config, request, null, null, _dataAcquisitionLogQueriesMock.Object);
 
             // Assert
             var pagedResult = Assert.IsType<PagedParameterQueryFactoryResult>(result);
@@ -100,7 +114,7 @@ namespace IntegrationTests.DataAcquisition.Factories
                 .ReturnsAsync(new List<string> { "id1", "id2", "id3" });
 
             // Act
-            var result = await ParameterQueryFactory.Build(config, request, null, null, _dataAcquisitionLogQueriesMock.Object);
+            var result = await _parameterQueryFactory.Build(config, request, null, null, _dataAcquisitionLogQueriesMock.Object);
 
             // Assert
             Assert.Null(result);
@@ -122,7 +136,7 @@ namespace IntegrationTests.DataAcquisition.Factories
             var request = new GetPatientDataRequest { CorrelationId = "corr1", FacilityId = "fac1" };
 
             // Act
-            var result = await ParameterQueryFactory.Build(config, request, null, null, _dataAcquisitionLogQueriesMock.Object);
+            var result = await _parameterQueryFactory.Build(config, request, null, null, _dataAcquisitionLogQueriesMock.Object);
 
             // Assert
             var singularResult = Assert.IsType<SingularParameterQueryFactoryResult>(result);

--- a/DotNet/ServiceTests/IntegrationTests/DataAcquisition/Factories/ParameterQueryFactoryTests.cs
+++ b/DotNet/ServiceTests/IntegrationTests/DataAcquisition/Factories/ParameterQueryFactoryTests.cs
@@ -1,0 +1,133 @@
+﻿using LantanaGroup.Link.DataAcquisition.Domain.Application.Factories.QueryFactories;
+using LantanaGroup.Link.DataAcquisition.Domain.Application.Models.Api.Requests;
+using LantanaGroup.Link.DataAcquisition.Domain.Application.Models.Factory.ParameterQuery;
+using LantanaGroup.Link.DataAcquisition.Domain.Application.Queries;
+using LantanaGroup.Link.DataAcquisition.Domain.Infrastructure.Interfaces;
+using LantanaGroup.Link.DataAcquisition.Domain.Infrastructure.Models.QueryConfig;
+using LantanaGroup.Link.DataAcquisition.Domain.Infrastructure.Models.QueryConfig.Parameter;
+using Moq;
+using Task = System.Threading.Tasks.Task;
+
+namespace IntegrationTests.DataAcquisition.Factories
+{
+    public class ParameterQueryFactoryTests
+    {
+        private readonly Mock<IDataAcquisitionLogQueries> _dataAcquisitionLogQueriesMock;
+
+        public ParameterQueryFactoryTests()
+        {
+            _dataAcquisitionLogQueriesMock = new Mock<IDataAcquisitionLogQueries>();
+        }
+
+        [Fact]
+        public async Task Build_WhenNoParametersArePaged_ReturnsSingularResult()
+        {
+            // Arrange
+            var config = new ParameterQueryConfig
+            {
+                ResourceType = "Patient",
+                Parameters = new List<IParameter>
+                {
+                    new LiteralParameter { Name = "lit1", Literal = "val1" },
+                    new LiteralParameter { Name = "lit2", Literal = "val2" }
+                }
+            };
+            var request = new GetPatientDataRequest { CorrelationId = "corr1", FacilityId = "fac1" };
+
+            // Act
+            var result = await ParameterQueryFactory.Build(config, request, null, null, _dataAcquisitionLogQueriesMock.Object);
+
+            // Assert
+            var singularResult = Assert.IsType<SingularParameterQueryFactoryResult>(result);
+            Assert.Equal(2, singularResult.SearchParams.Count);
+            Assert.Contains(singularResult.SearchParams, kvp => kvp.Key == "lit1" && kvp.Value == "val1");
+            Assert.Contains(singularResult.SearchParams, kvp => kvp.Key == "lit2" && kvp.Value == "val2");
+        }
+
+        [Fact]
+        public async Task Build_WhenOneParameterIsPaged_ReturnsPagedResult()
+        {
+            // Arrange
+            var config = new ParameterQueryConfig
+            {
+                ResourceType = "Patient",
+                Parameters = new List<IParameter>
+                {
+                    new LiteralParameter { Name = "lit1", Literal = "val1" },
+                    new ResourceIdsParameter { Name = "_id", Resource = "Patient", Paged = "2" }
+                }
+            };
+            var request = new GetPatientDataRequest { CorrelationId = "corr1", FacilityId = "fac1" };
+            var resourceIds = new List<string> { "id1", "id2", "id3" };
+
+            _dataAcquisitionLogQueriesMock
+                .Setup(q => q.GetResourceIdsForReportPatient(request.CorrelationId, request.FacilityId, "Patient", It.IsAny<CancellationToken>()))
+                .ReturnsAsync(resourceIds);
+
+            // Act
+            var result = await ParameterQueryFactory.Build(config, request, null, null, _dataAcquisitionLogQueriesMock.Object);
+
+            // Assert
+            var pagedResult = Assert.IsType<PagedParameterQueryFactoryResult>(result);
+            Assert.Equal(2, pagedResult.SearchParamsList.Count);
+            
+            // Page 1: lit1=val1, _id=id1,id2
+            Assert.Contains(pagedResult.SearchParamsList[0], kvp => kvp.Key == "lit1" && kvp.Value == "val1");
+            Assert.Contains(pagedResult.SearchParamsList[0], kvp => kvp.Key == "_id" && kvp.Value == "id1,id2");
+
+            // Page 2: lit1=val1, _id=id3
+            Assert.Contains(pagedResult.SearchParamsList[1], kvp => kvp.Key == "lit1" && kvp.Value == "val1");
+            Assert.Contains(pagedResult.SearchParamsList[1], kvp => kvp.Key == "_id" && kvp.Value == "id3");
+        }
+
+        [Fact]
+        public async Task Build_WhenMultipleParametersArePaged_ReturnsNull()
+        {
+            // Arrange
+            var config = new ParameterQueryConfig
+            {
+                ResourceType = "Patient",
+                Parameters = new List<IParameter>
+                {
+                    new ResourceIdsParameter { Name = "_id", Resource = "Patient", Paged = "2" },
+                    new ResourceIdsParameter { Name = "other", Resource = "Other", Paged = "1" }
+                }
+            };
+            var request = new GetPatientDataRequest { CorrelationId = "corr1", FacilityId = "fac1" };
+            
+            _dataAcquisitionLogQueriesMock
+                .Setup(q => q.GetResourceIdsForReportPatient(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new List<string> { "id1", "id2", "id3" });
+
+            // Act
+            var result = await ParameterQueryFactory.Build(config, request, null, null, _dataAcquisitionLogQueriesMock.Object);
+
+            // Assert
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public async Task Build_WhenParameterFactoryReturnsNull_SkipsIt()
+        {
+             // Arrange
+            var config = new ParameterQueryConfig
+            {
+                ResourceType = "Patient",
+                Parameters = new List<IParameter>
+                {
+                    new LiteralParameter { Name = "", Literal = "" }, // Invalid literal should return null from factory
+                    new LiteralParameter { Name = "lit2", Literal = "val2" }
+                }
+            };
+            var request = new GetPatientDataRequest { CorrelationId = "corr1", FacilityId = "fac1" };
+
+            // Act
+            var result = await ParameterQueryFactory.Build(config, request, null, null, _dataAcquisitionLogQueriesMock.Object);
+
+            // Assert
+            var singularResult = Assert.IsType<SingularParameterQueryFactoryResult>(result);
+            Assert.Single(singularResult.SearchParams);
+            Assert.Equal("lit2", singularResult.SearchParams[0].Key);
+        }
+    }
+}

--- a/DotNet/ServiceTests/IntegrationTests/DataAcquisition/Factories/ResourceIdParameterFactoryTests.cs
+++ b/DotNet/ServiceTests/IntegrationTests/DataAcquisition/Factories/ResourceIdParameterFactoryTests.cs
@@ -53,7 +53,7 @@ namespace IntegrationTests.DataAcquisition.Factories
         }
 
         [Fact]
-        public async Task Build_WhenPagedSetAndResultsLessThenPageSize_ReturnsJoinedEntries()
+        public async Task Build_WhenPagedSetAndResultsLessThanPageSize_ReturnsJoinedEntries()
         {
             // Arrange
             var parameter = new ResourceIdsParameter

--- a/DotNet/ServiceTests/IntegrationTests/DataAcquisition/Factories/ResourceIdParameterFactoryTests.cs
+++ b/DotNet/ServiceTests/IntegrationTests/DataAcquisition/Factories/ResourceIdParameterFactoryTests.cs
@@ -1,0 +1,143 @@
+﻿using LantanaGroup.Link.DataAcquisition.Domain.Application.Factories.ParameterFactories;
+using LantanaGroup.Link.DataAcquisition.Domain.Application.Models.Api.Requests;
+using LantanaGroup.Link.DataAcquisition.Domain.Application.Queries;
+using LantanaGroup.Link.DataAcquisition.Domain.Infrastructure.Models.QueryConfig.Parameter;
+using Moq;
+using Task = System.Threading.Tasks.Task;
+
+namespace IntegrationTests.DataAcquisition.Factories
+{
+    public class ResourceIdParameterFactoryTests
+    {
+        private readonly Mock<IDataAcquisitionLogQueries> _dataAcquisitionLogQueriesMock;
+
+        public ResourceIdParameterFactoryTests()
+        {
+            _dataAcquisitionLogQueriesMock = new Mock<IDataAcquisitionLogQueries>();
+        }
+
+        [Fact]
+        public async Task Build_WhenPagedNotSet_ReturnsJoinedEntries()
+        {
+            // Arrange
+            var parameter = new ResourceIdsParameter
+            {
+                Name = "TestParam",
+                Resource = "Patient",
+                Paged = null
+            };
+            var request = new GetPatientDataRequest
+            {
+                CorrelationId = "CorrId",
+                FacilityId = "FacId"
+            };
+            var resourceIds = new List<string> { "id1", "id2", "id3" };
+
+            _dataAcquisitionLogQueriesMock
+                .Setup(q => q.GetResourceIdsForReportPatient(request.CorrelationId, request.FacilityId, parameter.Resource, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(resourceIds);
+
+            // Act
+            var result = await ResourceIdParameterFactory.Build(parameter, request, _dataAcquisitionLogQueriesMock.Object);
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.Equal(parameter.Name, result.key);
+            Assert.Equal("id1,id2,id3", result.value);
+            Assert.False(result.paged);
+            Assert.Null(result.values);
+        }
+
+        [Fact]
+        public async Task Build_WhenPagedSetAndResultsLessThenPageSize_ReturnsJoinedEntries()
+        {
+            // Arrange
+            var parameter = new ResourceIdsParameter
+            {
+                Name = "TestParam",
+                Resource = "Patient",
+                Paged = "5"
+            };
+            var request = new GetPatientDataRequest
+            {
+                CorrelationId = "CorrId",
+                FacilityId = "FacId"
+            };
+            var resourceIds = new List<string> { "id1", "id2", "id3" };
+
+            _dataAcquisitionLogQueriesMock
+                .Setup(q => q.GetResourceIdsForReportPatient(request.CorrelationId, request.FacilityId, parameter.Resource, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(resourceIds);
+
+            // Act
+            var result = await ResourceIdParameterFactory.Build(parameter, request, _dataAcquisitionLogQueriesMock.Object);
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.Equal("id1,id2,id3", result.value);
+            Assert.False(result.paged);
+            Assert.Null(result.values);
+        }
+
+        [Fact]
+        public async Task Build_WhenPagedSetAndResultsMultiplePages_ReturnsPagedEntries()
+        {
+            // Arrange
+            var parameter = new ResourceIdsParameter
+            {
+                Name = "TestParam",
+                Resource = "Patient",
+                Paged = "2"
+            };
+            var request = new GetPatientDataRequest
+            {
+                CorrelationId = "CorrId",
+                FacilityId = "FacId"
+            };
+            var resourceIds = new List<string> { "id1", "id2", "id3", "id4", "id5" };
+
+            _dataAcquisitionLogQueriesMock
+                .Setup(q => q.GetResourceIdsForReportPatient(request.CorrelationId, request.FacilityId, parameter.Resource, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(resourceIds);
+
+            // Act
+            var result = await ResourceIdParameterFactory.Build(parameter, request, _dataAcquisitionLogQueriesMock.Object);
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.True(result.paged);
+            Assert.Null(result.value);
+            Assert.NotNull(result.values);
+            Assert.Equal(3, result.values.Count);
+            Assert.Equal(new[] { "id1", "id2" }, result.values[0]);
+            Assert.Equal(new[] { "id3", "id4" }, result.values[1]);
+            Assert.Equal(new[] { "id5" }, result.values[2]);
+        }
+
+        [Fact]
+        public async Task Build_WhenNoResourceIdsFound_ReturnsNull()
+        {
+            // Arrange
+            var parameter = new ResourceIdsParameter
+            {
+                Name = "TestParam",
+                Resource = "Patient"
+            };
+            var request = new GetPatientDataRequest
+            {
+                CorrelationId = "CorrId",
+                FacilityId = "FacId"
+            };
+
+            _dataAcquisitionLogQueriesMock
+                .Setup(q => q.GetResourceIdsForReportPatient(request.CorrelationId, request.FacilityId, parameter.Resource, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new List<string>());
+
+            // Act
+            var result = await ResourceIdParameterFactory.Build(parameter, request, _dataAcquisitionLogQueriesMock.Object);
+
+            // Assert
+            Assert.Null(result);
+        }
+    }
+}

--- a/DotNet/ServiceTests/IntegrationTests/DataAcquisition/Factories/ResourceIdParameterFactoryTests.cs
+++ b/DotNet/ServiceTests/IntegrationTests/DataAcquisition/Factories/ResourceIdParameterFactoryTests.cs
@@ -2,6 +2,7 @@
 using LantanaGroup.Link.DataAcquisition.Domain.Application.Models.Api.Requests;
 using LantanaGroup.Link.DataAcquisition.Domain.Application.Queries;
 using LantanaGroup.Link.DataAcquisition.Domain.Infrastructure.Models.QueryConfig.Parameter;
+using Microsoft.Extensions.Logging;
 using Moq;
 using Task = System.Threading.Tasks.Task;
 
@@ -10,10 +11,13 @@ namespace IntegrationTests.DataAcquisition.Factories
     public class ResourceIdParameterFactoryTests
     {
         private readonly Mock<IDataAcquisitionLogQueries> _dataAcquisitionLogQueriesMock;
+        private readonly IResourceIdParameterFactory _resourceIdParameterFactory;
 
         public ResourceIdParameterFactoryTests()
         {
             _dataAcquisitionLogQueriesMock = new Mock<IDataAcquisitionLogQueries>();
+            var logger = new Mock<ILogger<ResourceIdParameterFactory>>().Object;
+            _resourceIdParameterFactory = new ResourceIdParameterFactory(logger);
         }
 
         [Fact]
@@ -38,7 +42,7 @@ namespace IntegrationTests.DataAcquisition.Factories
                 .ReturnsAsync(resourceIds);
 
             // Act
-            var result = await ResourceIdParameterFactory.Build(parameter, request, _dataAcquisitionLogQueriesMock.Object);
+            var result = await _resourceIdParameterFactory.Build(parameter, request, _dataAcquisitionLogQueriesMock.Object);
 
             // Assert
             Assert.NotNull(result);
@@ -70,7 +74,7 @@ namespace IntegrationTests.DataAcquisition.Factories
                 .ReturnsAsync(resourceIds);
 
             // Act
-            var result = await ResourceIdParameterFactory.Build(parameter, request, _dataAcquisitionLogQueriesMock.Object);
+            var result = await _resourceIdParameterFactory.Build(parameter, request, _dataAcquisitionLogQueriesMock.Object);
 
             // Assert
             Assert.NotNull(result);
@@ -101,7 +105,7 @@ namespace IntegrationTests.DataAcquisition.Factories
                 .ReturnsAsync(resourceIds);
 
             // Act
-            var result = await ResourceIdParameterFactory.Build(parameter, request, _dataAcquisitionLogQueriesMock.Object);
+            var result = await _resourceIdParameterFactory.Build(parameter, request, _dataAcquisitionLogQueriesMock.Object);
 
             // Assert
             Assert.NotNull(result);
@@ -134,7 +138,7 @@ namespace IntegrationTests.DataAcquisition.Factories
                 .ReturnsAsync(new List<string>());
 
             // Act
-            var result = await ResourceIdParameterFactory.Build(parameter, request, _dataAcquisitionLogQueriesMock.Object);
+            var result = await _resourceIdParameterFactory.Build(parameter, request, _dataAcquisitionLogQueriesMock.Object);
 
             // Assert
             Assert.Null(result);


### PR DESCRIPTION
### 🛠️ Description of Changes

Parameter handling enhancements
- ParameterQueryFactory handles paged parameters better.
- ResourceIdParameterFactory queries for resourceIds from the DB before constructing the query.
- Literal parameters use `List<KeyValuePair<string, string>>` instead of Firely's `QueryParams` so that _count parameter is not ignored

Adding unit tests to ParameterQueryFactory and ResourceIdParameterFactory to confirm correct handling of paging scenarios

### 🧪 Testing Performed

Ran simple patient report as well as a mega-patient report and confirmed that fhir queries are constructed with parameters more accurately. Mega patient gets through data acquisition much quicker locally, now.

### 🧑‍🔬 Unit Testing

- [x] I have written or updated unit tests to cover my changes

### 📓 Documentation Updated
N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced data acquisition query functionality with improved resource ID retrieval and validation.
  * Expanded query parameter handling with paging support for large result sets.

* **Bug Fixes**
  * Improved validation and error handling for query parameters with enhanced logging of failures.
  * Better handling of null or invalid inputs in parameter processing.

* **Tests**
  * Added comprehensive integration tests for query parameter processing and resource ID retrieval scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->