### PR TITLE
LNK-4795: Show acq log statistics for a report

### DIFF
--- a/DotNet/DataAcquisition.Domain/Application/Models/Api/QueryLog/DataAcquisitionLogStatusStatistics.cs
+++ b/DotNet/DataAcquisition.Domain/Application/Models/Api/QueryLog/DataAcquisitionLogStatusStatistics.cs
@@ -1,0 +1,14 @@
+namespace LantanaGroup.Link.DataAcquisition.Domain.Application.Models.Api.QueryLog;
+
+public class DataAcquisitionLogStatusStatistics
+{
+    public string ReportId { get; set; } = string.Empty;
+    public string? PatientId { get; set; }
+    public List<DataAcquisitionLogStatusCount> Statuses { get; set; } = new();
+}
+
+public class DataAcquisitionLogStatusCount
+{
+    public string Name { get; set; } = string.Empty;
+    public int Count { get; set; }
+}

--- a/DotNet/DataAcquisition.Domain/Application/Queries/DataAcquisitionLogQueries.cs
+++ b/DotNet/DataAcquisition.Domain/Application/Queries/DataAcquisitionLogQueries.cs
@@ -63,6 +63,8 @@ public interface IDataAcquisitionLogQueries
 
     Task<DataAcquisitionLogStatistics> GetDataAcquisitionLogStatisticsByReportAsync(string reportId, CancellationToken cancellationToken = default);
 
+    Task<DataAcquisitionLogStatusStatistics> GetDataAcquisitionLogStatusStatisticsByReportAsync(string reportId, string? patientId = null, CancellationToken cancellationToken = default);
+
     Task<bool> CheckIfReferenceResourceHasBeenSent(string referenceId, string reportTrackingId, string facilityId, string correlationId, CancellationToken cancellationToken = default);
 
     Task<List<string>> GetFacilitiesWithPendingAndRetryableFailedRequests(CancellationToken cancellationToken = default);
@@ -535,6 +537,41 @@ public class DataAcquisitionLogQueries : IDataAcquisitionLogQueries
         }
 
         return statistics;
+    }
+
+    public async Task<DataAcquisitionLogStatusStatistics> GetDataAcquisitionLogStatusStatisticsByReportAsync(string reportId, string? patientId = null, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(reportId))
+        {
+            throw new ArgumentNullException(nameof(reportId), "Report ID cannot be null or empty.");
+        }
+
+        var query = _dbContext.DataAcquisitionLogs
+            .AsNoTracking()
+            .Where(log => log.ReportTrackingId == reportId);
+
+        if (!string.IsNullOrWhiteSpace(patientId))
+        {
+            query = query.Where(log => log.PatientId == patientId);
+        }
+
+        var statuses = await query
+            .Where(log => log.Status != null)
+            .GroupBy(log => log.Status!.Value)
+            .OrderBy(g => g.Key)
+            .Select(g => new DataAcquisitionLogStatusCount
+            {
+                Name = g.Key.ToString(),
+                Count = g.Count()
+            })
+            .ToListAsync(cancellationToken);
+
+        return new DataAcquisitionLogStatusStatistics
+        {
+            ReportId = reportId,
+            PatientId = string.IsNullOrWhiteSpace(patientId) ? null : patientId,
+            Statuses = statuses
+        };
     }
 
     public async Task<bool> CheckIfReferenceResourceHasBeenSent(string referenceId, string reportTrackingId, string facilityId, string correlationId, CancellationToken cancellationToken = default)

--- a/DotNet/DataAcquisition/Controllers/LogController.cs
+++ b/DotNet/DataAcquisition/Controllers/LogController.cs
@@ -1,3 +1,4 @@
+using System.Net;
 using LantanaGroup.Link.DataAcquisition.Domain.Application.Managers;
 using LantanaGroup.Link.DataAcquisition.Domain.Application.Models.Api.QueryLog;
 using LantanaGroup.Link.DataAcquisition.Domain.Application.Models.Api.Requests;
@@ -12,7 +13,6 @@ using LantanaGroup.Link.Shared.Settings;
 using Link.Authorization.Policies;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
-using System.Net;
 
 namespace LantanaGroup.Link.DataAcquisition.Controllers;
 
