### PR TITLE
LNK-4778: Admin UI allows users to view terminology service details

### DIFF
--- a/Web/Admin.UI/src/app/app-routing.module.ts
+++ b/Web/Admin.UI/src/app/app-routing.module.ts
@@ -1,7 +1,7 @@
-import { RouterModule, Routes } from '@angular/router';
+import {RouterModule, Routes} from '@angular/router';
 
-import { NgModule } from '@angular/core';
-import { AuthGuard } from './services/security/auth.guard'; // adjust the path
+import {NgModule} from '@angular/core';
+import {AuthGuard} from './services/security/auth.guard'; // adjust the path
 
 
 const routes: Routes = [
@@ -32,6 +32,7 @@ const routes: Routes = [
   { path: 'validation-config/validation-categories', loadComponent: () => import('./components/validation-config/validation-categories/validation-categories-list/validation-categories-list.component').then(mod => mod.ValidationCategoriesComponent) , canActivate: [AuthGuard] },
   { path: 'validation-config/validation-categories/:id/edit', loadComponent: () => import('./components/validation-config/validation-categories/edit-validation-category/edit-validation-category.component').then(mod => mod.EditValidationCategoryComponent), canActivate: [AuthGuard]  },
   { path: 'query-plans', loadComponent: () => import('./components/query-plans/query-plans-dashboard/query-plans-dashboard.component').then(mod => mod.QueryPlansDashboardComponent), canActivate: [AuthGuard]  },
+  { path: 'terminology-config', loadComponent: () => import('./components/terminology/terminology-config.component').then(mod => mod.TerminologyConfigComponent), canActivate: [AuthGuard]  },
   { path: 'app-configuration', loadComponent: () => import('./components/app-configuration/app-configuration-dashboard/app-configuration-dashboard.component').then(mod => mod.AppConfigurationDashboardComponent), canActivate: [AuthGuard]  },
   { path: 'kafka', loadComponent: () => import('./components/kafka/kafka-dashboard/kafka-dashboard.component').then(mod => mod.KafkaDashboardComponent) , canActivate: [AuthGuard] },
   { path: '', redirectTo: 'login', pathMatch: 'full' },

--- a/Web/Admin.UI/src/app/app.module.ts
+++ b/Web/Admin.UI/src/app/app.module.ts
@@ -1,42 +1,57 @@
-import { APP_INITIALIZER, NgModule } from '@angular/core';
-import { AuthConfig, OAuthModule, OAuthModuleConfig, OAuthService } from "angular-oauth2-oidc";
-import { provideHttpClient, withInterceptorsFromDi } from "@angular/common/http";
+import {APP_INITIALIZER, NgModule} from '@angular/core';
+import {AuthConfig, OAuthModule, OAuthModuleConfig, OAuthService} from "angular-oauth2-oidc";
+import {provideHttpClient, withInterceptorsFromDi} from "@angular/common/http";
 
-import { AppComponent } from './app.component';
-import { AppConfigService } from './services/app-config.service';
-import { AppRoutingModule } from './app-routing.module';
-import { AuthenticationService } from './services/security/authentication.service';
-import { BreadcrumbComponent } from "./components/core/breadcrumb/breadcrumb.component";
-import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
-import { BrowserModule } from '@angular/platform-browser';
-import { FooterComponent } from "./components/core/footer/footer.component";
-import { HttpInterceptorProviders } from './interceptors/interceptor.barrel';
-import { LayoutModule } from '@angular/cdk/layout';
-import { LinkNavBarComponent } from './components/core/link-nav-bar/link-nav-bar.component';
-import { LoadingIndicatorComponent } from './components/core/loading-indicator/loading-indicator.component';
-import { MatButtonModule } from '@angular/material/button';
-import { MatExpansionModule } from '@angular/material/expansion';
-import { MatIconModule } from '@angular/material/icon';
-import { MatListModule } from '@angular/material/list';
-import { MatMenuModule } from '@angular/material/menu';
-import { MatNativeDateModule } from '@angular/material/core';
-import { MatSidenavModule } from '@angular/material/sidenav';
-import { MatToolbarModule } from '@angular/material/toolbar';
-import { StyleManagerService } from './services/style-manager-service';
-import { SubPreQualReportBannerComponent } from './components/sub-pre-qual-report/sub-pre-qual-report-banner/sub-pre-qual-report-banner.component';
-import { SubPreQualReportCategoriesTableComponent } from './components/sub-pre-qual-report/sub-pre-qual-report-categories-table/sub-pre-qual-report-categories-table.component';
-import { SubPreQualReportComponent } from './components/sub-pre-qual-report/sub-pre-qual-report.component';
-import { SubPreQualReportMetaComponent } from './components/sub-pre-qual-report/sub-pre-qual-report-meta/sub-pre-qual-report-meta.component';
-import { SubPreQualReportSummaryComponent } from './components/sub-pre-qual-report/sub-pre-qual-report-summary/sub-pre-qual-report-summary.component';
-import { ThemePickerComponent } from './components/core/theme-picker/theme-picker.component';
-import { ToastrModule } from 'ngx-toastr';
-import { VdButtonComponent } from './components/core/vd-button/vd-button.component';
-import { VdIconComponent } from './components/core/vd-icon/vd-icon.component';
-import { provideCharts, withDefaultRegisterables } from 'ng2-charts';
-import { TenantSearchBarComponent } from "./components/core/tenant-search-bar/tenant-search-bar/tenant-search-bar.component";
-import { QueryPlansDashboardComponent } from './components/query-plans/query-plans-dashboard/query-plans-dashboard.component';
-import { AppConfigurationDashboardComponent } from './components/app-configuration/app-configuration-dashboard/app-configuration-dashboard.component';
-import { KafkaDashboardComponent } from './components/kafka/kafka-dashboard/kafka-dashboard.component';
+import {AppComponent} from './app.component';
+import {AppConfigService} from './services/app-config.service';
+import {AppRoutingModule} from './app-routing.module';
+import {AuthenticationService} from './services/security/authentication.service';
+import {BreadcrumbComponent} from "./components/core/breadcrumb/breadcrumb.component";
+import {BrowserAnimationsModule} from '@angular/platform-browser/animations';
+import {BrowserModule} from '@angular/platform-browser';
+import {FooterComponent} from "./components/core/footer/footer.component";
+import {HttpInterceptorProviders} from './interceptors/interceptor.barrel';
+import {LayoutModule} from '@angular/cdk/layout';
+import {LinkNavBarComponent} from './components/core/link-nav-bar/link-nav-bar.component';
+import {LoadingIndicatorComponent} from './components/core/loading-indicator/loading-indicator.component';
+import {MatButtonModule} from '@angular/material/button';
+import {MatExpansionModule} from '@angular/material/expansion';
+import {MatIconModule} from '@angular/material/icon';
+import {MatListModule} from '@angular/material/list';
+import {MatMenuModule} from '@angular/material/menu';
+import {MatNativeDateModule} from '@angular/material/core';
+import {MatSidenavModule} from '@angular/material/sidenav';
+import {MatToolbarModule} from '@angular/material/toolbar';
+import {StyleManagerService} from './services/style-manager-service';
+import {
+  SubPreQualReportBannerComponent
+} from './components/sub-pre-qual-report/sub-pre-qual-report-banner/sub-pre-qual-report-banner.component';
+import {
+  SubPreQualReportCategoriesTableComponent
+} from './components/sub-pre-qual-report/sub-pre-qual-report-categories-table/sub-pre-qual-report-categories-table.component';
+import {SubPreQualReportComponent} from './components/sub-pre-qual-report/sub-pre-qual-report.component';
+import {
+  SubPreQualReportMetaComponent
+} from './components/sub-pre-qual-report/sub-pre-qual-report-meta/sub-pre-qual-report-meta.component';
+import {
+  SubPreQualReportSummaryComponent
+} from './components/sub-pre-qual-report/sub-pre-qual-report-summary/sub-pre-qual-report-summary.component';
+import {ThemePickerComponent} from './components/core/theme-picker/theme-picker.component';
+import {ToastrModule} from 'ngx-toastr';
+import {VdButtonComponent} from './components/core/vd-button/vd-button.component';
+import {VdIconComponent} from './components/core/vd-icon/vd-icon.component';
+import {provideCharts, withDefaultRegisterables} from 'ng2-charts';
+import {
+  TenantSearchBarComponent
+} from "./components/core/tenant-search-bar/tenant-search-bar/tenant-search-bar.component";
+import {
+  QueryPlansDashboardComponent
+} from './components/query-plans/query-plans-dashboard/query-plans-dashboard.component';
+import {
+  AppConfigurationDashboardComponent
+} from './components/app-configuration/app-configuration-dashboard/app-configuration-dashboard.component';
+import {KafkaDashboardComponent} from './components/kafka/kafka-dashboard/kafka-dashboard.component';
+import {TerminologyConfigComponent} from './components/terminology/terminology-config.component';
 
 export function initConfig(appConfig: AppConfigService, oauthService: OAuthService, authService: AuthenticationService, oauthModuleConfig: OAuthModuleConfig) {
   const configPromise = appConfig.loadConfig()
@@ -109,7 +124,8 @@ export function initConfig(appConfig: AppConfigService, oauthService: OAuthServi
     TenantSearchBarComponent,
     QueryPlansDashboardComponent,
     AppConfigurationDashboardComponent,
-    KafkaDashboardComponent
+    KafkaDashboardComponent,
+    TerminologyConfigComponent
 ],
   providers: [
     {

--- a/Web/Admin.UI/src/app/components/core/link-nav-bar/link-nav-bar.component.ts
+++ b/Web/Admin.UI/src/app/components/core/link-nav-bar/link-nav-bar.component.ts
@@ -1,9 +1,9 @@
-import { IsActiveMatchOptions, Router, RouterLink, RouterLinkActive } from '@angular/router';
+import {Router, RouterLink, RouterLinkActive} from '@angular/router';
 
 
-import { Component } from '@angular/core';
-import { VdIconComponent } from "../vd-icon/vd-icon.component";
-import { AppConfigService } from "../../../services/app-config.service";
+import {Component} from '@angular/core';
+import {VdIconComponent} from "../vd-icon/vd-icon.component";
+import {AppConfigService} from "../../../services/app-config.service";
 
 export interface SubnavItem {
   label: string;
@@ -36,6 +36,7 @@ export class LinkNavBarComponent {
         { label: 'Measure Definitions', path: '/measure-def' },
         { label: 'Normalization Operations', path: '/tenant/operations' },
         { label: 'Query Plans', path: '/query-plans' },
+        { label: 'Terminology', path: '/terminology-config' },
         { label: 'Validation Categories', path: '/validation-config/validation-categories' },
         { label: 'Vendors', path: '/vendor' },
       ]

--- a/Web/Admin.UI/src/app/components/terminology/terminology-config.component.html
+++ b/Web/Admin.UI/src/app/components/terminology/terminology-config.component.html
@@ -1,0 +1,87 @@
+<div class="terminology-config-container">
+  <mat-card>
+    <mat-card-header>
+      <mat-card-title>Terminology Resources</mat-card-title>
+    </mat-card-header>
+    <mat-card-content>
+      <div class="filter-container">
+        <mat-form-field appearance="outline">
+          <mat-label>Resource Type</mat-label>
+          <mat-select [(ngModel)]="searchResourceType" (selectionChange)="applyFilter()">
+            <mat-option value="">All</mat-option>
+            <mat-option value="ValueSet">ValueSet</mat-option>
+            <mat-option value="CodeSystem">CodeSystem</mat-option>
+          </mat-select>
+        </mat-form-field>
+
+        <mat-form-field appearance="outline">
+          <mat-label>Search ID</mat-label>
+          <input matInput [(ngModel)]="searchId" (keyup)="applyFilter()" placeholder="Filter by ID">
+        </mat-form-field>
+
+        <mat-form-field appearance="outline">
+          <mat-label>Search URL</mat-label>
+          <input matInput [(ngModel)]="searchUrl" (keyup)="applyFilter()" placeholder="Filter by URL">
+        </mat-form-field>
+
+        <mat-form-field appearance="outline">
+          <mat-label>Search Version</mat-label>
+          <input matInput [(ngModel)]="searchVersion" (keyup)="applyFilter()" placeholder="Filter by Version">
+        </mat-form-field>
+      </div>
+
+      <div class="table-container mat-elevation-z8">
+        <table mat-table [dataSource]="dataSource" matSort>
+
+          <!-- Resource Type Column -->
+          <ng-container matColumnDef="resourceType">
+            <th mat-header-cell *matHeaderCellDef mat-sort-header> Resource Type </th>
+            <td mat-cell *matCellDef="let element"> {{element.resourceType}} </td>
+          </ng-container>
+
+          <!-- ID Column -->
+          <ng-container matColumnDef="id">
+            <th mat-header-cell *matHeaderCellDef mat-sort-header> ID </th>
+            <td mat-cell *matCellDef="let element"> {{element.id}} </td>
+          </ng-container>
+
+          <!-- URL Column -->
+          <ng-container matColumnDef="url">
+            <th mat-header-cell *matHeaderCellDef mat-sort-header> URL </th>
+            <td mat-cell *matCellDef="let element"> {{element.url}} </td>
+          </ng-container>
+
+          <!-- Version Column -->
+          <ng-container matColumnDef="version">
+            <th mat-header-cell *matHeaderCellDef mat-sort-header> Version </th>
+            <td mat-cell *matCellDef="let element"> {{element.version}} </td>
+          </ng-container>
+
+          <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+          <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
+
+          <!-- Row shown when there is no matching data. -->
+          <tr class="mat-row" *matNoDataRow>
+            <td class="mat-cell" colspan="4">No data matching the filter</td>
+          </tr>
+        </table>
+      </div>
+
+      <!--div class="upload-container">
+        <h3>Upload Terminology Package (Placeholder)</h3>
+        <p>Select a ZIP package containing directories for each ValueSet or CodeSystem.</p>
+
+        <input type="file" #fileInput style="display: none" (change)="onFileSelected($event)" accept=".zip">
+        <button mat-raised-button color="primary" (click)="fileInput.click()" [disabled]="isUploading">
+          <mat-icon>upload</mat-icon>
+          Upload Package
+        </button>
+
+        <div *ngIf="isUploading" class="upload-progress">
+          <p>{{uploadStatus}}</p>
+          <mat-progress-bar mode="determinate" [value]="uploadProgress"></mat-progress-bar>
+        </div>
+      </div-->
+    </mat-card-content>
+  </mat-card>
+</div>

--- a/Web/Admin.UI/src/app/components/terminology/terminology-config.component.scss
+++ b/Web/Admin.UI/src/app/components/terminology/terminology-config.component.scss
@@ -1,0 +1,56 @@
+.terminology-config-container {
+  padding: 20px;
+
+  mat-card {
+    max-width: 1200px;
+    margin: 0 auto;
+  }
+
+  .filter-container {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 16px;
+    margin-bottom: 20px;
+
+    mat-form-field {
+      flex: 1;
+      min-width: 200px;
+    }
+  }
+
+  .table-container {
+    margin-bottom: 30px;
+    overflow: auto;
+
+    table {
+      width: 100%;
+    }
+
+    .mat-column-resourceType {
+      width: 150px;
+    }
+
+    .mat-column-id {
+      width: 150px;
+    }
+
+    .mat-column-version {
+      width: 100px;
+    }
+  }
+
+  .upload-container {
+    padding: 20px;
+    border: 1px dashed #ccc;
+    border-radius: 4px;
+    background-color: #f9f9f9;
+
+    h3 {
+      margin-top: 0;
+    }
+
+    .upload-progress {
+      margin-top: 15px;
+    }
+  }
+}

--- a/Web/Admin.UI/src/app/components/terminology/terminology-config.component.ts
+++ b/Web/Admin.UI/src/app/components/terminology/terminology-config.component.ts
@@ -1,0 +1,120 @@
+import {Component, OnInit, ViewChild} from '@angular/core';
+import {CommonModule} from '@angular/common';
+import {MatTableDataSource, MatTableModule} from '@angular/material/table';
+import {MatSort, MatSortModule} from '@angular/material/sort';
+import {MatFormFieldModule} from '@angular/material/form-field';
+import {MatInputModule} from '@angular/material/input';
+import {MatSelectModule} from '@angular/material/select';
+import {MatButtonModule} from '@angular/material/button';
+import {MatIconModule} from '@angular/material/icon';
+import {MatProgressBarModule} from '@angular/material/progress-bar';
+import {MatCardModule} from '@angular/material/card';
+import {FormsModule} from '@angular/forms';
+import {TerminologyService} from '../../services/gateway/terminology/terminology.service';
+import {ITerminologyResource} from '../../interfaces/terminology/terminology-resource.interface';
+
+@Component({
+  selector: 'app-terminology-config',
+  standalone: true,
+  imports: [
+    CommonModule,
+    MatTableModule,
+    MatSortModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatSelectModule,
+    MatButtonModule,
+    MatIconModule,
+    MatProgressBarModule,
+    MatCardModule,
+    FormsModule
+  ],
+  templateUrl: './terminology-config.component.html',
+  styleUrls: ['./terminology-config.component.scss']
+})
+export class TerminologyConfigComponent implements OnInit {
+  displayedColumns: string[] = ['resourceType', 'id', 'url', 'version'];
+  dataSource = new MatTableDataSource<ITerminologyResource>([]);
+
+  searchResourceType: string = '';
+  searchId: string = '';
+  searchUrl: string = '';
+  searchVersion: string = '';
+
+  @ViewChild(MatSort) sort!: MatSort;
+
+  // Placeholder properties for upload
+  isUploading: boolean = false;
+  uploadProgress: number = 0;
+  uploadStatus: string = '';
+
+  constructor(private terminologyService: TerminologyService) { }
+
+  ngOnInit(): void {
+    // Initial data from service
+    this.loadResources();
+
+    // Set up custom filter predicate
+    this.dataSource.filterPredicate = (data: ITerminologyResource, filter: string) => {
+      const searchTerms = JSON.parse(filter);
+      return (searchTerms.resourceType === '' || data.resourceType === searchTerms.resourceType) &&
+             (data.id || '').toLowerCase().includes(searchTerms.id.toLowerCase()) &&
+             (data.url || '').toLowerCase().includes(searchTerms.url.toLowerCase()) &&
+             (data.version || '').toLowerCase().includes(searchTerms.version.toLowerCase());
+    };
+  }
+
+  ngAfterViewInit() {
+    this.dataSource.sort = this.sort;
+    // Set default sort by ID
+    this.sort.sort({ id: 'id', start: 'asc', disableClear: false });
+  }
+
+  loadResources() {
+    this.terminologyService.getResources().subscribe((resources: ITerminologyResource[]) => {
+      this.dataSource.data = resources;
+    });
+  }
+
+  applyFilter() {
+    const filterValue = {
+      resourceType: this.searchResourceType,
+      id: this.searchId,
+      url: this.searchUrl,
+      version: this.searchVersion
+    };
+    this.dataSource.filter = JSON.stringify(filterValue);
+  }
+
+  onFileSelected(event: any) {
+    const file: File = event.target.files[0];
+    if (file) {
+      this.uploadTerminologyPackage(file);
+    }
+  }
+
+  uploadTerminologyPackage(file: File) {
+    /*
+    // Placeholder code for when the backend DOES support this
+    this.isUploading = true;
+    this.uploadProgress = 0;
+    this.uploadStatus = 'Parsing ZIP package...';
+
+    // 1. Parse and validate the ZIP
+    // Using a library like JSZip to iterate through directories
+    // Each directory should have a .json and .csv file
+
+    // 2. Call backend operation for each ValueSet and CodeSystem found
+    // for (const resource of resourcesFound) {
+    //   this.uploadStatus = `Uploading ${resource.resourceType}/${resource.id}...`;
+    //   await this.terminologyService.uploadResource(resource).toPromise();
+    //   this.uploadProgress += (1 / resourcesFound.length) * 100;
+    // }
+
+    this.uploadStatus = 'Upload complete';
+    this.isUploading = false;
+    this.loadResources();
+    */
+    console.log('Upload functionality is currently a placeholder.', file);
+  }
+}

--- a/Web/Admin.UI/src/app/interfaces/terminology/terminology-resource.interface.ts
+++ b/Web/Admin.UI/src/app/interfaces/terminology/terminology-resource.interface.ts
@@ -1,0 +1,6 @@
+export interface ITerminologyResource {
+  resourceType: string;
+  id: string;
+  url: string;
+  version: string;
+}

--- a/Web/Admin.UI/src/app/services/gateway/terminology/terminology.service.ts
+++ b/Web/Admin.UI/src/app/services/gateway/terminology/terminology.service.ts
@@ -1,0 +1,58 @@
+import {Injectable} from '@angular/core';
+import {HttpClient} from '@angular/common/http';
+import {catchError, forkJoin, map, Observable, tap} from 'rxjs';
+import {AppConfigService} from '../../app-config.service';
+import {ErrorHandlingService} from '../../error-handling.service';
+import {ITerminologyResource} from '../../../interfaces/terminology/terminology-resource.interface';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class TerminologyService {
+  constructor(
+    private http: HttpClient,
+    private appConfigService: AppConfigService,
+    private errorHandler: ErrorHandlingService
+  ) { }
+
+  getResources(): Observable<ITerminologyResource[]> {
+    const valueSets$ = this.http.get<any>(`${this.appConfigService.config?.baseApiUrl}/terminology/fhir/ValueSet?_summary=true`);
+    const codeSystems$ = this.http.get<any>(`${this.appConfigService.config?.baseApiUrl}/terminology/fhir/CodeSystem?_summary=true`);
+
+    return forkJoin([valueSets$, codeSystems$]).pipe(
+      tap(_ => console.log('Fetched terminology resources')),
+      map(([vsBundle, csBundle]) => {
+        const resources: ITerminologyResource[] = [];
+
+        if (vsBundle && vsBundle.entry) {
+          vsBundle.entry.forEach((entry: any) => {
+            if (entry.resource) {
+              resources.push({
+                resourceType: 'ValueSet',
+                id: entry.resource.id,
+                url: entry.resource.url,
+                version: entry.resource.version || ''
+              });
+            }
+          });
+        }
+
+        if (csBundle && csBundle.entry) {
+          csBundle.entry.forEach((entry: any) => {
+            if (entry.resource) {
+              resources.push({
+                resourceType: 'CodeSystem',
+                id: entry.resource.id,
+                url: entry.resource.url,
+                version: entry.resource.version || ''
+              });
+            }
+          });
+        }
+
+        return resources;
+      }),
+      catchError((error) => this.errorHandler.handleError(error))
+    );
+  }
+}

--- a/Web/Admin.UI/src/app/services/gateway/terminology/terminology.service.ts
+++ b/Web/Admin.UI/src/app/services/gateway/terminology/terminology.service.ts
@@ -16,8 +16,9 @@ export class TerminologyService {
   ) { }
 
   getResources(): Observable<ITerminologyResource[]> {
-    const valueSets$ = this.http.get<any>(`${this.appConfigService.config?.baseApiUrl}/terminology/fhir/ValueSet?_summary=true`);
-    const codeSystems$ = this.http.get<any>(`${this.appConfigService.config?.baseApiUrl}/terminology/fhir/CodeSystem?_summary=true`);
+    const baseUrl = this.appConfigService.config?.baseApiUrl || '/api';
+    const valueSets$ = this.http.get<any>(`${baseUrl}/terminology/fhir/ValueSet?_summary=true`);
+    const codeSystems$ = this.http.get<any>(`${baseUrl}/terminology/fhir/CodeSystem?_summary=true`);
 
     return forkJoin([valueSets$, codeSystems$]).pipe(
       tap(_ => console.log('Fetched terminology resources')),


### PR DESCRIPTION
### 🛠️ Description of Changes

New screen under Configuration menu to view terminology artifacts on the terminology service.

### 🧪 Testing Performed

Ran UI via `ng serve` against docker compose environment and tested functionality of new screen in the browser, checking the ability to filter each of the columns in the screen, and sorting.

### 🧑‍🔬 Unit Testing

N/A

### 📓 Documentation Updated

N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new Terminology Configuration section in the admin panel, accessible from the Configuration menu.
  * Allows administrators to view and filter terminology resources by resource type, ID, URL, and version.
  * Supports sortable table display for streamlined resource management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->