### PR TITLE
LNK-4648: Fix issues found after integrating validation with Link terminology service

### DIFF
--- a/DotNet/Terminology/Application/Formatters/FhirModelBinder.cs
+++ b/DotNet/Terminology/Application/Formatters/FhirModelBinder.cs
@@ -34,7 +34,7 @@ public class FhirModelBinder : IModelBinder
         }
 
         var request = bindingContext.HttpContext.Request;
-        if (request.ContentType != "application/fhir+json" && request.ContentType != "application/json")
+        if (!request.HasJsonContentType())
         {
             bindingContext.Result = ModelBindingResult.Failed();
             return;

--- a/Java/validation/src/main/java/com/lantanagroup/link/validation/controllers/ArtifactController.java
+++ b/Java/validation/src/main/java/com/lantanagroup/link/validation/controllers/ArtifactController.java
@@ -9,6 +9,7 @@ import com.lantanagroup.link.validation.services.ArtifactService;
 import com.lantanagroup.link.validation.models.TerminologyDependency;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import jakarta.transaction.Transactional;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.server.ResponseStatusException;
@@ -21,6 +22,7 @@ import java.util.Set;
 @RestController
 @RequestMapping("/api/validation/artifact")
 @SecurityRequirement(name = "bearer-key")
+@Transactional
 public class ArtifactController {
     private final ArtifactRepository artifactRepository;
     private final ArtifactService artifactService;

--- a/Java/validation/src/main/java/com/lantanagroup/link/validation/repositories/ArtifactRepository.java
+++ b/Java/validation/src/main/java/com/lantanagroup/link/validation/repositories/ArtifactRepository.java
@@ -11,5 +11,5 @@ import java.util.Optional;
 public interface ArtifactRepository extends JpaRepository<Artifact, Long> {
     Optional<Artifact> findByTypeAndName(ArtifactType type, String name);
 
-    boolean deleteByTypeAndName(ArtifactType type, String name);
+    int deleteByTypeAndName(ArtifactType type, String name);
 }

--- a/Java/validation/src/main/java/com/lantanagroup/link/validation/services/ArtifactService.java
+++ b/Java/validation/src/main/java/com/lantanagroup/link/validation/services/ArtifactService.java
@@ -50,7 +50,7 @@ public class ArtifactService {
     }
 
     public void deleteArtifact(ArtifactType type, String name) {
-        if (artifactRepository.deleteByTypeAndName(type, name)) {
+        if (artifactRepository.deleteByTypeAndName(type, name) > 0) {
             invalidateValidationSupport();
         }
     }


### PR DESCRIPTION
### 🛠️ Description of Changes
Fixed a MIME type check in Terminology that was causing requests from Validation (via HAPI's `IGenericClient`) to fail.

### 🧪 Testing Performed
Verified locally that Validation's `$validate-code` requests are now succeeding (previously HTTP 400).

### 🧑‍🔬 Unit Testing
N/A: Fix was in Terminology middleware.

### 📓 Documentation Updated
N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved artifact deletion operations to ensure proper confirmation when records are successfully removed.

* **Refactor**
  * Enhanced transactional integrity for artifact management operations.
  * Simplified content-type validation logic for JSON requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->