### PR TITLE
LNK-4794: Slow performance in acq. logs screen

### DIFF
--- a/DotNet/DataAcquisition.Domain/Application/Queries/DataAcquisitionLogQueries.cs
+++ b/DotNet/DataAcquisition.Domain/Application/Queries/DataAcquisitionLogQueries.cs
@@ -1,5 +1,3 @@
-using System.Linq.Expressions;
-using System.Reflection;
 using DataAcquisition.Domain.Application.Models;
 using LantanaGroup.Link.DataAcquisition.Domain.Application.Models.Api.Configuration;
 using LantanaGroup.Link.DataAcquisition.Domain.Application.Models.Api.QueryLog;
@@ -17,7 +15,6 @@ using LantanaGroup.Link.Shared.Application.Models.Responses;
 using LantanaGroup.Link.Shared.Application.Services.Security;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
-using Expression = System.Linq.Expressions.Expression;
 using IDatabase = LantanaGroup.Link.DataAcquisition.Domain.Infrastructure.IDatabase;
 using RequestStatus = LantanaGroup.Link.DataAcquisition.Domain.Infrastructure.Models.Enums.RequestStatus;
 using ResourceType = Hl7.Fhir.Model.ResourceType;
@@ -271,83 +268,102 @@ public class DataAcquisitionLogQueries : IDataAcquisitionLogQueries
     {
         ArgumentNullException.ThrowIfNull(request);
 
-        var result = await SearchAsync(request, cancellationToken);
+        var query = BuildSearchQuery(request);
+        query = ApplySort(query, request.SortBy, request.SortOrder);
+
+        var total = await query.CountAsync(cancellationToken);
+        var pageLogs = await query
+            .Skip((request.PageNumber - 1) * request.PageSize)
+            .Take(request.PageSize)
+            .Select(log => new
+            {
+                log.Id,
+                log.Priority,
+                log.FacilityId,
+                log.PatientId,
+                log.FhirVersion,
+                log.QueryType,
+                log.QueryPhase,
+                log.ExecutionDate,
+                log.Status
+            })
+            .ToListAsync(cancellationToken);
+
+        List<QueryLogSummaryModel> records;
+
+        if (pageLogs.Count == 0)
+        {
+            records = new List<QueryLogSummaryModel>();
+        }
+        else
+        {
+            var logIds = pageLogs.Select(log => log.Id).ToList();
+            var queryInfo = await _dbContext.FhirQueries
+                .AsNoTracking()
+                .Where(q => logIds.Contains(q.DataAcquisitionLogId))
+                .Select(q => new
+                {
+                    q.Id,
+                    q.DataAcquisitionLogId,
+                    q.QueryParameters,
+                    ResourceTypes = q.FhirQueryResourceTypes.Select(rt => rt.ResourceType).ToList()
+                })
+                .ToListAsync(cancellationToken);
+
+            var firstQueryByLogId = queryInfo
+                .OrderBy(q => q.Id)
+                .GroupBy(q => q.DataAcquisitionLogId)
+                .ToDictionary(g => g.Key, g => g.First());
+
+            records = pageLogs.Select(log =>
+            {
+                firstQueryByLogId.TryGetValue(log.Id, out var fhirQuery);
+                var resourceTypes = fhirQuery?.ResourceTypes?.Select(rt => rt.ToString()).ToList() ?? new List<string>();
+                string? resourceId;
+
+                if (resourceTypes.Count > 0 && resourceTypes[0] == ResourceType.Patient.ToString())
+                {
+                    resourceId = log.PatientId;
+                }
+                else if (log.QueryType == FhirQueryType.Read)
+                {
+                    resourceId = fhirQuery?.QueryParameters?.FirstOrDefault();
+                }
+                else
+                {
+                    resourceId = string.Empty;
+                }
+
+                return new QueryLogSummaryModel
+                {
+                    Id = log.Id,
+                    Priority = log.Priority,
+                    FacilityId = log.FacilityId,
+                    PatientId = log.PatientId,
+                    ResourceTypes = resourceTypes,
+                    ResourceId = resourceId,
+                    FhirVersion = log.FhirVersion ?? string.Empty,
+                    QueryType = log.QueryType,
+                    QueryPhase = log.QueryPhase,
+                    ExecutionDate = log.ExecutionDate,
+                    Status = log.Status
+                };
+            }).ToList();
+        }
+
         return new QueryLogSummaryModelResponse
         {
-            Records = result.Records.Select(QueryLogSummaryModel.FromDomain).ToList(),
-            Metadata = new PaginationMetadata(request.PageSize, request.PageNumber, result.Metadata.TotalCount)
+            Records = records,
+            Metadata = new PaginationMetadata(request.PageSize, request.PageNumber, total)
         };
     }
 
     public async Task<PagedConfigModel<DataAcquisitionLogModel>> SearchAsync(SearchDataAcquisitionLogRequest model, CancellationToken cancellationToken = default)
     {
-        var query = _dbContext.DataAcquisitionLogs.AsNoTracking()
-            .AsQueryable();
+        var query = BuildSearchQuery(model);
+        query = ApplySort(query, model.SortBy, model.SortOrder);
 
-        if (!string.IsNullOrEmpty(model.FacilityId))
-        {
-            query = query.Where(log => log.FacilityId == model.FacilityId);
-        }
-
-        if (!string.IsNullOrEmpty(model.CorrelationId))
-        {
-            query = query.Where(log => log.CorrelationId == model.CorrelationId);
-        }
-
-        if (!string.IsNullOrEmpty(model.PatientId))
-        {
-            query = query.Where(log => log.PatientId == model.PatientId);
-        }
-
-        if (!string.IsNullOrEmpty(model.ReportTrackingId))
-        {
-            query = query.Where(log => log.ReportTrackingId == model.ReportTrackingId);
-        }
-
-        if (model.QueryPhase.HasValue)
-        {
-            query = query.Where(log => log.QueryPhase == model.QueryPhase.Value);
-        }
-
-        if (model.QueryType.HasValue)
-        {
-            query = query.Where(log => log.QueryType == model.QueryType.Value);
-        }
-
-        if (model.AcquisitionPriority.HasValue)
-        {
-            query = query.Where(log => log.Priority == model.AcquisitionPriority.Value);
-        }
-
-        if (model.RequestStatus.HasValue)
-        {
-            query = query.Where(log => log.Status == model.RequestStatus.Value);
-        }
-
-        if (model.RequestStatuses != null && model.RequestStatuses.Any())
-        {
-            query = (from l in query
-                     where l.Status != null && model.RequestStatuses.Contains(l.Status.Value)
-                     select l);
-        }
-
-        if (!string.IsNullOrEmpty(model.ResourceType))
-        {
-            var resourceType = (ResourceType)Enum.Parse(typeof(ResourceType), model.ResourceType);    
-            query = (from l in query
-                     join q in _dbContext.FhirQueries on l.Id equals q.DataAcquisitionLogId
-                     where q.FhirQueryResourceTypes.Any(r => r.ResourceType == resourceType)
-                     select l);
-        }
-
-        query = model.SortOrder switch
-        {
-            SortOrder.Ascending => query.OrderBy(SetSortBy<DataAcquisitionLog>(model.SortBy)),
-            SortOrder.Descending => query.OrderByDescending(SetSortBy<DataAcquisitionLog>(model.SortBy)),
-            _ => query
-        };
-
-        var total = await query.CountAsync();
+        var total = await query.CountAsync(cancellationToken);
 
         var logs = await query
             .Skip((model.PageNumber - 1) * model.PageSize)
@@ -566,6 +582,83 @@ public class DataAcquisitionLogQueries : IDataAcquisitionLogQueries
             .ToListAsync(cancellationToken);
     }
 
