### PR TITLE
LNK-4711: Enhancements to Implementation Guides screen

### DIFF
--- a/Java/validation/src/main/java/com/lantanagroup/link/validation/models/TerminologyDependency.java
+++ b/Java/validation/src/main/java/com/lantanagroup/link/validation/models/TerminologyDependency.java
@@ -4,6 +4,9 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
@@ -12,4 +15,20 @@ public class TerminologyDependency {
     private String version;
     private boolean resourceExists;
     private boolean versionExists;
+    private List<SourceProfile> sourceProfile = new ArrayList<>();
+
+    public TerminologyDependency(String url, String version, boolean resourceExists, boolean versionExists) {
+        this.url = url;
+        this.version = version;
+        this.resourceExists = resourceExists;
+        this.versionExists = versionExists;
+    }
+
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class SourceProfile {
+        private String url;
+        private List<String> element = new ArrayList<>();
+    }
 }

--- a/Java/validation/src/main/java/com/lantanagroup/link/validation/services/ArtifactService.java
+++ b/Java/validation/src/main/java/com/lantanagroup/link/validation/services/ArtifactService.java
@@ -109,20 +109,19 @@ public class ArtifactService {
             resources = support.fetchAllStructureDefinitions();
         }
 
-        Set<String> dependencyStrings = new HashSet<>();
+        Map<String, TerminologyDependency> dependencyMap = new HashMap<>();
         if (resources != null) {
             for (IBaseResource resource : resources) {
                 if (resource instanceof StructureDefinition sd) {
                     if (sd.hasSnapshot()) {
                         for (ElementDefinition ed : sd.getSnapshot().getElement()) {
-                            addBindingDependencies(ed, dependencyStrings);
-                            addFixedPatternDependencies(ed, dependencyStrings);
+                            addBindingDependencies(sd, ed, dependencyMap);
+                            //addFixedPatternDependencies(sd, ed, dependencyMap);
                         }
-                    }
-                    if (sd.hasDifferential()) {
+                    } else if (sd.hasDifferential()) {
                         for (ElementDefinition ed : sd.getDifferential().getElement()) {
-                            addBindingDependencies(ed, dependencyStrings);
-                            addFixedPatternDependencies(ed, dependencyStrings);
+                            addBindingDependencies(sd, ed, dependencyMap);
+                            addFixedPatternDependencies(sd, ed, dependencyMap);
                         }
                     }
                 }
@@ -132,7 +131,7 @@ public class ArtifactService {
         // Remove tx dependencies related to Core FHIR R4, that start with either
         // http://hl7.org/fhir/ValueSet
         // or http://hl7.org/fhir/CodeSystem
-        dependencyStrings.removeIf(s ->
+        dependencyMap.keySet().removeIf(s ->
                 s.startsWith("http://hl7.org/fhir/ValueSet") ||
                 s.startsWith("http://hl7.org/fhir/CodeSystem") ||
                 s.startsWith("http://terminology.hl7.org/ValueSet") ||
@@ -146,20 +145,9 @@ public class ArtifactService {
             fetchLocalTerminology(support, existingResources);
         }
 
-        List<TerminologyDependency> results = new ArrayList<>();
-        for (String depString : dependencyStrings) {
-            String url;
-            String version = null;
-            if (depString.contains("|")) {
-                url = depString.substring(0, depString.indexOf("|"));
-                version = depString.substring(depString.indexOf("|") + 1);
-            } else {
-                url = depString;
-            }
-
-            TerminologyDependency dep = new TerminologyDependency();
-            dep.setUrl(url);
-            dep.setVersion(version);
+        for (TerminologyDependency dep : dependencyMap.values()) {
+            String url = dep.getUrl();
+            String version = dep.getVersion();
             boolean resourceExists = existingResources.containsKey(url);
             dep.setResourceExists(resourceExists);
             if (version == null) {
@@ -167,8 +155,10 @@ public class ArtifactService {
             } else {
                 dep.setVersionExists(resourceExists && existingResources.get(url).contains(version));
             }
-            results.add(dep);
         }
+
+        List<TerminologyDependency> results = new ArrayList<>(dependencyMap.values());
+        results.sort(Comparator.comparing(TerminologyDependency::getUrl));
         return results;
     }
 
@@ -253,34 +243,68 @@ public class ArtifactService {
         }
     }
 
-    private void addBindingDependencies(ElementDefinition ed, Set<String> dependencies) {
+    private void addBindingDependencies(StructureDefinition sd, ElementDefinition ed, Map<String, TerminologyDependency> dependencyMap) {
         if (ed.hasBinding() && ed.getBinding().hasValueSet()) {
-            dependencies.add(ed.getBinding().getValueSet());
+            addDependency(ed.getBinding().getValueSet(), sd, ed, dependencyMap);
         }
     }
 
-    private void addFixedPatternDependencies(ElementDefinition ed, Set<String> dependencies) {
+    private void addFixedPatternDependencies(StructureDefinition sd, ElementDefinition ed, Map<String, TerminologyDependency> dependencyMap) {
         if (ed.hasFixed()) {
-            addTypeDependencies(ed.getFixed(), dependencies);
+            addTypeDependencies(sd, ed, ed.getFixed(), dependencyMap);
         }
         if (ed.hasPattern()) {
-            addTypeDependencies(ed.getPattern(), dependencies);
+            addTypeDependencies(sd, ed, ed.getPattern(), dependencyMap);
         }
     }
 
-    private void addTypeDependencies(Type type, Set<String> dependencies) {
+    private void addTypeDependencies(StructureDefinition sd, ElementDefinition ed, Type type, Map<String, TerminologyDependency> dependencyMap) {
         if (type instanceof Coding coding) {
             if (coding.hasSystem()) {
                 String dependency = coding.getSystem();
                 if (coding.hasVersion()) {
                     dependency += "|" + coding.getVersion();
                 }
-                dependencies.add(dependency);
+                addDependency(dependency, sd, ed, dependencyMap);
             }
         } else if (type instanceof CodeableConcept codeableConcept) {
             for (Coding coding : codeableConcept.getCoding()) {
-                addTypeDependencies(coding, dependencies);
+                addTypeDependencies(sd, ed, coding, dependencyMap);
             }
+        }
+    }
+
+    private void addDependency(String depString, StructureDefinition sd, ElementDefinition ed, Map<String, TerminologyDependency> dependencyMap) {
+        TerminologyDependency dep = dependencyMap.computeIfAbsent(depString, k -> {
+            TerminologyDependency d = new TerminologyDependency();
+            String url;
+            String version = null;
+            if (k.contains("|")) {
+                url = k.substring(0, k.indexOf("|"));
+                version = k.substring(k.indexOf("|") + 1);
+            } else {
+                url = k;
+            }
+            d.setUrl(url);
+            d.setVersion(version);
+            return d;
+        });
+
+        String profileUrl = sd.getUrl();
+        String elementPath = ed.getPath();
+
+        TerminologyDependency.SourceProfile sp = dep.getSourceProfile().stream()
+                .filter(s -> s.getUrl().equals(profileUrl))
+                .findFirst()
+                .orElseGet(() -> {
+                    TerminologyDependency.SourceProfile s = new TerminologyDependency.SourceProfile();
+                    s.setUrl(profileUrl);
+                    dep.getSourceProfile().add(s);
+                    return s;
+                });
+
+        if (!sp.getElement().contains(elementPath)) {
+            sp.getElement().add(elementPath);
         }
     }
 }

--- a/Java/validation/src/test/java/com/lantanagroup/link/validation/services/ArtifactServiceTest.java
+++ b/Java/validation/src/test/java/com/lantanagroup/link/validation/services/ArtifactServiceTest.java
@@ -1,11 +1,11 @@
 package com.lantanagroup.link.validation.services;
 
 import ca.uhn.fhir.context.FhirContext;
+import com.lantanagroup.link.validation.configs.LinkConfig;
 import com.lantanagroup.link.validation.entities.Artifact;
 import com.lantanagroup.link.validation.entities.ArtifactType;
-import com.lantanagroup.link.validation.repositories.ArtifactRepository;
-import com.lantanagroup.link.validation.configs.LinkConfig;
 import com.lantanagroup.link.validation.models.TerminologyDependency;
+import com.lantanagroup.link.validation.repositories.ArtifactRepository;
 import org.hl7.fhir.r4.model.*;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -47,29 +47,34 @@ class ArtifactServiceTest {
         ed.setPath("Patient.gender");
         ed.getBinding().setValueSet("http://example.org/ValueSet/administrative-gender|4.0.1");
 
-        // Snapshot with fixed Coding (with version) - does not exist
+        // Snapshot with binding (no version) - exists in artifacts
         ElementDefinition ed2 = sd.getSnapshot().addElement();
-        ed2.setPath("Patient.extension");
+        ed2.setPath("Patient.maritalStatus");
+        ed2.getBinding().setValueSet("http://example.org/ValueSet/marital-status");
+
+        // Snapshot with binding (no version) - does NOT exist
+        ElementDefinition ed3 = sd.getSnapshot().addElement();
+        ed3.setPath("Patient.active");
+        ed3.getBinding().setValueSet("http://example.org/ValueSet/non-existent");
+
+        // Snapshot with fixed Coding (with version) - ignored
+        ElementDefinition ed4 = sd.getSnapshot().addElement();
+        ed4.setPath("Patient.extension");
         Coding fixedCoding = new Coding("http://example.org/CodeSystem/test", "code1", "Code 1");
         fixedCoding.setVersion("1.2.3");
-        ed2.setFixed(fixedCoding);
+        ed4.setFixed(fixedCoding);
 
-        // Differential with binding (no version) - exists in artifacts
-        ElementDefinition ed3 = sd.getDifferential().addElement();
-        ed3.setPath("Patient.maritalStatus");
-        ed3.getBinding().setValueSet("http://example.org/ValueSet/marital-status");
-
-        // Differential with pattern CodeableConcept - exists but version mismatch (if we had version)
-        ElementDefinition ed4 = sd.getDifferential().addElement();
-        ed4.setPath("Patient.communication.language");
+        // Snapshot with pattern CodeableConcept - ignored
+        ElementDefinition ed5 = sd.getSnapshot().addElement();
+        ed5.setPath("Patient.communication.language");
         CodeableConcept patternCC = new CodeableConcept();
         patternCC.addCoding(new Coding("http://example.org/CodeSystem/lang", "en", "English"));
-        ed4.setPattern(patternCC);
+        ed5.setPattern(patternCC);
 
-        // Differential with binding (no version) - does NOT exist
-        ElementDefinition ed5 = sd.getDifferential().addElement();
-        ed5.setPath("Patient.active");
-        ed5.getBinding().setValueSet("http://example.org/ValueSet/non-existent");
+        // Snapshot with binding (set to a version) - value set found but version doesn't match
+        ElementDefinition ed6 = sd.getSnapshot().addElement();
+        ed6.setPath("Patient.communication.language");
+        ed6.getBinding().setValueSet("http://example.org/ValueSet/patient-communication|1.2.3");
 
         Artifact artifactSd = new Artifact();
         artifactSd.setType(ArtifactType.RESOURCE);
@@ -93,44 +98,40 @@ class ArtifactServiceTest {
         artifactVs2.setName("vs2");
         artifactVs2.setContent(fhirContext.newJsonParser().encodeResourceToString(vs2).getBytes());
 
-        // Add CodeSystem that exists
-        CodeSystem cs1 = new CodeSystem();
-        cs1.setUrl("http://example.org/CodeSystem/lang");
-        Artifact artifactCs1 = new Artifact();
-        artifactCs1.setType(ArtifactType.RESOURCE);
-        artifactCs1.setName("cs1");
-        artifactCs1.setContent(fhirContext.newJsonParser().encodeResourceToString(cs1).getBytes());
+        // Add ValueSet that exists (no version)
+        ValueSet vs3 = new ValueSet();
+        vs3.setUrl("http://example.org/ValueSet/patient-communication");
+        vs3.setVersion("3.2.1");
+        Artifact artifactVs3 = new Artifact();
+        artifactVs3.setType(ArtifactType.RESOURCE);
+        artifactVs3.setName("vs3");
+        artifactVs3.setContent(fhirContext.newJsonParser().encodeResourceToString(vs3).getBytes());
 
-        when(artifactRepository.findAll()).thenReturn(List.of(artifactSd, artifactVs1, artifactVs2, artifactCs1));
+        when(artifactRepository.findAll()).thenReturn(List.of(artifactSd, artifactVs1, artifactVs2, artifactVs3));
 
         List<TerminologyDependency> dependencies = artifactService.getTerminologyDependencies();
 
-        assertEquals(5, dependencies.size());
+        assertEquals(4, dependencies.size());
 
         TerminologyDependency dep1 = dependencies.stream().filter(d -> d.getUrl().equals("http://example.org/ValueSet/administrative-gender")).findFirst().orElseThrow();
         assertEquals("4.0.1", dep1.getVersion());
         assertTrue(dep1.isResourceExists());
         assertTrue(dep1.isVersionExists());
 
-        TerminologyDependency dep2 = dependencies.stream().filter(d -> d.getUrl().equals("http://example.org/CodeSystem/test")).findFirst().orElseThrow();
-        assertEquals("1.2.3", dep2.getVersion());
-        assertFalse(dep2.isResourceExists());
-        assertFalse(dep2.isVersionExists());
+        TerminologyDependency dep2 = dependencies.stream().filter(d -> d.getUrl().equals("http://example.org/ValueSet/marital-status")).findFirst().orElseThrow();
+        assertNull(dep2.getVersion());
+        assertTrue(dep2.isResourceExists());
+        assertTrue(dep2.isVersionExists()); // version specified was null, so versionExists is true
 
-        TerminologyDependency dep3 = dependencies.stream().filter(d -> d.getUrl().equals("http://example.org/ValueSet/marital-status")).findFirst().orElseThrow();
+        TerminologyDependency dep3 = dependencies.stream().filter(d -> d.getUrl().equals("http://example.org/ValueSet/non-existent")).findFirst().orElseThrow();
         assertNull(dep3.getVersion());
-        assertTrue(dep3.isResourceExists());
-        assertTrue(dep3.isVersionExists()); // version specified was null, so versionExists is true
+        assertFalse(dep3.isResourceExists());
+        assertTrue(dep3.isVersionExists());
 
-        TerminologyDependency dep4 = dependencies.stream().filter(d -> d.getUrl().equals("http://example.org/CodeSystem/lang")).findFirst().orElseThrow();
-        assertNull(dep4.getVersion());
+        TerminologyDependency dep4 = dependencies.stream().filter(d -> d.getUrl().equals("http://example.org/ValueSet/patient-communication")).findFirst().orElseThrow();
+        assertEquals("1.2.3", dep4.getVersion());
         assertTrue(dep4.isResourceExists());
-        assertTrue(dep4.isVersionExists());
-
-        TerminologyDependency dep5 = dependencies.stream().filter(d -> d.getUrl().equals("http://example.org/ValueSet/non-existent")).findFirst().orElseThrow();
-        assertNull(dep5.getVersion());
-        assertFalse(dep5.isResourceExists());
-        assertTrue(dep5.isVersionExists());
+        assertFalse(dep4.isVersionExists());
     }
 
     @Test

--- a/Java/validation/src/test/java/com/lantanagroup/link/validation/services/TerminologyDependencySourceProfileTest.java
+++ b/Java/validation/src/test/java/com/lantanagroup/link/validation/services/TerminologyDependencySourceProfileTest.java
@@ -1,0 +1,113 @@
+package com.lantanagroup.link.validation.services;
+
+import ca.uhn.fhir.context.FhirContext;
+import com.lantanagroup.link.validation.entities.Artifact;
+import com.lantanagroup.link.validation.entities.ArtifactType;
+import com.lantanagroup.link.validation.repositories.ArtifactRepository;
+import com.lantanagroup.link.validation.configs.LinkConfig;
+import com.lantanagroup.link.validation.models.TerminologyDependency;
+import org.hl7.fhir.r4.model.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.io.IOException;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class TerminologyDependencySourceProfileTest {
+    private ArtifactService artifactService;
+
+    @Mock
+    private ArtifactRepository artifactRepository;
+
+    @Mock
+    private LinkConfig linkConfig;
+
+    private final FhirContext fhirContext = FhirContext.forR4();
+
+    @BeforeEach
+    void setUp() {
+        artifactService = new ArtifactService(fhirContext, artifactRepository, linkConfig);
+    }
+
+    @Test
+    void getTerminologyDependencies_SourceProfile() throws IOException {
+        String vsUrl = "http://example.org/ValueSet/vs1";
+        String profile1Url = "http://example.org/StructureDefinition/p1";
+        String profile2Url = "http://example.org/StructureDefinition/p2";
+
+        StructureDefinition p1 = new StructureDefinition();
+        p1.setUrl(profile1Url);
+        ElementDefinition e1_1 = p1.getSnapshot().addElement();
+        e1_1.setPath("Patient.gender");
+        e1_1.getBinding().setValueSet(vsUrl);
+        ElementDefinition e1_2 = p1.getSnapshot().addElement();
+        e1_2.setPath("Patient.contact.gender");
+        e1_2.getBinding().setValueSet(vsUrl);
+
+        StructureDefinition p2 = new StructureDefinition();
+        p2.setUrl(profile2Url);
+        ElementDefinition e2_1 = p2.getSnapshot().addElement();
+        e2_1.setPath("Observation.code");
+        e2_1.getBinding().setValueSet(vsUrl);
+
+        Artifact a1 = new Artifact();
+        a1.setType(ArtifactType.RESOURCE);
+        a1.setName("p1");
+        a1.setContent(fhirContext.newJsonParser().encodeResourceToString(p1).getBytes());
+
+        Artifact a2 = new Artifact();
+        a2.setType(ArtifactType.RESOURCE);
+        a2.setName("p2");
+        a2.setContent(fhirContext.newJsonParser().encodeResourceToString(p2).getBytes());
+
+        when(artifactRepository.findAll()).thenReturn(List.of(a1, a2));
+
+        List<TerminologyDependency> dependencies = artifactService.getTerminologyDependencies();
+
+        assertEquals(1, dependencies.size());
+        TerminologyDependency dep = dependencies.get(0);
+        assertEquals(vsUrl, dep.getUrl());
+        assertEquals(2, dep.getSourceProfile().size());
+
+        TerminologyDependency.SourceProfile sp1 = dep.getSourceProfile().stream()
+                .filter(s -> s.getUrl().equals(profile1Url))
+                .findFirst().orElseThrow();
+        assertEquals(2, sp1.getElement().size());
+        assertTrue(sp1.getElement().contains("Patient.gender"));
+        assertTrue(sp1.getElement().contains("Patient.contact.gender"));
+
+        TerminologyDependency.SourceProfile sp2 = dep.getSourceProfile().stream()
+                .filter(s -> s.getUrl().equals(profile2Url))
+                .findFirst().orElseThrow();
+        assertEquals(1, sp2.getElement().size());
+        assertTrue(sp2.getElement().contains("Observation.code"));
+    }
+
+    @Test
+    void getTerminologyDependencies_Sorted() throws IOException {
+        StructureDefinition p = new StructureDefinition();
+        p.setUrl("http://example.org/SD");
+        p.getSnapshot().addElement().setPath("P.a").getBinding().setValueSet("http://example.org/VS/B");
+        p.getSnapshot().addElement().setPath("P.b").getBinding().setValueSet("http://example.org/VS/A");
+
+        Artifact a = new Artifact();
+        a.setType(ArtifactType.RESOURCE);
+        a.setName("p");
+        a.setContent(fhirContext.newJsonParser().encodeResourceToString(p).getBytes());
+
+        when(artifactRepository.findAll()).thenReturn(List.of(a));
+
+        List<TerminologyDependency> dependencies = artifactService.getTerminologyDependencies();
+
+        assertEquals(2, dependencies.size());
+        assertEquals("http://example.org/VS/A", dependencies.get(0).getUrl());
+        assertEquals("http://example.org/VS/B", dependencies.get(1).getUrl());
+    }
+}

--- a/Web/Admin.UI/src/app/components/validation-config/tx-dependencies/tx-dependencies-dialog/tx-dependencies-dialog.component.html
+++ b/Web/Admin.UI/src/app/components/validation-config/tx-dependencies/tx-dependencies-dialog/tx-dependencies-dialog.component.html
@@ -1,4 +1,8 @@
-<h2 mat-dialog-title>TX Dependencies for {{ data.package }}</h2>
+@if (data.package) {
+  <h2 mat-dialog-title>TX Dependencies for {{ data.package }}</h2>
+} @else {
+  <h2 mat-dialog-title>System TX Dependencies</h2>
+}
 <mat-dialog-content class="tx-dialog-content">
   <app-tx-dependencies [package]="data.package"></app-tx-dependencies>
 </mat-dialog-content>

--- a/Web/Admin.UI/src/app/components/validation-config/tx-dependencies/tx-dependencies-dialog/tx-dependencies-dialog.component.ts
+++ b/Web/Admin.UI/src/app/components/validation-config/tx-dependencies/tx-dependencies-dialog/tx-dependencies-dialog.component.ts
@@ -11,5 +11,5 @@ import {TxDependenciesComponent} from '../tx-dependencies.component';
   styleUrls: ['./tx-dependencies-dialog.component.scss']
 })
 export class TxDependenciesDialogComponent {
-  constructor(@Inject(MAT_DIALOG_DATA) public data: { package: string }) {}
+  constructor(@Inject(MAT_DIALOG_DATA) public data: { package?: string }) {}
 }

--- a/Web/Admin.UI/src/app/components/validation-config/tx-dependencies/tx-dependencies.component.html
+++ b/Web/Admin.UI/src/app/components/validation-config/tx-dependencies/tx-dependencies.component.html
@@ -25,7 +25,22 @@
   </div>
 } @else {
   <div class="table-container">
-    <table mat-table [dataSource]="dataSource" class="mat-elevation-z8">
+    <table mat-table [dataSource]="dataSource" multiTemplateDataRows class="mat-elevation-z8">
+      <ng-container matColumnDef="expand">
+        <th mat-header-cell *matHeaderCellDef aria-label="row actions">&nbsp;</th>
+        <td mat-cell *matCellDef="let element">
+          @if (element.sourceProfile && element.sourceProfile.length > 0) {
+            <button mat-icon-button aria-label="expand row" (click)="(expandedElement = expandedElement === element ? null : element); $event.stopPropagation()">
+              @if (expandedElement === element) {
+                <mat-icon>keyboard_arrow_up</mat-icon>
+              } @else {
+                <mat-icon>keyboard_arrow_down</mat-icon>
+              }
+            </button>
+          }
+        </td>
+      </ng-container>
+
       <ng-container matColumnDef="url">
         <th mat-header-cell *matHeaderCellDef>Resource URL</th>
         <td mat-cell *matCellDef="let row">{{ row.url }}</td>
@@ -60,8 +75,37 @@
         </td>
       </ng-container>
 
+      <!-- Expanded Content Column - The detail row is made up of this one column that spans all columns -->
+      <ng-container matColumnDef="expandedDetail">
+        <td mat-cell *matCellDef="let element" [attr.colspan]="displayedColumns.length">
+          <div class="element-detail"
+               [@detailExpand]="element == expandedElement ? 'expanded' : 'collapsed'">
+            <div class="source-profiles-container">
+              @for (profile of element.sourceProfile; track profile) {
+                <div class="source-profile-item">
+                  <div class="profile-url"><strong>Profile:</strong> {{ profile.url }}</div>
+                  <div class="profile-elements">
+                    <strong>Elements:</strong>
+                    <ul>
+                      @for (el of profile.element; track el) {
+                        <li>{{ el }}</li>
+                      }
+                    </ul>
+                  </div>
+                </div>
+              }
+            </div>
+          </div>
+        </td>
+      </ng-container>
+
       <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
-      <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
+      <tr mat-row *matRowDef="let row; columns: displayedColumns;"
+          class="element-row"
+          [class.expanded-row]="expandedElement === row"
+          (click)="expandedElement = expandedElement === row ? null : row">
+      </tr>
+      <tr mat-row *matRowDef="let row; columns: ['expandedDetail']" class="detail-row"></tr>
     </table>
 
     @if (!hasData) {

--- a/Web/Admin.UI/src/app/components/validation-config/tx-dependencies/tx-dependencies.component.scss
+++ b/Web/Admin.UI/src/app/components/validation-config/tx-dependencies/tx-dependencies.component.scss
@@ -54,3 +54,52 @@ table {
   gap: 8px;
   color: #d32f2f;
 }
+
+tr.detail-row {
+  height: 0;
+}
+
+tr.element-row:not(.expanded-row):hover {
+  background: whitesmoke;
+}
+
+tr.element-row:not(.expanded-row):active {
+  background: #efefef;
+}
+
+.element-row td {
+  border-bottom-width: 0;
+  cursor: pointer;
+}
+
+.element-detail {
+  overflow: hidden;
+  display: flex;
+}
+
+.source-profiles-container {
+  width: 100%;
+  padding: 16px;
+  background-color: #f9f9f9;
+  border-bottom: 1px solid #e0e0e0;
+}
+
+.source-profile-item {
+  margin-bottom: 16px;
+  &:last-child {
+    margin-bottom: 0;
+  }
+}
+
+.profile-url {
+  font-size: 14px;
+  margin-bottom: 4px;
+}
+
+.profile-elements {
+  font-size: 13px;
+  ul {
+    margin: 4px 0 0 20px;
+    padding: 0;
+  }
+}

--- a/Web/Admin.UI/src/app/components/validation-config/tx-dependencies/tx-dependencies.component.ts
+++ b/Web/Admin.UI/src/app/components/validation-config/tx-dependencies/tx-dependencies.component.ts
@@ -6,6 +6,8 @@ import {MatInputModule} from '@angular/material/input';
 import {MatCheckboxModule} from '@angular/material/checkbox';
 import {MatProgressSpinnerModule} from '@angular/material/progress-spinner';
 import {MatIconModule} from '@angular/material/icon';
+import {MatButtonModule} from '@angular/material/button';
+import {animate, state, style, transition, trigger} from '@angular/animations';
 import {Subscription} from 'rxjs';
 import {ValidationService} from '../../../services/gateway/validation/validation.service';
 import {ITerminologyDependency} from '../../../interfaces/validation/terminology-dependency.interface';
@@ -31,16 +33,25 @@ interface TxDependencyFilters {
     MatInputModule,
     MatCheckboxModule,
     MatProgressSpinnerModule,
-    MatIconModule
+    MatIconModule,
+    MatButtonModule
   ],
   templateUrl: './tx-dependencies.component.html',
-  styleUrls: ['./tx-dependencies.component.scss']
+  styleUrls: ['./tx-dependencies.component.scss'],
+  animations: [
+    trigger('detailExpand', [
+      state('collapsed,void', style({height: '0px', minHeight: '0'})),
+      state('expanded', style({height: '*'})),
+      transition('expanded <=> collapsed', animate('225ms cubic-bezier(0.4, 0.0, 0.2, 1)')),
+    ]),
+  ],
 })
 export class TxDependenciesComponent implements OnInit, OnDestroy {
-  @Input({ required: true }) package!: string;
+  @Input() package?: string;
   filters: FormGroup;
   dataSource = new MatTableDataSource<TxDependencyRow>([]);
-  displayedColumns: string[] = ['url', 'version', 'foundResource', 'foundVersion'];
+  displayedColumns: string[] = ['expand', 'url', 'version', 'foundResource', 'foundVersion'];
+  expandedElement: TxDependencyRow | null = null;
   loading = false;
   errorMessage = '';
 
@@ -80,16 +91,15 @@ export class TxDependenciesComponent implements OnInit, OnDestroy {
   }
 
   private loadDependencies(): void {
-    if (!this.package || !this.package.trim()) {
-      this.errorMessage = 'Please select a package to view TX dependencies.';
-      return;
-    }
-
     this.loading = true;
     this.errorMessage = '';
 
+    const obs = (this.package && this.package.trim())
+      ? this.validationService.getTxDependencies(this.package.trim())
+      : this.validationService.getAllTxDependencies();
+
     this.subscriptions.add(
-      this.validationService.getTxDependencies(this.package.trim()).subscribe({
+      obs.subscribe({
         next: (dependencies) => {
           this.dataSource.data = dependencies.map((dependency) => this.mapRow(dependency));
           this.loading = false;

--- a/Web/Admin.UI/src/app/components/validation-config/validation-config.component.html
+++ b/Web/Admin.UI/src/app/components/validation-config/validation-config.component.html
@@ -37,7 +37,13 @@
 <!-- IG Names -->
 <mat-card class="upload-card">
   <mat-card-content>
-    <mat-card-title>Validation Artifacts</mat-card-title>
+    <div class="header-with-action">
+      <mat-card-title>Validation Artifacts</mat-card-title>
+      <button mat-button color="primary" (click)="openTxDependencies()">
+        <mat-icon>list</mat-icon>
+        View All TX Dependencies
+      </button>
+    </div>
     <mat-list>
       @for (ig of implementationGuides; track ig) {
         <mat-list-item>

--- a/Web/Admin.UI/src/app/components/validation-config/validation-config.component.scss
+++ b/Web/Admin.UI/src/app/components/validation-config/validation-config.component.scss
@@ -52,3 +52,10 @@
   font-weight: 600;
 }
 
+.header-with-action {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 16px;
+}
+

--- a/Web/Admin.UI/src/app/components/validation-config/validation-config.component.ts
+++ b/Web/Admin.UI/src/app/components/validation-config/validation-config.component.ts
@@ -162,11 +162,7 @@ export class ValidationConfigComponent implements OnInit {
     }
   }
 
-  openTxDependencies(packageName: string): void {
-    if (!packageName) {
-      return;
-    }
-
+  openTxDependencies(packageName?: string): void {
     this.dialog.open(TxDependenciesDialogComponent, {
       width: '75%',
       maxWidth: '900px',

--- a/Web/Admin.UI/src/app/interfaces/validation/terminology-dependency.interface.ts
+++ b/Web/Admin.UI/src/app/interfaces/validation/terminology-dependency.interface.ts
@@ -3,4 +3,8 @@ export interface ITerminologyDependency {
   version: string | null;
   resourceExists: boolean;
   versionExists: boolean;
+  sourceProfile: {
+    url: string;
+    element: string[];
+  }[];
 }

--- a/Web/Admin.UI/src/app/services/gateway/validation/validation.service.ts
+++ b/Web/Admin.UI/src/app/services/gateway/validation/validation.service.ts
@@ -58,7 +58,14 @@ export class ValidationService {
 
     const sanitizedPackage = encodeURIComponent(packageName);
     return this.http.get<ITerminologyDependency[]>(`${this.appConfigService.config?.baseApiUrl}/validation/artifact/PACKAGE/${sanitizedPackage}/tx-dependencies`).pipe(
-      tap(_ => console.log(`Fetched TX dependencies.`)),
+      tap(_ => console.log(`Fetched TX dependencies for package ${packageName}.`)),
+      catchError((error) => this.errorHandler.handleError(error))
+    )
+  }
+
+  getAllTxDependencies(): Observable<ITerminologyDependency[]> {
+    return this.http.get<ITerminologyDependency[]>(`${this.appConfigService.config?.baseApiUrl}/validation/artifact/tx-dependencies`).pipe(
+      tap(_ => console.log(`Fetched all TX dependencies.`)),
       catchError((error) => this.errorHandler.handleError(error))
     )
   }


### PR DESCRIPTION
### 🛠️ Description of Changes

Add support for viewing source profiles/elements for TX dependencies in UI and backend, and extending to allow user to see system-wide terminology dependencies.

### 🧪 Testing Performed

Tested using Docker Compose, postman to confirm the endpoints work as expected, and checked the UI to ensure the information is presented to the screen correctly.

### 🧑‍🔬 Unit Testing

- [x] I have written or updated unit tests to cover my changes

### 📓 Documentation Updated

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added system-wide TX Dependencies view accessible from validation configuration
  * Added expandable detail rows in TX dependencies table showing source profiles and associated element paths

* **Tests**
  * Added test coverage for terminology dependency extraction with source profile support

<!-- end of auto-generated comment: release notes by coderabbit.ai -->