### PR TITLE
LNK-4704: Added SearchPost query type to FhirQueryModel.Query

### DIFF
--- a/DotNet/DataAcquisition.Domain/Application/Models/Api/Configuration/FhirQueryModel.cs
+++ b/DotNet/DataAcquisition.Domain/Application/Models/Api/Configuration/FhirQueryModel.cs
@@ -30,6 +30,7 @@ public class FhirQueryModel
             return QueryType switch
             {
                 FhirQueryType.Search => $"{ResourceTypes[0]}?{string.Join("&", QueryParameters)}",
+                FhirQueryType.SearchPost => $"{ResourceTypes[0]}/_search [{string.Join(",", QueryParameters)}]",
                 FhirQueryType.Read => $"{ResourceTypes[0]}/{string.Join("&", QueryParameters)}",
                 FhirQueryType.BulkDataRequest => "BulkDataRequest", // add logic when bulk fhir is implemented
                 FhirQueryType.BulkDataPoll => string.Join("&", QueryParameters),


### PR DESCRIPTION
### 🛠️ Description of Changes
The new SearchPost query type was missing from FhirQueryModel.Query. This mostly affected the Admin UI not showing what the search criteria was for a query done using SearchPost.

### 🧪 Testing Performed
Generated a report and was able to see the query body show in the UI:
<img width="1375" height="818" alt="image" src="https://github.com/user-attachments/assets/6f3b6ba5-ca21-4241-9531-7d433f9e4de7" />

### 🧑‍🔬 Unit Testing
N/A

### 📓 Documentation Updated
N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended FHIR query capabilities to support POST-based search operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->