### PR TITLE
LNK-3835: SFTP Configuration API

### DIFF
--- a/DotNet/Admin.BFF/Infrastructure/SecretManagers/LinkAzureKeyVault.cs
+++ b/DotNet/Admin.BFF/Infrastructure/SecretManagers/LinkAzureKeyVault.cs
@@ -6,6 +6,7 @@ using Microsoft.Extensions.Options;
 
 namespace LantanaGroup.Link.LinkAdmin.BFF.Infrastructure.SecretManagers
 {
+    //TODO: Review this vs the AzureKeyVaultSecretManager in Shared.Application.Services.SecretManager
     public class LinkAzureKeyVault : ISecretManager
     {
         private readonly ILogger<LinkAzureKeyVault> _logger;
@@ -17,13 +18,14 @@ namespace LantanaGroup.Link.LinkAdmin.BFF.Infrastructure.SecretManagers
             _secretClient = new SecretClient(new Uri(secretMangerConfig.Value.ManagerUri), new DefaultAzureCredential());
         }
 
-        public async Task<string> GetSecretAsync(string secretName, CancellationToken cancellationToken)
+        public async Task<string?> GetSecretAsync(string secretName, CancellationToken cancellationToken)
         {            
             var secret = await _secretClient.GetSecretAsync(secretName, cancellationToken: cancellationToken);
             return secret.Value.Value;
         }
 
-        public async Task<string> GetSecretAsync(string secretName, string version, CancellationToken cancellationToken)
+        public async Task<string?> GetSecretAsync(string secretName, string version,
+            CancellationToken cancellationToken)
         {
             var secret = await _secretClient.GetSecretAsync(secretName, version, cancellationToken);
             return secret.Value.Value;
@@ -33,6 +35,11 @@ namespace LantanaGroup.Link.LinkAdmin.BFF.Infrastructure.SecretManagers
         {
             var result = await _secretClient.SetSecretAsync(secretName, secretValue, cancellationToken);  
             return result.Value != null;
+        }
+
+        public Task<bool> DeleteSecretAsync(string secretName, CancellationToken cancellationToken)
+        {
+            throw new NotImplementedException();
         }
     }
 }

--- a/DotNet/DataAcquisition.Domain/Application/Managers/FhirListQueryConfigurationManager.cs
+++ b/DotNet/DataAcquisition.Domain/Application/Managers/FhirListQueryConfigurationManager.cs
@@ -105,6 +105,17 @@ public class FhirListQueryConfigurationManager : IFhirListQueryConfigurationMana
             activity?.SetStatus(ActivityStatusCode.Error, "FhirBaseServerUrl cannot be null");
             throw new ArgumentNullException(nameof(model.FhirBaseServerUrl));
         }
