### PR TITLE
LNK-4826: Removed duplicate MeasureReportGenerated topics from topics.txt

### DIFF
--- a/topics.txt
+++ b/topics.txt
@@ -53,6 +53,3 @@ SubmitPayload-Retry:3:1
 ValidationComplete:3:1
 ValidationComplete-Error:3:1
 ValidationComplete-Retry:3:1
-MeasureReportGenerated:3:1
-MeasureReportGenerated-Error:3:1
-MeasureReportGenerated-Retry:3:1


### PR DESCRIPTION
### 🛠️ Description of Changes

Duplicate topics in the file. Michael mentioned the must be in alphabetical order:
<img width="1181" height="1861" alt="2026-02-17 10_01_38-link-cloud_topics txt at dev · lantanagroup_link-cloud — Mozilla Firefox" src="https://github.com/user-attachments/assets/92e1b088-9d8e-4487-bccc-c8bdc024465b" />

### 🧪 Testing Performed

N/A

### 🧑‍🔬 Unit Testing

- Coverage: 0.0%

N/A

### 📓 Documentation Updated

N/A
