### PR TITLE
TECH_DEBT: ACA Init Order Fix

### DIFF
--- a/DotNet/Audit/Program.cs
+++ b/DotNet/Audit/Program.cs
@@ -1,3 +1,5 @@
+using System.Reflection;
+using System.Text;
 using HealthChecks.UI.Client;
 using LantanaGroup.Link.Audit.Application.Interfaces;
 using LantanaGroup.Link.Audit.Application.Services;
@@ -31,15 +33,9 @@ using Microsoft.AspNetCore.Diagnostics.HealthChecks;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Compliance.Classification;
 using Microsoft.Extensions.Compliance.Redaction;
-using Quartz;
-using Quartz.Impl;
-using Quartz.Spi;
 using Serilog;
 using Serilog.Enrichers.Span;
 using Serilog.Settings.Configuration;
-using System.Collections.Specialized;
-using System.Reflection;
-using System.Text;
 
 var builder = WebApplication.CreateBuilder(args);
 builder.Configuration.AddStandardEnvironmentConfiguration();
@@ -89,9 +85,6 @@ static void RegisterServices(WebApplicationBuilder builder)
     builder.Services.AddTransient<IAuditEventProcessor, AuditEventProcessor>();
 
     //Add factories
-    //Add Quartz scheduler with SQL persistence
-    builder.Services.RegisterQuartzDatabase(serviceInformation.ConnectionString);
-
     builder.Services.AddTransient<IKafkaConsumerFactory<string, AuditEventMessage>, KafkaConsumerFactory<string, AuditEventMessage>>();
     builder.Services.AddTransient<IKafkaConsumerFactory<string, string>, KafkaConsumerFactory<string, string>>();
     builder.Services.AddTransient<IKafkaProducerFactory<string, AuditEventMessage>, KafkaProducerFactory<string, AuditEventMessage>>();
@@ -106,25 +99,31 @@ static void RegisterServices(WebApplicationBuilder builder)
     //Add persistence interceptors
     builder.Services.AddSingleton<UpdateBaseEntityInterceptor>();
 
