### PR TITLE
LNK-4751: Non-Reference Query Hits MaxRetriesReached Status Causes Re…

### DIFF
--- a/DotNet/DataAcquisition.Domain/Application/Queries/DataAcquisitionLogQueries.cs
+++ b/DotNet/DataAcquisition.Domain/Application/Queries/DataAcquisitionLogQueries.cs
@@ -203,7 +203,7 @@ public class DataAcquisitionLogQueries : IDataAcquisitionLogQueries
                       where l.FacilityId == facilityId
                             && l.ReportTrackingId == reportTrackingId
                             && l.CorrelationId == correlationId
-                             && l.Status != RequestStatus.Completed
+                             && !(l.Status == RequestStatus.Completed || l.Status == RequestStatus.MaxRetriesReached)
                              && !l.TailSent
                              && l.FhirQueries.Any(fq => fq.IsReference == false)
                       select l).CountAsync();           


### PR DESCRIPTION
This is a cherry-pick of https://github.com/lantanagroup/link-cloud/commit/4c28a98cf5687ef2b41bdbc075223faab6151baa from the 0.4.1 release branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined incomplete log identification to exclude logs that have reached maximum retry attempts, alongside completed logs. This adjustment improves accuracy in tracking data acquisition log statuses and ensures proper log classification within the system.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->