### PR TITLE
LNK-4849: Excluded soft deleted facilities to be picked up by the sch…

### DIFF
--- a/DotNet/ServiceTests/IntegrationTests/Tenant/ScheduleServiceTests.cs
+++ b/DotNet/ServiceTests/IntegrationTests/Tenant/ScheduleServiceTests.cs
@@ -201,6 +201,87 @@ namespace IntegrationTests.Tenant
         }
 
         [Fact]
+        public async Task StartAsync_DoesNotCreateJobsForSoftDeletedFacilities()
+        {
+            var scheduler = await _schedulerFactory.GetScheduler();
+            await scheduler.Clear();
+
+            _dbContext.Facilities.RemoveRange(_dbContext.Facilities.ToList());
+            await _dbContext.SaveChangesAsync();
+
+            var softDeletedFacility = new Facility
+            {
+                FacilityId = "SoftDeletedFacility",
+                FacilityName = "Soft Deleted Facility",
+                TimeZone = "America/Chicago",
+                IsDeleted = true,
+                ScheduledReports = new ScheduledReportModel
+                {
+                    Daily = new string[] { "Report1" },
+                    Weekly = new string[] { },
+                    Monthly = new string[] { }
+                }
+            };
+            _dbContext.Facilities.Add(softDeletedFacility);
+            await _dbContext.SaveChangesAsync();
+
+            await _service.StartAsync(CancellationToken.None);
+
+            var jobKeys = await scheduler.GetJobKeys(GroupMatcher<JobKey>.GroupEquals(nameof(KafkaTopic.ReportScheduled)));
+
+            Assert.Empty(jobKeys);
+        }
+
+        [Fact]
+        public async Task StartAsync_OnlyCreatesJobsForActiveFacilities()
+        {
+            var scheduler = await _schedulerFactory.GetScheduler();
+            await scheduler.Clear();
+
+            _dbContext.Facilities.RemoveRange(_dbContext.Facilities.ToList());
+            await _dbContext.SaveChangesAsync();
+
+            var activeFacility = new Facility
+            {
+                FacilityId = "ActiveFacility",
+                FacilityName = "Active Facility",
+                TimeZone = "America/Chicago",
+                IsDeleted = false,
+                ScheduledReports = new ScheduledReportModel
+                {
+                    Daily = new string[] { "DailyReport" },
+                    Weekly = new string[] { },
+                    Monthly = new string[] { }
+                }
+            };
+
+            var softDeletedFacility = new Facility
+            {
+                FacilityId = "SoftDeletedFacility2",
+                FacilityName = "Soft Deleted Facility 2",
+                TimeZone = "America/New_York",
+                IsDeleted = true,
+                ScheduledReports = new ScheduledReportModel
+                {
+                    Daily = new string[] { "Report1" },
+                    Weekly = new string[] { "Report2" },
+                    Monthly = new string[] { "Report3" }
+                }
+            };
+
+            _dbContext.Facilities.AddRange(activeFacility, softDeletedFacility);
+            await _dbContext.SaveChangesAsync();
+
+            await _service.StartAsync(CancellationToken.None);
+
+            var jobKeys = await scheduler.GetJobKeys(GroupMatcher<JobKey>.GroupEquals(nameof(KafkaTopic.ReportScheduled)));
+
+            Assert.Single(jobKeys);
+            Assert.Contains(jobKeys, j => j.Name == "ActiveFacility-Daily");
+            Assert.DoesNotContain(jobKeys, j => j.Name.StartsWith("SoftDeletedFacility2"));
+        }
+
+        [Fact]
         public async Task CreateJobAndTrigger_UsesCorrectCronAndTimeZone()
         {
             var scheduler = await _schedulerFactory.GetScheduler();

--- a/DotNet/Tenant/Services/ScheduleService.cs
+++ b/DotNet/Tenant/Services/ScheduleService.cs
@@ -42,7 +42,7 @@ namespace LantanaGroup.Link.Tenant.Services
             using (var scope = _scopeFactory.CreateScope())
             {
                 var context = scope.ServiceProvider.GetRequiredService<TenantDbContext>();
-                var facilities = await context.Facilities.ToListAsync(cancellationToken);
+                var facilities = await context.Facilities.Where(f => !f.IsDeleted).ToListAsync(cancellationToken);
                 foreach (Facility facility in facilities)
                 {
                     if (string.IsNullOrEmpty(facility.TimeZone))


### PR DESCRIPTION
 Excluded soft deleted facilities to be picked up by the ScheduleService that creates jobs

### 🛠️ Description of Changes

Tested locally to exclude jobs for Tenant that is deleted

### 🧪 Testing Performed

Please describe the testing that was performed on the changes included in this PR.

### 🧑‍🔬 Unit Testing

- [ ] I have written or updated unit tests to cover my changes
- Coverage: 0.0%

### 📓 Documentation Updated

Please update any relevant sections in the project documentation that were impacted by the changes in the PR.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed scheduling operations to exclude soft-deleted facilities from job creation, ensuring only active facilities are processed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->