+    private IQueryable<DataAcquisitionLog> BuildSearchQuery(SearchDataAcquisitionLogRequest model)
+    {
+        var query = _dbContext.DataAcquisitionLogs.AsNoTracking().AsQueryable();
+
+        if (!string.IsNullOrEmpty(model.FacilityId))
+        {
+            query = query.Where(log => log.FacilityId == model.FacilityId);
+        }
+
+        if (!string.IsNullOrEmpty(model.CorrelationId))
+        {
+            query = query.Where(log => log.CorrelationId == model.CorrelationId);
+        }
+
+        if (!string.IsNullOrEmpty(model.PatientId))
+        {
+            query = query.Where(log => log.PatientId == model.PatientId);
+        }
+
+        if (!string.IsNullOrEmpty(model.ReportTrackingId))
+        {
+            query = query.Where(log => log.ReportTrackingId == model.ReportTrackingId);
+        }
+
+        if (model.QueryPhase.HasValue)
+        {
+            query = query.Where(log => log.QueryPhase == model.QueryPhase.Value);
+        }
+
+        if (model.QueryType.HasValue)
+        {
+            query = query.Where(log => log.QueryType == model.QueryType.Value);
+        }
+
+        if (model.AcquisitionPriority.HasValue)
+        {
+            query = query.Where(log => log.Priority == model.AcquisitionPriority.Value);
+        }
+
+        if (model.RequestStatus.HasValue)
+        {
+            query = query.Where(log => log.Status == model.RequestStatus.Value);
+        }
+
+        if (model.RequestStatuses != null && model.RequestStatuses.Any())
+        {
+            query = query.Where(log => log.Status != null && model.RequestStatuses.Contains(log.Status.Value));
+        }
+
+        if (!string.IsNullOrEmpty(model.ResourceType))
+        {
+            var resourceType = Enum.Parse<ResourceType>(model.ResourceType, ignoreCase: true);
+            query = query.Where(log =>
+                log.FhirQueries.Any(q => q.FhirQueryResourceTypes.Any(r => r.ResourceType == resourceType)));
+        }
+
+        return query;
+    }
+
+    private static IQueryable<DataAcquisitionLog> ApplySort(IQueryable<DataAcquisitionLog> query, string? sortBy, SortOrder sortOrder)
+    {
+        var normalizedSortBy = sortBy?.Trim().ToLowerInvariant();
+        var descending = sortOrder == SortOrder.Descending;
+
+        return normalizedSortBy switch
+        {
+            "executiondate" => descending ? query.OrderByDescending(log => log.ExecutionDate) : query.OrderBy(log => log.ExecutionDate),
+            "facilityid" => descending ? query.OrderByDescending(log => log.FacilityId) : query.OrderBy(log => log.FacilityId),
+            "patientid" => descending ? query.OrderByDescending(log => log.PatientId) : query.OrderBy(log => log.PatientId),
+            "querytype" => descending ? query.OrderByDescending(log => log.QueryType) : query.OrderBy(log => log.QueryType),
+            "queryphase" => descending ? query.OrderByDescending(log => log.QueryPhase) : query.OrderBy(log => log.QueryPhase),
+            "status" => descending ? query.OrderByDescending(log => log.Status) : query.OrderBy(log => log.Status),
+            "priority" => descending ? query.OrderByDescending(log => log.Priority) : query.OrderBy(log => log.Priority),
+            _ => descending ? query.OrderByDescending(log => log.Id) : query.OrderBy(log => log.Id)
+        };
+    }
+
     public async Task<List<DataAcquisitionLogModel>> GetNextEligibleBatchForFacility(string facilityId, long? lastId, int batchSize, List<RequestStatus> statuses, DateTime? designagtedExecutionTime = null, CancellationToken cancellationToken = default)
     {
         designagtedExecutionTime ??= DateTime.UtcNow;
@@ -603,27 +696,6 @@ public class DataAcquisitionLogQueries : IDataAcquisitionLogQueries
         return await query
             .Take(batchSize)
             .ToListAsync(cancellationToken);
-    }
-
-    private Expression<Func<T, object>> SetSortBy<T>(string? sortBy)
-    {
-        var type = typeof(T);
-        var inputSortBy = sortBy?.Trim();
-        string sortKey = "Id"; // default
-
-        if (!string.IsNullOrEmpty(inputSortBy))
-        {
-            var prop = type.GetProperty(inputSortBy, BindingFlags.Public | BindingFlags.Instance | BindingFlags.IgnoreCase);
-            if (prop != null)
-            {
-                sortKey = prop.Name;
-            }
-        }
-
-        var parameter = Expression.Parameter(type, "p");
-        var property = Expression.Property(parameter, sortKey);
-        var converted = Expression.Convert(property, typeof(object));
-        return Expression.Lambda<Func<T, object>>(converted, parameter);
     }
 
     public Task<List<DataAcquisitionLogModel>> GetNextBatchForFacility(string facilityId, long? lastId, int batchSize, CancellationToken cancellationToken = default)