@@ -304,6 +304,46 @@ public class LogController : Controller
         catch (Exception ex)
         {
             _logger.LogWarning(new EventId(LoggingIds.GetItem, "GetReportStatistics"), ex, "An exception occurred while attempting to get report statistics with a report id of {id}", reportId.Sanitize());
+            return Problem(title: "Internal Server Error", detail: ex.Message, statusCode: (int)HttpStatusCode.InternalServerError);
+        }
+    }
+
+    /// <summary>
+    /// Get data acquisition log status counts for a report.
+    /// </summary>
+    /// <param name="reportId"></param>
+    /// <param name="patientId"></param>
+    /// <param name="cancellationToken"></param>
+    /// <returns></returns>
+    [HttpGet("report/{reportId}/status-counts")]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(DataAcquisitionLogStatusStatistics))]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+    public async Task<ActionResult<DataAcquisitionLogStatusStatistics>> GetReportStatusCounts(
+        [FromRoute] string reportId,
+        [FromQuery] string? patientId = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(reportId))
+        {
+            return BadRequest($"{nameof(reportId)} cannot be null or empty.");
+        }
+
+        reportId = HtmlInputSanitizer.Sanitize(reportId).SanitizeAndRemove();
+        patientId = string.IsNullOrWhiteSpace(patientId)
+            ? null
+            : HtmlInputSanitizer.Sanitize(patientId).SanitizeAndRemove();
+
+        try
+        {
+            var statistics = await _logQueries.GetDataAcquisitionLogStatusStatisticsByReportAsync(reportId, patientId, cancellationToken);
+
+            return Ok(statistics);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(new EventId(LoggingIds.GetItem, "GetReportStatusCounts"), ex, "An exception occurred while attempting to get report status counts with a report id of {id}", reportId.Sanitize());
             return Problem(title: "Internal Server Error", detail: ex.Message, statusCode: (int)HttpStatusCode.InternalServerError);
         }
     }

--- a/Web/Admin.UI/src/app/components/core/pie-chart/pie-chart.component.ts
+++ b/Web/Admin.UI/src/app/components/core/pie-chart/pie-chart.component.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, Input, ViewChild } from '@angular/core';
+import {AfterViewInit, Component, ElementRef, Input, OnChanges, SimpleChanges, ViewChild} from '@angular/core';
 import * as d3 from 'd3';
 
 
@@ -8,7 +8,7 @@ import * as d3 from 'd3';
   templateUrl: './pie-chart.component.html',
   styleUrl: './pie-chart.component.scss'
 })