+    var dbProvider = builder.Configuration.GetValue<string>(AuditConstants.AppSettingsSectionNames.DatabaseProvider);
+    string? databaseConnectionString = null;
+
+    if (dbProvider == ConfigurationConstants.AppSettings.SqlServerDatabaseProvider)
+    {
+        databaseConnectionString = builder.Configuration.GetConnectionString(ConfigurationConstants.DatabaseConnections.DatabaseConnection);
+
+        if (string.IsNullOrEmpty(databaseConnectionString))
+            throw new InvalidOperationException("Database connection string is null or empty.");
+
+        //Add Quartz scheduler with SQL persistence
+        builder.Services.RegisterQuartzDatabase(databaseConnectionString);
+    }
+
     //Add database context
     builder.Services.AddDbContext<AuditDbContext>((sp, options) => {
 
         var updateBaseEntityInterceptor = sp.GetRequiredService<UpdateBaseEntityInterceptor>();
 
-        switch(builder.Configuration.GetValue<string>(AuditConstants.AppSettingsSectionNames.DatabaseProvider))
+        switch(dbProvider)
         {          
             case ConfigurationConstants.AppSettings.SqlServerDatabaseProvider:
-                string? connectionString =
-                    builder.Configuration.GetConnectionString(ConfigurationConstants.DatabaseConnections
-                        .DatabaseConnection);
-                
-                if (string.IsNullOrEmpty(connectionString))
-                    throw new InvalidOperationException("Database connection string is null or empty.");
-
                 options
-                    .UseSqlServer(connectionString)
+                    .UseSqlServer(databaseConnectionString)
                     .AddInterceptors(updateBaseEntityInterceptor);
-
                 break;
             default:
                 throw new InvalidOperationException("Database provider not supported.");

--- a/DotNet/Census/Program.cs
+++ b/DotNet/Census/Program.cs
@@ -1,3 +1,6 @@
+using System.Diagnostics;
+using System.Reflection;
+using System.Text.Json.Serialization;
 using Census.Domain.Entities;
 using Confluent.Kafka;
 using HealthChecks.UI.Client;
@@ -36,14 +39,10 @@ using LantanaGroup.Link.Shared.Settings;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Diagnostics.HealthChecks;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.OpenApi.Models;
-using Quartz;
 using Serilog;
 using Serilog.Enrichers.Span;
 using Serilog.Exceptions;
-using System.Diagnostics;
-using System.Reflection;
 using PatientEvent = LantanaGroup.Link.Census.Domain.Entities.POI.PatientEvent;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -78,21 +77,32 @@ static void RegisterServices(WebApplicationBuilder builder)
 
     // EF Core and Interceptors
     builder.Services.AddTransient<UpdateBaseEntityInterceptor>();
+    var dbProvider = builder.Configuration.GetValue<string>(CensusConstants.AppSettings.DatabaseProvider);
+    string? databaseConnectionString = null;
+
+    if (dbProvider == ConfigurationConstants.AppSettings.SqlServerDatabaseProvider)
+    {
+        databaseConnectionString = builder.Configuration.GetConnectionString(ConfigurationConstants.DatabaseConnections.DatabaseConnection);
+
+        if (string.IsNullOrEmpty(databaseConnectionString))
+            throw new InvalidOperationException("Database connection string is null or empty.");
+
+        // Quartz Scheduler with SQL persistence
+        builder.Services.RegisterQuartzDatabase(databaseConnectionString);
+    }
+
     builder.Services.AddDbContext<CensusContext>((sp, options) =>
     {
         var updateBaseEntityInterceptor = sp.GetService<UpdateBaseEntityInterceptor>();
-        switch (builder.Configuration.GetValue<string>(CensusConstants.AppSettings.DatabaseProvider))
+        switch (dbProvider)
         {
             case ConfigurationConstants.AppSettings.SqlServerDatabaseProvider:
-                string? connectionString = builder.Configuration.GetConnectionString(ConfigurationConstants.DatabaseConnections.DatabaseConnection);
-                if (string.IsNullOrEmpty(connectionString))
-                    throw new InvalidOperationException("Database connection string is null or empty.");
-
-                options.UseSqlServer(connectionString, sqlOptions =>
+                options.UseSqlServer(databaseConnectionString, sqlOptions =>
                 {
                     sqlOptions.UseQuerySplittingBehavior(QuerySplittingBehavior.SplitQuery);
                 })
                 .AddInterceptors(updateBaseEntityInterceptor);
+
                 break;
             default:
                 throw new InvalidOperationException($"Database provider not supported. Attempting to find section named: {CensusConstants.AppSettings.DatabaseProvider}");
@@ -103,7 +113,7 @@ static void RegisterServices(WebApplicationBuilder builder)
     builder.Services.AddHttpClient();
     builder.Services.AddControllers().AddJsonOptions(options =>
     {
-        options.JsonSerializerOptions.DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull;
+        options.JsonSerializerOptions.DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull;
         options.JsonSerializerOptions.PropertyNameCaseInsensitive = true;
         options.JsonSerializerOptions.ForFhir();
     });
@@ -150,8 +160,6 @@ static void RegisterServices(WebApplicationBuilder builder)
     builder.Services.AddTransient<ITransientExceptionHandler<string, string>, TransientExceptionHandler<string, string>>();
     builder.Services.AddTransient<ITransientExceptionHandler<string, PatientListMessage>, TransientExceptionHandler<string, PatientListMessage>>();
 
-    // Quartz Scheduler with SQL persistence
-    builder.Services.RegisterQuartzDatabase(serviceInformation.ConnectionString);
     builder.Services.AddTransient<SchedulePatientListRetrieval>();
     builder.Services.AddTransient<RetryJob>();
 

--- a/DotNet/DataAcquisition.Domain/Extensions/GeneralStartupExtensions.cs
+++ b/DotNet/DataAcquisition.Domain/Extensions/GeneralStartupExtensions.cs
@@ -1,4 +1,7 @@
-﻿using Confluent.Kafka;
+﻿using System.Diagnostics;
+using System.Net;
+using System.Reflection;
+using Confluent.Kafka;
 using DataAcquisition.Domain.Application.Queries;
 using FluentValidation;
 using LantanaGroup.Link.DataAcquisition.Domain.Application.Factories.ParameterFactories;
@@ -39,14 +42,10 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
-using Quartz;
 using Serilog;
 using Serilog.Enrichers.Span;
 using Serilog.Settings.Configuration;
 using Serilog.Sinks.SystemConsole.Themes;
-using System.Diagnostics;
-using System.Net;
-using System.Reflection;
 using IHostingEnvironment = Microsoft.Extensions.Hosting.IHostingEnvironment;
 
 namespace LantanaGroup.Link.DataAcquisition.Domain.Extensions;
@@ -61,11 +60,12 @@ public static class GeneralStartupExtensions
 
         var serviceInformation = builder.SetupServiceInformation(serviceName, assemblyVersion);
 
-        //Add Quartz scheduler with SQL persistence
-        builder.Services.RegisterQuartzDatabase(serviceInformation.ConnectionString);
-
         // load external configuration source (if specified)
         builder.AddExternalConfiguration(serviceInformation.ServiceConfigName);
+
+        //Add Quartz scheduler with SQL persistence
+        var connectionString = builder.Configuration.GetConnectionString(ConfigurationConstants.DatabaseConnections.DatabaseConnection);
+        builder.Services.RegisterQuartzDatabase(connectionString);
         
         builder.Configuration.RegisterMonitoring(builder.Logging, builder.Services);
         builder.Services.RegisterConfigs(builder.Configuration);

--- a/DotNet/Normalization/Program.cs
+++ b/DotNet/Normalization/Program.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using Confluent.Kafka;
 using HealthChecks.UI.Client;
 using LantanaGroup.Link.Normalization.Application.Models.Messages;
@@ -32,11 +33,9 @@ using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Diagnostics.HealthChecks;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.OpenApi.Models;
-using Quartz;
 using Serilog;
 using Serilog.Enrichers.Span;
 using Serilog.Exceptions;
-using System.Reflection;
 using AuditEventMessage = LantanaGroup.Link.Shared.Application.Models.Kafka.AuditEventMessage;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -113,23 +112,30 @@ static void RegisterServices(WebApplicationBuilder builder)
     //Add persistence interceptors
     builder.Services.AddSingleton<UpdateBaseEntityInterceptor>();
 
+    var dbProvider =
+        builder.Configuration.GetValue<string>(NormalizationConstants.AppSettingsSectionNames.DatabaseProvider);
+    string? databaseConnectionString = null;
+
+    if (dbProvider == ConfigurationConstants.AppSettings.SqlServerDatabaseProvider)
+    {
+        databaseConnectionString = builder.Configuration.GetConnectionString(ConfigurationConstants.DatabaseConnections.DatabaseConnection);
+
+        if (string.IsNullOrEmpty(databaseConnectionString))
+            throw new InvalidOperationException("Database connection string is null or empty.");
+
+        //Add Quartz scheduler with SQL persistence
+        builder.Services.RegisterQuartzDatabase(databaseConnectionString);
+    }
+
     builder.Services.AddDbContext<NormalizationDbContext>((sp, options) => {
 
         var updateBaseEntityInterceptor = sp.GetRequiredService<UpdateBaseEntityInterceptor>();
-        var dbProvider =
-            builder.Configuration.GetValue<string>(NormalizationConstants.AppSettingsSectionNames.DatabaseProvider);
         switch (dbProvider)
         {
             case ConfigurationConstants.AppSettings.SqlServerDatabaseProvider:
-                string? connectionString = builder.Configuration.GetConnectionString(ConfigurationConstants.DatabaseConnections.DatabaseConnection);
-
-                if (string.IsNullOrEmpty(connectionString))
-                    throw new InvalidOperationException("Database connection string is null or empty.");
-
                 options
-                    .UseSqlServer(connectionString)
+                    .UseSqlServer(databaseConnectionString)
                     .AddInterceptors(updateBaseEntityInterceptor);
-
                 break;
             default:
                 throw new InvalidOperationException("Database provider not supported.");
@@ -175,8 +181,6 @@ static void RegisterServices(WebApplicationBuilder builder)
         options.JsonSerializerOptions.Converters.Add(new OperationConverter());
     });
 
-    //Add Quartz scheduler with SQL persistence
-    builder.Services.RegisterQuartzDatabase(serviceInformation.ConnectionString);
     builder.Services.AddTransient<RetryJob>();
 
     builder.Services.AddSingleton<CopyPropertyOperationService>();

--- a/DotNet/QueryDispatch/Program.cs
+++ b/DotNet/QueryDispatch/Program.cs
@@ -1,3 +1,6 @@
+using System.Diagnostics;
+using System.Reflection;
+using System.Text.Json.Serialization;
 using HealthChecks.UI.Client;
 using LanatanGroup.Link.QueryDispatch.Jobs;
 using LantanaGroup.Link.QueryDispatch.Application.Factory;
@@ -37,9 +40,6 @@ using QueryDispatch.Domain.Managers;
 using Serilog;
 using Serilog.Enrichers.Span;
 using Serilog.Exceptions;
-using System.Diagnostics;
-using System.Reflection;
-using System.Text.Json.Serialization;
 
 var builder = WebApplication.CreateBuilder(args);
 builder.Configuration.AddStandardEnvironmentConfiguration();
@@ -112,7 +112,8 @@ builder.Services.AddTransient<ITransientExceptionHandler<string, PatientEventVal
 //Add Services
 builder.Services.AddTransient<ITenantApiService, TenantApiService>();
 
-builder.Services.RegisterQuartzDatabase(serviceInformation.ConnectionString);
+var connectionString = builder.Configuration.GetConnectionString(ConfigurationConstants.DatabaseConnections.DatabaseConnection);
+builder.Services.RegisterQuartzDatabase(connectionString);
 
 //Add Hosted Services
 if (consumerSettings != null && !consumerSettings.DisableConsumer)

--- a/DotNet/Report/Program.cs
+++ b/DotNet/Report/Program.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using Confluent.Kafka;
 using HealthChecks.UI.Client;
 using Hl7.Fhir.Serialization;
@@ -51,7 +52,6 @@ using Serilog.Enrichers.Span;
 using Serilog.Exceptions;
 using StackExchange.Redis.Extensions.Core.Configuration;
 using StackExchange.Redis.Extensions.System.Text.Json;
-using System.Reflection;
 
 var builder = WebApplication.CreateBuilder(args);
 builder.Configuration.AddStandardEnvironmentConfiguration();
@@ -75,18 +75,18 @@ static void RegisterServices(WebApplicationBuilder builder)
         cm.SetIgnoreExtraElements(true);
         cm.GetMemberMap(c => c.Id).SetSerializer(new GuidSerializer(GuidRepresentation.Standard));
     });
+    
+    var assemblyVersion = Assembly.GetExecutingAssembly().GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion ?? string.Empty;
+    var serviceInformation = builder.SetupServiceInformation(ReportConstants.ServiceName, assemblyVersion);
+
+    // load external configuration source (if specified)
+    builder.AddExternalConfiguration(serviceInformation.ServiceConfigName);
 
     BsonSerializer.RegisterSerializer(objectSerializer);
 
     // Bind MongoConnection settings from configuration (e.g., appsettings.json)
     builder.Services.Configure<MongoConnection>(builder.Configuration.GetRequiredSection(ReportConstants.AppSettingsSectionNames.Mongo));
     var mongoSettings = builder.Services.BuildServiceProvider().GetRequiredService<IOptions<MongoConnection>>().Value;
-    var assemblyVersion = Assembly.GetExecutingAssembly().GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion ?? string.Empty;
-
-    var serviceInformation = builder.SetupServiceInformation(ReportConstants.ServiceName, assemblyVersion, mongoSettings.ConnectionString);
-
-    // load external configuration source (if specified)
-    builder.AddExternalConfiguration(serviceInformation.ServiceConfigName);
 
     builder.WebHost.ConfigureKestrel(options =>
     {

--- a/DotNet/ServiceTests/IntegrationTests/Census/CensusIntegrationTestFixture.cs
+++ b/DotNet/ServiceTests/IntegrationTests/Census/CensusIntegrationTestFixture.cs
@@ -9,11 +9,10 @@ using LantanaGroup.Link.Census.Domain.Context;
 using LantanaGroup.Link.Census.Domain.Entities.POI;
 using LantanaGroup.Link.Census.Domain.Managers;
 using LantanaGroup.Link.Census.Domain.Queries;
-using LantanaGroup.Link.Shared.Application.Extensions; // Added for SetupServiceInformation
+using LantanaGroup.Link.Shared.Application.Extensions;
 using LantanaGroup.Link.Shared.Application.Models.Tenant;
 using LantanaGroup.Link.Shared.Application.Services;
 using LantanaGroup.Link.Shared.Domain.Repositories.Interfaces;
-using LantanaGroup.Link.Shared.Settings;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.Extensions.DependencyInjection;
@@ -21,11 +20,10 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using OpenTelemetry.Trace;
 using Quartz;
-using Quartz.Impl;
 using Quartz.Logging;
+// Added for SetupServiceInformation
 using LogLevel = Microsoft.Extensions.Logging.LogLevel;
 using Task = System.Threading.Tasks.Task;
-using System.Reflection;
 
 namespace IntegrationTests.Census;
 
@@ -72,8 +70,7 @@ public sealed class CensusIntegrationTestFixture : IDisposable
         // Register ServiceInformation using the extension method with the in-memory db name
         var serviceInformation = builder.SetupServiceInformation(
             "CensusService", // Replace with a constant if available
-            assemblyVersion,
-            dbName
+            assemblyVersion
         );
 
         builder.Services.AddDbContext<CensusContext>(options =>

--- a/DotNet/ServiceTests/IntegrationTests/DataAcquisition/DataAcquisitionIntegrationTestFixture.cs
+++ b/DotNet/ServiceTests/IntegrationTests/DataAcquisition/DataAcquisitionIntegrationTestFixture.cs
@@ -5,6 +5,7 @@ using LantanaGroup.Link.DataAcquisition.Domain.Application.Models.Kafka;
 using LantanaGroup.Link.DataAcquisition.Domain.Application.Queries;
 using LantanaGroup.Link.DataAcquisition.Domain.Application.Services;
 using LantanaGroup.Link.DataAcquisition.Domain.Application.Validators;
+using LantanaGroup.Link.DataAcquisition.Domain.Infrastructure;
 using LantanaGroup.Link.DataAcquisition.Domain.Infrastructure.Context;
 using LantanaGroup.Link.DataAcquisition.Domain.Infrastructure.Entities;
 using LantanaGroup.Link.Shared.Application.Extensions;
@@ -21,7 +22,6 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Moq;
 using OpenTelemetry.Trace;
-using System.Reflection;
 
 namespace IntegrationTests.DataAcquisition
 {
@@ -55,10 +55,9 @@ namespace IntegrationTests.DataAcquisition
                 .GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion ?? string.Empty;
 
             // Setup ServiceInformation with the correct connection string
-            var serviceInformation = builder.SetupServiceInformation(
+            builder.SetupServiceInformation(
                 "DataAcquisitionService", // Replace with your actual service name constant if available
-                assemblyVersion,
-                sqliteConnectionString
+                assemblyVersion
             );
 
             builder.Services.AddDbContext<DataAcquisitionDbContext>(options =>
@@ -77,7 +76,7 @@ namespace IntegrationTests.DataAcquisition
             builder.Services.AddTransient<IEntityRepository<ResourceReferenceType>, EntityRepository<ResourceReferenceType, DataAcquisitionDbContext>>();
 
             // Register IDatabase implementation
-            builder.Services.AddScoped<LantanaGroup.Link.DataAcquisition.Domain.Infrastructure.IDatabase, LantanaGroup.Link.DataAcquisition.Domain.Infrastructure.Database>();
+            builder.Services.AddScoped<IDatabase, Database>();
             builder.Services.AddScoped<IQueryPlanValidator, QueryPlanValidator>();
             builder.Services.AddTransient<IDataAcquisitionLogService, DataAcquisitionLogService>();
 

--- a/DotNet/ServiceTests/IntegrationTests/Tenant/TenantIntegrationTestFixture.cs
+++ b/DotNet/ServiceTests/IntegrationTests/Tenant/TenantIntegrationTestFixture.cs
@@ -1,4 +1,7 @@
-﻿using Confluent.Kafka;
+﻿using System.Collections.Specialized;
+using System.Diagnostics;
+using System.Net;
+using Confluent.Kafka;
 using LantanaGroup.Link.Account.Persistence.Interceptors;
 using LantanaGroup.Link.Shared.Application.Extensions;
 using LantanaGroup.Link.Shared.Application.Extensions.Quartz;
@@ -28,8 +31,6 @@ using Microsoft.Extensions.Options;
 using Quartz;
 using Quartz.Impl;
 using Quartz.Spi;
-using System.Collections.Specialized;
-using System.Net;
 using static LantanaGroup.Link.Shared.Application.Extensions.Security.BackendAuthenticationServiceExtension;
 using Task = System.Threading.Tasks.Task;
 
@@ -55,7 +56,7 @@ namespace IntegrationTests.Tenant
                 .GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion ?? string.Empty;
 
             // Register ServiceInformation using the extension method
-           var serviceInformation = builder.SetupServiceInformation(TenantConstants.ServiceName, assemblyVersion, _inMemoryDatabaseName);
+           var serviceInformation = builder.SetupServiceInformation(TenantConstants.ServiceName, assemblyVersion);
 
             // Add in-memory database with warning suppression
             builder.Services.AddSingleton<UpdateBaseEntityInterceptor>();
@@ -136,7 +137,7 @@ namespace IntegrationTests.Tenant
             builder.Services.AddSingleton<IJobFactory, TestJobFactory>();
 
             // Configure Quartz with RAMJobStore
-            builder.Services.RegisterQuartzDatabase(serviceInformation.ConnectionString);
+            builder.Services.RegisterQuartzDatabase(_inMemoryDatabaseName);
 
             var quartzProps = new NameValueCollection
             {
@@ -194,9 +195,9 @@ namespace IntegrationTests.Tenant
             }
             catch (OperationCanceledException) { /* ignore – already stopped */ }
 
-            var threads = System.Diagnostics.Process.GetCurrentProcess().Threads;
+            var threads = Process.GetCurrentProcess().Threads;
             Console.WriteLine($"Threads alive: {threads.Count}");
-            foreach (System.Diagnostics.ProcessThread t in threads)
+            foreach (ProcessThread t in threads)
                 Console.WriteLine($"  ID:{t.Id} StartTime:{t.StartTime} State:{t.ThreadState}");
 
             _host.Dispose();

--- a/DotNet/Shared/Application/Extensions/ExternalConfigurationExtension.cs
+++ b/DotNet/Shared/Application/Extensions/ExternalConfigurationExtension.cs
@@ -78,13 +78,6 @@ public static class ExternalConfigurationExtension
 
     public static ServiceInformation SetupServiceInformation(this IHostApplicationBuilder builder, string serviceName, string assemblyVersion)
     {
-        var connectionString = builder.Configuration.GetConnectionString(ConfigurationConstants.DatabaseConnections.DatabaseConnection);
-
-        return SetupServiceInformation(builder, serviceName, assemblyVersion, connectionString);
-    }
-
-    public static ServiceInformation SetupServiceInformation(this IHostApplicationBuilder builder, string serviceName, string assemblyVersion, string? connectionString)
-    {
         if (string.IsNullOrEmpty(serviceName))
         {
             throw new NullReferenceException("Service Name is required.");
@@ -100,7 +93,6 @@ public static class ExternalConfigurationExtension
         if (serviceInformation != null)
         {
             serviceInformation!.ServiceConfigName = serviceName;
-            serviceInformation.ConnectionString = connectionString;
             builder.Services.AddSingleton<ServiceInformation>(serviceInformation);
             ServiceActivitySource.Initialize(assemblyVersion, serviceInformation);
         }

--- a/DotNet/Shared/Application/Extensions/Quartz/QuartzRegistrationExtensions.cs
+++ b/DotNet/Shared/Application/Extensions/Quartz/QuartzRegistrationExtensions.cs
@@ -3,6 +3,7 @@ using Quartz;
 using Quartz.Impl.AdoJobStore;
 
 namespace LantanaGroup.Link.Shared.Application.Extensions.Quartz;
+
 public static class QuartzRegistrationExtensions
 {
     public static void RegisterQuartzDatabase(this IServiceCollection collection, string? connectionString) {
@@ -26,29 +27,5 @@ public static class QuartzRegistrationExtensions
                 c.UseSystemTextJsonSerializer();
             });
         });
-    }
-}
-
-public static class JobDataExtensions
-{
-    public static T GetJobDataValue<T>(this IJobExecutionContext context, string key)
-    {
-        if (context == null)
-        {
-            throw new ArgumentNullException(nameof(context));
-        }
-        if (string.IsNullOrEmpty(key))
-        {
-            throw new ArgumentNullException(nameof(key));
-        }
-        JobDataMap dataMap = context.JobDetail.JobDataMap;
-        if (dataMap.ContainsKey(key))
-        {
-            return (T)dataMap.Get(key);
-        }
-        else
-        {
-            throw new KeyNotFoundException($"The key '{key}' was not found in the JobDataMap.");
-        }
     }
 }

--- a/DotNet/Shared/Application/Models/ServiceInformation.cs
+++ b/DotNet/Shared/Application/Models/ServiceInformation.cs
@@ -1,7 +1,7 @@
-﻿using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.Logging;
-using System.Reflection;
+﻿using System.Reflection;
 using System.Text.Json;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
 
 namespace LantanaGroup.Link.Shared.Application.Models;
 
@@ -15,10 +15,6 @@ public class ServiceInformation
     public string Commit { get; init; } = string.Empty;
     public string Build { get; init; } = string.Empty;
     public string SwaggerUrl { get; set; } = string.Empty;
-
-    [System.Text.Json.Serialization.JsonIgnore]
-    [Newtonsoft.Json.JsonIgnore]
-    public string? ConnectionString { get; set; }
 
     public static ServiceInformation GetServiceInformation(Assembly assembly, IConfiguration configuration)
     {

--- a/DotNet/Submission/Program.cs
+++ b/DotNet/Submission/Program.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using Confluent.Kafka;
 using HealthChecks.UI.Client;
 using LantanaGroup.Link.Shared.Application.Error.Handlers;
@@ -34,7 +35,6 @@ using Serilog.Enrichers.Span;
 using Serilog.Exceptions;
 using Serilog.Settings.Configuration;
 using Submission.Data;
-using System.Reflection;
 
 var builder = WebApplication.CreateBuilder(args);
 builder.Configuration.AddStandardEnvironmentConfiguration();
@@ -141,7 +141,8 @@ static void RegisterServices(WebApplicationBuilder builder)
     builder.Services.AddControllers();
 
     //Add Quartz scheduler with SQL persistence
-    builder.Services.RegisterQuartzDatabase(serviceInformation.ConnectionString);
+    string? connectionString = builder.Configuration.GetConnectionString(ConfigurationConstants.DatabaseConnections.DatabaseConnection);
+    builder.Services.RegisterQuartzDatabase(connectionString);
 
     // Add hosted services
     builder.Services.AddHostedService<SubmitPayloadListener>();

--- a/DotNet/Tenant/Program.cs
+++ b/DotNet/Tenant/Program.cs
@@ -1,3 +1,5 @@
+using System.Diagnostics;
+using System.Reflection;
 using Confluent.Kafka;
 using HealthChecks.UI.Client;
 using LantanaGroup.Link.Shared.Application.Extensions;
@@ -27,14 +29,11 @@ using LantanaGroup.Link.Tenant.Services;
 using Microsoft.AspNetCore.Diagnostics.HealthChecks;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Options;
-using Quartz;
 using Serilog;
 using Serilog.Debugging;
 using Serilog.Enrichers.Span;
 using Serilog.Exceptions;
 using Serilog.Settings.Configuration;
-using System.Diagnostics;
-using System.Reflection;
 
 namespace Tenant
 {
@@ -102,22 +101,29 @@ namespace Tenant
             builder.Services.AddSingleton<UpdateBaseEntityInterceptor>();
             builder.Services.AddSingleton<CreateAuditEventCommand>();
 
+            var dbProvider = builder.Configuration.GetValue<string>(TenantConstants.AppSettingsSectionNames.DatabaseProvider);
+            string? databaseConnectionString = null;
+
+            if (dbProvider == ConfigurationConstants.AppSettings.SqlServerDatabaseProvider)
+            {
+                databaseConnectionString = builder.Configuration.GetConnectionString(ConfigurationConstants.DatabaseConnections.DatabaseConnection);
+
+                if (string.IsNullOrEmpty(databaseConnectionString))
+                    throw new InvalidOperationException("Database connection string is null or empty.");
+
+                // Add Quartz scheduler with SQL persistence
+                builder.Services.RegisterQuartzDatabase(databaseConnectionString);
+            }
+
             //Add database context
             builder.Services.AddDbContext<TenantDbContext>((sp, options) =>
             {
                 var updateBaseEntityInterceptor = sp.GetService<UpdateBaseEntityInterceptor>()!;
 
-                switch (builder.Configuration.GetValue<string>(TenantConstants.AppSettingsSectionNames.DatabaseProvider))
+                switch (dbProvider)
                 {
                     case ConfigurationConstants.AppSettings.SqlServerDatabaseProvider:
-                        string? connectionString =
-                            builder.Configuration.GetConnectionString(ConfigurationConstants.DatabaseConnections
-                                .DatabaseConnection);
-
-                        if (string.IsNullOrEmpty(connectionString))
-                            throw new InvalidOperationException("Database connection string is null or empty.");
-
-                        options.UseSqlServer(connectionString)
+                        options.UseSqlServer(databaseConnectionString)
                            .AddInterceptors(updateBaseEntityInterceptor);
                         break;
                     default:
@@ -189,9 +195,6 @@ namespace Tenant
                 .CreateLogger();
 
             SelfLog.Enable(Console.Error);
-
-            //Add Quartz scheduler with SQL persistence
-            builder.Services.RegisterQuartzDatabase(serviceInformation.ConnectionString);
 
             builder.Services.AddSingleton<ReportScheduledJob>();
 


### PR DESCRIPTION
### 🛠️ Description of Changes

Refactor Quartz scheduler registration to use direct connection string from configuration and remove ConnectionString from `ServiceInformation`, allowing the external configuration to load before anything else.

### 🧪 Testing Performed

Ran services in docker compose, all services reported healthy status.

### 🧑‍🔬 Unit Testing
- 
- [ ] I have written or updated unit tests to cover my changes

### 📓 Documentation Updated

N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Reorganized database connection handling across services to use configuration-based retrieval instead of service information
  * Consolidated SQL Server provider-specific initialization in service startup flow
  * Removed JobDataExtensions utility class and ConnectionString property from service model

<!-- end of auto-generated comment: release notes by coderabbit.ai -->