### PR TITLE
LNK-4818: Removed local host URL for ABS Blob storage used for testing

### DIFF
--- a/DotNet/Report/Properties/launchSettings.json
+++ b/DotNet/Report/Properties/launchSettings.json
@@ -16,7 +16,7 @@
         "KafkaConnection__BootstrapServers__0": "localhost:9094",
         "MongoDB__ConnectionString": "mongodb://localhost:17017",
         "ConnectionStrings__Redis": "localhost:6379",
-        "InternalBlobStorage__ConnectionString": "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://localhost:10000/devstoreaccount1",
+        "InternalBlobStorage__ConnectionString": "",
         "Serilog__WriteTo__0__Args__uri": "http://localhost:3100",
         "Telemetry__OtelCollectorEndpoint": "http://localhost:4317",
         "ServiceRegistry__TenantService__TenantServiceUrl": "http://localhost:8074",


### PR DESCRIPTION
### 🛠️ Description of Changes

Resolving fortify static scan result marked as 'critical'


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker environment configuration by clearing the default storage connection setting, requiring explicit configuration for deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


### 🧑‍🔬 Unit Testing
- Coverage: 0.0%