-export class PieChartComponent {
+export class PieChartComponent implements AfterViewInit, OnChanges {
   @ViewChild('chart', { static: true }) chartElement!: ElementRef<SVGSVGElement>;
   @Input() data: Record<string, number> = {};
   @Input() width = 700;
@@ -16,16 +16,22 @@ export class PieChartComponent {
 
   constructor() { }
 
-   ngOnInit(): void {
+  ngAfterViewInit(): void {
+    this.createChart();
+  }
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (this.chartElement) {
       this.createChart();
-    } 
-  
+    }
+  }
+
     private createChart(): void {
       const svgEl = this.chartElement.nativeElement;
-  
+
       // Clear previous chart
       d3.select(svgEl).selectAll('*').remove();
-  
+
       const svg = d3.select(svgEl)
         .attr('width', this.width)
         .attr('height', this.height)
@@ -33,24 +39,24 @@ export class PieChartComponent {
         .attr('transform', `translate(${this.width / 2}, ${this.height / 2})`);
 
       const radius = Math.min(this.width, this.height) / 2;
-  
+
       // Color scale
       const color = d3.scaleOrdinal<string>()
         .domain(Object.keys(this.data))
         .range(d3.schemeCategory10);
-  
+
       // Pie & Arc generators
       const pie = d3.pie<{ key: string; value: number }>()
         .value(d => d.value);
-  
+
       const arc = d3.arc<d3.PieArcDatum<{ key: string; value: number }>>()
         .innerRadius(5) // set >0 for a donut chart
         .outerRadius(radius - 10);
-  
+
       const pieData = pie(
-        Object.entries(this.data).map(([key, value]) => ({ key, value }))          
+        Object.entries(this.data).map(([key, value]) => ({ key, value }))
       );
-  
+
       // Draw slices
       svg.selectAll('path')
         .data(pieData)
@@ -73,7 +79,7 @@ export class PieChartComponent {
         .on('mouseout', () => {
           tooltip.transition().duration(150).style('opacity', 0);
         });
-  
+
         // Create a group-level tooltip text element (initially hidden)
         const tooltip = svg.append('text')
         .attr('text-anchor', 'middle')
@@ -82,16 +88,16 @@ export class PieChartComponent {
         .style('fill', '#000')
         .style('pointer-events', 'none')
         .style('opacity', 0);
-  
+
 
         const margin = { top: 10, left: 10 };
         const legendSpacing = 20;
-  
+
         const legend = d3.select(svgEl)
           .append('g')
           .attr('class', 'legend')
-          .attr('transform', `translate(${margin.left}, ${margin.top})`);     
-  
+          .attr('transform', `translate(${margin.left}, ${margin.top})`);
+
         legend.selectAll('g')
           .data(
             Object.entries(this.data).map(([key, value]) => ({ key, value }))
@@ -100,18 +106,18 @@ export class PieChartComponent {
           .append('g')
           .attr('transform', (_, i) => `translate(0, ${i * 20})`)
           .each(function(d) {
-            const g = d3.select(this);  
+            const g = d3.select(this);
             g.append('rect')
               .attr('width', 14)
               .attr('height', 14)
               .attr('fill', color(d.key));
-  
+
             g.append('text')
               .attr('x', 20)
               .attr('y', 11)
               .text(`${d.key}: ${d.value}`)
               .style('font-size', '14px');
-          });     
-  
+          });
+
     }
 }

--- a/Web/Admin.UI/src/app/components/tenant/acquisition-log/acquisition-log-view/acquisition-log-view.component.html
+++ b/Web/Admin.UI/src/app/components/tenant/acquisition-log/acquisition-log-view/acquisition-log-view.component.html
@@ -47,6 +47,31 @@
         </div>
       </div>
     </div>
+    @if (showStatusChart) {
+      <div class="status-summary">
+        <div class="status-summary-header">
+          <div class="status-summary-title">Status breakdown</div>
+          <div class="status-summary-meta">
+            Report <span class="selectable-value">{{statusChartReportId || reportIdFilter}}</span>
+            @if (statusChartPatientId || patientFilter) {
+              <span class="status-summary-separator">|</span>
+              Patient <span class="selectable-value">{{statusChartPatientId || patientFilter}}</span>
+            }
+          </div>
+        </div>
+        <div class="status-summary-body">
+          @if (statusChartLoading) {
+            <div class="status-summary-loading">Loading status counts...</div>
+          } @else if (hasStatusChartData) {
+            <div class="status-summary-chart">
+              <app-pie-chart [data]="statusChartData" [width]="360" [height]="220"></app-pie-chart>
+            </div>
+          } @else {
+            <div class="status-summary-empty">No status data available for the current filters.</div>
+          }
+        </div>
+      </div>
+    }
     <div class="filter-container">
       @if (filterPanelOpen) {
         <div class="filter-panel" id="filterPanel" [@fadeGrowRightOut]>

--- a/Web/Admin.UI/src/app/components/tenant/acquisition-log/acquisition-log-view/acquisition-log-view.component.scss
+++ b/Web/Admin.UI/src/app/components/tenant/acquisition-log/acquisition-log-view/acquisition-log-view.component.scss
@@ -193,3 +193,68 @@ $skipped-status: #ffbf00;
 .page-jump-total {
   color: #6b7280;
 }
+
+.status-summary {
+  margin: 1rem 1rem 0;
+  padding: 1rem 1.25rem;
+  border: 1px solid #e2e8f0;
+  border-radius: 12px;
+  background: #f8fafc;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.status-summary-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.status-summary-title {
+  font-weight: 600;
+  font-size: 0.95rem;
+  color: #1f2937;
+}
+
+.status-summary-meta {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  flex-wrap: wrap;
+  font-size: 0.85rem;
+  color: #6b7280;
+}
+
+.status-summary-separator {
+  color: #cbd5e1;
+}
+
+.status-summary-body {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 220px;
+}
+
+.status-summary-chart {
+  width: 360px;
+  max-width: 100%;
+}
+
+.status-summary-loading,
+.status-summary-empty {
+  font-size: 0.9rem;
+  color: #6b7280;
+}
+
+@media (max-width: 900px) {
+  .status-summary {
+    margin: 0.75rem 0.5rem 0;
+  }
+
+  .status-summary-body {
+    min-height: 200px;
+  }
+}

--- a/Web/Admin.UI/src/app/components/tenant/acquisition-log/acquisition-log-view/acquisition-log-view.component.ts
+++ b/Web/Admin.UI/src/app/components/tenant/acquisition-log/acquisition-log-view/acquisition-log-view.component.ts
@@ -25,6 +25,11 @@ import {MatDialogModule} from '@angular/material/dialog';
 import {ActivatedRoute, Router} from '@angular/router';
 import {TableCommandComponent} from "./table-command/table-command.component";
 import {ReportService} from 'src/app/services/gateway/report/report.service';
+import {PieChartComponent} from 'src/app/components/core/pie-chart/pie-chart.component';
+import {
+  IDataAcquisitionLogStatusCount,
+  IDataAcquisitionLogStatusStatistics
+} from 'src/app/interfaces/data-acquisition/data-acquisition-log-status-statistics.interface';
 
 @Component({
   selector: 'app-acquisition-log-view',
@@ -35,7 +40,8 @@ import {ReportService} from 'src/app/services/gateway/report/report.service';
     FontAwesomeModule,
     MatPaginatorModule,
     MatDialogModule,
-    TableCommandComponent
+    TableCommandComponent,
+    PieChartComponent
 ],
   templateUrl: './acquisition-log-view.component.html',
   styleUrl: './acquisition-log-view.component.scss',
@@ -101,6 +107,7 @@ export class AcquisitionLogViewComponent implements OnInit {
   reportIdFilter: string = '';
   reportIdFromRoute: string = '';
   reportFacilityId: string = '';
+  patientIdFromRoute: string = '';
   facilityFilterOptions: Record<string, string> = {};
   selectedFacilityFilter: string = 'Any';
   resourceTypeFilterOptions: string[] = [];
@@ -114,6 +121,10 @@ export class AcquisitionLogViewComponent implements OnInit {
   statusFilterOptions: string[] = [ "Pending", "Ready", "Processing", "Completed", "Failed", "Cancelled", "MaxRetriesReached", "Skipped"];
   selectedStatusFilter: string = 'Any';
   targetPageNumber: number | null = null;
+  statusChartData: Record<string, number> = {};
+  statusChartLoading = false;
+  statusChartReportId = '';
+  statusChartPatientId = '';
 
   constructor(
     private route: ActivatedRoute,
@@ -134,6 +145,7 @@ export class AcquisitionLogViewComponent implements OnInit {
     this.route.queryParamMap.subscribe(params => {
       const reportId = params.get('reportId');
       const facilityId = params.get('facilityId');
+      const patientId = params.get('patientId');
       if (reportId) {
         this.reportIdFilter = reportId;
         this.reportIdFromRoute = reportId;
@@ -145,6 +157,14 @@ export class AcquisitionLogViewComponent implements OnInit {
         this.reportIdFilter = '';
         this.reportIdFromRoute = '';
         this.reportFacilityId = '';
+      }
+
+      if (patientId) {
+        this.patientFilter = patientId;
+        this.patientIdFromRoute = patientId;
+      } else {
+        this.patientFilter = '';
+        this.patientIdFromRoute = '';
       }
     });
 
@@ -160,6 +180,7 @@ export class AcquisitionLogViewComponent implements OnInit {
             this.acquisitionLogs = response[2].records;
             this.paginationMetadata = response[2].metadata;
             this.syncTargetPageNumber();
+            this.loadStatusCounts();
 
             this.loadingService.hide();
           },
@@ -214,6 +235,7 @@ export class AcquisitionLogViewComponent implements OnInit {
 
   applyFilters(): void {
     this.loadLogs(this.defaultPageNumber, this.defaultPageSize, true);
+    this.loadStatusCounts();
     this.filterPanelOpen = false;
     this.onFilterApplication();
   }
@@ -232,10 +254,11 @@ export class AcquisitionLogViewComponent implements OnInit {
 
   refreshLogs(): void {
     this.loadLogs(this.getCurrentPageNumber(), this.getCurrentPageSize(), true);
+    this.loadStatusCounts();
   }
 
   clearFilters(): void {
-    this.patientFilter = '';
+    this.patientFilter = this.patientIdFromRoute;
     this.resourceIdFilter = '';
     this.selectedFacilityFilter = 'Any';
     this.reportIdFilter = this.reportIdFromRoute;
@@ -246,6 +269,7 @@ export class AcquisitionLogViewComponent implements OnInit {
     this.selectedStatusFilter = 'Any';
     this.filtersApplied = false;
     this.loadLogs(this.defaultPageNumber, this.defaultPageSize, true);
+    this.loadStatusCounts();
   }
 
   onSort(column: string): void {
@@ -361,6 +385,59 @@ export class AcquisitionLogViewComponent implements OnInit {
         console.error('Error loading report schedule:', error);
       }
     });
+  }
+
+  get showStatusChart(): boolean {
+    return this.reportIdFilter.trim().length > 0;
+  }
+
+  get hasStatusChartData(): boolean {
+    return Object.keys(this.statusChartData).length > 0;
+  }
+
+  private loadStatusCounts(): void {
+    const reportId = this.reportIdFilter.trim();
+    if (!reportId) {
+      this.clearStatusCounts();
+      return;
+    }
+
+    const patientId = this.patientFilter.trim();
+    this.statusChartLoading = true;
+    this.statusChartReportId = reportId;
+    this.statusChartPatientId = patientId;
+
+    this.acquisitionLogService.getAcquisitionLogStatusStatistics(reportId, patientId.length > 0 ? patientId : null)
+      .pipe(
+        finalize(() => {
+          this.statusChartLoading = false;
+        })
+      )
+      .subscribe({
+        next: (response: IDataAcquisitionLogStatusStatistics) => {
+          this.statusChartReportId = response.reportId;
+          this.statusChartPatientId = response.patientId ?? '';
+          this.statusChartData = this.toStatusChartData(response.statuses);
+        },
+        error: (error) => {
+          console.error('Error loading acquisition log status counts:', error);
+          this.clearStatusCounts();
+        }
+      });
+  }
+
+  private toStatusChartData(statuses: IDataAcquisitionLogStatusCount[]): Record<string, number> {
+    return statuses.reduce((acc, status) => {
+      acc[status.name] = status.count;
+      return acc;
+    }, {} as Record<string, number>);
+  }
+
+  private clearStatusCounts(): void {
+    this.statusChartData = {};
+    this.statusChartLoading = false;
+    this.statusChartReportId = '';
+    this.statusChartPatientId = '';
   }
 
 }

--- a/Web/Admin.UI/src/app/components/tenant/acquisition-log/acquisition-log.service.ts
+++ b/Web/Admin.UI/src/app/components/tenant/acquisition-log/acquisition-log.service.ts
@@ -1,11 +1,16 @@
-import { HttpClient, HttpErrorResponse, HttpHeaders, HttpParams } from '@angular/common/http';
-import { Injectable } from '@angular/core';
-import { catchError, map, Observable } from 'rxjs';
-import { AppConfigService } from 'src/app/services/app-config.service';
-import { ErrorHandlingService } from 'src/app/services/error-handling.service';
-import { IPagedAcquisitionLogSummary } from './models/acquisition-log-summary';
-import { AcquisitionLog } from './models/acquisition-log';
-import { IDataAcquisitionLogStatistics } from 'src/app/interfaces/data-acquisition/data-acquisition-log-statistics.interface';
+import {HttpClient, HttpErrorResponse, HttpHeaders, HttpParams} from '@angular/common/http';
+import {Injectable} from '@angular/core';
+import {catchError, map, Observable} from 'rxjs';
+import {AppConfigService} from 'src/app/services/app-config.service';
+import {ErrorHandlingService} from 'src/app/services/error-handling.service';
+import {IPagedAcquisitionLogSummary} from './models/acquisition-log-summary';
+import {AcquisitionLog} from './models/acquisition-log';
+import {
+  IDataAcquisitionLogStatistics
+} from 'src/app/interfaces/data-acquisition/data-acquisition-log-statistics.interface';
+import {
+  IDataAcquisitionLogStatusStatistics
+} from 'src/app/interfaces/data-acquisition/data-acquisition-log-status-statistics.interface';
 
 @Injectable({
   providedIn: 'root'
@@ -75,7 +80,7 @@ export class AcquisitionLogService {
     }
     if(priority) {
         params = params.set('priority', priority);
-    }  
+    }
 
     if(showLoadingIndicator)
     {
@@ -83,7 +88,7 @@ export class AcquisitionLogService {
       .pipe(
         map((response: IPagedAcquisitionLogSummary) => {
           //revert back to zero based paging
-          response.metadata.pageNumber--;          
+          response.metadata.pageNumber--;
           return response;
         }),
         catchError((error: HttpErrorResponse) => {
@@ -98,7 +103,7 @@ export class AcquisitionLogService {
       .pipe(
         map((response: IPagedAcquisitionLogSummary) => {
           //revert back to zero based paging
-          response.metadata.pageNumber--; 
+          response.metadata.pageNumber--;
           return response;
         }),
         catchError((error: HttpErrorResponse) => {
@@ -109,7 +114,7 @@ export class AcquisitionLogService {
     }
   }
 
-  getAcquisitionLog(id: string) : Observable<AcquisitionLog> {    
+  getAcquisitionLog(id: string) : Observable<AcquisitionLog> {
 
 
     return this.http.get<AcquisitionLog>(`${this.baseUrl}/${id}`)
@@ -139,10 +144,30 @@ export class AcquisitionLogService {
 
   getAcquisitionLogStatistics(reportId: string): Observable<IDataAcquisitionLogStatistics> {
     const headers = new HttpHeaders({ 'X-Skip-Loading': 'true' });
-    
+
     return this.http.get<IDataAcquisitionLogStatistics>(`${this.baseUrl}/report/${reportId}/statistics`, { headers: headers })
       .pipe(
         map((response: IDataAcquisitionLogStatistics) => {
+          return response;
+        }),
+        catchError((error: HttpErrorResponse) => {
+          var err = this.errorHandler.handleError(error);
+          return err;
+        })
+      );
+  }
+
+  getAcquisitionLogStatusStatistics(reportId: string, patientId?: string | null): Observable<IDataAcquisitionLogStatusStatistics> {
+    const headers = new HttpHeaders({ 'X-Skip-Loading': 'true' });
+    let params = new HttpParams();
+
+    if (patientId) {
+      params = params.set('patientId', patientId);
+    }
+
+    return this.http.get<IDataAcquisitionLogStatusStatistics>(`${this.baseUrl}/report/${reportId}/status-counts`, { headers: headers, params: params })
+      .pipe(
+        map((response: IDataAcquisitionLogStatusStatistics) => {
           return response;
         }),
         catchError((error: HttpErrorResponse) => {

--- a/Web/Admin.UI/src/app/interfaces/data-acquisition/data-acquisition-log-status-statistics.interface.ts
+++ b/Web/Admin.UI/src/app/interfaces/data-acquisition/data-acquisition-log-status-statistics.interface.ts
@@ -1,0 +1,10 @@
+export interface IDataAcquisitionLogStatusStatistics {
+  reportId: string;
+  patientId?: string;
+  statuses: IDataAcquisitionLogStatusCount[];
+}
+
+export interface IDataAcquisitionLogStatusCount {
+  name: string;
+  count: number;
+}


### PR DESCRIPTION
### 🛠️ Description of Changes

A pie chart is shown on the acquisition logs view when a report and/or patient is filtered that shows the breakdown of statuses across all logs.

### 🧪 Testing Performed

Running with docker compose, ran a mega-patient report, viewed the acq. logs for the report while it was processing and confirmed the pie chart shows correctly.

### 🧑‍🔬 Unit Testing

- [ ] I have written or updated unit tests to cover my changes

### 📓 Documentation Updated

N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added status breakdown chart to acquisition log view showing log status counts
  * Enhanced pagination with page jump controls for faster navigation
  * Added "Return to Report" button in acquisition log view

* **Documentation**
  * Added system guidelines documentation
  * Updated migration requirements documentation

* **Chores**
  * Updated data acquisition service configuration references
  * Updated solution file structure

<!-- end of auto-generated comment: release notes by coderabbit.ai -->