--- a/DotNet/DataAcquisition.Domain/Infrastructure/Context/DataAcquisitionDbContext.cs
+++ b/DotNet/DataAcquisition.Domain/Infrastructure/Context/DataAcquisitionDbContext.cs
@@ -1,4 +1,6 @@
-﻿using AppAny.Quartz.EntityFrameworkCore.Migrations;
+﻿using System.Text.Json;
+using System.Text.Json.Serialization;
+using AppAny.Quartz.EntityFrameworkCore.Migrations;
 using AppAny.Quartz.EntityFrameworkCore.Migrations.SqlServer;
 using LantanaGroup.Link.DataAcquisition.Domain.Application.Serializers;
 using LantanaGroup.Link.DataAcquisition.Domain.Infrastructure.Entities;
@@ -10,9 +12,8 @@ using Microsoft.EntityFrameworkCore.Design;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Microsoft.Extensions.Configuration;
-using System.Text.Json;
-using System.Text.Json.Serialization;
 using RequestStatus = LantanaGroup.Link.DataAcquisition.Domain.Infrastructure.Models.Enums.RequestStatus;
+using ResourceType = Hl7.Fhir.Model.ResourceType;
 using ScheduledReport = LantanaGroup.Link.Shared.Application.Models.ScheduledReport;
 
 namespace LantanaGroup.Link.DataAcquisition.Domain.Infrastructure.Context;
