### PR TITLE
LNK-4791: Admin.BFF proxy is missing the report population and resource endpoints

### DIFF
--- a/DotNet/Admin.BFF/appsettings.Development.json
+++ b/DotNet/Admin.BFF/appsettings.Development.json
@@ -195,6 +195,34 @@
           "Path": "api/reportconfig/{**catch-all}"
         }
       },
+      "route_schedules": {
+        "ClusterId": "ReportService",
+        "AuthorizationPolicy": "AuthenticatedUser",
+        "Match": {
+          "Path": "api/schedules/{**catch-all}"
+        }
+      },
+      "route_reportEntries": {
+        "ClusterId": "ReportService",
+        "AuthorizationPolicy": "AuthenticatedUser",
+        "Match": {
+          "Path": "api/entries/{**catch-all}"
+        }
+      },
+      "route_reportResources": {
+        "ClusterId": "ReportService",
+        "AuthorizationPolicy": "AuthenticatedUser",
+        "Match": {
+          "Path": "api/resources/{**catch-all}"
+        }
+      },
+      "route_reportPopulations": {
+        "ClusterId": "ReportService",
+        "AuthorizationPolicy": "AuthenticatedUser",
+        "Match": {
+          "Path": "api/populations/{**catch-all}"
+        }
+      },
       "route10": {
         "ClusterId": "TenantService",
         "AuthorizationPolicy": "AuthenticatedUser",

--- a/DotNet/Admin.BFF/appsettings.json
+++ b/DotNet/Admin.BFF/appsettings.json
@@ -212,6 +212,20 @@
           "Path": "api/entries/{**catch-all}"
         }
       },
+      "route_reportResources": {
+        "ClusterId": "ReportService",
+        "AuthorizationPolicy": "AuthenticatedUser",
+        "Match": {
+          "Path": "api/resources/{**catch-all}"
+        }
+      },
+      "route_reportPopulations": {
+        "ClusterId": "ReportService",
+        "AuthorizationPolicy": "AuthenticatedUser",
+        "Match": {
+          "Path": "api/populations/{**catch-all}"
+        }
+      },
       "route10": {
         "ClusterId": "TenantService",
         "AuthorizationPolicy": "AuthenticatedUser",


### PR DESCRIPTION
### 🛠️ Description of Changes

Added report populations and resources endpoints to the Admin.BFF proxy.

### 🧪 Testing Performed

Confirmed with Postman that the endpoints can be accessed through the BFF.

### 🧑‍🔬 Unit Testing

- [ ] I have written or updated unit tests to cover my changes
- Coverage: 0.0%

### 📓 Documentation Updated

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended Report Service routing capabilities with two new reverse-proxy routes for resources and populations endpoints. Both routes feature ReportService cluster routing and authenticated user authorization policies, enabling secure access to expanded service functionality. The new routes integrate seamlessly into existing configurations, maintaining full backward compatibility and service stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
