### PR TITLE
TECH_DEBT: Standardizing the info endpoint for measureeval and validation

### DIFF
--- a/Java/measureeval/src/main/java/com/lantanagroup/link/measureeval/configs/SecurityConfig.java
+++ b/Java/measureeval/src/main/java/com/lantanagroup/link/measureeval/configs/SecurityConfig.java
@@ -1,10 +1,12 @@
 package com.lantanagroup.link.measureeval.configs;
-import com.lantanagroup.link.shared.config.AuthenticationConfig;
+
 import com.lantanagroup.link.shared.auth.JwtAuthenticationEntryPoint;
 import com.lantanagroup.link.shared.auth.JwtAuthenticationFilter;
+import com.lantanagroup.link.shared.config.AuthenticationConfig;
 import com.lantanagroup.link.shared.security.SecurityHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
@@ -25,6 +27,9 @@ public class SecurityConfig {
   private final JwtAuthenticationFilter authFilter;
   private final AuthenticationConfig authenticationConfig;
 
+  @Value("${link.info-route:/api/info}")
+  private String infoRoute;
+
   public SecurityConfig(JwtAuthenticationEntryPoint point, JwtAuthenticationFilter authFilter, AuthenticationConfig authenticationConfig) {
     this.point = point;
     this.authFilter = authFilter;
@@ -37,7 +42,7 @@ public class SecurityConfig {
       return SecurityHelper.buildAnonymous(http);
     }
     else{
-      return SecurityHelper.build(http, point, authFilter);
+      return SecurityHelper.build(http, point, authFilter, infoRoute);
     }
   }
 

--- a/Java/measureeval/src/main/java/com/lantanagroup/link/measureeval/controllers/ApiInfoController.java
+++ b/Java/measureeval/src/main/java/com/lantanagroup/link/measureeval/controllers/ApiInfoController.java
@@ -2,11 +2,9 @@ package com.lantanagroup.link.measureeval.controllers;
 
 import com.lantanagroup.link.shared.config.ServiceInformationConfig;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/api/measureeval")
 public class ApiInfoController {
     private final ServiceInformationConfig serviceInformationConfig;
 
@@ -14,7 +12,7 @@ public class ApiInfoController {
         this.serviceInformationConfig = serviceInformationConfig;
     }
 
-    @GetMapping("/info")
+    @GetMapping("${link.info-route:/api/info}")
     public ServiceInformationConfig info() {
         return this.serviceInformationConfig;
     }

--- a/Java/measureeval/src/main/resources/application.yml
+++ b/Java/measureeval/src/main/resources/application.yml
@@ -80,6 +80,7 @@ spring:
       retry-backoff-ms: 3000
 
 link:
+  info-route: /api/measureeval/info
   reportability-predicate: com.lantanagroup.link.measureeval.reportability.IsInInitialPopulation
   cql-debug: false
 

--- a/Java/shared/src/main/java/com/lantanagroup/link/shared/BaseSpringConfig.java
+++ b/Java/shared/src/main/java/com/lantanagroup/link/shared/BaseSpringConfig.java
@@ -7,6 +7,7 @@ import com.lantanagroup.link.shared.mongo.FhirConversions;
 import com.lantanagroup.link.shared.security.SecurityHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
@@ -18,6 +19,10 @@ import org.springframework.security.web.SecurityFilterChain;
 @ComponentScan(basePackages = "com.lantanagroup.link.shared.auth")
 public class BaseSpringConfig {
     private static final Logger logger = LoggerFactory.getLogger(BaseSpringConfig.class);
+
+    @Value("${link.info-route:/api/info}")
+    private String infoRoute;
+
     @Bean
     SecurityFilterChain web(
             AuthenticationConfig authenticationConfig,
@@ -31,7 +36,7 @@ public class BaseSpringConfig {
 
         return authenticationConfig.isAnonymous()
                 ? SecurityHelper.buildAnonymous(http)
-                : SecurityHelper.build(http, point, authFilter);
+                : SecurityHelper.build(http, point, authFilter, infoRoute);
     }
 
     @Bean

--- a/Java/shared/src/main/java/com/lantanagroup/link/shared/security/SecurityHelper.java
+++ b/Java/shared/src/main/java/com/lantanagroup/link/shared/security/SecurityHelper.java
@@ -41,12 +41,12 @@ public class SecurityHelper {
         return http.build();
     }
 */
-  public static SecurityFilterChain build(HttpSecurity http, JwtAuthenticationEntryPoint point, JwtAuthenticationFilter authFilter) throws Exception {
+  public static SecurityFilterChain build(HttpSecurity http, JwtAuthenticationEntryPoint point, JwtAuthenticationFilter authFilter, String infoRoute) throws Exception {
     http.csrf(AbstractHttpConfigurer::disable).addFilterBefore(authFilter, UsernamePasswordAuthenticationFilter.class)
             .authorizeRequests().
             requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
             .requestMatchers(HttpMethod.GET, "/health").permitAll()
-            .requestMatchers(HttpMethod.GET, "/info").permitAll()
+            .requestMatchers(HttpMethod.GET, infoRoute).permitAll()
             .requestMatchers(HttpMethod.GET, "/v3/api-docs/**").permitAll()
             .requestMatchers(HttpMethod.GET, "/swagger-ui.html").permitAll()
             .requestMatchers(HttpMethod.GET, "/swagger-ui/**").permitAll()

--- a/Java/validation/src/main/java/com/lantanagroup/link/validation/controllers/ApiInfoController.java
+++ b/Java/validation/src/main/java/com/lantanagroup/link/validation/controllers/ApiInfoController.java
@@ -2,11 +2,9 @@ package com.lantanagroup.link.validation.controllers;
 
 import com.lantanagroup.link.shared.config.ServiceInformationConfig;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/api/validation")
 public class ApiInfoController {
     private final ServiceInformationConfig serviceInformationConfig;
 
@@ -14,7 +12,7 @@ public class ApiInfoController {
         this.serviceInformationConfig = serviceInformationConfig;
     }
 
-    @GetMapping("/info")
+    @GetMapping("${link.info-route:/api/info}")
     public ServiceInformationConfig info() {
         return this.serviceInformationConfig;
     }

--- a/Java/validation/src/main/resources/application.yml
+++ b/Java/validation/src/main/resources/application.yml
@@ -104,6 +104,7 @@ authentication:
   authority: 'https://localhost:7004'
 
 link:
+  info-route: /api/validation/info
   terminology-service-url: ''
   report:
     base-url: http://localhost:5110


### PR DESCRIPTION
### 🛠️ Description of Changes

Make `/info` route configurable across services and apply it in security configurations

### 🧪 Testing Performed

Within docker compose, ensuring builds. Checked that GET /api/measureeval/info and GET /api/validation/info works, like AdminBFF is expecting.

### 🧑‍🔬 Unit Testing

- [ ] I have written or updated unit tests to cover my changes
- Coverage: 0.0%

### 📓 Documentation Updated

N/A