@@ -80,8 +81,8 @@ public class DataAcquisitionDbContext : DbContext
 
             entity.Property(p => p.EHRPatientLists)
             .HasConversion(
-                v => JsonSerializer.Serialize(v, new JsonSerializerOptions { Converters = { new System.Text.Json.Serialization.JsonStringEnumConverter() } }),
-                v => JsonSerializer.Deserialize<List<EhrPatientList>>(v, new JsonSerializerOptions { Converters = { new System.Text.Json.Serialization.JsonStringEnumConverter() } }));
+                v => JsonSerializer.Serialize(v, new JsonSerializerOptions { Converters = { new JsonStringEnumConverter() } }),
+                v => JsonSerializer.Deserialize<List<EhrPatientList>>(v, new JsonSerializerOptions { Converters = { new JsonStringEnumConverter() } }));
         });
 
         //-------------------ReferenceResources-------------------
@@ -115,7 +116,7 @@ public class DataAcquisitionDbContext : DbContext
         {
             entity.Property(e => e.Id).ValueGeneratedOnAdd();
 
-            entity.Property(e => e.ResourceType).HasConversion(new EnumToStringConverter<Hl7.Fhir.Model.ResourceType>());
+            entity.Property(e => e.ResourceType).HasConversion(new EnumToStringConverter<ResourceType>());
 
             entity.HasOne(d => d.FhirQuery).WithMany(p => p.FhirQueryResourceTypes)
                 .OnDelete(DeleteBehavior.ClientSetNull)
@@ -170,6 +171,29 @@ public class DataAcquisitionDbContext : DbContext
                     nameof(DataAcquisitionLog.RetryAttempts),
                     nameof(DataAcquisitionLog.CompletionDate),
                     nameof(DataAcquisitionLog.CompletionTimeMilliseconds)
+                );
+
+            entity.HasIndex(e => new { e.FacilityId, e.ExecutionDate, e.Id })
+                .HasDatabaseName("IX_DataAcquisitionLogs_Facility_ExecutionDate_Id")
+                .IncludeProperties(
+                    nameof(DataAcquisitionLog.Priority),
+                    nameof(DataAcquisitionLog.PatientId),
+                    nameof(DataAcquisitionLog.FhirVersion),
+                    nameof(DataAcquisitionLog.QueryType),
+                    nameof(DataAcquisitionLog.QueryPhase),
+                    nameof(DataAcquisitionLog.Status)
+                );
+
+            entity.HasIndex(e => new { e.ReportTrackingId, e.ExecutionDate, e.Id })
+                .HasDatabaseName("IX_DataAcquisitionLogs_ReportTrackingId_ExecutionDate_Id")
+                .IncludeProperties(
+                    nameof(DataAcquisitionLog.FacilityId),
+                    nameof(DataAcquisitionLog.Priority),
+                    nameof(DataAcquisitionLog.PatientId),
+                    nameof(DataAcquisitionLog.FhirVersion),
+                    nameof(DataAcquisitionLog.QueryType),
+                    nameof(DataAcquisitionLog.QueryPhase),
+                    nameof(DataAcquisitionLog.Status)
                 );
         });
 

--- a/DotNet/DataAcquisition.Domain/Infrastructure/Entities/DataAcquisitionLog.cs
+++ b/DotNet/DataAcquisition.Domain/Infrastructure/Entities/DataAcquisitionLog.cs
@@ -1,8 +1,8 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
 using LantanaGroup.Link.DataAcquisition.Domain.Application.Models.Api.Configuration;
 using LantanaGroup.Link.DataAcquisition.Domain.Infrastructure.Models.Enums;
 using LantanaGroup.Link.Shared.Application.Models;
-using System.ComponentModel.DataAnnotations;
-using System.ComponentModel.DataAnnotations.Schema;
 
 namespace LantanaGroup.Link.DataAcquisition.Domain.Infrastructure.Entities;
 