+        
+        // Verify that the facility does not already have an SFTP configuration
+        // A facility can only have one census acquisition method (SFTP or FHIR List)
+        var existingSftpConfig = await _database.SftpConfigurationRepository
+            .SingleOrDefaultAsync(s => s.OrganizationId == model.FacilityId, cancellationToken);
+        if (existingSftpConfig is not null)
+        {
+            activity?.SetStatus(ActivityStatusCode.Error, "SFTP configuration already exists for facility");
+            throw new InvalidOperationException(
+                $"The facility '{model.FacilityId?.SanitizeAndRemove()}' already has an SFTP configuration. A facility can only have one census acquisition method.");
+        }
 
         var entity = new FhirListConfiguration()
         {

--- a/DotNet/DataAcquisition.Domain/Application/Managers/SftpConfigurationManager.cs
+++ b/DotNet/DataAcquisition.Domain/Application/Managers/SftpConfigurationManager.cs
@@ -1,10 +1,14 @@
+using System.Diagnostics;
 using LantanaGroup.Link.DataAcquisition.Domain.Application.Models.Api.Configuration;
 using LantanaGroup.Link.DataAcquisition.Domain.Application.Models.Exceptions;
-using LantanaGroup.Link.DataAcquisition.Domain.Application.Queries;
 using LantanaGroup.Link.DataAcquisition.Domain.Infrastructure;
 using LantanaGroup.Link.DataAcquisition.Domain.Infrastructure.Entities;
 using LantanaGroup.Link.DataAcquisition.Domain.Infrastructure.Models;
 using LantanaGroup.Link.Shared.Application.Error.Exceptions;
+using LantanaGroup.Link.Shared.Application.Models.Telemetry;
+using LantanaGroup.Link.Shared.Application.SerDes;
+using LantanaGroup.Link.Shared.Application.Services.Security;
+using Microsoft.Extensions.Logging;
 
 namespace LantanaGroup.Link.DataAcquisition.Domain.Application.Managers;
 
@@ -50,19 +54,25 @@ public interface ISftpConfigurationManager
 
 
 public class SftpConfigurationManager(
+    ILogger<SftpConfigurationManager> logger,
     IDatabase database,
     IFhirQueryListConfigurationQueries fhirListConfigurationQueries) : ISftpConfigurationManager
 {
     /// <inheritdoc/>
     public async Task<SftpConfigurationModel> CreateAsync(SftpConfigurationModel model, string organizationId, CancellationToken cancellationToken = default)
     {
+        using var activity = Activity.Current?.Source.StartActivity();
+        activity?.SetTag(DiagnosticNames.FacilityId, organizationId);
+        
         if (string.IsNullOrEmpty(organizationId))
         {
+            activity?.SetStatus(ActivityStatusCode.Error, "OrganizationId cannot be null or empty");
             throw new ArgumentNullException(nameof(organizationId), "OrganizationId cannot be null or empty");
         }
 
         if (string.IsNullOrEmpty(model.Host))
         {
+            activity?.SetStatus(ActivityStatusCode.Error, "Host cannot be null or empty");
             throw new ArgumentNullException(nameof(model.Host), "Host cannot be null or empty");
         }
 
@@ -71,6 +81,7 @@ public class SftpConfigurationManager(
         var existingFhirListConfig = await fhirListConfigurationQueries.GetByFacilityIdAsync(organizationId, cancellationToken);
         if (existingFhirListConfig is not null)
         {
+            activity?.SetStatus(ActivityStatusCode.Error, "FHIR List configuration already exists for facility");
             throw new InvalidOperationException(
                 $"The facility '{organizationId}' already has a FHIR List configuration. A facility can only have one census acquisition method.");
         }
@@ -81,72 +92,119 @@ public class SftpConfigurationManager(
 
         if (existingEntity is not null)
         {
+            activity?.SetStatus(ActivityStatusCode.Error, "SFTP configuration already exists for organization");
             throw new EntityAlreadyExistsException(
                 $"A {nameof(SftpConfiguration)} already exists for organizationId: {organizationId}");
         }
 
-        // Default AuthType to Basic as per requirements
-        model.AuthenticationProtocol = AuthType.Basic;
+        try
+        {
+            // Default AuthType to Basic as per requirements
+            model.AuthenticationProtocol = AuthType.Basic;
 
-        var entity = model.ToEntity(organizationId);
+            var entity = model.ToEntity(organizationId);
 
-        await database.SftpConfigurationRepository.AddAsync(entity, cancellationToken);
-        await database.SftpConfigurationRepository.SaveChangesAsync(cancellationToken);
+            await database.SftpConfigurationRepository.AddAsync(entity, cancellationToken);
+            await database.SftpConfigurationRepository.SaveChangesAsync(cancellationToken);
 
-        return entity.ToModel();
+            return entity.ToModel();
+        }
+        catch (Exception ex)
+        {
+            activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
+            activity?.SetTag("SftpConfiguration", System.Text.Json.JsonSerializer.Serialize(model, LinkFhirSerializerOptions.ActivityTagging));
+            logger.LogError(ex, "Error creating SFTP Configuration for OrganizationId: {OrganizationId}", organizationId.Sanitize());
+            throw;
+        }
     }
 
     /// <inheritdoc/>
     public async Task<SftpConfigurationModel> UpdateAsync(string organizationId, SftpConfigurationModel model, CancellationToken cancellationToken = default)
     {
+        using var activity = Activity.Current?.Source.StartActivity();
+        activity?.SetTag(DiagnosticNames.FacilityId, organizationId);
+        
         var existingEntity = await database.SftpConfigurationRepository
             .SingleOrDefaultAsync(q => q.Id == model.Id, cancellationToken);
 
         if (existingEntity is null)
+        {
+            activity?.SetStatus(ActivityStatusCode.Error, "No configuration found to update");
             throw new NotFoundException($"No configuration found for Id: {model.Id}. Unable to update configuration.");
+        }
 
         if (existingEntity.OrganizationId != organizationId)
+        {
+            activity?.SetStatus(ActivityStatusCode.Error, "Organizational access violation");
             throw new OrganizationalAccessException(existingEntity.OrganizationId, organizationId);
+        }
 
         if (string.IsNullOrEmpty(model.Host))
         {
+            activity?.SetStatus(ActivityStatusCode.Error, "Host cannot be null or empty");
             throw new ArgumentNullException(nameof(model.Host), "Host cannot be null or empty");
         }
 
-        // Default AuthType to Basic as per requirements
-        model.AuthenticationProtocol = AuthType.Basic;
+        try
+        {
+            // Default AuthType to Basic as per requirements
+            model.AuthenticationProtocol = AuthType.Basic;
 
-        existingEntity.Host = model.Host;
-        existingEntity.Port = model.Port;
-        existingEntity.RemoteDirectory = model.RemoteDirectory;
-        existingEntity.Timeout = model.Timeout;
-        existingEntity.RemoveAfterProcessing = model.RemoveAfterProcessing;
+            existingEntity.Host = model.Host;
+            existingEntity.Port = model.Port;
+            existingEntity.RemoteDirectory = model.RemoteDirectory;
+            existingEntity.Timeout = model.Timeout;
+            existingEntity.RemoveAfterProcessing = model.RemoveAfterProcessing;
         
-        // For now, we are only allowing Basic auth, so no need to update this field
-        //existingEntity.AuthenticationProtocol = model.AuthenticationProtocol;
+            // For now, we are only allowing Basic auth, so no need to update this field
+            //existingEntity.AuthenticationProtocol = model.AuthenticationProtocol;
 
-        await database.SftpConfigurationRepository.SaveChangesAsync(cancellationToken);
+            await database.SftpConfigurationRepository.SaveChangesAsync(cancellationToken);
 
-        return existingEntity.ToModel();
+            return existingEntity.ToModel();
+        }
+        catch (Exception ex)
+        {
+            activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
+            activity?.SetTag("SftpConfiguration", System.Text.Json.JsonSerializer.Serialize(model, LinkFhirSerializerOptions.ActivityTagging));
+            logger.LogError(ex, "Error updating SFTP Configuration for OrganizationId: {OrganizationId}, ConfigurationId: {ConfigurationId}", organizationId.Sanitize(), model.Id);
+            throw;
+        }
     }
 
     /// <inheritdoc/>
     public async Task<bool> DeleteAsync(string organizationId, Guid configurationId, CancellationToken cancellationToken = default)
     {
+        using var activity = Activity.Current?.Source.StartActivity();
+        activity?.SetTag(DiagnosticNames.FacilityId, organizationId);
+        
         var entity = await database.SftpConfigurationRepository
             .FirstOrDefaultAsync(x => x.OrganizationId == organizationId, cancellationToken);
 
         if (entity is null)
+        {
+            activity?.SetStatus(ActivityStatusCode.Error, "No configuration found to delete");
             throw new NotFoundException($"No configuration found for organizationId: {organizationId}. Unable to delete configuration.");
+        }
 
         if (entity.OrganizationId != organizationId)
         {
+            activity?.SetStatus(ActivityStatusCode.Error, "Organizational access violation");
             throw new OrganizationalAccessException(entity.OrganizationId, organizationId);
         }
 
-        database.SftpConfigurationRepository.Remove(entity);
-        await database.SftpConfigurationRepository.SaveChangesAsync(cancellationToken);
+        try
+        {
+            database.SftpConfigurationRepository.Remove(entity);
+            await database.SftpConfigurationRepository.SaveChangesAsync(cancellationToken);
 
-        return true;
+            return true;
+        }
+        catch (Exception ex)
+        {
+            activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
+            logger.LogError(ex, "Error deleting SFTP Configuration for OrganizationId: {OrganizationId}, ConfigurationId: {ConfigurationId}", organizationId.Sanitize(), configurationId);
+            throw;
+        }
     }
 }

--- a/DotNet/DataAcquisition.Domain/Application/Managers/SftpConfigurationManager.cs
+++ b/DotNet/DataAcquisition.Domain/Application/Managers/SftpConfigurationManager.cs
@@ -1,0 +1,124 @@
+using LantanaGroup.Link.DataAcquisition.Domain.Application.Models.Api.Configuration;
+using LantanaGroup.Link.DataAcquisition.Domain.Application.Models.Exceptions;
+using LantanaGroup.Link.DataAcquisition.Domain.Infrastructure;
+using LantanaGroup.Link.DataAcquisition.Domain.Infrastructure.Entities;
+using LantanaGroup.Link.DataAcquisition.Domain.Infrastructure.Models;
+
+namespace LantanaGroup.Link.DataAcquisition.Domain.Application.Managers;
+
+/// <summary>
+/// Manages SFTP configuration operations for an organization.
+/// </summary>
+public interface ISftpConfigurationManager
+{
+    /// <summary>
+    /// Creates a new SFTP configuration for the specified organization.
+    /// </summary>
+    /// <param name="model">The SFTP configuration model to create.</param>
+    /// <param name="organizationId">The unique identifier for the organization.</param>
+    /// <param name="cancellationToken">Token to cancel the operation.</param>
+    /// <returns>The created <see cref="SftpConfigurationModel"/>.</returns>
+    /// <exception cref="EntityAlreadyExistsException">Thrown if a configuration already exists for the organization.</exception>
+    /// <exception cref="ArgumentNullException">Thrown if required parameters are null or empty.</exception>
+    Task<SftpConfigurationModel> CreateAsync(SftpConfigurationModel model, string organizationId, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Updates an existing SFTP configuration.
+    /// </summary>
+    /// <param name="model">The updated SFTP configuration model.</param>
+    /// <param name="cancellationToken">Token to cancel the operation.</param>
+    /// <returns>The updated <see cref="SftpConfigurationModel"/>.</returns>
+    /// <exception cref="NotFoundException">Thrown if the configuration does not exist.</exception>
+    /// <exception cref="ArgumentNullException">Thrown if required parameters are null or empty.</exception>
+    Task<SftpConfigurationModel> UpdateAsync(SftpConfigurationModel model, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Deletes the SFTP configuration for the specified organization.
+    /// </summary>
+    /// <param name="organizationId">The unique identifier for the organization.</param>
+    /// <param name="cancellationToken">Token to cancel the operation.</param>
+    /// <returns><c>true</c> if the configuration was deleted; otherwise, <c>false</c>.</returns>
+    /// <exception cref="NotFoundException">Thrown if the configuration does not exist.</exception>
+    Task<bool> DeleteAsync(string organizationId, CancellationToken cancellationToken);
+}
+
+
+public class SftpConfigurationManager(IDatabase database) : ISftpConfigurationManager
+{
+    /// <inheritdoc/>
+    public async Task<SftpConfigurationModel> CreateAsync(SftpConfigurationModel model, string organizationId, CancellationToken cancellationToken = default)
+    {
+        var existingEntity = await database.SftpConfigurationRepository
+            .FirstOrDefaultAsync(x => x.OrganizationId == organizationId, cancellationToken);
+
+        if (existingEntity is not null)
+        {
+            throw new EntityAlreadyExistsException(
+                $"A {nameof(SftpConfiguration)} already exists for organizationId: {organizationId}");
+        }
+
+        if (string.IsNullOrEmpty(organizationId))
+        {
+            throw new ArgumentNullException(nameof(organizationId), "OrganizationId cannot be null or empty");
+        }
+
+        if (string.IsNullOrEmpty(model.Host))
+        {
+            throw new ArgumentNullException(nameof(model.Host), "Host cannot be null or empty");
+        }
+
+        // Default AuthType to Basic as per requirements
+        model.AuthenticationProtocol = AuthType.Basic;
+
+        var entity = model.ToEntity(organizationId);
+
+        await database.SftpConfigurationRepository.AddAsync(entity, cancellationToken);
+        await database.SftpConfigurationRepository.SaveChangesAsync(cancellationToken);
+
+        return entity.ToModel();
+    }
+
+    /// <inheritdoc/>
+    public async Task<SftpConfigurationModel> UpdateAsync(SftpConfigurationModel model, CancellationToken cancellationToken = default)
+    {
+        var existingEntity = await database.SftpConfigurationRepository
+            .SingleOrDefaultAsync(q => q.Id == model.Id, cancellationToken);
+
+        if (existingEntity is null)
+            throw new NotFoundException($"No configuration found for Id: {model.Id}. Unable to update configuration.");
+
+        if (string.IsNullOrEmpty(model.Host))
+        {
+            throw new ArgumentNullException(nameof(model.Host), "Host cannot be null or empty");
+        }
+
+        // Default AuthType to Basic as per requirements
+        model.AuthenticationProtocol = AuthType.Basic;
+
+        existingEntity.Host = model.Host;
+        existingEntity.Port = model.Port;
+        existingEntity.RemoteDirectory = model.RemoteDirectory;
+        existingEntity.Timeout = model.Timeout;
+        existingEntity.RemoveAfterProcessing = model.RemoveAfterProcessing;
+        existingEntity.AuthenticationProtocol = model.AuthenticationProtocol;
+
+        await database.SftpConfigurationRepository.SaveChangesAsync(cancellationToken);
+
+        return existingEntity.ToModel();
+    }
+
+    /// <inheritdoc/>
+    public async Task<bool> DeleteAsync(string organizationId, CancellationToken cancellationToken = default)
+    {
+        var entity = await database.SftpConfigurationRepository
+            .FirstOrDefaultAsync(x => x.OrganizationId == organizationId, cancellationToken);
+
+        if (entity is null)
+            throw new NotFoundException($"No configuration found for organizationId: {organizationId}. Unable to delete configuration.");
+
+        database.SftpConfigurationRepository.Remove(entity);
+        await database.SftpConfigurationRepository.SaveChangesAsync(cancellationToken);
+
+        return true;
+    }
+}

--- a/DotNet/DataAcquisition.Domain/Application/Managers/SftpConfigurationManager.cs
+++ b/DotNet/DataAcquisition.Domain/Application/Managers/SftpConfigurationManager.cs
@@ -1,8 +1,10 @@
 using LantanaGroup.Link.DataAcquisition.Domain.Application.Models.Api.Configuration;
 using LantanaGroup.Link.DataAcquisition.Domain.Application.Models.Exceptions;
+using LantanaGroup.Link.DataAcquisition.Domain.Application.Queries;
 using LantanaGroup.Link.DataAcquisition.Domain.Infrastructure;
 using LantanaGroup.Link.DataAcquisition.Domain.Infrastructure.Entities;
 using LantanaGroup.Link.DataAcquisition.Domain.Infrastructure.Models;
+using LantanaGroup.Link.Shared.Application.Error.Exceptions;
 
 namespace LantanaGroup.Link.DataAcquisition.Domain.Application.Managers;
 
@@ -18,45 +20,42 @@ public interface ISftpConfigurationManager
     /// <param name="organizationId">The unique identifier for the organization.</param>
     /// <param name="cancellationToken">Token to cancel the operation.</param>
     /// <returns>The created <see cref="SftpConfigurationModel"/>.</returns>
-    /// <exception cref="EntityAlreadyExistsException">Thrown if a configuration already exists for the organization.</exception>
+    /// <exception cref="EntityAlreadyExistsException">Thrown if an SFTP configuration already exists for the organization.</exception>
+    /// <exception cref="InvalidOperationException">Thrown if the organization already has a FHIR List configuration (only one census acquisition method allowed).</exception>
     /// <exception cref="ArgumentNullException">Thrown if required parameters are null or empty.</exception>
     Task<SftpConfigurationModel> CreateAsync(SftpConfigurationModel model, string organizationId, CancellationToken cancellationToken);
 
     /// <summary>
     /// Updates an existing SFTP configuration.
     /// </summary>
+    /// <param name="organizationId">The unique identifier for the organization.</param>
     /// <param name="model">The updated SFTP configuration model.</param>
     /// <param name="cancellationToken">Token to cancel the operation.</param>
     /// <returns>The updated <see cref="SftpConfigurationModel"/>.</returns>
     /// <exception cref="NotFoundException">Thrown if the configuration does not exist.</exception>
+    /// <exception cref="OrganizationalAccessException">Thrown if the configuration does not belong to the organization.</exception>
     /// <exception cref="ArgumentNullException">Thrown if required parameters are null or empty.</exception>
-    Task<SftpConfigurationModel> UpdateAsync(SftpConfigurationModel model, CancellationToken cancellationToken);
+    Task<SftpConfigurationModel> UpdateAsync(string organizationId, SftpConfigurationModel model, CancellationToken cancellationToken);
 
     /// <summary>
     /// Deletes the SFTP configuration for the specified organization.
     /// </summary>
     /// <param name="organizationId">The unique identifier for the organization.</param>
+    /// <param name="configurationId">The unique identifier for the configuration</param>
     /// <param name="cancellationToken">Token to cancel the operation.</param>
     /// <returns><c>true</c> if the configuration was deleted; otherwise, <c>false</c>.</returns>
     /// <exception cref="NotFoundException">Thrown if the configuration does not exist.</exception>
-    Task<bool> DeleteAsync(string organizationId, CancellationToken cancellationToken);
+    Task<bool> DeleteAsync(string organizationId, Guid configurationId, CancellationToken cancellationToken);
 }
 
 
-public class SftpConfigurationManager(IDatabase database) : ISftpConfigurationManager
+public class SftpConfigurationManager(
+    IDatabase database,
+    IFhirQueryListConfigurationQueries fhirListConfigurationQueries) : ISftpConfigurationManager
 {
     /// <inheritdoc/>
     public async Task<SftpConfigurationModel> CreateAsync(SftpConfigurationModel model, string organizationId, CancellationToken cancellationToken = default)
     {
-        var existingEntity = await database.SftpConfigurationRepository
-            .FirstOrDefaultAsync(x => x.OrganizationId == organizationId, cancellationToken);
-
-        if (existingEntity is not null)
-        {
-            throw new EntityAlreadyExistsException(
-                $"A {nameof(SftpConfiguration)} already exists for organizationId: {organizationId}");
-        }
-
         if (string.IsNullOrEmpty(organizationId))
         {
             throw new ArgumentNullException(nameof(organizationId), "OrganizationId cannot be null or empty");
@@ -65,6 +64,25 @@ public class SftpConfigurationManager(IDatabase database) : ISftpConfigurationMa
         if (string.IsNullOrEmpty(model.Host))
         {
             throw new ArgumentNullException(nameof(model.Host), "Host cannot be null or empty");
+        }
+
+        // Verify the facility doesn't already have a FHIR List configuration
+        // A facility can only have one census acquisition method (SFTP or FHIR List)
+        var existingFhirListConfig = await fhirListConfigurationQueries.GetByFacilityIdAsync(organizationId, cancellationToken);
+        if (existingFhirListConfig is not null)
+        {
+            throw new InvalidOperationException(
+                $"The facility '{organizationId}' already has a FHIR List configuration. A facility can only have one census acquisition method.");
+        }
+
+        // Verify an SFTP configuration doesn't already exist for this organization
+        var existingEntity = await database.SftpConfigurationRepository
+            .FirstOrDefaultAsync(x => x.OrganizationId == organizationId, cancellationToken);
+
+        if (existingEntity is not null)
+        {
+            throw new EntityAlreadyExistsException(
+                $"A {nameof(SftpConfiguration)} already exists for organizationId: {organizationId}");
         }
 
         // Default AuthType to Basic as per requirements
@@ -79,13 +97,16 @@ public class SftpConfigurationManager(IDatabase database) : ISftpConfigurationMa
     }
 
     /// <inheritdoc/>
-    public async Task<SftpConfigurationModel> UpdateAsync(SftpConfigurationModel model, CancellationToken cancellationToken = default)
+    public async Task<SftpConfigurationModel> UpdateAsync(string organizationId, SftpConfigurationModel model, CancellationToken cancellationToken = default)
     {
         var existingEntity = await database.SftpConfigurationRepository
             .SingleOrDefaultAsync(q => q.Id == model.Id, cancellationToken);
 
         if (existingEntity is null)
             throw new NotFoundException($"No configuration found for Id: {model.Id}. Unable to update configuration.");
+
+        if (existingEntity.OrganizationId != organizationId)
+            throw new OrganizationalAccessException(existingEntity.OrganizationId, organizationId);
 
         if (string.IsNullOrEmpty(model.Host))
         {
@@ -100,7 +121,9 @@ public class SftpConfigurationManager(IDatabase database) : ISftpConfigurationMa
         existingEntity.RemoteDirectory = model.RemoteDirectory;
         existingEntity.Timeout = model.Timeout;
         existingEntity.RemoveAfterProcessing = model.RemoveAfterProcessing;
-        existingEntity.AuthenticationProtocol = model.AuthenticationProtocol;
+        
+        // For now, we are only allowing Basic auth, so no need to update this field
+        //existingEntity.AuthenticationProtocol = model.AuthenticationProtocol;
 
         await database.SftpConfigurationRepository.SaveChangesAsync(cancellationToken);
 
@@ -108,13 +131,18 @@ public class SftpConfigurationManager(IDatabase database) : ISftpConfigurationMa
     }
 
     /// <inheritdoc/>
-    public async Task<bool> DeleteAsync(string organizationId, CancellationToken cancellationToken = default)
+    public async Task<bool> DeleteAsync(string organizationId, Guid configurationId, CancellationToken cancellationToken = default)
     {
         var entity = await database.SftpConfigurationRepository
             .FirstOrDefaultAsync(x => x.OrganizationId == organizationId, cancellationToken);
 
         if (entity is null)
             throw new NotFoundException($"No configuration found for organizationId: {organizationId}. Unable to delete configuration.");
+
+        if (entity.OrganizationId != organizationId)
+        {
+            throw new OrganizationalAccessException(entity.OrganizationId, organizationId);
+        }
 
         database.SftpConfigurationRepository.Remove(entity);
         await database.SftpConfigurationRepository.SaveChangesAsync(cancellationToken);

--- a/DotNet/DataAcquisition.Domain/Application/Managers/SftpConfigurationManager.cs
+++ b/DotNet/DataAcquisition.Domain/Application/Managers/SftpConfigurationManager.cs
@@ -177,14 +177,14 @@ public class SftpConfigurationManager(
     {
         using var activity = Activity.Current?.Source.StartActivity();
         activity?.SetTag(DiagnosticNames.FacilityId, organizationId);
-        
+
         var entity = await database.SftpConfigurationRepository
-            .FirstOrDefaultAsync(x => x.OrganizationId == organizationId, cancellationToken);
+            .FirstOrDefaultAsync(x => x.Id == configurationId, cancellationToken);
 
         if (entity is null)
         {
             activity?.SetStatus(ActivityStatusCode.Error, "No configuration found to delete");
-            throw new NotFoundException($"No configuration found for organizationId: {organizationId}. Unable to delete configuration.");
+            throw new NotFoundException($"No configuration found for Id: {configurationId}. Unable to delete configuration.");
         }
 
         if (entity.OrganizationId != organizationId)

--- a/DotNet/DataAcquisition.Domain/Application/Models/Api/Configuration/SftpConfigurationModel.cs
+++ b/DotNet/DataAcquisition.Domain/Application/Models/Api/Configuration/SftpConfigurationModel.cs
@@ -29,7 +29,7 @@ public class CreateSftpConfigurationModel : SftpConfigurationModel
 
 public static class SftpConfigurationModelExtensions
 {
-    public static SftpConfigurationModel ToModel(this Infrastructure.Entities.SftpConfiguration entity)
+    public static SftpConfigurationModel ToModel(this SftpConfiguration entity)
     {
         return new SftpConfigurationModel
         {

--- a/DotNet/DataAcquisition.Domain/Application/Models/Api/Configuration/SftpConfigurationModel.cs
+++ b/DotNet/DataAcquisition.Domain/Application/Models/Api/Configuration/SftpConfigurationModel.cs
@@ -1,0 +1,47 @@
+﻿using LantanaGroup.Link.DataAcquisition.Domain.Infrastructure.Entities;
+using LantanaGroup.Link.DataAcquisition.Domain.Infrastructure.Models;
+
+namespace LantanaGroup.Link.DataAcquisition.Domain.Application.Models.Api.Configuration;
+
+public class SftpConfigurationModel
+{
+    public Guid Id { get; set; }
+    public string Host { get; set; } = string.Empty;
+    public int Port { get; set; }
+    public string? RemoteDirectory { get; set; }
+    public TimeSpan Timeout { get; set; }
+    public bool RemoveAfterProcessing { get; set; }
+    public AuthType AuthenticationProtocol { get; set; }
+}
+
+public static class SftpConfigurationModelExtensions
+{
+    public static SftpConfigurationModel ToModel(this Infrastructure.Entities.SftpConfiguration entity)
+    {
+        return new SftpConfigurationModel
+        {
+            Id = entity.Id,
+            Host = entity.Host,
+            Port = entity.Port,
+            RemoteDirectory = entity.RemoteDirectory,
+            Timeout = entity.Timeout,
+            RemoveAfterProcessing = entity.RemoveAfterProcessing,
+            AuthenticationProtocol = entity.AuthenticationProtocol
+        };
+    }
+    
+    public static SftpConfiguration ToEntity(this SftpConfigurationModel model, string organizationId)
+    {
+        return new SftpConfiguration
+        {
+            Id = model.Id,
+            OrganizationId = organizationId,
+            Host = model.Host,
+            Port = model.Port,
+            RemoteDirectory = model.RemoteDirectory,
+            Timeout = model.Timeout,
+            RemoveAfterProcessing = model.RemoveAfterProcessing,
+            AuthenticationProtocol = model.AuthenticationProtocol
+        };
+    }
+}

--- a/DotNet/DataAcquisition.Domain/Application/Models/Api/Configuration/SftpConfigurationModel.cs
+++ b/DotNet/DataAcquisition.Domain/Application/Models/Api/Configuration/SftpConfigurationModel.cs
@@ -14,6 +14,19 @@ public class SftpConfigurationModel
     public AuthType AuthenticationProtocol { get; set; }
 }
 
+/// <summary>
+/// Model for creating SFTP configuration with optional credentials.
+/// Credentials are stored separately in Azure Key Vault, not in the database.
+/// </summary>
+public class CreateSftpConfigurationModel : SftpConfigurationModel
+{
+    /// <summary>
+    /// Optional credentials for basic authentication.
+    /// Will be stored in Azure Key Vault, not in the database.
+    /// </summary>
+    public SftpCredentialsModel? Credentials { get; set; }
+}
+
 public static class SftpConfigurationModelExtensions
 {
     public static SftpConfigurationModel ToModel(this Infrastructure.Entities.SftpConfiguration entity)

--- a/DotNet/DataAcquisition.Domain/Application/Models/Api/Configuration/SftpConfigurationModel.cs
+++ b/DotNet/DataAcquisition.Domain/Application/Models/Api/Configuration/SftpConfigurationModel.cs
@@ -6,6 +6,7 @@ namespace LantanaGroup.Link.DataAcquisition.Domain.Application.Models.Api.Config
 public class SftpConfigurationModel
 {
     public Guid Id { get; set; }
+    public string OrganizationId { get; set; } = string.Empty;
     public string Host { get; set; } = string.Empty;
     public int Port { get; set; }
     public string? RemoteDirectory { get; set; }
@@ -34,6 +35,7 @@ public static class SftpConfigurationModelExtensions
         return new SftpConfigurationModel
         {
             Id = entity.Id,
+            OrganizationId =  entity.OrganizationId,
             Host = entity.Host,
             Port = entity.Port,
             RemoteDirectory = entity.RemoteDirectory,

--- a/DotNet/DataAcquisition.Domain/Application/Models/Api/Configuration/SftpCredentialsModel.cs
+++ b/DotNet/DataAcquisition.Domain/Application/Models/Api/Configuration/SftpCredentialsModel.cs
@@ -1,0 +1,34 @@
+namespace LantanaGroup.Link.DataAcquisition.Domain.Application.Models.Api.Configuration;
+
+/// <summary>
+/// Model for SFTP basic authentication credentials.
+/// Used for create/update operations only - never returned from GET endpoints.
+/// </summary>
+public class SftpCredentialsModel
+{
+    /// <summary>
+    /// The username for SFTP authentication.
+    /// </summary>
+    public string Username { get; set; } = string.Empty;
+
+    /// <summary>
+    /// The password for SFTP authentication.
+    /// </summary>
+    public string Password { get; set; } = string.Empty;
+}
+
+/// <summary>
+/// Response model indicating credential status without exposing actual credential values.
+/// </summary>
+public class SftpCredentialStatusModel
+{
+    /// <summary>
+    /// Indicates whether credentials have been configured for the organization.
+    /// </summary>
+    public bool HasCredentials { get; set; }
+
+    /// <summary>
+    /// The timestamp when credentials were last updated, if available.
+    /// </summary>
+    public DateTime? LastUpdated { get; set; }
+}

--- a/DotNet/DataAcquisition.Domain/Application/Queries/SftpConfigurationQueries.cs
+++ b/DotNet/DataAcquisition.Domain/Application/Queries/SftpConfigurationQueries.cs
@@ -29,6 +29,7 @@ public interface ISftpConfigurationQueries
 
 public class SftpConfigurationQueries(DataAcquisitionDbContext database) : ISftpConfigurationQueries
 {
+    /// <inheritdoc/>
     public async Task<SftpConfigurationModel?> GetByIdAsync(Guid id, CancellationToken cancellationToken = default)
     {
         var result = await (from config in database.SftpConfigurations
@@ -38,6 +39,7 @@ public class SftpConfigurationQueries(DataAcquisitionDbContext database) : ISftp
         return result;
     }
 
+    /// <inheritdoc/>
     public async Task<SftpConfigurationModel?> GetByOrganizationIdAsync(string organizationId, CancellationToken cancellationToken = default)
     {
         var result = await (from config in database.SftpConfigurations

--- a/DotNet/DataAcquisition.Domain/Application/Queries/SftpConfigurationQueries.cs
+++ b/DotNet/DataAcquisition.Domain/Application/Queries/SftpConfigurationQueries.cs
@@ -1,0 +1,49 @@
+using LantanaGroup.Link.DataAcquisition.Domain.Application.Models.Api.Configuration;
+using LantanaGroup.Link.DataAcquisition.Domain.Infrastructure.Context;
+using Microsoft.EntityFrameworkCore;
+
+namespace LantanaGroup.Link.DataAcquisition.Domain.Application.Queries;
+
+/// <summary>
+/// Provides query operations for the SFTP configuration entity.
+/// </summary>
+public interface ISftpConfigurationQueries
+{
+    /// <summary>
+    /// Retrieves the SFTP configuration by its unique identifier.
+    /// </summary>
+    /// <param name="id">The unique identifier of the SFTP configuration.</param>
+    /// <param name="cancellationToken">Token to cancel the operation.</param>
+    /// <returns>The <see cref="SftpConfigurationModel"/> if found; otherwise, <c>null</c>.</returns>
+    Task<SftpConfigurationModel?> GetByIdAsync(Guid id, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Retrieves the SFTP configuration for a specific organization.
+    /// </summary>
+    /// <param name="organizationId">The unique identifier of the organization.</param>
+    /// <param name="cancellationToken">Token to cancel the operation.</param>
+    /// <returns>The <see cref="SftpConfigurationModel"/> if found; otherwise, <c>null</c>.</returns>
+    Task<SftpConfigurationModel?> GetByOrganizationIdAsync(string organizationId, CancellationToken cancellationToken);
+}
+
+
+public class SftpConfigurationQueries(DataAcquisitionDbContext database) : ISftpConfigurationQueries
+{
+    public async Task<SftpConfigurationModel?> GetByIdAsync(Guid id, CancellationToken cancellationToken = default)
+    {
+        var result = await (from config in database.SftpConfigurations
+                            where config.Id == id
+                            select config.ToModel()).SingleOrDefaultAsync(cancellationToken);
+
+        return result;
+    }
+
+    public async Task<SftpConfigurationModel?> GetByOrganizationIdAsync(string organizationId, CancellationToken cancellationToken = default)
+    {
+        var result = await (from config in database.SftpConfigurations
+                            where config.OrganizationId == organizationId
+                            select config.ToModel()).SingleOrDefaultAsync(cancellationToken);
+
+        return result;
+    }
+}

--- a/DotNet/DataAcquisition.Domain/Application/Services/SftpCredentialService.cs
+++ b/DotNet/DataAcquisition.Domain/Application/Services/SftpCredentialService.cs
@@ -1,0 +1,174 @@
+using System.Text.Json;
+using LantanaGroup.Link.DataAcquisition.Domain.Application.Models.Api.Configuration;
+using LantanaGroup.Link.Shared.Application.Interfaces.Services;
+using Microsoft.Extensions.Logging;
+
+namespace LantanaGroup.Link.DataAcquisition.Domain.Application.Services;
+
+/// <summary>
+/// Service for managing SFTP authentication credentials stored in a secure secret manager.
+/// </summary>
+public interface ISftpCredentialService
+{
+    /// <summary>
+    /// Stores SFTP credentials in the secret manager for an organization.
+    /// </summary>
+    /// <param name="organizationId">The unique identifier for the organization.</param>
+    /// <param name="credentials">The credentials to store.</param>
+    /// <param name="cancellationToken">Token to cancel the operation.</param>
+    /// <returns><c>true</c> if credentials were stored successfully; otherwise, <c>false</c>.</returns>
+    Task<bool> SetCredentialsAsync(string organizationId, SftpCredentialsModel credentials, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Retrieves SFTP credentials from the secret manager.
+    /// </summary>
+    /// <param name="organizationId">The unique identifier for the organization.</param>
+    /// <param name="cancellationToken">Token to cancel the operation.</param>
+    /// <returns>The credentials if found; otherwise, <c>null</c>.</returns>
+    Task<SftpCredentialsModel?> GetCredentialsAsync(string organizationId, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Deletes SFTP credentials from the secret manager.
+    /// </summary>
+    /// <param name="organizationId">The unique identifier for the organization.</param>
+    /// <param name="cancellationToken">Token to cancel the operation.</param>
+    /// <returns><c>true</c> if credentials were deleted successfully; otherwise, <c>false</c>.</returns>
+    Task<bool> DeleteCredentialsAsync(string organizationId, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Checks if credentials exist for an organization without retrieving the actual values.
+    /// </summary>
+    /// <param name="organizationId">The unique identifier for the organization.</param>
+    /// <param name="cancellationToken">Token to cancel the operation.</param>
+    /// <returns>A status model indicating whether credentials exist.</returns>
+    Task<SftpCredentialStatusModel> GetCredentialStatusAsync(string organizationId, CancellationToken cancellationToken);
+}
+
+/// <summary>
+/// Service for managing SFTP credentials using the configured secret manager.
+/// </summary>
+public class SftpCredentialService : ISftpCredentialService
+{
+    private readonly ISecretManager _secretManager;
+    private readonly ILogger<SftpCredentialService> _logger;
+    private const string SecretNamePrefix = "sftp-credentials-";
+
+    public SftpCredentialService(
+        ISecretManager secretManager,
+        ILogger<SftpCredentialService> logger)
+    {
+        _secretManager = secretManager ?? throw new ArgumentNullException(nameof(secretManager));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <summary>
+    /// Generates a consistent secret name for the given organization.
+    /// </summary>
+    private static string GetSecretName(string organizationId) =>
+        $"{SecretNamePrefix}{organizationId}";
+
+    /// <inheritdoc/>
+    public async Task<bool> SetCredentialsAsync(string organizationId, SftpCredentialsModel credentials, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(organizationId))
+            throw new ArgumentNullException(nameof(organizationId));
+
+        if (credentials == null)
+            throw new ArgumentNullException(nameof(credentials));
+
+        if (string.IsNullOrWhiteSpace(credentials.Username))
+            throw new ArgumentException("Username cannot be empty", nameof(credentials));
+
+        if (string.IsNullOrWhiteSpace(credentials.Password))
+            throw new ArgumentException("Password cannot be empty", nameof(credentials));
+
+        var secretName = GetSecretName(organizationId);
+        var secretValue = JsonSerializer.Serialize(credentials);
+
+        _logger.LogInformation("Setting SFTP credentials for organization {OrganizationId}", organizationId);
+
+        var result = await _secretManager.SetSecretAsync(secretName, secretValue, cancellationToken);
+
+        if (result)
+        {
+            _logger.LogInformation("Successfully stored SFTP credentials for organization {OrganizationId}", organizationId);
+        }
+        else
+        {
+            _logger.LogWarning("Failed to store SFTP credentials for organization {OrganizationId}", organizationId);
+        }
+
+        return result;
+    }
+
+    /// <inheritdoc/>
+    public async Task<SftpCredentialsModel?> GetCredentialsAsync(string organizationId, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(organizationId))
+            throw new ArgumentNullException(nameof(organizationId));
+
+        var secretName = GetSecretName(organizationId);
+
+        try
+        {
+            var secretValue = await _secretManager.GetSecretAsync(secretName, cancellationToken);
+
+            if (string.IsNullOrEmpty(secretValue))
+            {
+                _logger.LogDebug("No SFTP credentials found for organization {OrganizationId}", organizationId);
+                return null;
+            }
+
+            return JsonSerializer.Deserialize<SftpCredentialsModel>(secretValue);
+        }
+        catch (JsonException ex)
+        {
+            _logger.LogError(ex, "Failed to deserialize SFTP credentials for organization {OrganizationId}", organizationId);
+            throw;
+        }
+    }
+
+    /// <inheritdoc/>
+    public async Task<bool> DeleteCredentialsAsync(string organizationId, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(organizationId))
+            throw new ArgumentNullException(nameof(organizationId));
+
+        var secretName = GetSecretName(organizationId);
+
+        _logger.LogInformation("Deleting SFTP credentials for organization {OrganizationId}", organizationId);
+
+        var result = await _secretManager.DeleteSecretAsync(secretName, cancellationToken);
+
+        if (result)
+        {
+            _logger.LogInformation("Successfully deleted SFTP credentials for organization {OrganizationId}", organizationId);
+        }
+
+        return result;
+    }
+
+    /// <inheritdoc/>
+    public async Task<SftpCredentialStatusModel> GetCredentialStatusAsync(string organizationId, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(organizationId))
+            throw new ArgumentNullException(nameof(organizationId));
+
+        try
+        {
+            var credentials = await GetCredentialsAsync(organizationId, cancellationToken);
+
+            return new SftpCredentialStatusModel
+            {
+                HasCredentials = credentials != null &&
+                                 !string.IsNullOrEmpty(credentials.Username) &&
+                                 !string.IsNullOrEmpty(credentials.Password)
+            };
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Error checking credential status for organization {OrganizationId}", organizationId);
+            return new SftpCredentialStatusModel { HasCredentials = false };
+        }
+    }
+}

--- a/DotNet/DataAcquisition.Domain/Application/Services/SftpCredentialService.cs
+++ b/DotNet/DataAcquisition.Domain/Application/Services/SftpCredentialService.cs
@@ -65,8 +65,7 @@ public class SftpCredentialService : ISftpCredentialService
     /// <summary>
     /// Generates a consistent secret name for the given organization.
     /// </summary>
-    private static string GetSecretName(string organizationId) =>
-        $"{SecretNamePrefix}{organizationId}";
+    private static string GetSecretName(string organizationId) => $"{SecretNamePrefix}{organizationId}";
 
     /// <inheritdoc/>
     public async Task<bool> SetCredentialsAsync(string organizationId, SftpCredentialsModel credentials, CancellationToken cancellationToken)

--- a/DotNet/DataAcquisition.Domain/Application/Services/SftpCredentialService.cs
+++ b/DotNet/DataAcquisition.Domain/Application/Services/SftpCredentialService.cs
@@ -1,6 +1,7 @@
 using System.Text.Json;
 using LantanaGroup.Link.DataAcquisition.Domain.Application.Models.Api.Configuration;
 using LantanaGroup.Link.Shared.Application.Interfaces.Services;
+using LantanaGroup.Link.Shared.Application.Services.Security;
 using Microsoft.Extensions.Logging;
 
 namespace LantanaGroup.Link.DataAcquisition.Domain.Application.Services;
@@ -136,13 +137,13 @@ public class SftpCredentialService : ISftpCredentialService
 
         var secretName = GetSecretName(organizationId);
 
-        _logger.LogInformation("Deleting SFTP credentials for organization {OrganizationId}", organizationId);
+        _logger.LogInformation("Deleting SFTP credentials for organization {OrganizationId}", organizationId.SanitizeAndRemove());
 
         var result = await _secretManager.DeleteSecretAsync(secretName, cancellationToken);
 
         if (result)
         {
-            _logger.LogInformation("Successfully deleted SFTP credentials for organization {OrganizationId}", organizationId);
+            _logger.LogInformation("Successfully deleted SFTP credentials for organization {OrganizationId}", organizationId.SanitizeAndRemove());
         }
 
         return result;
@@ -167,7 +168,7 @@ public class SftpCredentialService : ISftpCredentialService
         }
         catch (Exception ex)
         {
-            _logger.LogWarning(ex, "Error checking credential status for organization {OrganizationId}", organizationId);
+            _logger.LogWarning(ex, "Error checking credential status for organization {OrganizationId}", organizationId.SanitizeAndRemove());
             return new SftpCredentialStatusModel { HasCredentials = false };
         }
     }

--- a/DotNet/DataAcquisition.Domain/Extensions/GeneralStartupExtensions.cs
+++ b/DotNet/DataAcquisition.Domain/Extensions/GeneralStartupExtensions.cs
@@ -1,9 +1,9 @@
-﻿using Azure.Identity;
-using DataAcquisition.Domain.Application.Queries;
+﻿using DataAcquisition.Domain.Application.Queries;
 using FluentValidation;
 using LantanaGroup.Link.DataAcquisition.Domain.Application.Interfaces;
 using LantanaGroup.Link.DataAcquisition.Domain.Application.Managers;
-using LantanaGroup.Link.DataAcquisition.Domain.Application.Models.Domain;
+using LantanaGroup.Link.Shared.Application.Interfaces.Services;
+using LantanaGroup.Link.Shared.Application.Services.SecretManager;
 using LantanaGroup.Link.DataAcquisition.Domain.Application.Models.Kafka;
 using LantanaGroup.Link.DataAcquisition.Domain.Application.Queries;
 using LantanaGroup.Link.DataAcquisition.Domain.Application.Serializers;
@@ -31,14 +31,13 @@ using LantanaGroup.Link.Shared.Domain.Repositories.Interceptors;
 using LantanaGroup.Link.Shared.Domain.Repositories.Interfaces;
 using LantanaGroup.Link.Shared.Settings;
 using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.DataProtection;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.Configuration.AzureAppConfiguration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
-using OpenTelemetry.Trace;
 using Serilog;
 using Serilog.Enrichers.Span;
 using Serilog.Settings.Configuration;
@@ -49,13 +48,14 @@ namespace LantanaGroup.Link.DataAcquisition.Domain.Extensions;
 public static class GeneralStartupExtensions
 {
     public static void RegisterAll(
-        this WebApplicationBuilder builder, 
+        this WebApplicationBuilder builder,
         string serviceName,
-        bool? configureRedis = false)
+        bool? configureRedis = false,
+        bool? configureSecretManager = false)
     {
         // load external configuration source (if specified)
         builder.AddExternalConfiguration(serviceName);
-        
+
         builder.Configuration.RegisterMonitoring(builder.Logging, builder.Services);
         builder.Services.RegisterConfigs(builder.Configuration);
         builder.RegisterEntityFramework();
@@ -63,6 +63,11 @@ public static class GeneralStartupExtensions
         if (configureRedis.GetValueOrDefault())
         {
             builder.RegisterRedis();
+        }
+
+        if (configureSecretManager.GetValueOrDefault())
+        {
+            builder.Services.RegisterSecretManager(builder.Configuration);
         }
 
         builder.Services.RegisterInMemoryCache();
@@ -116,6 +121,7 @@ public static class GeneralStartupExtensions
         services.Configure<CorsSettings>(configuration.GetSection(ConfigurationConstants.AppSettings.CORS));
         services.Configure<LinkTokenServiceSettings>(configuration.GetSection(ConfigurationConstants.AppSettings.LinkTokenService));
         services.Configure<ApiSettings>(configuration.GetSection(ConfigurationConstants.AppSettings.ApiSettings));
+        services.Configure<SecretManagerSettings>(configuration.GetSection(ConfigurationConstants.AppSettings.SecretManagement));
 
         IConfigurationSection consumerSettingsSection = configuration.GetRequiredSection(nameof(ConsumerSettings));
         services.Configure<ConsumerSettings>(consumerSettingsSection);
@@ -250,6 +256,29 @@ public static class GeneralStartupExtensions
         //Data Pull Commands
         services.AddTransient<IReadFhirCommand, ReadFhirCommand>();
         services.AddTransient<ISearchFhirCommand, SearchFhirCommand>();
+    }
+
+    private static void RegisterSecretManager(this IServiceCollection services, IConfiguration configuration)
+    {
+        var manager = configuration.GetValue<string>("SecretManagement:Manager");
+
+        if (string.Equals(manager, "AzureKeyVault", StringComparison.OrdinalIgnoreCase))
+        {
+            Log.Information("Registering Azure Key Vault Secret Manager");
+            services.AddSingleton<ISecretManager, AzureKeyVaultSecretManager>();
+        }
+        else
+        {
+            // LocalSecretManager requires Data Protection for encrypted file storage
+            services.AddDataProtection()
+                .SetApplicationName(configuration.GetValue<string>("DataProtection:KeyRing") ?? "Link");
+
+            Log.Information("Registering Local Secret Manager (file-based with encryption)");
+            services.AddSingleton<ISecretManager, LocalSecretManager>();
+        }
+
+        // Register credential service (depends on ISecretManager)
+        services.AddScoped<ISftpCredentialService, SftpCredentialService>();
     }
 
     public static void RegisterFactories(this IServiceCollection services, IConfigurationManager configuration)

--- a/DotNet/DataAcquisition.Domain/Extensions/GeneralStartupExtensions.cs
+++ b/DotNet/DataAcquisition.Domain/Extensions/GeneralStartupExtensions.cs
@@ -205,6 +205,7 @@ public static class GeneralStartupExtensions
         services.AddTransient<IEntityRepository<DataAcquisitionLog>, EntityRepository<DataAcquisitionLog, DataAcquisitionDbContext>>();
         services.AddTransient<IEntityRepository<FhirQueryResourceType>, EntityRepository<FhirQueryResourceType, DataAcquisitionDbContext>>();
         services.AddTransient<IEntityRepository<SftpAcquisitionLog>, EntityRepository<SftpAcquisitionLog, DataAcquisitionDbContext>>();
+        services.AddTransient<IEntityRepository<SftpConfiguration>, EntityRepository<SftpConfiguration, DataAcquisitionDbContext>>();
 
         //Database
         services.AddTransient<IDatabase, Database>();
@@ -220,6 +221,7 @@ public static class GeneralStartupExtensions
         services.AddTransient<IFhirQueryQueries, FhirQueryQueries>();
         services.AddTransient<IQueryPlanQueries, QueryPlanQueries>();
         services.AddTransient<IReferenceResourcesQueries, ReferenceResourcesQueries>();
+        services.AddTransient<ISftpConfigurationQueries, SftpConfigurationQueries>();
 
         //Managers
         services.AddTransient<IFhirQueryConfigurationManager, FhirQueryConfigurationManager>();
@@ -229,6 +231,7 @@ public static class GeneralStartupExtensions
         services.AddTransient<IFhirQueryManager, FhirQueryManager>();
         services.AddTransient<IDataAcquisitionLogManager, DataAcquisitionLogManager>();
         services.AddTransient<ISftpAcquisitionLogManager, SftpAcquisitionLogManager>();
+        services.AddTransient<ISftpConfigurationManager, SftpConfigurationManager>();
     }
 
     public static void RegisterServices(this IServiceCollection services)

--- a/DotNet/DataAcquisition.Domain/Infrastructure/Context/DataAcquisitionDbContext.cs
+++ b/DotNet/DataAcquisition.Domain/Infrastructure/Context/DataAcquisitionDbContext.cs
@@ -32,6 +32,7 @@ public class DataAcquisitionDbContext : DbContext
     public virtual DbSet<FhirQueryResourceType> FhirQueryResourceTypes { get; set; }
     public DbSet<DataAcquisitionLog> DataAcquisitionLogs { get; set; }
     public DbSet<SftpAcquisitionLog> SftpAcquisitionLogs { get; set; }
+    public DbSet<SftpConfiguration> SftpConfigurations { get; set; }
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
@@ -196,6 +197,23 @@ public class DataAcquisitionDbContext : DbContext
 
             entity.HasIndex(i => i.FacilityId)
                 .HasDatabaseName("IX_SftpAcquisitionLog_FacilityId");
+        });
+        
+        //-------------------SftpConfiguration-------------------
+        modelBuilder.Entity<SftpConfiguration>(entity =>
+        {
+            entity.HasKey(e => e.Id);
+
+            entity.Property(e => e.OrganizationId)
+                .IsRequired()
+                .HasMaxLength(DataAcquisitionConstants.DatabaseSettings.MaxFacilityIdLength);
+            
+            entity.Property(e => e.Host)
+                .IsRequired()
+                .HasMaxLength(256);
+
+            entity.Property(e => e.RemoteDirectory)
+                .HasMaxLength(4096);
         });
 
         // Prefix and schema can be passed as parameters

--- a/DotNet/DataAcquisition.Domain/Infrastructure/Database.cs
+++ b/DotNet/DataAcquisition.Domain/Infrastructure/Database.cs
@@ -15,6 +15,7 @@ namespace LantanaGroup.Link.DataAcquisition.Domain.Infrastructure
         IEntityRepository<FhirQueryResourceType> FhirQueryResourceTypeRepository { get; set; }
         IEntityRepository<DataAcquisitionLog> DataAcquisitionLogRepository { get; set; }
         IEntityRepository<SftpAcquisitionLog> SftpAcquisitionLogRepository { get; set; }
+        IEntityRepository<SftpConfiguration> SftpConfigurationRepository { get; set; }
         Task SaveChangesAsync();
     }
     public class Database : IDatabase
@@ -29,6 +30,7 @@ namespace LantanaGroup.Link.DataAcquisition.Domain.Infrastructure
         public IEntityRepository<FhirQueryResourceType> FhirQueryResourceTypeRepository { get; set; }
         public IEntityRepository<DataAcquisitionLog> DataAcquisitionLogRepository { get; set; }
         public IEntityRepository<SftpAcquisitionLog> SftpAcquisitionLogRepository { get; set; }
+        public IEntityRepository<SftpConfiguration> SftpConfigurationRepository { get; set; }
 
         public Database(
             DataAcquisitionDbContext context,
@@ -40,7 +42,8 @@ namespace LantanaGroup.Link.DataAcquisition.Domain.Infrastructure
             IEntityRepository<DataAcquisitionLog> dataAcquisitionLogRepository,
             IEntityRepository<ResourceReferenceType> resourceReferenceTypeRepository,
             IEntityRepository<FhirQueryResourceType> fhirQueryResourceTypeRepository,
-            IEntityRepository<SftpAcquisitionLog> sftpAcquisitionLogRepository)
+            IEntityRepository<SftpAcquisitionLog> sftpAcquisitionLogRepository,
+            IEntityRepository<SftpConfiguration> sftpConfigurationRepository)
         {
             _context = context;
             QueryPlanRepository = queryPlans;
@@ -52,6 +55,7 @@ namespace LantanaGroup.Link.DataAcquisition.Domain.Infrastructure
             ResourceReferenceTypeRepository = resourceReferenceTypeRepository;
             FhirQueryResourceTypeRepository = fhirQueryResourceTypeRepository;
             SftpAcquisitionLogRepository = sftpAcquisitionLogRepository;
+            SftpConfigurationRepository = sftpConfigurationRepository;
         }
 
         public async Task SaveChangesAsync()

--- a/DotNet/DataAcquisition.Domain/Infrastructure/Entities/SftpConfiguration.cs
+++ b/DotNet/DataAcquisition.Domain/Infrastructure/Entities/SftpConfiguration.cs
@@ -1,0 +1,49 @@
+﻿using System.ComponentModel.DataAnnotations.Schema;
+using LantanaGroup.Link.DataAcquisition.Domain.Infrastructure.Models;
+
+namespace LantanaGroup.Link.DataAcquisition.Domain.Infrastructure.Entities;
+
+[Table("SftpConfiguration")]
+public class SftpConfiguration
+{
+    /// <summary>
+    /// Unique identifier for the SFTP configuration.
+    /// </summary>
+    public Guid Id { get; set; } = Guid.NewGuid();
+    
+    /// <summary>
+    ///  Identifier for the organization associated with this SFTP configuration.
+    /// </summary>
+    public string OrganizationId { get; set; } = null!;
+    
+    /// <summary>
+    /// Hostname or IP address of the SFTP server.
+    /// </summary>
+    public string Host { get; set; } = null!;
+    
+    /// <summary>
+    /// Port number for the SFTP server. Defaults to standard SFTP port 22.
+    /// </summary>
+    public int Port { get; set; } = 22; // Default SFTP port
+    
+    /// <summary>
+    /// Path to the remote directory on the SFTP server.
+    /// </summary>
+    public string? RemoteDirectory { get; set; } //path to pull files from
+    
+    /// <summary>
+    /// How long to wait for SFTP operations before timing out.
+    /// </summary>
+    public TimeSpan Timeout { get; set; } = TimeSpan.FromSeconds(60);
+    
+    /// <summary>
+    /// Indicates whether to remove files from the SFTP server after processing. Defaults to false.
+    /// </summary>
+    public bool RemoveAfterProcessing { get; set; }
+
+    /// <summary>
+    /// Authentication type for SFTP connection. If no type is specified, defaults to "Basic".
+    /// Current supported types: "Basic"
+    /// </summary>
+    public AuthType AuthenticationProtocol { get; set; } = AuthType.Basic;
+}

--- a/DotNet/DataAcquisition.Domain/Migrations/20260112204836_AddSftpConfiguration.Designer.cs
+++ b/DotNet/DataAcquisition.Domain/Migrations/20260112204836_AddSftpConfiguration.Designer.cs
@@ -4,6 +4,7 @@ using LantanaGroup.Link.DataAcquisition.Domain.Infrastructure.Context;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace DataAcquisition.Domain.Migrations
 {
     [DbContext(typeof(DataAcquisitionDbContext))]
-    partial class DataAcquisitionDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260112204836_AddSftpConfiguration")]
+    partial class AddSftpConfiguration
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/DotNet/DataAcquisition.Domain/Migrations/20260112204836_AddSftpConfiguration.cs
+++ b/DotNet/DataAcquisition.Domain/Migrations/20260112204836_AddSftpConfiguration.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace DataAcquisition.Domain.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddSftpConfiguration : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "SftpConfiguration",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false, defaultValueSql: "NEWID()"),
+                    OrganizationId = table.Column<string>(type: "nvarchar(250)", maxLength: 250, nullable: false),
+                    Host = table.Column<string>(type: "nvarchar(256)", maxLength: 256, nullable: false),
+                    Port = table.Column<int>(type: "int", nullable: false),
+                    RemoteDirectory = table.Column<string>(type: "nvarchar(max)", maxLength: 4096, nullable: true),
+                    Timeout = table.Column<TimeSpan>(type: "time", nullable: false),
+                    RemoveAfterProcessing = table.Column<bool>(type: "bit", nullable: false),
+                    AuthenticationProtocol = table.Column<int>(type: "int", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_SftpConfiguration", x => x.Id);
+                });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "SftpConfiguration");
+        }
+    }
+}

--- a/DotNet/DataAcquisition/Controllers/SftpConfigurationController.cs
+++ b/DotNet/DataAcquisition/Controllers/SftpConfigurationController.cs
@@ -1,0 +1,295 @@
+using LantanaGroup.Link.DataAcquisition.Domain.Application.Managers;
+using LantanaGroup.Link.DataAcquisition.Domain.Application.Models.Api.Configuration;
+using LantanaGroup.Link.DataAcquisition.Domain.Application.Queries;
+using LantanaGroup.Link.DataAcquisition.Domain.Infrastructure.Entities;
+using LantanaGroup.Link.DataAcquisition.Domain.Infrastructure.Models;
+using LantanaGroup.Link.Shared.Application.Services.Security;
+using Link.Authorization.Policies;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using System.Net;
+using LantanaGroup.Link.DataAcquisition.Domain.Application.Models.Exceptions;
+using static LantanaGroup.Link.DataAcquisition.Domain.Settings.DataAcquisitionConstants;
+
+namespace LantanaGroup.Link.DataAcquisition.Controllers;
+
+[Route("api/data")]
+[Authorize(Policy = PolicyNames.IsLinkAdmin)]
+[ApiController]
+public class SftpConfigurationController : Controller
+{
+    private readonly ILogger<SftpConfigurationController> _logger;
+    private readonly ISftpConfigurationManager _sftpConfigurationManager;
+    private readonly ISftpConfigurationQueries _sftpConfigurationQueries;
+
+    public SftpConfigurationController(
+        ILogger<SftpConfigurationController> logger,
+        ISftpConfigurationManager sftpConfigurationManager,
+        ISftpConfigurationQueries sftpConfigurationQueries)
+    {
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _sftpConfigurationManager = sftpConfigurationManager ?? throw new ArgumentNullException(nameof(sftpConfigurationManager));
+        _sftpConfigurationQueries = sftpConfigurationQueries ?? throw new ArgumentNullException(nameof(sftpConfigurationQueries));
+    }
+
+    /// <summary>
+    /// Gets an SftpConfiguration record by its unique identifier.
+    /// </summary>
+    /// <param name="id">The unique identifier of the SFTP configuration.</param>
+    /// <param name="cancellationToken"></param>
+    /// <returns>
+    ///     Success: 200
+    ///     Not Found: 404
+    ///     Bad Request: 400
+    ///     Server Error: 500
+    /// </returns>
+    [HttpGet("sftpConfiguration/{id}")]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(SftpConfigurationModel))]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+    public async Task<ActionResult<SftpConfigurationModel>> GetSftpConfigurationById(Guid id, CancellationToken cancellationToken)
+    {
+        var httpContext = HttpContext;
+
+        try
+        {
+            if (id == Guid.Empty)
+            {
+                return BadRequest("SftpConfiguration Id cannot be empty.");
+            }
+
+            var result = await _sftpConfigurationQueries.GetByIdAsync(id, cancellationToken);
+
+            if (result is null)
+            {
+                return NotFound($"No {nameof(SftpConfiguration)} found for Id: {id}");
+            }
+
+            return Ok(result);
+        }
+        catch (Exception ex)
+        {
+            var message = $"An unexpected error occurred while attempting to get an SFTP configuration with Id: {id}. Trace Id: {httpContext.TraceIdentifier}";
+            _logger.LogError(new EventId(LoggingIds.GetItem, "GetSftpConfigurationById"), ex, "An exception occurred while attempting to get an SFTP configuration with Id: {Id}", id);
+            return Problem(title: "Internal Server Error", detail: message, statusCode: (int)HttpStatusCode.InternalServerError);
+        }
+    }
+
+    /// <summary>
+    /// Gets an SftpConfiguration record for a given organization.
+    /// </summary>
+    /// <param name="organizationId">The organization identifier representing either a health care system or individual facility.</param>
+    /// <param name="cancellationToken"></param>
+    /// <returns>
+    ///     Success: 200
+    ///     Not Found: 404
+    ///     Bad Request: 400
+    ///     Server Error: 500
+    /// </returns>
+    [HttpGet("{organizationId}/sftpConfiguration")]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(SftpConfigurationModel))]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+    public async Task<ActionResult<SftpConfigurationModel>> GetOrgSftpConfiguration(string organizationId, CancellationToken cancellationToken)
+    {
+        var httpContext = HttpContext;
+
+        try
+        {
+            if (string.IsNullOrWhiteSpace(organizationId))
+            {
+                return BadRequest("OrganizationId is null or empty.");
+            }
+
+            organizationId = organizationId.SanitizeAndRemove();
+            var result = await _sftpConfigurationQueries.GetByOrganizationIdAsync(organizationId, cancellationToken);
+
+            if (result is null)
+            {
+                return NotFound($"No {nameof(SftpConfiguration)} found for organization: {organizationId}");
+            }
+
+            return Ok(result);
+        }
+        catch (Exception ex)
+        {
+            var message = $"An unexpected error occurred while attempting to get an SFTP configuration for organizationId: {organizationId}. Trace Id: {httpContext.TraceIdentifier}";
+            _logger.LogError(new EventId(LoggingIds.GetItem, "GetOrgSftpConfiguration"), ex, "An exception occurred while attempting to get an SFTP configuration for organizationId: {OrganizationId}", organizationId);
+            return Problem(title: "Internal Server Error", detail: message, statusCode: (int)HttpStatusCode.InternalServerError);
+        }
+    }
+
+    /// <summary>
+    /// Creates an SftpConfiguration record for an organization. Should only be used for initial configuration.
+    /// Supported Authentication Types: Basic (default)
+    /// </summary>
+    /// <param name="organizationId">The organization identifier.</param>
+    /// <param name="sftpConfiguration">The SFTP configuration model.</param>
+    /// <param name="cancellationToken"></param>
+    /// <returns>
+    ///     Success: 201
+    ///     Bad Request: 400
+    ///     Not Found: 404
+    ///     Organization Already Exists: 409
+    ///     Server Error: 500
+    /// </returns>
+    [HttpPost("{organizationId}/sftpConfiguration")]
+    [ProducesResponseType(StatusCodes.Status201Created, Type = typeof(SftpConfigurationModel))]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status409Conflict)]
+    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+    public async Task<ActionResult<SftpConfigurationModel>> CreateSftpConfiguration(string organizationId, SftpConfigurationModel? sftpConfiguration, CancellationToken cancellationToken)
+    {
+        var httpContext = HttpContext;
+
+        try
+        {
+            if (sftpConfiguration is null)
+            {
+                return BadRequest("sftpConfiguration is null.");
+            }
+
+            if (string.IsNullOrWhiteSpace(organizationId))
+            {
+                return BadRequest("OrganizationId is null or empty.");
+            }
+
+            // Default AuthType to Basic until other authentication options are supported
+            sftpConfiguration.AuthenticationProtocol = AuthType.Basic;
+
+            organizationId = organizationId.SanitizeAndRemove();
+            var result =
+                await _sftpConfigurationManager.CreateAsync(sftpConfiguration, organizationId, cancellationToken);
+
+            return CreatedAtAction(nameof(GetOrgSftpConfiguration),
+                new { organizationId },
+                result);
+        }
+        catch (EntityAlreadyExistsException ex)
+        {
+            _logger.LogWarning(new EventId(LoggingIds.InsertItem, "CreateSftpConfiguration"), ex,
+                "An attempt was made to create a duplicate SFTP configuration for organizationId: {OrganizationId}",
+                organizationId);
+            return Conflict($"An SftpConfiguration already exists for organization: {organizationId}. Use PUT endpoint to update it.");
+        }
+        catch (Exception ex)
+        {
+            var message =
+                $"An unexpected error occurred while attempting to create an SFTP configuration for organizationId: {organizationId}. Trace Id: {httpContext.TraceIdentifier}";
+            _logger.LogError(new EventId(LoggingIds.InsertItem, "CreateSftpConfiguration"), ex,
+                "An exception occurred while attempting to create an SFTP configuration for organizationId: {OrganizationId}",
+                organizationId);
+            return Problem(title: "Internal Server Error", detail: message,
+                statusCode: (int)HttpStatusCode.InternalServerError);
+        }
+    }
+
+    /// <summary>
+    /// Updates an SftpConfiguration record for an organization. This update will do a clean replace of the existing record.
+    /// Supported Authentication Types: Basic (default)
+    /// </summary>
+    /// <param name="sftpConfiguration">The SFTP configuration model.</param>
+    /// <param name="cancellationToken"></param>
+    /// <returns>
+    ///     Success: 202
+    ///     Not Modified: 304
+    ///     Bad Request: 400
+    ///     Not Found: 404
+    ///     Server Error: 500
+    /// </returns>
+    [HttpPut("sftpConfiguration")]
+    [ProducesResponseType(StatusCodes.Status202Accepted, Type = typeof(SftpConfigurationModel))]
+    [ProducesResponseType(StatusCodes.Status304NotModified)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+    public async Task<ActionResult<SftpConfigurationModel>> UpdateSftpConfiguration(SftpConfigurationModel? sftpConfiguration, CancellationToken cancellationToken)
+    {
+        var httpContext = HttpContext;
+
+        try
+        {
+            if (sftpConfiguration is null)
+            {
+                return BadRequest("sftpConfiguration is null.");
+            }
+
+            if (sftpConfiguration.Id == Guid.Empty)
+            {
+                return BadRequest("SftpConfiguration.Id cannot be empty.");
+            }
+
+            // Default AuthType to Basic as per requirements
+            sftpConfiguration.AuthenticationProtocol = AuthType.Basic;
+
+            var result = await _sftpConfigurationManager.UpdateAsync(sftpConfiguration, cancellationToken);
+
+            if (result is null)
+            {
+                return Problem("SftpConfiguration not updated.", statusCode: (int)HttpStatusCode.NotModified);
+            }
+
+            return Accepted(result);
+        }
+        catch (NotFoundException ex)
+        {
+            _logger.LogWarning(new EventId(LoggingIds.UpdateItem, "UpdateSftpConfiguration"), ex,
+                "An attempt was made to update a non-existent SFTP configuration with Id: {Id}",
+                sftpConfiguration?.Id);
+            return NotFound($"No {nameof(SftpConfiguration)} found for the provided Id: {sftpConfiguration?.Id}. Unable to update configuration.");
+        }
+        catch (Exception ex)
+        {
+            var message =
+                $"An unexpected error occurred while attempting to update an SFTP configuration with Id: {sftpConfiguration?.Id}. Trace Id: {httpContext.TraceIdentifier}";
+            _logger.LogError(new EventId(LoggingIds.UpdateItem, "UpdateSftpConfiguration"), ex,
+                "An exception occurred while attempting to update an SFTP configuration with Id: {Id}",
+                sftpConfiguration?.Id);
+            return Problem(title: "Internal Server Error", detail: message,
+                statusCode: (int)HttpStatusCode.InternalServerError);
+        }
+    }
+
+    /// <summary>
+    /// Deletes an SftpConfiguration record for a given organization.
+    /// </summary>
+    /// <param name="organizationId">The organization identifier.</param>
+    /// <param name="cancellationToken"></param>
+    /// <returns>
+    ///     Success: 202
+    ///     Bad Request: 400
+    ///     Not Found: 404
+    ///     Server Error: 500
+    /// </returns>
+    [HttpDelete("{organizationId}/sftpConfiguration")]
+    [ProducesResponseType(StatusCodes.Status202Accepted)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+    public async Task<ActionResult> DeleteSftpConfiguration(string organizationId, CancellationToken cancellationToken)
+    {
+        var httpContext = HttpContext;
+
+        try
+        {
+            if (string.IsNullOrWhiteSpace(organizationId))
+            {
+                return BadRequest("OrganizationId is null or empty.");
+            }
+
+            organizationId = organizationId.SanitizeAndRemove();
+            var result = await _sftpConfigurationManager.DeleteAsync(organizationId, cancellationToken);
+
+            return Accepted(result);
+        }
+        catch (Exception ex)
+        {
+            var message = $"An unexpected error occurred while attempting to delete an SFTP configuration for organizationId: {organizationId}. Trace Id: {httpContext.TraceIdentifier}";
+            _logger.LogError(new EventId(LoggingIds.DeleteItem, "DeleteSftpConfiguration"), ex, "An exception occurred while attempting to delete an SFTP configuration for organizationId: {OrganizationId}", organizationId);
+            return Problem(title: "Internal Server Error", detail: message, statusCode: (int)HttpStatusCode.InternalServerError);
+        }
+    }
+}

--- a/DotNet/DataAcquisition/Controllers/SftpConfigurationController.cs
+++ b/DotNet/DataAcquisition/Controllers/SftpConfigurationController.cs
@@ -10,6 +10,7 @@ using Microsoft.AspNetCore.Mvc;
 using System.Net;
 using LantanaGroup.Link.DataAcquisition.Domain.Application.Models.Exceptions;
 using LantanaGroup.Link.DataAcquisition.Domain.Application.Services;
+using LantanaGroup.Link.Shared.Application.Error.Exceptions;
 using static LantanaGroup.Link.DataAcquisition.Domain.Settings.DataAcquisitionConstants;
 
 namespace LantanaGroup.Link.DataAcquisition.Controllers;
@@ -55,6 +56,8 @@ public class SftpConfigurationController : Controller
     public async Task<ActionResult<SftpConfigurationModel>> GetSftpConfigurationById(Guid id, CancellationToken cancellationToken)
     {
         var httpContext = HttpContext;
+        
+        // validate user access to organization before proceeding - future enhancement
 
         try
         {
@@ -99,6 +102,8 @@ public class SftpConfigurationController : Controller
     public async Task<ActionResult<SftpConfigurationModel>> GetOrgSftpConfiguration(string organizationId, CancellationToken cancellationToken)
     {
         var httpContext = HttpContext;
+        
+        // validate user access to organization before proceeding - future enhancement
 
         try
         {
@@ -130,7 +135,7 @@ public class SftpConfigurationController : Controller
     /// Optionally accepts credentials which will be stored securely in a configured secret manager.
     /// Supported Authentication Types: Basic (default)
     /// </summary>
-    /// <param name="organizationId">The organization identifier.</param>
+    /// <param name="organizationId">The identifier for the reporting organization.</param>
     /// <param name="sftpConfiguration">The SFTP configuration model with optional credentials.</param>
     /// <param name="cancellationToken"></param>
     /// <returns>
@@ -149,6 +154,8 @@ public class SftpConfigurationController : Controller
     public async Task<ActionResult<SftpConfigurationModel>> CreateSftpConfiguration(string organizationId, CreateSftpConfigurationModel? sftpConfiguration, CancellationToken cancellationToken)
     {
         var httpContext = HttpContext;
+        
+        // validate user access to organization before proceeding - future enhancement
 
         try
         {
@@ -201,6 +208,13 @@ public class SftpConfigurationController : Controller
                 organizationId);
             return Conflict($"An SftpConfiguration already exists for organization: {organizationId}. Use PUT endpoint to update it.");
         }
+        catch (InvalidOperationException ex)
+        {
+            _logger.LogWarning(new EventId(LoggingIds.InsertItem, "CreateSftpConfiguration"), ex,
+                "An attempt was made to create an SFTP configuration for organizationId: {OrganizationId} which already has a FHIR List configuration",
+                organizationId);
+            return Conflict(ex.Message);
+        }
         catch (Exception ex)
         {
             var message =
@@ -217,6 +231,8 @@ public class SftpConfigurationController : Controller
     /// Updates an SftpConfiguration record for an organization. This update will do a clean replace of the existing record.
     /// Supported Authentication Types: Basic (default)
     /// </summary>
+    /// <param name="organizationId">The identifier for the reporting organization.</param>
+    /// <param name="configurationId">The identifier of the SFTP configuration.</param>
     /// <param name="sftpConfiguration">The SFTP configuration model.</param>
     /// <param name="cancellationToken"></param>
     /// <returns>
@@ -226,18 +242,25 @@ public class SftpConfigurationController : Controller
     ///     Not Found: 404
     ///     Server Error: 500
     /// </returns>
-    [HttpPut("sftp-configurations")]
+    [HttpPut("{organizationId}/sftp-configurations/{configurationId}")]
     [ProducesResponseType(StatusCodes.Status202Accepted, Type = typeof(SftpConfigurationModel))]
     [ProducesResponseType(StatusCodes.Status304NotModified)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-    public async Task<ActionResult<SftpConfigurationModel>> UpdateSftpConfiguration(SftpConfigurationModel? sftpConfiguration, CancellationToken cancellationToken)
+    public async Task<ActionResult<SftpConfigurationModel>> UpdateSftpConfiguration(string organizationId, string configurationId, SftpConfigurationModel? sftpConfiguration, CancellationToken cancellationToken)
     {
         var httpContext = HttpContext;
 
+        // validate user access to organization before proceeding - future enhancement
+
         try
         {
+            if (string.IsNullOrWhiteSpace(organizationId))
+            {
+                return BadRequest("OrganizationId is null or empty.");
+            }
+
             if (sftpConfiguration is null)
             {
                 return BadRequest("sftpConfiguration is null.");
@@ -248,10 +271,14 @@ public class SftpConfigurationController : Controller
                 return BadRequest("SftpConfiguration.Id cannot be empty.");
             }
 
-            // Default AuthType to Basic as per requirements
-            sftpConfiguration.AuthenticationProtocol = AuthType.Basic;
+            if (!Guid.TryParse(configurationId, out var configId) || configId != sftpConfiguration.Id)
+            {
+                return BadRequest("The Id in the request does not match the Id in the SftpConfiguration model.");
+            }
 
-            var result = await _sftpConfigurationManager.UpdateAsync(sftpConfiguration, cancellationToken);
+            organizationId = organizationId.SanitizeAndRemove();
+            
+            var result = await _sftpConfigurationManager.UpdateAsync(organizationId, sftpConfiguration, cancellationToken);
 
             if (result is null)
             {
@@ -259,6 +286,15 @@ public class SftpConfigurationController : Controller
             }
 
             return Accepted(result);
+        }
+        catch (OrganizationalAccessException ex)
+        {
+            _logger.LogWarning(
+                new EventId(LoggingIds.UpdateItem, "UpdateSftpConfiguration"),
+                ex,
+                "The organizationId: {OrganizationId} does not have access to SFTP configuration Id: {ConfigurationId}",
+                organizationId, configurationId.SanitizeAndRemove());
+            return BadRequest($"The organizationId: {organizationId} does not have access to SFTP configuration Id: {configurationId.SanitizeAndRemove()}");
         }
         catch (NotFoundException ex)
         {
@@ -282,7 +318,8 @@ public class SftpConfigurationController : Controller
     /// <summary>
     /// Deletes an SftpConfiguration record for a given organization.
     /// </summary>
-    /// <param name="organizationId">The organization identifier.</param>
+    /// <param name="organizationId">The identifier for the reporting organization</param>
+    /// <param name="configurationId">The identifier for the SFTP configuration</param>
     /// <param name="cancellationToken"></param>
     /// <returns>
     ///     Success: 202
@@ -290,14 +327,16 @@ public class SftpConfigurationController : Controller
     ///     Not Found: 404
     ///     Server Error: 500
     /// </returns>
-    [HttpDelete("{organizationId}/sftp-configurations")]
+    [HttpDelete("{organizationId}/sftp-configurations/{configurationId}")]
     [ProducesResponseType(StatusCodes.Status202Accepted)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-    public async Task<ActionResult> DeleteSftpConfiguration(string organizationId, CancellationToken cancellationToken)
+    public async Task<ActionResult> DeleteSftpConfiguration(string organizationId, string configurationId, CancellationToken cancellationToken)
     {
         var httpContext = HttpContext;
+        
+        // validate user access to organization before proceeding - future enhancement
 
         try
         {
@@ -305,33 +344,49 @@ public class SftpConfigurationController : Controller
             {
                 return BadRequest("OrganizationId is null or empty.");
             }
+            
+            if(!Guid.TryParse(configurationId, out var configId))
+            {
+                return BadRequest("The SFTP configuration Id is in an invalid format.");
+            }
 
             organizationId = organizationId.SanitizeAndRemove();
 
             // Delete the configuration from the database
-            var result = await _sftpConfigurationManager.DeleteAsync(organizationId, cancellationToken);
-
-            // Also delete credentials from Key Vault (if they exist)
             try
             {
-                await _sftpCredentialService.DeleteCredentialsAsync(organizationId, cancellationToken);
+                var result = await _sftpConfigurationManager.DeleteAsync(organizationId, configId, cancellationToken);
+
+                // Also delete credentials from Key Vault (if they exist)
+                try
+                {
+                    await _sftpCredentialService.DeleteCredentialsAsync(configurationId, cancellationToken);
+                }
+                catch (Exception credEx)
+                {
+                    // Log but don't fail the request if credential deletion fails
+                    _logger.LogWarning(
+                        new EventId(LoggingIds.DeleteItem, "DeleteSftpConfiguration"),
+                        credEx,
+                        "SFTP configuration deleted but credentials could not be removed for organizationId: {OrganizationId}",
+                        organizationId);
+                }
+
+                return Accepted(result);
             }
-            catch (Exception credEx)
-            {
-                // Log but don't fail the request if credential deletion fails
+            catch (OrganizationalAccessException ex) {
                 _logger.LogWarning(
                     new EventId(LoggingIds.DeleteItem, "DeleteSftpConfiguration"),
-                    credEx,
-                    "SFTP configuration deleted but credentials could not be removed for organizationId: {OrganizationId}",
-                    organizationId);
+                    ex,
+                    "The organizationId: {OrganizationId} does not have access to SFTP configuration Id: {ConfigurationId}",
+                    organizationId, configurationId.SanitizeAndRemove());
+                return BadRequest($"The organizationId: {organizationId} does not have access to SFTP configuration Id: {configurationId.SanitizeAndRemove()}");
             }
-
-            return Accepted(result);
         }
         catch (Exception ex)
         {
-            var message = $"An unexpected error occurred while attempting to delete an SFTP configuration for organizationId: {organizationId}. Trace Id: {httpContext.TraceIdentifier}";
-            _logger.LogError(new EventId(LoggingIds.DeleteItem, "DeleteSftpConfiguration"), ex, "An exception occurred while attempting to delete an SFTP configuration for organizationId: {OrganizationId}", organizationId);
+            var message = $"An unexpected error occurred while attempting to delete an SFTP configuration for organizationId: {configurationId}. Trace Id: {httpContext.TraceIdentifier}";
+            _logger.LogError(new EventId(LoggingIds.DeleteItem, "DeleteSftpConfiguration"), ex, "An exception occurred while attempting to delete an SFTP configuration for organizationId: {OrganizationId}", configurationId);
             return Problem(title: "Internal Server Error", detail: message, statusCode: (int)HttpStatusCode.InternalServerError);
         }
     }
@@ -359,6 +414,8 @@ public class SftpConfigurationController : Controller
     public async Task<ActionResult> UpdateSftpCredentials(string organizationId, SftpCredentialsModel? credentials, CancellationToken cancellationToken)
     {
         var httpContext = HttpContext;
+        
+        // validate user access to organization before proceeding - future enhancement
 
         try
         {
@@ -428,6 +485,8 @@ public class SftpConfigurationController : Controller
     public async Task<ActionResult<SftpCredentialStatusModel>> GetSftpCredentialStatus(string organizationId, CancellationToken cancellationToken)
     {
         var httpContext = HttpContext;
+        
+        // validate user access to organization before proceeding - future enhancement
 
         try
         {
@@ -476,6 +535,8 @@ public class SftpConfigurationController : Controller
     public async Task<ActionResult> DeleteSftpCredentials(string organizationId, CancellationToken cancellationToken)
     {
         var httpContext = HttpContext;
+        
+        // validate user access to organization before proceeding - future enhancement
 
         try
         {

--- a/DotNet/DataAcquisition/Controllers/SftpConfigurationController.cs
+++ b/DotNet/DataAcquisition/Controllers/SftpConfigurationController.cs
@@ -317,7 +317,7 @@ public class SftpConfigurationController : Controller
         {
             _logger.LogWarning(new EventId(LoggingIds.UpdateItem, "UpdateSftpConfiguration"), ex,
                 "An attempt was made to update a non-existent SFTP configuration with Id: {Id}",
-                sftpConfiguration?.Id);
+                sftpConfiguration?.Id.ToString().SanitizeAndRemove());
             return NotFound($"No {nameof(SftpConfiguration)} found for the provided Id: {sftpConfiguration?.Id.ToString().SanitizeAndRemove()}. Unable to update configuration.");
         }
         catch (Exception ex)
@@ -404,7 +404,7 @@ public class SftpConfigurationController : Controller
         catch (Exception ex)
         {
             var message = $"An unexpected error occurred while attempting to delete an SFTP configuration for organizationId: {configurationId.SanitizeAndRemove()}. Trace Id: {httpContext.TraceIdentifier}";
-            _logger.LogError(new EventId(LoggingIds.DeleteItem, "DeleteSftpConfiguration"), ex, "An exception occurred while attempting to delete an SFTP configuration for organizationId: {OrganizationId}", configurationId);
+            _logger.LogError(new EventId(LoggingIds.DeleteItem, "DeleteSftpConfiguration"), ex, "An exception occurred while attempting to delete an SFTP configuration for organizationId: {OrganizationId}", organizationId);
             return Problem(title: "Internal Server Error", detail: message, statusCode: (int)HttpStatusCode.InternalServerError);
         }
     }

--- a/DotNet/DataAcquisition/Controllers/SftpConfigurationController.cs
+++ b/DotNet/DataAcquisition/Controllers/SftpConfigurationController.cs
@@ -108,19 +108,21 @@ public class SftpConfigurationController : Controller
         
         // validate user access to organization before proceeding - future enhancement
 
+        // Sanitize organizationId
+        organizationId = organizationId.SanitizeAndRemove();
+        
         try
         {
             if (string.IsNullOrWhiteSpace(organizationId))
             {
                 return BadRequest("OrganizationId is null or empty.");
             }
-
-            organizationId = organizationId.SanitizeAndRemove();
+            
             var result = await _sftpConfigurationQueries.GetByOrganizationIdAsync(organizationId, cancellationToken);
 
             if (result is null)
             {
-                return NotFound($"No {nameof(SftpConfiguration)} found for organization: {organizationId}");
+                return NotFound($"No {nameof(SftpConfiguration)} found for organization: {organizationId.SanitizeAndRemove()}");
             }
 
             return Ok(result);
@@ -159,7 +161,10 @@ public class SftpConfigurationController : Controller
         var httpContext = HttpContext;
         
         // validate user access to organization before proceeding - future enhancement
-
+        
+        // Sanitize organizationId
+        organizationId = organizationId.SanitizeAndRemove();
+        
         try
         {
             if (sftpConfiguration is null)
@@ -182,9 +187,7 @@ public class SftpConfigurationController : Controller
 
             // Default AuthType to Basic until other authentication options are supported
             sftpConfiguration.AuthenticationProtocol = AuthType.Basic;
-
-            organizationId = organizationId.SanitizeAndRemove();
-
+            
             // Create the configuration in the database
             var result =
                 await _sftpConfigurationManager.CreateAsync(sftpConfiguration, organizationId, cancellationToken);
@@ -265,6 +268,9 @@ public class SftpConfigurationController : Controller
 
         // validate user access to organization before proceeding - future enhancement
 
+        // Sanitize organizationId
+        organizationId = organizationId.SanitizeAndRemove();
+        
         try
         {
             if (string.IsNullOrWhiteSpace(organizationId))
@@ -349,6 +355,9 @@ public class SftpConfigurationController : Controller
         
         // validate user access to organization before proceeding - future enhancement
 
+        // Sanitize organizationId
+        organizationId = organizationId.SanitizeAndRemove();
+        
         try
         {
             if (string.IsNullOrWhiteSpace(organizationId))
@@ -360,8 +369,6 @@ public class SftpConfigurationController : Controller
             {
                 return BadRequest("The SFTP configuration Id is in an invalid format.");
             }
-
-            organizationId = organizationId.SanitizeAndRemove();
 
             // Delete the configuration from the database
             try
@@ -428,6 +435,9 @@ public class SftpConfigurationController : Controller
         
         // validate user access to organization before proceeding - future enhancement
 
+        // Sanitize organizationId
+        organizationId = organizationId.SanitizeAndRemove();
+        
         try
         {
             if (string.IsNullOrWhiteSpace(organizationId))
@@ -449,8 +459,6 @@ public class SftpConfigurationController : Controller
             {
                 return BadRequest("Password is required.");
             }
-
-            organizationId = organizationId.SanitizeAndRemove();
 
             // Verify the SFTP configuration exists
             var existingConfig = await _sftpConfigurationQueries.GetByOrganizationIdAsync(organizationId, cancellationToken);
@@ -499,14 +507,15 @@ public class SftpConfigurationController : Controller
         
         // validate user access to organization before proceeding - future enhancement
 
+        // Sanitize organizationId
+        organizationId = organizationId.SanitizeAndRemove();
+        
         try
         {
             if (string.IsNullOrWhiteSpace(organizationId))
             {
                 return BadRequest("OrganizationId is null or empty.");
             }
-
-            organizationId = organizationId.SanitizeAndRemove();
 
             // Verify the SFTP configuration exists
             var existingConfig = await _sftpConfigurationQueries.GetByOrganizationIdAsync(organizationId, cancellationToken);
@@ -549,14 +558,15 @@ public class SftpConfigurationController : Controller
         
         // validate user access to organization before proceeding - future enhancement
 
+        // Sanitize organizationId
+        organizationId = organizationId.SanitizeAndRemove();
+        
         try
         {
             if (string.IsNullOrWhiteSpace(organizationId))
             {
                 return BadRequest("OrganizationId is null or empty.");
             }
-
-            organizationId = organizationId.SanitizeAndRemove();
 
             // Verify the SFTP configuration exists
             var existingConfig = await _sftpConfigurationQueries.GetByOrganizationIdAsync(organizationId, cancellationToken);

--- a/DotNet/DataAcquisition/Controllers/SftpConfigurationController.cs
+++ b/DotNet/DataAcquisition/Controllers/SftpConfigurationController.cs
@@ -11,6 +11,7 @@ using System.Net;
 using LantanaGroup.Link.DataAcquisition.Domain.Application.Models.Exceptions;
 using LantanaGroup.Link.DataAcquisition.Domain.Application.Services;
 using LantanaGroup.Link.Shared.Application.Error.Exceptions;
+using LantanaGroup.Link.Shared.Application.Services;
 using static LantanaGroup.Link.DataAcquisition.Domain.Settings.DataAcquisitionConstants;
 
 namespace LantanaGroup.Link.DataAcquisition.Controllers;
@@ -24,17 +25,19 @@ public class SftpConfigurationController : Controller
     private readonly ISftpConfigurationManager _sftpConfigurationManager;
     private readonly ISftpConfigurationQueries _sftpConfigurationQueries;
     private readonly ISftpCredentialService _sftpCredentialService;
+    private readonly ITenantApiService _tenantApiService;
 
     public SftpConfigurationController(
         ILogger<SftpConfigurationController> logger,
         ISftpConfigurationManager sftpConfigurationManager,
         ISftpConfigurationQueries sftpConfigurationQueries,
-        ISftpCredentialService sftpCredentialService)
+        ISftpCredentialService sftpCredentialService, ITenantApiService tenantApiService)
     {
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _sftpConfigurationManager = sftpConfigurationManager ?? throw new ArgumentNullException(nameof(sftpConfigurationManager));
         _sftpConfigurationQueries = sftpConfigurationQueries ?? throw new ArgumentNullException(nameof(sftpConfigurationQueries));
         _sftpCredentialService = sftpCredentialService ?? throw new ArgumentNullException(nameof(sftpCredentialService));
+        _tenantApiService = tenantApiService ?? throw new ArgumentNullException(nameof(tenantApiService));
     }
 
     /// <summary>
@@ -167,6 +170,14 @@ public class SftpConfigurationController : Controller
             if (string.IsNullOrWhiteSpace(organizationId))
             {
                 return BadRequest("OrganizationId is null or empty.");
+            }
+            
+            // Verify that the facility/organization exists
+            var facilityExists = await _tenantApiService.CheckFacilityExists(organizationId, cancellationToken);
+            
+            if (!facilityExists)
+            {
+                return NotFound($"No facility found for organizationId: {organizationId}");
             }
 
             // Default AuthType to Basic until other authentication options are supported

--- a/DotNet/DataAcquisition/Controllers/SftpConfigurationController.cs
+++ b/DotNet/DataAcquisition/Controllers/SftpConfigurationController.cs
@@ -9,6 +9,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using System.Net;
 using LantanaGroup.Link.DataAcquisition.Domain.Application.Models.Exceptions;
+using LantanaGroup.Link.DataAcquisition.Domain.Application.Services;
 using static LantanaGroup.Link.DataAcquisition.Domain.Settings.DataAcquisitionConstants;
 
 namespace LantanaGroup.Link.DataAcquisition.Controllers;
@@ -21,15 +22,18 @@ public class SftpConfigurationController : Controller
     private readonly ILogger<SftpConfigurationController> _logger;
     private readonly ISftpConfigurationManager _sftpConfigurationManager;
     private readonly ISftpConfigurationQueries _sftpConfigurationQueries;
+    private readonly ISftpCredentialService _sftpCredentialService;
 
     public SftpConfigurationController(
         ILogger<SftpConfigurationController> logger,
         ISftpConfigurationManager sftpConfigurationManager,
-        ISftpConfigurationQueries sftpConfigurationQueries)
+        ISftpConfigurationQueries sftpConfigurationQueries,
+        ISftpCredentialService sftpCredentialService)
     {
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _sftpConfigurationManager = sftpConfigurationManager ?? throw new ArgumentNullException(nameof(sftpConfigurationManager));
         _sftpConfigurationQueries = sftpConfigurationQueries ?? throw new ArgumentNullException(nameof(sftpConfigurationQueries));
+        _sftpCredentialService = sftpCredentialService ?? throw new ArgumentNullException(nameof(sftpCredentialService));
     }
 
     /// <summary>
@@ -43,7 +47,7 @@ public class SftpConfigurationController : Controller
     ///     Bad Request: 400
     ///     Server Error: 500
     /// </returns>
-    [HttpGet("sftpConfiguration/{id}")]
+    [HttpGet("sftp-configurations/{id}")]
     [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(SftpConfigurationModel))]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
@@ -87,7 +91,7 @@ public class SftpConfigurationController : Controller
     ///     Bad Request: 400
     ///     Server Error: 500
     /// </returns>
-    [HttpGet("{organizationId}/sftpConfiguration")]
+    [HttpGet("{organizationId}/sftp-configurations")]
     [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(SftpConfigurationModel))]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
@@ -123,10 +127,11 @@ public class SftpConfigurationController : Controller
 
     /// <summary>
     /// Creates an SftpConfiguration record for an organization. Should only be used for initial configuration.
+    /// Optionally accepts credentials which will be stored securely in a configured secret manager.
     /// Supported Authentication Types: Basic (default)
     /// </summary>
     /// <param name="organizationId">The organization identifier.</param>
-    /// <param name="sftpConfiguration">The SFTP configuration model.</param>
+    /// <param name="sftpConfiguration">The SFTP configuration model with optional credentials.</param>
     /// <param name="cancellationToken"></param>
     /// <returns>
     ///     Success: 201
@@ -135,13 +140,13 @@ public class SftpConfigurationController : Controller
     ///     Organization Already Exists: 409
     ///     Server Error: 500
     /// </returns>
-    [HttpPost("{organizationId}/sftpConfiguration")]
+    [HttpPost("{organizationId}/sftp-configurations")]
     [ProducesResponseType(StatusCodes.Status201Created, Type = typeof(SftpConfigurationModel))]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     [ProducesResponseType(StatusCodes.Status409Conflict)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-    public async Task<ActionResult<SftpConfigurationModel>> CreateSftpConfiguration(string organizationId, SftpConfigurationModel? sftpConfiguration, CancellationToken cancellationToken)
+    public async Task<ActionResult<SftpConfigurationModel>> CreateSftpConfiguration(string organizationId, CreateSftpConfigurationModel? sftpConfiguration, CancellationToken cancellationToken)
     {
         var httpContext = HttpContext;
 
@@ -161,8 +166,29 @@ public class SftpConfigurationController : Controller
             sftpConfiguration.AuthenticationProtocol = AuthType.Basic;
 
             organizationId = organizationId.SanitizeAndRemove();
+
+            // Create the configuration in the database
             var result =
                 await _sftpConfigurationManager.CreateAsync(sftpConfiguration, organizationId, cancellationToken);
+
+            // If credentials were provided, store them in the configured secret manager
+            if (sftpConfiguration.Credentials is not null &&
+                !string.IsNullOrWhiteSpace(sftpConfiguration.Credentials.Username) &&
+                !string.IsNullOrWhiteSpace(sftpConfiguration.Credentials.Password))
+            {
+                var credentialResult = await _sftpCredentialService.SetCredentialsAsync(
+                    organizationId,
+                    sftpConfiguration.Credentials,
+                    cancellationToken);
+
+                if (!credentialResult)
+                {
+                    _logger.LogWarning(
+                        new EventId(LoggingIds.InsertItem, "CreateSftpConfiguration"),
+                        "SFTP configuration created but credentials could not be stored for organizationId: {OrganizationId}",
+                        organizationId);
+                }
+            }
 
             return CreatedAtAction(nameof(GetOrgSftpConfiguration),
                 new { organizationId },
@@ -200,7 +226,7 @@ public class SftpConfigurationController : Controller
     ///     Not Found: 404
     ///     Server Error: 500
     /// </returns>
-    [HttpPut("sftpConfiguration")]
+    [HttpPut("sftp-configurations")]
     [ProducesResponseType(StatusCodes.Status202Accepted, Type = typeof(SftpConfigurationModel))]
     [ProducesResponseType(StatusCodes.Status304NotModified)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
@@ -264,7 +290,7 @@ public class SftpConfigurationController : Controller
     ///     Not Found: 404
     ///     Server Error: 500
     /// </returns>
-    [HttpDelete("{organizationId}/sftpConfiguration")]
+    [HttpDelete("{organizationId}/sftp-configurations")]
     [ProducesResponseType(StatusCodes.Status202Accepted)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
@@ -281,7 +307,24 @@ public class SftpConfigurationController : Controller
             }
 
             organizationId = organizationId.SanitizeAndRemove();
+
+            // Delete the configuration from the database
             var result = await _sftpConfigurationManager.DeleteAsync(organizationId, cancellationToken);
+
+            // Also delete credentials from Key Vault (if they exist)
+            try
+            {
+                await _sftpCredentialService.DeleteCredentialsAsync(organizationId, cancellationToken);
+            }
+            catch (Exception credEx)
+            {
+                // Log but don't fail the request if credential deletion fails
+                _logger.LogWarning(
+                    new EventId(LoggingIds.DeleteItem, "DeleteSftpConfiguration"),
+                    credEx,
+                    "SFTP configuration deleted but credentials could not be removed for organizationId: {OrganizationId}",
+                    organizationId);
+            }
 
             return Accepted(result);
         }
@@ -292,4 +335,174 @@ public class SftpConfigurationController : Controller
             return Problem(title: "Internal Server Error", detail: message, statusCode: (int)HttpStatusCode.InternalServerError);
         }
     }
+
+    #region Credential Endpoints
+
+    /// <summary>
+    /// Updates SFTP credentials for an organization's configuration.
+    /// Credentials are stored securely in a configured secret manager.
+    /// </summary>
+    /// <param name="organizationId">The organization identifier.</param>
+    /// <param name="credentials">The credentials to store.</param>
+    /// <param name="cancellationToken"></param>
+    /// <returns>
+    ///     Success: 202
+    ///     Bad Request: 400
+    ///     Not Found: 404
+    ///     Server Error: 500
+    /// </returns>
+    [HttpPut("{organizationId}/sftp-configurations/credentials")]
+    [ProducesResponseType(StatusCodes.Status202Accepted)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+    public async Task<ActionResult> UpdateSftpCredentials(string organizationId, SftpCredentialsModel? credentials, CancellationToken cancellationToken)
+    {
+        var httpContext = HttpContext;
+
+        try
+        {
+            if (string.IsNullOrWhiteSpace(organizationId))
+            {
+                return BadRequest("OrganizationId is null or empty.");
+            }
+
+            if (credentials is null)
+            {
+                return BadRequest("Credentials are required.");
+            }
+
+            if (string.IsNullOrWhiteSpace(credentials.Username))
+            {
+                return BadRequest("Username is required.");
+            }
+
+            if (string.IsNullOrWhiteSpace(credentials.Password))
+            {
+                return BadRequest("Password is required.");
+            }
+
+            organizationId = organizationId.SanitizeAndRemove();
+
+            // Verify the SFTP configuration exists
+            var existingConfig = await _sftpConfigurationQueries.GetByOrganizationIdAsync(organizationId, cancellationToken);
+            if (existingConfig is null)
+            {
+                return NotFound($"No {nameof(SftpConfiguration)} found for organization: {organizationId}. Create a configuration first.");
+            }
+
+            var result = await _sftpCredentialService.SetCredentialsAsync(organizationId, credentials, cancellationToken);
+
+            if (!result)
+            {
+                return Problem("Failed to store credentials.", statusCode: (int)HttpStatusCode.InternalServerError);
+            }
+
+            return Accepted();
+        }
+        catch (Exception ex)
+        {
+            var message = $"An unexpected error occurred while attempting to update SFTP credentials for organizationId: {organizationId}. Trace Id: {httpContext.TraceIdentifier}";
+            _logger.LogError(new EventId(LoggingIds.UpdateItem, "UpdateSftpCredentials"), ex, "An exception occurred while attempting to update SFTP credentials for organizationId: {OrganizationId}", organizationId);
+            return Problem(title: "Internal Server Error", detail: message, statusCode: (int)HttpStatusCode.InternalServerError);
+        }
+    }
+
+    /// <summary>
+    /// Gets the credential status for an organization's SFTP configuration.
+    /// Returns whether credentials exist, without exposing the actual values.
+    /// </summary>
+    /// <param name="organizationId">The organization identifier.</param>
+    /// <param name="cancellationToken"></param>
+    /// <returns>
+    ///     Success: 200
+    ///     Bad Request: 400
+    ///     Not Found: 404
+    ///     Server Error: 500
+    /// </returns>
+    [HttpGet("{organizationId}/sftp-configurations/credentials/status")]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(SftpCredentialStatusModel))]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+    public async Task<ActionResult<SftpCredentialStatusModel>> GetSftpCredentialStatus(string organizationId, CancellationToken cancellationToken)
+    {
+        var httpContext = HttpContext;
+
+        try
+        {
+            if (string.IsNullOrWhiteSpace(organizationId))
+            {
+                return BadRequest("OrganizationId is null or empty.");
+            }
+
+            organizationId = organizationId.SanitizeAndRemove();
+
+            // Verify the SFTP configuration exists
+            var existingConfig = await _sftpConfigurationQueries.GetByOrganizationIdAsync(organizationId, cancellationToken);
+            if (existingConfig is null)
+            {
+                return NotFound($"No {nameof(SftpConfiguration)} found for organization: {organizationId}");
+            }
+
+            var result = await _sftpCredentialService.GetCredentialStatusAsync(organizationId, cancellationToken);
+            return Ok(result);
+        }
+        catch (Exception ex)
+        {
+            var message = $"An unexpected error occurred while attempting to get SFTP credential status for organizationId: {organizationId}. Trace Id: {httpContext.TraceIdentifier}";
+            _logger.LogError(new EventId(LoggingIds.GetItem, "GetSftpCredentialStatus"), ex, "An exception occurred while attempting to get SFTP credential status for organizationId: {OrganizationId}", organizationId);
+            return Problem(title: "Internal Server Error", detail: message, statusCode: (int)HttpStatusCode.InternalServerError);
+        }
+    }
+
+    /// <summary>
+    /// Deletes SFTP credentials for an organization.
+    /// The SFTP configuration itself is not deleted.
+    /// </summary>
+    /// <param name="organizationId">The organization identifier.</param>
+    /// <param name="cancellationToken"></param>
+    /// <returns>
+    ///     Success: 202
+    ///     Bad Request: 400
+    ///     Not Found: 404
+    ///     Server Error: 500
+    /// </returns>
+    [HttpDelete("{organizationId}/sftp-configurations/credentials")]
+    [ProducesResponseType(StatusCodes.Status202Accepted)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+    public async Task<ActionResult> DeleteSftpCredentials(string organizationId, CancellationToken cancellationToken)
+    {
+        var httpContext = HttpContext;
+
+        try
+        {
+            if (string.IsNullOrWhiteSpace(organizationId))
+            {
+                return BadRequest("OrganizationId is null or empty.");
+            }
+
+            organizationId = organizationId.SanitizeAndRemove();
+
+            // Verify the SFTP configuration exists
+            var existingConfig = await _sftpConfigurationQueries.GetByOrganizationIdAsync(organizationId, cancellationToken);
+            if (existingConfig is null)
+            {
+                return NotFound($"No {nameof(SftpConfiguration)} found for organization: {organizationId}");
+            }
+
+            var result = await _sftpCredentialService.DeleteCredentialsAsync(organizationId, cancellationToken);
+            return Accepted(result);
+        }
+        catch (Exception ex)
+        {
+            var message = $"An unexpected error occurred while attempting to delete SFTP credentials for organizationId: {organizationId}. Trace Id: {httpContext.TraceIdentifier}";
+            _logger.LogError(new EventId(LoggingIds.DeleteItem, "DeleteSftpCredentials"), ex, "An exception occurred while attempting to delete SFTP credentials for organizationId: {OrganizationId}", organizationId);
+            return Problem(title: "Internal Server Error", detail: message, statusCode: (int)HttpStatusCode.InternalServerError);
+        }
+    }
+
+    #endregion
 }

--- a/DotNet/DataAcquisition/Controllers/SftpConfigurationController.cs
+++ b/DotNet/DataAcquisition/Controllers/SftpConfigurationController.cs
@@ -318,7 +318,7 @@ public class SftpConfigurationController : Controller
             _logger.LogWarning(new EventId(LoggingIds.UpdateItem, "UpdateSftpConfiguration"), ex,
                 "An attempt was made to update a non-existent SFTP configuration with Id: {Id}",
                 sftpConfiguration?.Id);
-            return NotFound($"No {nameof(SftpConfiguration)} found for the provided Id: {sftpConfiguration?.Id}. Unable to update configuration.");
+            return NotFound($"No {nameof(SftpConfiguration)} found for the provided Id: {sftpConfiguration?.Id.ToString().SanitizeAndRemove()}. Unable to update configuration.");
         }
         catch (Exception ex)
         {
@@ -326,7 +326,7 @@ public class SftpConfigurationController : Controller
                 $"An unexpected error occurred while attempting to update an SFTP configuration with Id: {sftpConfiguration?.Id}. Trace Id: {httpContext.TraceIdentifier}";
             _logger.LogError(new EventId(LoggingIds.UpdateItem, "UpdateSftpConfiguration"), ex,
                 "An exception occurred while attempting to update an SFTP configuration with Id: {Id}",
-                sftpConfiguration?.Id);
+                sftpConfiguration?.Id.ToString().SanitizeAndRemove());
             return Problem(title: "Internal Server Error", detail: message,
                 statusCode: (int)HttpStatusCode.InternalServerError);
         }
@@ -403,7 +403,7 @@ public class SftpConfigurationController : Controller
         }
         catch (Exception ex)
         {
-            var message = $"An unexpected error occurred while attempting to delete an SFTP configuration for organizationId: {configurationId}. Trace Id: {httpContext.TraceIdentifier}";
+            var message = $"An unexpected error occurred while attempting to delete an SFTP configuration for organizationId: {configurationId.SanitizeAndRemove()}. Trace Id: {httpContext.TraceIdentifier}";
             _logger.LogError(new EventId(LoggingIds.DeleteItem, "DeleteSftpConfiguration"), ex, "An exception occurred while attempting to delete an SFTP configuration for organizationId: {OrganizationId}", configurationId);
             return Problem(title: "Internal Server Error", detail: message, statusCode: (int)HttpStatusCode.InternalServerError);
         }

--- a/DotNet/DataAcquisition/Program.cs
+++ b/DotNet/DataAcquisition/Program.cs
@@ -19,6 +19,7 @@ using LantanaGroup.Link.Shared.Application.Models;
 using LantanaGroup.Link.Shared.Application.Models.Configs;
 using LantanaGroup.Link.Shared.Settings;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.AspNetCore.DataProtection;
 using Microsoft.AspNetCore.Diagnostics.HealthChecks;
 using Microsoft.OpenApi.Models;
 using System.Reflection;
@@ -38,7 +39,14 @@ static void RegisterServices(WebApplicationBuilder builder)
 {
     var consumerSettings = builder.Configuration.GetRequiredSection(nameof(ConsumerSettings)).Get<ConsumerSettings>();
 
-    builder.RegisterAll(DataAcquisitionConstants.ServiceName, true);
+    // Determine if secret manager should be enabled based on configuration
+    var secretManagerEnabled = builder.Configuration.GetValue<bool>("SecretManagement:Enabled");
+
+    builder.RegisterAll(DataAcquisitionConstants.ServiceName, configureRedis: true, configureSecretManager: secretManagerEnabled);
+
+    // Add Data Protection
+    builder.Services.AddDataProtection()
+        .SetApplicationName(builder.Configuration.GetValue<string>("DataProtection:KeyRing") ?? "Link");
 
     builder.Services.AddTransient<IRetryModelFactory, RetryModelFactory>();
 

--- a/DotNet/DataAcquisition/appsettings.Development.json
+++ b/DotNet/DataAcquisition/appsettings.Development.json
@@ -16,6 +16,11 @@
     "SaslProtocolEnabled": false,
     "SaslUsername": ""
   },
+  "SecretManagement": {
+    "Enabled": true,
+    "Manager": "",
+    "ManagerUri": ""
+  },
   "Authentication": {
     "EnableAnonymousAccess": false,
     "Schemas": {

--- a/DotNet/DataAcquisition/appsettings.json
+++ b/DotNet/DataAcquisition/appsettings.json
@@ -36,6 +36,11 @@
     "DatabaseConnection": "Server=localhost\\SQLEXPRESS; Initial Catalog=link-dev-botw-data;Integrated Security=true;Encrypt=false;TrustServerCertificate=True",
     "Redis": "localhost:6379"
   },
+  "SecretManagement": {
+    "Enabled": false,
+    "Manager": "",
+    "ManagerUri": ""
+  },
   "Authentication": {
     "EnableAnonymousAccess": true,
     "Schemas": {

--- a/DotNet/ServiceTests/IntegrationTests/DataAcquisition/DataAcquisitionIntegrationTestFixture.cs
+++ b/DotNet/ServiceTests/IntegrationTests/DataAcquisition/DataAcquisitionIntegrationTestFixture.cs
@@ -61,6 +61,8 @@ namespace IntegrationTests.DataAcquisition
                     services.AddScoped<IEntityRepository<QueryPlan>, EntityRepository<QueryPlan, DataAcquisitionDbContext>>();
                     services.AddTransient<IEntityRepository<FhirQueryResourceType>, EntityRepository<FhirQueryResourceType, DataAcquisitionDbContext>>();
                     services.AddTransient<IEntityRepository<ResourceReferenceType>, EntityRepository<ResourceReferenceType, DataAcquisitionDbContext>>();
+                    services.AddScoped<IEntityRepository<SftpAcquisitionLog>, EntityRepository<SftpAcquisitionLog, DataAcquisitionDbContext>>();
+                    services.AddScoped<IEntityRepository<SftpConfiguration>, EntityRepository<SftpConfiguration, DataAcquisitionDbContext>>();
 
                     // Register IDatabase implementation
                     services.AddScoped<LantanaGroup.Link.DataAcquisition.Domain.Infrastructure.IDatabase, LantanaGroup.Link.DataAcquisition.Domain.Infrastructure.Database>();

--- a/DotNet/ServiceTests/IntegrationTests/DataAcquisition/Managers/FhirListQueryConfigurationManagerTests.cs
+++ b/DotNet/ServiceTests/IntegrationTests/DataAcquisition/Managers/FhirListQueryConfigurationManagerTests.cs
@@ -1,0 +1,63 @@
+using LantanaGroup.Link.DataAcquisition.Domain.Application.Managers;
+using LantanaGroup.Link.DataAcquisition.Domain.Application.Models;
+using LantanaGroup.Link.DataAcquisition.Domain.Application.Models.Api.Configuration;
+using LantanaGroup.Link.DataAcquisition.Domain.Infrastructure;
+using LantanaGroup.Link.DataAcquisition.Domain.Infrastructure.Context;
+using LantanaGroup.Link.DataAcquisition.Domain.Infrastructure.Entities;
+using Microsoft.Extensions.DependencyInjection;
+using Task = System.Threading.Tasks.Task;
+
+namespace IntegrationTests.DataAcquisition.Managers;
+
+[Collection("DataAcquisitionIntegrationTests")]
+[Trait("Category", "IntegrationTests")]
+public class FhirListQueryConfigurationManagerTests(DataAcquisitionIntegrationTestFixture fixture)
+    : IClassFixture<DataAcquisitionIntegrationTestFixture>
+{
+    private IFhirListQueryConfigurationManager CreateManager(IServiceScope scope)
+    {
+        var database = scope.ServiceProvider.GetRequiredService<IDatabase>();
+        return new FhirListQueryConfigurationManager(database);
+    }
+
+    [Fact]
+    public async Task CreateAsync_FacilityHasSftpConfiguration_ThrowsInvalidOperationException()
+    {
+        // Arrange
+        using var scope = fixture.ServiceProvider.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<DataAcquisitionDbContext>();
+
+        await dbContext.Database.EnsureDeletedAsync();
+        await dbContext.Database.EnsureCreatedAsync();
+
+        const string facilityId = "TestFacility";
+
+        // Create existing SFTP configuration for the facility
+        var sftpConfig = new SftpConfiguration
+        {
+            Id = Guid.NewGuid(),
+            OrganizationId = facilityId,
+            Host = "sftp.example.com",
+            Port = 22,
+            RemoteDirectory = "/data",
+            Timeout = TimeSpan.FromSeconds(60)
+        };
+
+        dbContext.SftpConfigurations.Add(sftpConfig);
+        await dbContext.SaveChangesAsync();
+
+        var manager = CreateManager(scope);
+        var fhirListConfigModel = new CreateFhirListConfigurationModel
+        {
+            FacilityId = facilityId,
+            FhirBaseServerUrl = "https://fhir.example.com",
+            EHRPatientLists = new List<EhrPatientListModel>()
+        };
+
+        // Act & Assert
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => manager.CreateAsync(fhirListConfigModel, CancellationToken.None));
+        
+        Assert.Contains(facilityId, exception.Message);
+    }
+}

--- a/DotNet/ServiceTests/IntegrationTests/DataAcquisition/Managers/SftpConfigurationManagerTests.cs
+++ b/DotNet/ServiceTests/IntegrationTests/DataAcquisition/Managers/SftpConfigurationManagerTests.cs
@@ -1,0 +1,142 @@
+using LantanaGroup.Link.DataAcquisition.Domain.Application.Managers;
+using LantanaGroup.Link.DataAcquisition.Domain.Application.Models.Api.Configuration;
+using LantanaGroup.Link.DataAcquisition.Domain.Infrastructure;
+using LantanaGroup.Link.DataAcquisition.Domain.Infrastructure.Context;
+using LantanaGroup.Link.DataAcquisition.Domain.Infrastructure.Entities;
+using LantanaGroup.Link.DataAcquisition.Domain.Infrastructure.Models;
+using LantanaGroup.Link.Shared.Application.Error.Exceptions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Task = System.Threading.Tasks.Task;
+
+namespace IntegrationTests.DataAcquisition.Managers;
+
+[Collection("DataAcquisitionIntegrationTests")]
+[Trait("Category", "IntegrationTests")]
+public class SftpConfigurationManagerTests(DataAcquisitionIntegrationTestFixture fixture)
+    : IClassFixture<DataAcquisitionIntegrationTestFixture>
+{
+    private ISftpConfigurationManager CreateManager(IServiceScope scope)
+    {
+        var logger = new Mock<ILogger<SftpConfigurationManager>>().Object;
+        var database = scope.ServiceProvider.GetRequiredService<IDatabase>();
+        var fhirListConfigurationQueries = scope.ServiceProvider.GetRequiredService<IFhirQueryListConfigurationQueries>();
+        return new SftpConfigurationManager(logger, database, fhirListConfigurationQueries);
+    }
+
+    [Fact]
+    public async Task CreateAsync_FacilityHasFhirListConfiguration_ThrowsInvalidOperationException()
+    {
+        // Arrange
+        using var scope = fixture.ServiceProvider.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<DataAcquisitionDbContext>();
+
+        await dbContext.Database.EnsureDeletedAsync();
+        await dbContext.Database.EnsureCreatedAsync();
+
+        const string organizationId = "TestFacility";
+
+        // Create existing FHIR List configuration for the facility
+        var fhirListConfig = new FhirListConfiguration
+        {
+            Id = Guid.NewGuid(),
+            FacilityId = organizationId,
+            FhirBaseServerUrl = "https://fhir.example.com",
+            EHRPatientLists = new List<EhrPatientList>()
+        };
+        
+        dbContext.FhirListConfigurations.Add(fhirListConfig);
+        await dbContext.SaveChangesAsync();
+
+        var manager = CreateManager(scope);
+        var sftpConfigModel = new SftpConfigurationModel
+        {
+            Host = "sftp.example.com",
+            Port = 22,
+            RemoteDirectory = "/data",
+            Timeout = TimeSpan.FromSeconds(60)
+        };
+
+        // Act & Assert
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => manager.CreateAsync(sftpConfigModel, organizationId, CancellationToken.None));
+        
+        Assert.Contains(organizationId, exception.Message);
+    }
+
+    [Fact]
+    public async Task UpdateAsync_OrganizationIdMismatch_ThrowsOrganizationalAccessException()
+    {
+        // Arrange
+        using var scope = fixture.ServiceProvider.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<DataAcquisitionDbContext>();
+
+        await dbContext.Database.EnsureDeletedAsync();
+        await dbContext.Database.EnsureCreatedAsync();
+
+        const string storedOrganizationId = "StoredOrganization";
+        const string requestOrganizationId = "DifferentOrganization";
+
+        // Create existing SFTP configuration for a different organization
+        var existingConfig = new SftpConfiguration
+        {
+            Id = Guid.NewGuid(),
+            OrganizationId = storedOrganizationId,
+            Host = "sftp.example.com",
+            Port = 22,
+            RemoteDirectory = "/data",
+            Timeout = TimeSpan.FromSeconds(60)
+        };
+        
+        dbContext.SftpConfigurations.Add(existingConfig);
+        await dbContext.SaveChangesAsync();
+
+        var manager = CreateManager(scope);
+        var updateModel = new SftpConfigurationModel
+        {
+            Id = existingConfig.Id,
+            Host = "sftp.updated.com",
+            Port = 22,
+            RemoteDirectory = "/updated-data",
+            Timeout = TimeSpan.FromSeconds(120)
+        };
+
+        // Act & Assert
+        await Assert.ThrowsAsync<OrganizationalAccessException>(
+            () => manager.UpdateAsync(requestOrganizationId, updateModel, CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task DeleteAsync_OrganizationIdMismatch_ThrowsOrganizationalAccessException()
+    {
+        // Arrange
+        using var scope = fixture.ServiceProvider.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<DataAcquisitionDbContext>();
+
+        await dbContext.Database.EnsureDeletedAsync();
+        await dbContext.Database.EnsureCreatedAsync();
+
+        const string storedOrganizationId = "StoredOrganization";
+        const string requestOrganizationId = "DifferentOrganization";
+
+        // Create existing SFTP configuration for a different organization
+        var existingConfig = new SftpConfiguration
+        {
+            Id = Guid.NewGuid(),
+            OrganizationId = storedOrganizationId,
+            Host = "sftp.example.com",
+            Port = 22,
+            RemoteDirectory = "/data",
+            Timeout = TimeSpan.FromSeconds(60)
+        };
+        dbContext.SftpConfigurations.Add(existingConfig);
+        await dbContext.SaveChangesAsync();
+
+        var manager = CreateManager(scope);
+
+        // Act & Assert
+        await Assert.ThrowsAsync<OrganizationalAccessException>(
+            () => manager.DeleteAsync(requestOrganizationId, existingConfig.Id, CancellationToken.None));
+    }
+}

--- a/DotNet/Shared/Application/Error/Exceptions/OrganizationalAccessException.cs
+++ b/DotNet/Shared/Application/Error/Exceptions/OrganizationalAccessException.cs
@@ -1,0 +1,53 @@
+﻿namespace LantanaGroup.Link.Shared.Application.Error.Exceptions;
+
+/// <summary>
+/// Exception thrown when a user or process attempts to access an organization they are not authorized for.
+/// </summary>
+public class OrganizationalAccessException : Exception
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="OrganizationalAccessException"/> class.
+    /// </summary>
+    public OrganizationalAccessException()
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="OrganizationalAccessException"/> class with a specified error message.
+    /// </summary>
+    /// <param name="message">The message that describes the error.</param>
+    public OrganizationalAccessException(string message)
+        : base(message)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="OrganizationalAccessException"/> class with organization identifiers.
+    /// </summary>
+    /// <param name="organizationId">The expected organization identifier.</param>
+    /// <param name="requestedOrganizationId">The requested organization identifier.</param>
+    public OrganizationalAccessException(string organizationId, string requestedOrganizationId)
+        : base($"Organization {requestedOrganizationId} does not match the expected organization {organizationId}.")
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="OrganizationalAccessException"/> class with a user and organization identifier.
+    /// </summary>
+    /// <param name="userId">The user identifier.</param>
+    /// <param name="organizationId">The organization identifier.</param>
+    public OrganizationalAccessException(Guid userId, string organizationId)
+        : base($"User {userId} does not have access to organization {organizationId}.")
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="OrganizationalAccessException"/> class with a specified error message and a reference to the inner exception that is the cause of this exception.
+    /// </summary>
+    /// <param name="message">The error message.</param>
+    /// <param name="innerException">The exception that is the cause of the current exception.</param>
+    public OrganizationalAccessException(string message, Exception innerException)
+        : base(message, innerException)
+    {
+    }
+}

--- a/DotNet/Shared/Application/Interfaces/Services/ISecretManager.cs
+++ b/DotNet/Shared/Application/Interfaces/Services/ISecretManager.cs
@@ -2,8 +2,9 @@
 {
     public interface ISecretManager
     {
-        Task<string> GetSecretAsync(string secretName, CancellationToken cancellationToken);
-        Task<string> GetSecretAsync(string secretName, string version, CancellationToken cancellationToken);
+        Task<string?> GetSecretAsync(string secretName, CancellationToken cancellationToken);
+        Task<string?> GetSecretAsync(string secretName, string version, CancellationToken cancellationToken);
         Task<bool> SetSecretAsync(string secretName, string secretValue, CancellationToken cancellationToken);
+        Task<bool> DeleteSecretAsync(string secretName, CancellationToken cancellationToken);
     }
 }

--- a/DotNet/Shared/Application/Services/SecretManager/AzureKeyVaultSecretManager.cs
+++ b/DotNet/Shared/Application/Services/SecretManager/AzureKeyVaultSecretManager.cs
@@ -2,6 +2,7 @@
 using Azure.Security.KeyVault.Secrets;
 using LantanaGroup.Link.Shared.Application.Interfaces.Services;
 using LantanaGroup.Link.Shared.Application.Models.Configs;
+using LantanaGroup.Link.Shared.Application.Services.Security;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
@@ -43,7 +44,7 @@ namespace LantanaGroup.Link.Shared.Application.Services.SecretManager
         {
             var operation = await _secretClient.StartDeleteSecretAsync(secretName, cancellationToken);
             await operation.WaitForCompletionAsync(cancellationToken);
-            _logger.LogInformation("Secret {SecretName} deleted from Azure Key Vault", secretName);
+            _logger.LogInformation("Secret {SecretName} deleted from Azure Key Vault", secretName.SanitizeAndRemove());
             return true;
         }
     }

--- a/DotNet/Shared/Application/Services/SecretManager/AzureKeyVaultSecretManager.cs
+++ b/DotNet/Shared/Application/Services/SecretManager/AzureKeyVaultSecretManager.cs
@@ -20,13 +20,14 @@ namespace LantanaGroup.Link.Shared.Application.Services.SecretManager
             _logger.LogInformation("Azure Key Vault Secret Manager initialized");
         }
 
-        public async Task<string> GetSecretAsync(string secretName, CancellationToken cancellationToken)
+        public async Task<string?> GetSecretAsync(string secretName, CancellationToken cancellationToken)
         {
             var secret = await _secretClient.GetSecretAsync(secretName, cancellationToken: cancellationToken);
             return secret.Value.Value;
         }
 
-        public async Task<string> GetSecretAsync(string secretName, string version, CancellationToken cancellationToken)
+        public async Task<string?> GetSecretAsync(string secretName, string version,
+            CancellationToken cancellationToken)
         {
             var secret = await _secretClient.GetSecretAsync(secretName, version, cancellationToken);
             return secret.Value.Value;
@@ -36,6 +37,14 @@ namespace LantanaGroup.Link.Shared.Application.Services.SecretManager
         {
             var result = await _secretClient.SetSecretAsync(secretName, secretValue, cancellationToken);
             return result.Value != null;
+        }
+
+        public async Task<bool> DeleteSecretAsync(string secretName, CancellationToken cancellationToken)
+        {
+            var operation = await _secretClient.StartDeleteSecretAsync(secretName, cancellationToken);
+            await operation.WaitForCompletionAsync(cancellationToken);
+            _logger.LogInformation("Secret {SecretName} deleted from Azure Key Vault", secretName);
+            return true;
         }
     }
 }

--- a/DotNet/Shared/Application/Services/SecretManager/LocalSecretManager.cs
+++ b/DotNet/Shared/Application/Services/SecretManager/LocalSecretManager.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.DataProtection;
 using Microsoft.Extensions.Logging;
 using System.Security.Cryptography;
 using System.Text.Json;
+using LantanaGroup.Link.Shared.Application.Services.Security;
 
 namespace LantanaGroup.Link.Shared.Application.Services.SecretManager
 {
@@ -63,7 +64,7 @@ namespace LantanaGroup.Link.Shared.Application.Services.SecretManager
         {
             _secrets[secretName] = secretValue;
             SaveSecretsToFile();
-            _logger.LogInformation("Secret {SecretName} saved to local secret manager", secretName);
+            _logger.LogInformation("Secret {SecretName} saved to local secret manager", secretName.SanitizeAndRemove());
             return Task.FromResult(true);
         }
 
@@ -74,7 +75,7 @@ namespace LantanaGroup.Link.Shared.Application.Services.SecretManager
             {
                 SaveSecretsToFile();
             }
-            _logger.LogInformation("Secret {SecretName} {Result} from local secret manager", secretName, removed ? "deleted" : "not found");
+            _logger.LogInformation("Secret {SecretName} {Result} from local secret manager", secretName.SanitizeAndRemove(), removed ? "deleted" : "not found");
             return Task.FromResult(true);
         }
 

--- a/DotNet/Shared/Application/Services/SecretManager/LocalSecretManager.cs
+++ b/DotNet/Shared/Application/Services/SecretManager/LocalSecretManager.cs
@@ -1,64 +1,153 @@
-﻿using LantanaGroup.Link.Shared.Application.Interfaces.Services;
+using LantanaGroup.Link.Shared.Application.Interfaces.Services;
 using Link.Authorization.Infrastructure;
+using Microsoft.AspNetCore.DataProtection;
 using Microsoft.Extensions.Logging;
 using System.Security.Cryptography;
+using System.Text.Json;
 
 namespace LantanaGroup.Link.Shared.Application.Services.SecretManager
 {
-    internal class LocalSecretManager : ISecretManager
+    /// <summary>
+    /// Local secret manager for development environments.
+    /// Stores secrets in an encrypted JSON file using Data Protection API.
+    /// Secrets are loaded into memory on startup for fast access.
+    /// </summary>
+    public class LocalSecretManager : ISecretManager
     {
         private readonly ILogger<LocalSecretManager> _logger;
+        private readonly IDataProtector _protector;
+        private readonly string _secretsFilePath;
+        private readonly object _fileLock = new();
         private Dictionary<string, string> _secrets = [];
 
-        public LocalSecretManager(ILogger<LocalSecretManager> logger)
+        private const string ProtectorPurpose = "LocalSecretManager.Secrets.v1";
+        private const string SecretsFileName = "link-local-secrets.enc";
+        private readonly JsonSerializerOptions _jsonSerializerOptions = new() { WriteIndented = false };
+
+        public LocalSecretManager(
+            ILogger<LocalSecretManager> logger,
+            IDataProtectionProvider dataProtectionProvider)
         {
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+            _protector = dataProtectionProvider?.CreateProtector(ProtectorPurpose)
+                ?? throw new ArgumentNullException(nameof(dataProtectionProvider));
 
-            _secrets.Add(LinkAuthorizationConstants.LinkBearerService.LinkBearerKeyName, GenerateRandomKey(64));
-            _logger.LogInformation("Local Secret Manager initialized");
+            // Store secrets file in user's local app data folder
+            var appDataPath = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+            var linkSecretsPath = Path.Combine(appDataPath, "Link", "Secrets");
+            Directory.CreateDirectory(linkSecretsPath);
+            _secretsFilePath = Path.Combine(linkSecretsPath, SecretsFileName);
+
+            // Load existing secrets from file
+            LoadSecretsFromFile();
+
+            // Ensure the bearer key exists (generate if not present)
+            EnsureBearerKeyExists();
+
+            _logger.LogInformation("Local Secret Manager initialized with persistence at {SecretsPath}", linkSecretsPath);
         }
 
-
-        public Task<string> GetSecretAsync(string secretName, CancellationToken cancellationToken)
+        public Task<string?> GetSecretAsync(string secretName, CancellationToken cancellationToken)
         {
-            return Task.FromResult(GetSecret(secretName));
+            var secret = _secrets.GetValueOrDefault(secretName);
+            return Task.FromResult(secret);
         }
 
-        public Task<string> GetSecretAsync(string secretName, string version, CancellationToken cancellationToken)
+        public Task<string?> GetSecretAsync(string secretName, string version, CancellationToken cancellationToken)
         {
-            throw new NotImplementedException();
+            // Version not supported in local secret manager
+            return GetSecretAsync(secretName, cancellationToken);
         }
 
         public Task<bool> SetSecretAsync(string secretName, string secretValue, CancellationToken cancellationToken)
         {
-            return Task.FromResult(SetSecret(secretName, secretValue));
+            _secrets[secretName] = secretValue;
+            SaveSecretsToFile();
+            _logger.LogInformation("Secret {SecretName} saved to local secret manager", secretName);
+            return Task.FromResult(true);
         }
 
-        private string GetSecret(string secretKey)
+        public Task<bool> DeleteSecretAsync(string secretName, CancellationToken cancellationToken)
         {
-            return _secrets.TryGetValue(secretKey, out var secret) ? secret : null;
+            var removed = _secrets.Remove(secretName);
+            if (removed)
+            {
+                SaveSecretsToFile();
+            }
+            _logger.LogInformation("Secret {SecretName} {Result} from local secret manager", secretName, removed ? "deleted" : "not found");
+            return Task.FromResult(true);
         }
 
-        private bool SetSecret(string secretKey, string secretValue)
+        private void LoadSecretsFromFile()
         {
-            _secrets.TryGetValue(secretKey, out var secret);
-
-            if (secret is not null)
+            lock (_fileLock)
             {
-                _secrets[secretKey] = secretValue;
-            }
-            else
-            {
-                _secrets.Add(secretKey, secretValue);
-            }
+                try
+                {
+                    if (!File.Exists(_secretsFilePath))
+                    {
+                        _logger.LogInformation("No existing secrets file found, starting with empty secrets");
+                        return;
+                    }
 
-            return true;
+                    var encryptedContent = File.ReadAllText(_secretsFilePath);
+                    if (string.IsNullOrWhiteSpace(encryptedContent))
+                    {
+                        return;
+                    }
+
+                    var decryptedContent = _protector.Unprotect(encryptedContent);
+                    _secrets = JsonSerializer.Deserialize<Dictionary<string, string>>(decryptedContent) ?? [];
+
+                    _logger.LogInformation("Loaded {Count} secrets from encrypted file", _secrets.Count);
+                }
+                catch (CryptographicException ex)
+                {
+                    _logger.LogWarning(ex, "Failed to decrypt secrets file (encryption key may have changed). Starting with empty secrets.");
+                    _secrets = [];
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Error loading secrets from file. Starting with empty secrets.");
+                    _secrets = [];
+                }
+            }
+        }
+
+        private void SaveSecretsToFile()
+        {
+            lock (_fileLock)
+            {
+                try
+                {
+                    var json = JsonSerializer.Serialize(_secrets, _jsonSerializerOptions);
+                    var encryptedContent = _protector.Protect(json);
+                    File.WriteAllText(_secretsFilePath, encryptedContent);
+                    _logger.LogDebug("Secrets persisted to encrypted file");
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Failed to save secrets to file");
+                    throw;
+                }
+            }
+        }
+
+        private void EnsureBearerKeyExists()
+        {
+            const string bearerKeyName = LinkAuthorizationConstants.LinkBearerService.LinkBearerKeyName;
+
+            if (_secrets.ContainsKey(bearerKeyName)) return;
+            
+            var key = GenerateRandomKey(64);
+            _secrets[bearerKeyName] = key;
+            
+            SaveSecretsToFile();
         }
 
         private static string GenerateRandomKey(int size)
         {
             using var rng = RandomNumberGenerator.Create();
-
             var randomNumber = new byte[size];
             rng.GetBytes(randomNumber);
             return Convert.ToBase64String(randomNumber);

--- a/Web/Admin.UI/src/app/components/data-acquisition/sftp-config-dialog/sftp-config-dialog.component.html
+++ b/Web/Admin.UI/src/app/components/data-acquisition/sftp-config-dialog/sftp-config-dialog.component.html
@@ -1,0 +1,19 @@
+<h1 mat-dialog-title class="dialog-form-header">{{dialogTitle}}</h1>
+<div mat-dialog-content>
+  <app-sftp-config-form
+    [item]="config"
+    [formMode]="formMode"
+    [viewOnly]="viewOnly"
+    (formValueChanged)="onFormValueChanged($event)"
+    (submittedConfiguration)="onSubmittedConfiguration($event)">
+  </app-sftp-config-form>
+</div>
+<div mat-dialog-actions align="end">
+  @if (!viewOnly) {
+    <button mat-raised-button color="primary" [disabled]="formIsInvalid" (click)="submitConfiguration()">
+      <mat-icon>{{ formMode == FormMode.Create ? 'save' : 'save_as' }}</mat-icon>
+      {{ formMode == FormMode.Create ? 'Create' : 'Update' }} SFTP Configuration
+    </button>
+  }
+  <button mat-raised-button mat-dialog-close>Close</button>
+</div>

--- a/Web/Admin.UI/src/app/components/data-acquisition/sftp-config-dialog/sftp-config-dialog.component.ts
+++ b/Web/Admin.UI/src/app/components/data-acquisition/sftp-config-dialog/sftp-config-dialog.component.ts
@@ -1,0 +1,74 @@
+import { Component, Inject, ViewChild } from '@angular/core';
+import { MatButtonModule } from '@angular/material/button';
+import { MatDialogModule, MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { MatIconModule } from '@angular/material/icon';
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { ISftpConfigurationModel } from '../../../interfaces/data-acquisition/sftp-config-model.interface';
+import { IEntityCreatedResponse } from '../../../interfaces/entity-created-response.model';
+import { FormMode } from '../../../models/FormMode.enum';
+import { SftpConfigFormComponent } from '../sftp-config-form/sftp-config-form.component';
+
+@Component({
+  selector: 'app-sftp-config-dialog',
+  standalone: true,
+  imports: [
+    MatDialogModule,
+    MatButtonModule,
+    MatIconModule,
+    SftpConfigFormComponent
+  ],
+  templateUrl: './sftp-config-dialog.component.html',
+  styleUrls: ['./sftp-config-dialog.component.scss']
+})
+export class SftpConfigDialogComponent {
+  dialogTitle: string = '';
+  viewOnly: boolean = false;
+  config!: ISftpConfigurationModel;
+  formMode!: FormMode;
+  formIsInvalid: boolean = true;
+
+  @ViewChild(SftpConfigFormComponent) configForm!: SftpConfigFormComponent;
+
+  constructor(
+    @Inject(MAT_DIALOG_DATA) public data: {
+      dialogTitle: string,
+      formMode: FormMode,
+      viewOnly: boolean,
+      sftpConfig: ISftpConfigurationModel
+    },
+    private dialogRef: MatDialogRef<SftpConfigDialogComponent>,
+    private snackBar: MatSnackBar
+  ) { }
+
+  ngOnInit(): void {
+    this.dialogTitle = this.data.dialogTitle;
+    this.viewOnly = this.data.viewOnly;
+    this.config = this.data.sftpConfig;
+    this.formMode = this.data.formMode;
+  }
+
+  get FormMode(): typeof FormMode {
+    return FormMode;
+  }
+
+  onFormValueChanged(formValidity: boolean) {
+    this.formIsInvalid = formValidity;
+  }
+
+  onSubmittedConfiguration(outcome: IEntityCreatedResponse) {
+    if (outcome.message.length > 0) {
+      this.dialogRef.close(outcome.message);
+    } else {
+      this.snackBar.open('Failed to save SFTP configuration, see error for details.', '', {
+        duration: 3500,
+        panelClass: 'error-snackbar',
+        horizontalPosition: 'end',
+        verticalPosition: 'top'
+      });
+    }
+  }
+
+  submitConfiguration() {
+    this.configForm.submitConfiguration();
+  }
+}

--- a/Web/Admin.UI/src/app/components/data-acquisition/sftp-config-form/sftp-config-form.component.html
+++ b/Web/Admin.UI/src/app/components/data-acquisition/sftp-config-form/sftp-config-form.component.html
@@ -1,0 +1,123 @@
+<form [formGroup]="configForm" class="dialog-form">
+  <div class="form-input">
+    <mat-form-field appearance="outline" class="form-input">
+      <mat-label>Facility Id</mat-label>
+      <input matInput formControlName="facilityId" [disabled]="true" placeholder="Facility Id">
+    </mat-form-field>
+  </div>
+
+  <div class="host-port-row">
+    <mat-form-field appearance="outline" class="form-input host-field">
+      <mat-label>Host</mat-label>
+      <input matInput formControlName="host" [readonly]="viewOnly" placeholder="SFTP Server Host">
+      @if (hostControl.value && !viewOnly) {
+        <button matSuffix mat-icon-button aria-label="Clear" (click)="clearHost()">
+          <mat-icon>close</mat-icon>
+        </button>
+      }
+      @if (!viewOnly && hostControl.hasError('required')) {
+        <mat-error>Host is <strong>required</strong></mat-error>
+      }
+    </mat-form-field>
+    <mat-form-field appearance="outline" class="form-input port-field">
+      <mat-label>Port</mat-label>
+      <input matInput type="number" formControlName="port" [readonly]="viewOnly" placeholder="22">
+      @if (!viewOnly && portControl.hasError('required')) {
+        <mat-error>Port is <strong>required</strong></mat-error>
+      }
+      @if (!viewOnly && (portControl.hasError('min') || portControl.hasError('max'))) {
+        <mat-error>Port must be between 1 and 65535</mat-error>
+      }
+    </mat-form-field>
+  </div>
+
+  <div class="form-input">
+    <mat-form-field appearance="outline" class="form-input">
+      <mat-label>Remote Directory</mat-label>
+      <input matInput formControlName="remoteDirectory" [readonly]="viewOnly" placeholder="/path/to/census/files">
+      @if (remoteDirectoryControl.value && !viewOnly) {
+        <button matSuffix mat-icon-button aria-label="Clear" (click)="clearRemoteDirectory()">
+          <mat-icon>close</mat-icon>
+        </button>
+      }
+      <mat-hint>Path to the directory containing census files (optional)</mat-hint>
+    </mat-form-field>
+  </div>
+
+  <div class="form-row">
+    <mat-form-field appearance="outline" class="form-input timeout-field">
+      <mat-label>Timeout</mat-label>
+      <input matInput formControlName="timeout" [readonly]="viewOnly" placeholder="00:01:00">
+      @if (!viewOnly && timeoutControl.hasError('required')) {
+        <mat-error>Timeout is <strong>required</strong></mat-error>
+      }
+      <mat-hint>Format: HH:MM:SS</mat-hint>
+    </mat-form-field>
+
+    <div class="toggle-container">
+      <mat-slide-toggle formControlName="removeAfterProcessing" [disabled]="viewOnly">
+        Remove files after processing
+      </mat-slide-toggle>
+    </div>
+  </div>
+
+  @if (!viewOnly) {
+    <div class="credentials-section">
+      <div class="credentials-header">
+        <h4>Credentials</h4>
+        @if (formMode === 2 && credentialStatus) {
+          <span class="credential-status">
+            @if (credentialStatus.hasCredentials) {
+              <mat-icon class="status-icon configured">check_circle</mat-icon>
+              <span>Credentials configured</span>
+            } @else {
+              <mat-icon class="status-icon not-configured">warning</mat-icon>
+              <span>No credentials configured</span>
+            }
+          </span>
+        }
+      </div>
+
+      @if (formMode === 2) {
+        <button mat-stroked-button type="button" (click)="toggleCredentialFields()">
+          <mat-icon>{{ showCredentialFields ? 'visibility_off' : 'edit' }}</mat-icon>
+          {{ showCredentialFields ? 'Hide Credential Fields' : 'Update Credentials' }}
+        </button>
+      }
+
+      @if (showCredentialFields) {
+        <div class="credential-fields">
+          <mat-form-field appearance="outline" class="form-input">
+            <mat-label>Username</mat-label>
+            <input matInput formControlName="username" placeholder="SFTP Username" autocomplete="off">
+          </mat-form-field>
+
+          <mat-form-field appearance="outline" class="form-input">
+            <mat-label>Password</mat-label>
+            <input matInput type="password" formControlName="password" placeholder="SFTP Password" autocomplete="new-password">
+          </mat-form-field>
+
+          <p class="credential-hint">
+            <mat-icon>info</mat-icon>
+            Credentials are stored securely and are never displayed after saving.
+          </p>
+        </div>
+      }
+    </div>
+  }
+
+  @if (viewOnly && credentialStatus) {
+    <div class="credentials-section readonly">
+      <h4>Credentials</h4>
+      <span class="credential-status">
+        @if (credentialStatus.hasCredentials) {
+          <mat-icon class="status-icon configured">check_circle</mat-icon>
+          <span>Credentials configured</span>
+        } @else {
+          <mat-icon class="status-icon not-configured">warning</mat-icon>
+          <span>No credentials configured</span>
+        }
+      </span>
+    </div>
+  }
+</form>

--- a/Web/Admin.UI/src/app/components/data-acquisition/sftp-config-form/sftp-config-form.component.scss
+++ b/Web/Admin.UI/src/app/components/data-acquisition/sftp-config-form/sftp-config-form.component.scss
@@ -1,0 +1,113 @@
+@use '../../../../styles/core.scss';
+
+.host-port-row {
+  display: grid;
+  grid-template-columns: 4fr 1fr;
+  gap: 1rem;
+  align-items: flex-start;
+}
+
+.host-field {
+  width: 100%;
+}
+
+.port-field {
+  width: 100%;
+}
+
+.form-row {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1rem;
+  align-items: flex-start;
+}
+
+.flex-grow {
+  flex: 1;
+}
+
+.port-field {
+  width: 120px;
+  flex-shrink: 0;
+}
+
+.timeout-field {
+  width: auto;
+}
+
+.toggle-container {
+  display: flex;
+  align-items: center;
+  padding-top: 1rem;
+  width: auto;
+}
+
+.credentials-section {
+  margin-top: 1.5rem;
+  padding: 1rem;
+  border: 1px solid #e0e0e0;
+  border-radius: 4px;
+  background-color: #fafafa;
+
+  &.readonly {
+    background-color: transparent;
+    border: none;
+    padding: 0;
+  }
+
+  h4 {
+    margin: 0 0 0.5rem 0;
+    font-size: 1rem;
+    font-weight: 500;
+  }
+}
+
+.credentials-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 0.5rem;
+}
+
+.credential-status {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.875rem;
+
+  .status-icon {
+    font-size: 1.25rem;
+    width: 1.25rem;
+    height: 1.25rem;
+
+    &.configured {
+      color: #4caf50;
+    }
+
+    &.not-configured {
+      color: #ff9800;
+    }
+  }
+}
+
+.credential-fields {
+  margin-top: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.credential-hint {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.75rem;
+  color: #666;
+  margin: 0.5rem 0 0 0;
+
+  mat-icon {
+    font-size: 1rem;
+    width: 1rem;
+    height: 1rem;
+  }
+}

--- a/Web/Admin.UI/src/app/components/data-acquisition/sftp-config-form/sftp-config-form.component.ts
+++ b/Web/Admin.UI/src/app/components/data-acquisition/sftp-config-form/sftp-config-form.component.ts
@@ -1,0 +1,319 @@
+import { Component, EventEmitter, Input, OnChanges, OnInit, Output, SimpleChanges } from '@angular/core';
+import {
+  FormBuilder,
+  FormControl,
+  FormGroup,
+  ReactiveFormsModule,
+  Validators
+} from '@angular/forms';
+import { MatButtonModule } from '@angular/material/button';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatIconModule } from '@angular/material/icon';
+import { MatInputModule } from '@angular/material/input';
+import { MatSlideToggleModule } from '@angular/material/slide-toggle';
+import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
+import { MatSelectModule } from '@angular/material/select';
+import { FormMode } from 'src/app/models/FormMode.enum';
+import { IEntityCreatedResponse } from 'src/app/interfaces/entity-created-response.model';
+import { DataAcquisitionService } from 'src/app/services/gateway/data-acquisition/data-acquisition.service';
+import {
+  ICreateSftpConfigurationModel,
+  ISftpConfigurationModel,
+  ISftpCredentialStatusModel
+} from '../../../interfaces/data-acquisition/sftp-config-model.interface';
+
+@Component({
+  selector: 'app-sftp-config-form',
+  standalone: true,
+  imports: [
+    MatButtonModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatIconModule,
+    MatSlideToggleModule,
+    ReactiveFormsModule,
+    MatSnackBarModule,
+    MatSelectModule
+  ],
+  templateUrl: './sftp-config-form.component.html',
+  styleUrls: ['./sftp-config-form.component.scss']
+})
+export class SftpConfigFormComponent implements OnInit, OnChanges {
+  @Input() item!: ISftpConfigurationModel;
+
+  @Input() formMode!: FormMode;
+
+  private _viewOnly: boolean = false;
+  @Input()
+  set viewOnly(v: boolean) {
+    if (v !== null) this._viewOnly = v;
+  }
+
+  get viewOnly() {
+    return this._viewOnly;
+  }
+
+  @Output() formValueChanged = new EventEmitter<boolean>();
+
+  @Output() submittedConfiguration = new EventEmitter<IEntityCreatedResponse>();
+
+  configForm!: FormGroup;
+  credentialStatus: ISftpCredentialStatusModel | null = null;
+  showCredentialFields: boolean = false;
+
+  constructor(
+    private snackBar: MatSnackBar,
+    private dataAcquisitionService: DataAcquisitionService,
+    private fb: FormBuilder
+  ) {
+    this.configForm = this.fb.group({
+      facilityId: this.fb.control('', Validators.required),
+      host: this.fb.control('', Validators.required),
+      port: this.fb.control(22, [Validators.required, Validators.min(1), Validators.max(65535)]),
+      remoteDirectory: this.fb.control(''),
+      timeout: this.fb.control('00:01:00', Validators.required),
+      removeAfterProcessing: this.fb.control(false),
+      username: this.fb.control(''),
+      password: this.fb.control('')
+    });
+  }
+
+  ngOnInit(): void {
+    this.configForm.reset();
+
+    if (this.item) {
+      this.facilityIdControl.setValue(this.item.organizationId);
+      this.facilityIdControl.updateValueAndValidity();
+      this.hostControl.setValue(this.item.host);
+      this.hostControl.updateValueAndValidity();
+      this.portControl.setValue(this.item.port);
+      this.portControl.updateValueAndValidity();
+      this.remoteDirectoryControl.setValue(this.item.remoteDirectory || '');
+      this.remoteDirectoryControl.updateValueAndValidity();
+      this.timeoutControl.setValue(this.item.timeout);
+      this.timeoutControl.updateValueAndValidity();
+      this.removeAfterProcessingControl.setValue(this.item.removeAfterProcessing);
+      this.removeAfterProcessingControl.updateValueAndValidity();
+
+      // Load credential status if editing
+      if (this.formMode === FormMode.Edit) {
+        this.loadCredentialStatus();
+      }
+    } else {
+      // Set defaults for new configuration
+      this.portControl.setValue(22);
+      this.portControl.updateValueAndValidity();
+      this.timeoutControl.setValue('00:01:00');
+      this.timeoutControl.updateValueAndValidity();
+      this.removeAfterProcessingControl.setValue(false);
+      this.removeAfterProcessingControl.updateValueAndValidity();
+      this.formMode = FormMode.Create;
+      this.showCredentialFields = true;
+    }
+
+    this.toggleViewOnly(this.viewOnly);
+
+    this.configForm.valueChanges.subscribe(() => {
+      this.formValueChanged.emit(this.configForm.invalid);
+    });
+  }
+
+  ngOnChanges(changes: SimpleChanges) {
+    // Always reset the form when item changes
+    this.configForm.reset();
+
+    if (changes['item'] && changes['item'].currentValue) {
+      this.facilityIdControl.setValue(this.item.organizationId);
+      this.facilityIdControl.updateValueAndValidity();
+      this.hostControl.setValue(this.item.host);
+      this.hostControl.updateValueAndValidity();
+      this.portControl.setValue(this.item.port);
+      this.portControl.updateValueAndValidity();
+      this.remoteDirectoryControl.setValue(this.item.remoteDirectory || '');
+      this.remoteDirectoryControl.updateValueAndValidity();
+      this.timeoutControl.setValue(this.item.timeout);
+      this.timeoutControl.updateValueAndValidity();
+      this.removeAfterProcessingControl.setValue(this.item.removeAfterProcessing);
+      this.removeAfterProcessingControl.updateValueAndValidity();
+
+      // Load credential status if editing
+      if (this.formMode === FormMode.Edit) {
+        this.loadCredentialStatus();
+      }
+    } else {
+      // Set defaults for new configuration
+      this.portControl.setValue(22);
+      this.portControl.updateValueAndValidity();
+      this.timeoutControl.setValue('00:01:00');
+      this.timeoutControl.updateValueAndValidity();
+      this.removeAfterProcessingControl.setValue(false);
+      this.removeAfterProcessingControl.updateValueAndValidity();
+      this.showCredentialFields = true;
+    }
+
+    this.toggleViewOnly(this.viewOnly);
+  }
+
+  loadCredentialStatus(): void {
+    if (this.item?.organizationId) {
+      this.dataAcquisitionService.getSftpCredentialStatus(this.item.organizationId).subscribe({
+        next: (status) => {
+          this.credentialStatus = status;
+        },
+        error: () => {
+          this.credentialStatus = { hasCredentials: false };
+        }
+      });
+    }
+  }
+
+  toggleCredentialFields(): void {
+    this.showCredentialFields = !this.showCredentialFields;
+    if (!this.showCredentialFields) {
+      this.usernameControl.setValue('');
+      this.passwordControl.setValue('');
+    }
+  }
+
+  toggleViewOnly(viewOnly: boolean) {
+    this.facilityIdControl.disable();
+    if (viewOnly) {
+      this.hostControl.disable();
+      this.portControl.disable();
+      this.remoteDirectoryControl.disable();
+      this.timeoutControl.disable();
+      this.removeAfterProcessingControl.disable();
+      this.usernameControl.disable();
+      this.passwordControl.disable();
+    } else {
+      this.hostControl.enable();
+      this.portControl.enable();
+      this.remoteDirectoryControl.enable();
+      this.timeoutControl.enable();
+      this.removeAfterProcessingControl.enable();
+      this.usernameControl.enable();
+      this.passwordControl.enable();
+    }
+  }
+
+  get facilityIdControl(): FormControl {
+    return this.configForm.get('facilityId') as FormControl;
+  }
+
+  get hostControl(): FormControl {
+    return this.configForm.get('host') as FormControl;
+  }
+
+  get portControl(): FormControl {
+    return this.configForm.get('port') as FormControl;
+  }
+
+  get remoteDirectoryControl(): FormControl {
+    return this.configForm.get('remoteDirectory') as FormControl;
+  }
+
+  get timeoutControl(): FormControl {
+    return this.configForm.get('timeout') as FormControl;
+  }
+
+  get removeAfterProcessingControl(): FormControl {
+    return this.configForm.get('removeAfterProcessing') as FormControl;
+  }
+
+  get usernameControl(): FormControl {
+    return this.configForm.get('username') as FormControl;
+  }
+
+  get passwordControl(): FormControl {
+    return this.configForm.get('password') as FormControl;
+  }
+
+  clearHost(): void {
+    this.hostControl.setValue('');
+    this.hostControl.updateValueAndValidity();
+  }
+
+  clearRemoteDirectory(): void {
+    this.remoteDirectoryControl.setValue('');
+    this.remoteDirectoryControl.updateValueAndValidity();
+  }
+
+  submitConfiguration(): void {
+    if (this.configForm.valid) {
+      const config: ICreateSftpConfigurationModel = {
+        organizationId: this.facilityIdControl.value,
+        host: this.hostControl.value,
+        port: this.portControl.value,
+        remoteDirectory: this.remoteDirectoryControl.value || undefined,
+        timeout: this.timeoutControl.value,
+        removeAfterProcessing: this.removeAfterProcessingControl.value,
+        authenticationProtocol: 'Basic'
+      };
+
+      // Add credentials if provided
+      if (this.usernameControl.value && this.passwordControl.value) {
+        config.credentials = {
+          username: this.usernameControl.value,
+          password: this.passwordControl.value
+        };
+      }
+
+      if (this.formMode === FormMode.Create) {
+        this.dataAcquisitionService.createSftpConfiguration(this.facilityIdControl.value, config).subscribe({
+          next: (response) => {
+            this.submittedConfiguration.emit({ id: response.id, message: 'SFTP Configuration Created' });
+          },
+          error: (err) => {
+            this.snackBar.open(err.error || 'Failed to create SFTP configuration', '', {
+              duration: 3500,
+              panelClass: 'error-snackbar',
+              horizontalPosition: 'end',
+              verticalPosition: 'top'
+            });
+          }
+        });
+      } else if (this.formMode === FormMode.Edit) {
+        config.id = this.item.id;
+        this.dataAcquisitionService.updateSftpConfiguration(
+          this.facilityIdControl.value,
+          this.item.id!,
+          config
+        ).subscribe({
+          next: (response) => {
+            // If credentials were provided, update them separately
+            if (config.credentials) {
+              this.dataAcquisitionService.updateSftpCredentials(
+                this.facilityIdControl.value,
+                config.credentials
+              ).subscribe({
+                next: () => {
+                  this.submittedConfiguration.emit({ id: response.id, message: 'SFTP Configuration Updated' });
+                },
+                error: () => {
+                  this.submittedConfiguration.emit({ id: response.id, message: 'SFTP Configuration Updated (credentials update failed)' });
+                }
+              });
+            } else {
+              this.submittedConfiguration.emit({ id: response.id, message: 'SFTP Configuration Updated' });
+            }
+          },
+          error: (err) => {
+            this.snackBar.open(err.error || 'Failed to update SFTP configuration', '', {
+              duration: 3500,
+              panelClass: 'error-snackbar',
+              horizontalPosition: 'end',
+              verticalPosition: 'top'
+            });
+          }
+        });
+      }
+    } else {
+      this.snackBar.open('Invalid form, please check for errors.', '', {
+        duration: 3500,
+        panelClass: 'error-snackbar',
+        horizontalPosition: 'end',
+        verticalPosition: 'top'
+      });
+    }
+  }
+}

--- a/Web/Admin.UI/src/app/components/tenant/facility-edit/facility-edit.component.html
+++ b/Web/Admin.UI/src/app/components/tenant/facility-edit/facility-edit.component.html
@@ -156,6 +156,31 @@
             }
           </mat-action-row>
         </mat-tab>
+        <mat-tab label="SFTP Configuration">
+          @if (showNoSftpConfigAlert) {
+            <app-link-alert [type]="linkNoConfigAlertType" [message]="noSftpConfigAlertMessage"
+            ></app-link-alert>
+          }
+          <app-sftp-config-form [item]="sftpConfig"
+          [viewOnly]="true"></app-sftp-config-form>
+          <mat-action-row>
+            @if (showNoSftpConfigAlert) {
+              <button mat-mini-fab aria-label="Add SFTP configuration" matTooltip="Add SFTP configuration"
+                (click)="showSftpConfigDialog()">
+                <mat-icon>add</mat-icon>
+              </button>
+            }
+            @if (!showNoSftpConfigAlert) {
+              <button mat-mini-fab aria-label="Edit SFTP configuration" matTooltip="Edit SFTP configuration"
+                (click)="showSftpConfigDialog()">
+                <mat-icon>edit</mat-icon>
+              </button>
+              <button mat-mini-fab aria-label="Delete SFTP configuration" color="warn" (click)="onDeleteSftpConfig()">
+                <mat-icon>delete</mat-icon>
+              </button>
+            }
+          </mat-action-row>
+        </mat-tab>
         <mat-tab label="Query Plan">
           @if (showNoDataAcqQueryPlanConfigAlert) {
             <app-link-alert [type]="linkNoConfigAlertType" [message]="noDataAcqQueryPlanConfigAlertMessage"

--- a/Web/Admin.UI/src/app/components/tenant/facility-edit/facility-edit.component.ts
+++ b/Web/Admin.UI/src/app/components/tenant/facility-edit/facility-edit.component.ts
@@ -41,6 +41,13 @@ import {
 import {
   DataAcquisitionFhirListConfigFormComponent
 } from '../../data-acquisition/data-acquisition-fhir-list-config-form/data-acquisition-fhir-list-config-form.component';
+import {
+  SftpConfigDialogComponent
+} from '../../data-acquisition/sftp-config-dialog/sftp-config-dialog.component';
+import {
+  SftpConfigFormComponent
+} from '../../data-acquisition/sftp-config-form/sftp-config-form.component';
+import { ISftpConfigurationModel } from '../../../interfaces/data-acquisition/sftp-config-model.interface';
 import {IQueryPlanModel} from "../../../interfaces/data-acquisition/query-plan-model.interface";
 import {
   QueryPlanConfigDialogComponent
@@ -88,6 +95,7 @@ import { concatMap } from 'rxjs';
     LinkAlertComponent,
     DataAcquisitionFhirQueryConfigFormComponent,
     DataAcquisitionFhirListConfigFormComponent,
+    SftpConfigFormComponent,
     QueryPlanConfigFormComponent,
     MatMenu,
     MatMenuTrigger,
@@ -120,6 +128,10 @@ export class FacilityEditComponent implements OnInit {
   showNoDataAcqFhirQueryConfigAlert: boolean = false;
   noDataAcqFhirListConfigAlertMessage = 'No FHIR List configuration found for this facility.';
   showNoDataAcqFhirListConfigAlert: boolean = false;
+
+  noSftpConfigAlertMessage = 'No SFTP configuration found for this facility.';
+  showNoSftpConfigAlert: boolean = false;
+  sftpConfig!: ISftpConfigurationModel;
 
   noDataAcqQueryPlanConfigAlertMessage = 'No FHIR query plan found for this facility and type';
   showNoDataAcqQueryPlanConfigAlert: boolean = false;
@@ -410,6 +422,7 @@ export class FacilityEditComponent implements OnInit {
   loadDataAcquisitionConfig() {
     this.loadFhirQueryConfig();
     this.loadFhirListConfig();
+    this.loadSftpConfig();
     this.loadQueryPlan("Discharge", "Discharge")
   }
 
@@ -477,6 +490,117 @@ export class FacilityEditComponent implements OnInit {
         }
       });
     }
+  }
+
+  loadSftpConfig() {
+    if (!this.sftpConfig) {
+      this.dataAcquisitionService.getSftpConfiguration(this.facilityId).subscribe((data: ISftpConfigurationModel) => {
+        this.sftpConfig = data;
+        this.showNoSftpConfigAlert = !this.sftpConfig;
+      }, error => {
+        if (error.status == 404) {
+          this.sftpConfig = {
+            organizationId: this.facilityConfig.facilityId,
+            host: '',
+            port: 22,
+            timeout: '00:01:00',
+            removeAfterProcessing: false,
+            authenticationProtocol: 'Basic'
+          } as ISftpConfigurationModel;
+          this.showNoSftpConfigAlert = true;
+        } else {
+          this.snackBar.open(`Failed to load SFTP configuration for the facility, see error for details.`, '', {
+            duration: 3500,
+            panelClass: 'error-snackbar',
+            horizontalPosition: 'end',
+            verticalPosition: 'top'
+          });
+        }
+      });
+    }
+  }
+
+  showSftpConfigDialog(): void {
+    this.dialog.open(SftpConfigDialogComponent,
+      {
+        width: '50vw',
+        maxWidth: '50vw',
+        data: {
+          dialogTitle: 'SFTP Configuration',
+          formMode: this.showNoSftpConfigAlert ? FormMode.Create : FormMode.Edit,
+          viewOnly: false,
+          sftpConfig: this.sftpConfig
+        }
+      }).afterClosed().subscribe(res => {
+      if (res) {
+        this.dataAcquisitionService.getSftpConfiguration(this.facilityId).subscribe((data: ISftpConfigurationModel) => {
+          if (data) {
+            this.showNoSftpConfigAlert = false;
+            this.sftpConfig = data;
+          }
+        });
+        this.snackBar.open(`${res}`, '', {
+          duration: 3500,
+          panelClass: 'success-snackbar',
+          horizontalPosition: 'end',
+          verticalPosition: 'top'
+        });
+      }
+    });
+  }
+
+  onDeleteSftpConfig(): void {
+    const dialogRef = this.dialog.open(DeleteConfirmationDialogComponent, {
+      width: '400px',
+      data: {
+        message: `Are you sure you want to delete this SFTP configuration?`
+      }
+    });
+    dialogRef.afterClosed().subscribe(result => {
+      if (result) {
+        this.dataAcquisitionService.deleteSftpConfiguration(this.sftpConfig.organizationId, this.sftpConfig.id!).subscribe({
+          next: () => {
+            this.dataAcquisitionService.getSftpConfiguration(this.facilityId).subscribe({
+              next: (data: ISftpConfigurationModel | null) => {
+                if (data) {
+                  this.showNoSftpConfigAlert = false;
+                  this.sftpConfig = data;
+                } else {
+                  this.showNoSftpConfigAlert = true;
+                  this.sftpConfig = {
+                    organizationId: this.facilityId,
+                    host: '',
+                    port: 22,
+                    timeout: '00:01:00',
+                    removeAfterProcessing: false,
+                    authenticationProtocol: 'Basic'
+                  };
+                }
+              },
+              error: () => {
+                this.showNoSftpConfigAlert = true;
+                this.sftpConfig = {
+                  organizationId: this.facilityId,
+                  host: '',
+                  port: 22,
+                  timeout: '00:01:00',
+                  removeAfterProcessing: false,
+                  authenticationProtocol: 'Basic'
+                };
+              }
+            });
+          },
+          error: () => {
+            this.snackBar.open('Error deleting SFTP configuration', 'Close', {
+              duration: 3500,
+              panelClass: 'error-snackbar',
+              horizontalPosition: 'end',
+              verticalPosition: 'top'
+            });
+          }
+        });
+      }
+    });
   }
 
   onPlanSelected(outcome: any) {

--- a/Web/Admin.UI/src/app/interfaces/data-acquisition/sftp-config-model.interface.ts
+++ b/Web/Admin.UI/src/app/interfaces/data-acquisition/sftp-config-model.interface.ts
@@ -1,0 +1,24 @@
+export interface ISftpConfigurationModel {
+  id?: string;
+  organizationId: string;
+  host: string;
+  port: number;
+  remoteDirectory?: string;
+  timeout: string;
+  removeAfterProcessing: boolean;
+  authenticationProtocol: string;
+}
+
+export interface ISftpCredentialsModel {
+  username: string;
+  password: string;
+}
+
+export interface ISftpCredentialStatusModel {
+  hasCredentials: boolean;
+  lastUpdated?: Date;
+}
+
+export interface ICreateSftpConfigurationModel extends ISftpConfigurationModel {
+  credentials?: ISftpCredentialsModel;
+}

--- a/Web/Admin.UI/src/app/services/gateway/data-acquisition/data-acquisition.service.ts
+++ b/Web/Admin.UI/src/app/services/gateway/data-acquisition/data-acquisition.service.ts
@@ -6,6 +6,12 @@ import { IEntityCreatedResponse } from 'src/app/interfaces/entity-created-respon
 import { IEntityDeletedResponse } from 'src/app/interfaces/entity-deleted-response.interface';
 import { IDataAcquisitionQueryConfigModel } from 'src/app/interfaces/data-acquisition/data-acquisition-fhir-query-config-model.interface';
 import { IDataAcquisitionFhirListConfigModel } from 'src/app/interfaces/data-acquisition/data-acquisition-fhir-list-config-model.interface';
+import {
+  ICreateSftpConfigurationModel,
+  ISftpConfigurationModel,
+  ISftpCredentialsModel,
+  ISftpCredentialStatusModel
+} from 'src/app/interfaces/data-acquisition/sftp-config-model.interface';
 import { IDataAcquisitionAuthenticationConfigModel } from '../../../interfaces/data-acquisition/data-acquisition-auth-config-model.interface';
 import { AppConfigService } from '../../app-config.service';
 import {IQueryPlanModel} from "../../../interfaces/data-acquisition/query-plan-model.interface";
@@ -201,6 +207,86 @@ export class DataAcquisitionService {
         }),
         catchError((error) => {
           return this.errorHandler.handleError(error);
+        })
+      )
+  }
+
+  // SFTP Configuration Methods
+
+  getSftpConfiguration(facilityId: string): Observable<ISftpConfigurationModel> {
+    return this.http.get<ISftpConfigurationModel>(`${this.appConfigService.config?.baseApiUrl}/data/${facilityId}/sftp-configurations`)
+      .pipe(
+        tap(_ => console.log(`Fetched SFTP configuration.`)),
+        catchError((error) => {
+          return this.errorHandler.handleError(error, false);
+        })
+      )
+  }
+
+  createSftpConfiguration(facilityId: string, config: ICreateSftpConfigurationModel): Observable<IEntityCreatedResponse> {
+    return this.http.post<IEntityCreatedResponse>(`${this.appConfigService.config?.baseApiUrl}/data/${facilityId}/sftp-configurations`, config)
+      .pipe(
+        tap(_ => console.log(`Request for SFTP configuration creation was sent.`)),
+        map((response: IEntityCreatedResponse) => {
+          return response;
+        }),
+        catchError((error) => {
+          return this.errorHandler.handleError(error);
+        })
+      )
+  }
+
+  updateSftpConfiguration(facilityId: string, configId: string, config: ISftpConfigurationModel): Observable<IEntityCreatedResponse> {
+    return this.http.put<IEntityCreatedResponse>(`${this.appConfigService.config?.baseApiUrl}/data/${facilityId}/sftp-configurations/${configId}`, config)
+      .pipe(
+        tap(_ => console.log(`Request for SFTP configuration update was sent.`)),
+        map((response: IEntityCreatedResponse) => {
+          return response;
+        }),
+        catchError((error) => {
+          return this.errorHandler.handleError(error);
+        })
+      )
+  }
+
+  deleteSftpConfiguration(facilityId: string, configId: string): Observable<IEntityDeletedResponse> {
+    return this.http.delete<IEntityDeletedResponse>(`${this.appConfigService.config?.baseApiUrl}/data/${facilityId}/sftp-configurations/${configId}`)
+      .pipe(
+        tap(_ => console.log(`Request for SFTP configuration deletion was sent.`)),
+        catchError((error) => {
+          throw error;
+        })
+      )
+  }
+
+  // SFTP Credentials Methods
+
+  getSftpCredentialStatus(facilityId: string): Observable<ISftpCredentialStatusModel> {
+    return this.http.get<ISftpCredentialStatusModel>(`${this.appConfigService.config?.baseApiUrl}/data/${facilityId}/sftp-configurations/credentials/status`)
+      .pipe(
+        tap(_ => console.log(`Fetched SFTP credential status.`)),
+        catchError((error) => {
+          return this.errorHandler.handleError(error, false);
+        })
+      )
+  }
+
+  updateSftpCredentials(facilityId: string, credentials: ISftpCredentialsModel): Observable<void> {
+    return this.http.put<void>(`${this.appConfigService.config?.baseApiUrl}/data/${facilityId}/sftp-configurations/credentials`, credentials)
+      .pipe(
+        tap(_ => console.log(`Request for SFTP credentials update was sent.`)),
+        catchError((error) => {
+          return this.errorHandler.handleError(error);
+        })
+      )
+  }
+
+  deleteSftpCredentials(facilityId: string): Observable<void> {
+    return this.http.delete<void>(`${this.appConfigService.config?.baseApiUrl}/data/${facilityId}/sftp-configurations/credentials`)
+      .pipe(
+        tap(_ => console.log(`Request for SFTP credentials deletion was sent.`)),
+        catchError((error) => {
+          throw error;
         })
       )
   }

--- a/docs/domains/DataAccess/services/DataAcquisitionService/index.mdx
+++ b/docs/domains/DataAccess/services/DataAcquisitionService/index.mdx
@@ -35,7 +35,7 @@ badges:
 
 ## Overview
 
-The Data Acquisition service is responsible for connecting and querying a tenant's endpoint for FHIR resources that are needed to evaluate patients for a measure. For Epic installations, Link Cloud is utilizing the Epic FHIR STU3 Patient List resource to inform which patients are currently admitted in the facility. While this is the current solution to acquiring the patient census, there are other means of patient acquisition being investigated (ADT V2, Bulk FHIR) to provide universal support across multiple EHR vendors.
+The Data Acquisition service is responsible for connecting and querying a tenant's endpoint for FHIR resources that are needed to evaluate patients for a measure. For Epic installations, Link Cloud is utilizing the Epic FHIR STU3 Patient List resource to inform which patients are currently admitted in the facility. Additionally, facilities can configure SFTP-based census acquisition, allowing them to upload patient census files that Link will process. While FHIR List and SFTP are the current solutions for acquiring the patient census, other means of patient acquisition are being investigated (ADT V2, Bulk FHIR) to provide universal support across multiple EHR vendors.
 
 ## Nodes
 
@@ -60,7 +60,8 @@ The Data Acquisition service is responsible for connecting and querying a tenant
 ### Key Roles of Data Acquisition
 
 1. **Patient List Acquisition**:
- - Retrieves a FHIR List of patients from the EHR, if configured.
+ - Retrieves a FHIR List of patients from the EHR, if configured, OR processes census files from a configured SFTP server.
+ - A facility can use either FHIR List or SFTP for census acquisition, but not both.
  - Serves as the initial step for identifying patients relevant to quality measure evaluations.
 
 2. **Individual Patient Data Acquisition**:
@@ -75,7 +76,7 @@ The Data Acquisition service is responsible for connecting and querying a tenant
 Data acquisition plays a role in three distinct stages of the report generation pipeline:
 
 1. **Patient Identification**:
- - Acquiring a list of patients from the EHR to determine the cohort for evaluation.
+ - Acquiring a list of patients from the EHR (via FHIR List) or from census files (via SFTP) to determine the cohort for evaluation.
 
 2. **Initial Data Collection and Evaluation**:
  - Obtaining the primary dataset needed for evaluating quality measures.
@@ -129,7 +130,8 @@ Data acquisition is configurable per tenant, ensuring flexibility to accommodate
   - Such as client credentials (e.g., "client id").
 
 - **Patient Census Retrieval**:
-  - FHIR List "id" or Bulk FHIR "Group ID" used for identifying the patient cohort.
+  - FHIR List "id", Bulk FHIR "Group ID", or SFTP configuration used for identifying the patient cohort.
+  - See [SFTP Configuration](#sftp-configuration) for details on SFTP-based census acquisition.
 
 - **EHR Query Throttling/Limitations**:
   - Configurable settings to respect EHR query limitations (e.g., maximum queries per minute).
@@ -264,6 +266,128 @@ Data sources (where the FHIR server is located and how to authenticate) are conf
 
 TODO: Add details about how to authenticate against Epic, Cerner, Basic, and/or OAuth data sources.
 
+### SFTP Configuration
+
+As an alternative to FHIR List-based patient census acquisition, facilities can configure SFTP-based census acquisition. This allows facilities to upload patient census files to an SFTP server, which Link will poll and process to identify patients for quality measure evaluation.
+
+**Key Characteristics:**
+- A facility can only have **one** census acquisition method (either FHIR List OR SFTP, not both)
+- SFTP credentials are stored securely in a secret manager, for example Azure Key Vault, (or a local secret manager for development)
+- Credentials are never stored in the database or returned in API responses
+
+#### SFTP Configuration Properties
+
+| Property | Description | Required | Default |
+|----------|-------------|----------|---------|
+| Host | Hostname or IP address of the SFTP server | Yes | - |
+| Port | Port number for the SFTP connection | No | 22 |
+| RemoteDirectory | Path to the directory containing census files | No | (root) |
+| Timeout | Connection timeout duration | No | 00:01:00 |
+| RemoveAfterProcessing | Whether to delete files after successful processing | No | false |
+| AuthenticationProtocol | Authentication method (currently only "Basic" supported) | No | Basic |
+
+#### SFTP Credentials
+
+Credentials are managed separately from the configuration for security:
+- Credentials can be set during initial configuration creation
+- Credentials can be updated independently without modifying other settings
+- A credential status endpoint allows checking if credentials exist without exposing them
+- Credentials can be deleted without removing the SFTP configuration
+
+#### SFTP Configuration API Endpoints
+
+| Endpoint | Method | Description |
+|----------|--------|-------------|
+| `/api/data/{orgId}/sftp-configurations` | POST | Create SFTP configuration |
+| `/api/data/{orgId}/sftp-configurations` | GET | Get configuration by organization |
+| `/api/data/sftp-configurations/{id}` | GET | Get configuration by ID |
+| `/api/data/{orgId}/sftp-configurations/{configId}` | PUT | Update configuration |
+| `/api/data/{orgId}/sftp-configurations/{configId}` | DELETE | Delete configuration |
+| `/api/data/{orgId}/sftp-configurations/credentials` | PUT | Set/update credentials |
+| `/api/data/{orgId}/sftp-configurations/credentials/status` | GET | Check credential status |
+| `/api/data/{orgId}/sftp-configurations/credentials` | DELETE | Delete credentials only |
+
+All endpoints require LinkAdmin authorization.
+
+#### Example SFTP Configuration Request
+
+```json
+{
+  "host": "sftp.facility.example.com",
+  "port": 22,
+  "remoteDirectory": "/census/incoming",
+  "timeout": "00:02:00",
+  "removeAfterProcessing": true,
+  "credentials": {
+    "username": "link-service",
+    "password": "secure-password"
+  }
+}
+```
+
+### SFTP Acquisition Logs
+
+When census files are processed via SFTP, the system maintains acquisition logs to track processing history. These logs provide visibility into which files have been processed and the patient/encounter counts extracted.
+
+#### SFTP Acquisition Log Properties
+
+| Property | Description |
+|----------|-------------|
+| ExternalId | Unique identifier (GUID) for the log entry |
+| FacilityId | The facility/organization that owns the census file |
+| FileName | Name of the processed file |
+| PatientCount | Number of patients extracted from the file |
+| EncounterCount | Number of encounters extracted from the file |
+| ProcessDate | Timestamp when the file was processed |
+
+#### SFTP Log API Endpoints
+
+| Endpoint | Method | Description |
+|----------|--------|-------------|
+| `/api/data/sftp-logs` | GET | Search logs with filtering and pagination |
+| `/api/data/sftp-logs/{logId}` | GET | Get a specific log by external ID |
+| `/api/data/sftp-logs` | POST | Create a new log entry |
+| `/api/data/sftp-logs/{logId}` | PUT | Update log process date |
+
+All endpoints require LinkAdmin authorization.
+
+## Secret Management Configuration
+
+SFTP credentials and other sensitive data are stored using a configurable secret manager. The service supports Azure Key Vault for production environments and a local in-memory manager for development.
+
+| Property | Description | Required | Default Value | Secret? |
+|----------|-------------|----------|---------------|---------|
+| SecretManagement__Enabled | Enable/disable secret management | No | true | No |
+| SecretManagement__Manager | Secret manager type: "AzureKeyVault" or "Local" | No | Local | No |
+| SecretManagement__ManagerUri | Azure Key Vault URI (required for AzureKeyVault) | Conditional | - | No |
+| DataProtection__KeyRing | Key ring name for data protection | No | Link | No |
+
+**Azure Key Vault Configuration:**
+```json
+{
+  "SecretManagement": {
+    "Enabled": true,
+    "Manager": "AzureKeyVault",
+    "ManagerUri": "https://your-keyvault.vault.azure.net/"
+  },
+  "DataProtection": {
+    "KeyRing": "Link"
+  }
+}
+```
+
+**Local Development Configuration:**
+```json
+{
+  "SecretManagement": {
+    "Enabled": true,
+    "Manager": "Local"
+  },
+  "DataProtection": {
+    "KeyRing": "Link"
+  }
+}
+```
 
 ## Logging
 


### PR DESCRIPTION
### 🛠️ Description of Changes
This PR implements the SFTP Configuration API for the DataAcquisition service, enabling facilities to configure SFTP-based census acquisition as an alternative to FHIR List-based acquisition.

Backend (DataAcquisition Service):
  - Added SftpConfiguration entity and database migration for storing SFTP connection settings
  - Added SftpAcquisitionLog entity for tracking SFTP acquisition operations
  - Implemented SftpConfigurationManager for CRUD operations on SFTP configurations
  - Implemented SftpAcquisitionLogManager and SftpAcquisitionLogQueries for log management
  - Added SftpConfigurationController and SftpLogController API endpoints
  - Added SftpCredentialService for secure credential management via Azure Key Vault
  - Added mutual exclusivity check: a facility can only have one census acquisition method (SFTP or FHIR List)
  - Added OrganizationalAccessException for enforcing organization-level access control
  - Fixed bug in SftpConfigurationManager.DeleteAsync - was querying by organizationId instead of configurationId, making the
  organizational access check unreachable

  Frontend (Admin.UI):
  - Added SFTP configuration form components (sftp-config-form, sftp-config-dialog)
  - Integrated SFTP configuration management into facility edit view
  - Added DataAcquisitionService methods for SFTP configuration API calls

  Shared:
  - Added OrganizationalAccessException for cross-service organizational access validation
  - Added telemetry diagnostic names for SFTP operations
  - 
### 🧪 Testing Performed
- Manual testing through Postman and newly added UI configuration component
- Added integration tests for SftpConfigurationManager:
    - CreateAsync_FacilityHasFhirListConfiguration_ThrowsInvalidOperationException - Verifies SFTP config cannot be created if facility
   already has FHIR List config
    - UpdateAsync_OrganizationIdMismatch_ThrowsOrganizationalAccessException - Verifies organizational access control on update
    - DeleteAsync_OrganizationIdMismatch_ThrowsOrganizationalAccessException - Verifies organizational access control on delete
  - Added integration tests for FhirListQueryConfigurationManager:
    - CreateAsync_FacilityHasSftpConfiguration_ThrowsInvalidOperationException - Verifies FHIR List config cannot be created if
  facility already has SFTP config
  - Updated DataAcquisitionIntegrationTestFixture with required repository registrations for SftpConfiguration and SftpAcquisitionLog
  - All new tests passing

### 🧑‍🔬 Unit Testing
- [ x ] I have written or updated unit tests to cover my changes

### 📓 Documentation Updated
 - Updated EventCatalog documentation for DataAcquisitionService to include SFTP configuration endpoints and models
