### PR TITLE
LNK-4747: Tenant's Max Request Concurrency is Set to Zero

### DIFF
--- a/DotNet/DataAcquisition.Domain/Application/Models/FhirQueryConfigurationModel.cs
+++ b/DotNet/DataAcquisition.Domain/Application/Models/FhirQueryConfigurationModel.cs
@@ -34,4 +34,10 @@ public class FhirQueryConfigurationModel
             ModifyDate = entity.ModifyDate
         };
     }
+
+    public int GetMaxConcurrentRequestsOrDefault()
+    {
+        int value = MaxConcurrentRequests.GetValueOrDefault();
+        return value < 1 ? 1 : value;
+    }
 }

--- a/DotNet/DataAcquisition.Domain/Application/Services/FhirApi/Commands/ReadFhirCommand.cs
+++ b/DotNet/DataAcquisition.Domain/Application/Services/FhirApi/Commands/ReadFhirCommand.cs
@@ -60,7 +60,7 @@ public class ReadFhirCommand : IReadFhirCommand
         if (request.fhirQueryConfiguration == null)
             throw new ArgumentNullException(nameof(request.fhirQueryConfiguration), "FhirQueryConfiguration cannot be null.");
 
-        using (_distributedSemaphoreProvider.AcquireSemaphore(request.facilityId, request.fhirQueryConfiguration.MaxConcurrentRequests.GetValueOrDefault(1), _distributedLockSettings.Expiration, cancellationToken))
+        using (_distributedSemaphoreProvider.AcquireSemaphore(request.facilityId, request.fhirQueryConfiguration.GetMaxConcurrentRequestsOrDefault(), _distributedLockSettings.Expiration, cancellationToken))
         {
             // Create a new handler chain using a DelegatingHandler around a base HttpClientHandler
             var innerHandler = new HttpClientHandler();

--- a/DotNet/DataAcquisition.Domain/Application/Services/FhirApi/Commands/SearchFhirCommand.cs
+++ b/DotNet/DataAcquisition.Domain/Application/Services/FhirApi/Commands/SearchFhirCommand.cs
@@ -74,7 +74,7 @@ public class SearchFhirCommand : ISearchFhirCommand
         }
 
 
-        using (_distributedSemaphoreProvider.AcquireSemaphore(request.facilityId, request.queryConfig.MaxConcurrentRequests.GetValueOrDefault(1), _distributedLockSettings.Expiration, cancellationToken))
+        using (_distributedSemaphoreProvider.AcquireSemaphore(request.facilityId, request.queryConfig.GetMaxConcurrentRequestsOrDefault(), _distributedLockSettings.Expiration, cancellationToken))
         {
             // Create a new handler chain using a DelegatingHandler around a base HttpClientHandler
             var innerHandler = new HttpClientHandler();
@@ -160,7 +160,7 @@ public class SearchFhirCommand : ISearchFhirCommand
                 new KeyValuePair<string, object?>(DiagnosticNames.Resource, request.resourceType)
             ]);
 
-        using (_distributedSemaphoreProvider.AcquireSemaphore(request.facilityId, request.queryConfig.MaxConcurrentRequests.GetValueOrDefault(1), _distributedLockSettings.Expiration, cancellationToken))
+        using (_distributedSemaphoreProvider.AcquireSemaphore(request.facilityId, request.queryConfig.GetMaxConcurrentRequestsOrDefault(), _distributedLockSettings.Expiration, cancellationToken))
         {
             // Create a new handler chain using a DelegatingHandler around a base HttpClientHandler
             var innerHandler = new HttpClientHandler();


### PR DESCRIPTION
### 🛠️ Description of Changes
Coerce an invalid `MaxConcurrentRequests` value before acquiring a permit from the rate-limiting semaphore.

### 🧪 Testing Performed
Tested locally with invalid tenant config (zero `MaxConcurrentRequests`).  Report completed successfully.

### 🧑‍🔬 Unit Testing
N/A

### 📓 Documentation Updated
N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal configuration handling for concurrent request management by centralizing logic into a dedicated method with consistent default enforcement.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->