@@ -12,6 +12,7 @@ public class DataAcquisitionLog
     public const int MaxRetryAttempts = 5;
 
     [Required]
+    [MaxLength(128)]
     public string FacilityId { get; set; }
 
     [Required]
@@ -49,6 +50,7 @@ public class DataAcquisitionLog
 
     public bool TailSent { get; set; } = false;
 
+    [MaxLength(128)]
     public string? ReportTrackingId { get; set; }
 
     public DateTime? ReportEndDate { get; set; }

--- a/DotNet/DataAcquisition.Domain/Migrations/20260206170000_IX_DataAcquisitionLogs_Search_Indexes.Designer.cs
+++ b/DotNet/DataAcquisition.Domain/Migrations/20260206170000_IX_DataAcquisitionLogs_Search_Indexes.Designer.cs
@@ -4,6 +4,7 @@ using LantanaGroup.Link.DataAcquisition.Domain.Infrastructure.Context;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace DataAcquisition.Domain.Migrations
 {
     [DbContext(typeof(DataAcquisitionDbContext))]
-    partial class DataAcquisitionDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260206170000_IX_DataAcquisitionLogs_Search_Indexes")]
+    partial class IX_DataAcquisitionLogs_Search_Indexes
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -632,6 +635,9 @@ namespace DataAcquisition.Domain.Migrations
                         .HasColumnType("int");
 
                     b.Property<string>("ResourceAcquiredIds")
+                        .HasColumnType("nvarchar(max)");
+
+                    b.Property<string>("ResourceId")
                         .HasColumnType("nvarchar(max)");
 
                     b.Property<int?>("RetryAttempts")

--- a/DotNet/DataAcquisition.Domain/Migrations/20260206170000_IX_DataAcquisitionLogs_Search_Indexes.cs
+++ b/DotNet/DataAcquisition.Domain/Migrations/20260206170000_IX_DataAcquisitionLogs_Search_Indexes.cs
@@ -1,0 +1,76 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace DataAcquisition.Domain.Migrations
+{
+    /// <inheritdoc />
+    public partial class IX_DataAcquisitionLogs_Search_Indexes : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "FacilityId",
+                table: "DataAcquisitionLog",
+                type: "nvarchar(128)",
+                maxLength: 128,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(max)");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "ReportTrackingId",
+                table: "DataAcquisitionLog",
+                type: "nvarchar(128)",
+                maxLength: 128,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(max)",
+                oldNullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_DataAcquisitionLogs_Facility_ExecutionDate_Id",
+                table: "DataAcquisitionLog",
+                columns: new[] { "FacilityId", "ExecutionDate", "Id" })
+                .Annotation("SqlServer:Include", new[] { "Priority", "PatientId", "FhirVersion", "QueryType", "QueryPhase", "Status" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_DataAcquisitionLogs_ReportTrackingId_ExecutionDate_Id",
+                table: "DataAcquisitionLog",
+                columns: new[] { "ReportTrackingId", "ExecutionDate", "Id" })
+                .Annotation("SqlServer:Include", new[] { "FacilityId", "Priority", "PatientId", "FhirVersion", "QueryType", "QueryPhase", "Status" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_DataAcquisitionLogs_Facility_ExecutionDate_Id",
+                table: "DataAcquisitionLog");
+
+            migrationBuilder.DropIndex(
+                name: "IX_DataAcquisitionLogs_ReportTrackingId_ExecutionDate_Id",
+                table: "DataAcquisitionLog");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "ReportTrackingId",
+                table: "DataAcquisitionLog",
+                type: "nvarchar(max)",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(128)",
+                oldMaxLength: 128,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "FacilityId",
+                table: "DataAcquisitionLog",
+                type: "nvarchar(max)",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(128)",
+                oldMaxLength: 128);
+        }
+    }
+}


### PR DESCRIPTION
### 🛠️ Description of Changes

During testing of larger quantities of data, noticed that the acquisition logs screen slows the more logs that get created. Added some extra indexing to address the performance problem.

### 🧪 Testing Performed

Ran a mega-patient report and observed the acq log screen responding much faster.

### 🧑‍🔬 Unit Testing

- [ ] I have written or updated unit tests to cover my changes

### 📓 Documentation Updated

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced acquisition log view with page jump navigation and expanded pagination options for improved data browsing.

* **Refactor**
  * Improved component navigation for acquisition log and report views; simplified routing patterns.

* **Chores**
  * Docker service endpoint configuration updates for improved service discovery.
  * Database index optimization for acquisition log query performance.
  * Solution documentation and guidelines added for internal workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->