### PR TITLE
LNK-4751: Non-Reference Query Hits MaxRetriesReached Status Causes Retries on Subsequent Reference Queries

### DIFF
--- a/DotNet/DataAcquisition.Domain/Application/Queries/DataAcquisitionLogQueries.cs
+++ b/DotNet/DataAcquisition.Domain/Application/Queries/DataAcquisitionLogQueries.cs
@@ -203,7 +203,7 @@ public class DataAcquisitionLogQueries : IDataAcquisitionLogQueries
                       where l.FacilityId == facilityId
                             && l.ReportTrackingId == reportTrackingId
                             && l.CorrelationId == correlationId
-                             && l.Status != RequestStatus.Completed
+                             && !(l.Status == RequestStatus.Completed || l.Status == RequestStatus.MaxRetriesReached)
                              && !l.TailSent
                              && l.FhirQueries.Any(fq => fq.IsReference == false)
                       select l).CountAsync();           


### PR DESCRIPTION
### 🛠️ Description of Changes
Recognize `MaxRetriesReached` as a terminal DA log status.

### 🧪 Testing Performed
Tested locally with invalid tenant config (causing all calls to `Read`/`SearchFhirCommand` to fail).  Reference queries were deferred until non-reference queries hit `MaxRetriesReached`, at which point reference queries were completed/skipped.

### 🧑‍🔬 Unit Testing
N/A

### 📓 Documentation Updated
N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated incomplete data acquisition log counting logic to exclude logs that have reached their maximum retry limit, in addition to completed logs.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->