### PR TITLE
LNK-4853: Kafka message keys for ResourceAcquired and ResourceNormalized topics include CorellationId

### DIFF
--- a/DotNet/DataAcquisition.Domain/Application/Services/BundleEventService.cs
+++ b/DotNet/DataAcquisition.Domain/Application/Services/BundleEventService.cs
@@ -1,12 +1,13 @@
-﻿using Confluent.Kafka;
+﻿using System.Text;
+using Confluent.Kafka;
 using Hl7.Fhir.Model;
-using Task = System.Threading.Tasks.Task;
+using LantanaGroup.Link.DataAcquisition.Domain.Application.Models.Api.Configuration;
 using LantanaGroup.Link.DataAcquisition.Domain.Application.Models.Kafka;
 using LantanaGroup.Link.DataAcquisition.Domain.Settings;
 using LantanaGroup.Link.Shared.Application.Models;
-using System.Text;
+using LantanaGroup.Link.Shared.Application.Models.Kafka;
 using Microsoft.Extensions.Logging;
-using LantanaGroup.Link.DataAcquisition.Domain.Application.Models.Api.Configuration;
+using Task = System.Threading.Tasks.Task;
 
 namespace LantanaGroup.Link.DataAcquisition.Domain.Application.Services;
 
@@ -17,12 +18,12 @@ public interface IBundleEventService<EventKey, EventValue, EventRequest>
     Task GenerateEventAsync(Bundle bundle, EventRequest request, CancellationToken cancellationToken = default);
 }
 
-public class BundleResourceAcquiredEventService : IBundleEventService<string, ResourceAcquired, ResourceAcquiredMessageGenerationRequest>
+public class BundleResourceAcquiredEventService : IBundleEventService<ResourceKey, ResourceAcquired, ResourceAcquiredMessageGenerationRequest>
 {
     private readonly ILogger<BundleResourceAcquiredEventService> _logger;
-    private readonly IProducer<string, ResourceAcquired> _producer;
+    private readonly IProducer<ResourceKey, ResourceAcquired> _producer;
 
-    public BundleResourceAcquiredEventService(ILogger<BundleResourceAcquiredEventService> logger, IProducer<string, ResourceAcquired> producer)
+    public BundleResourceAcquiredEventService(ILogger<BundleResourceAcquiredEventService> logger, IProducer<ResourceKey, ResourceAcquired> producer)
     {
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _producer = producer ?? throw new ArgumentNullException(nameof(producer));
@@ -36,9 +37,13 @@ public class BundleResourceAcquiredEventService : IBundleEventService<string, Re
             {
                 await _producer.ProduceAsync(
                     KafkaTopic.ResourceAcquired.ToString(),
-                    new Message<string, ResourceAcquired>
+                    new Message<ResourceKey, ResourceAcquired>
                     {
-                        Key = request.facilityId,
+                        Key = new ResourceKey
+                        {
+                            FacilityId = request.facilityId,
+                            CorrelationId = request.correlationId
+                        },
                         Headers = new Headers
                         {
                             new Header(DataAcquisitionConstants.HeaderNames.CorrelationId, Encoding.UTF8.GetBytes(request.correlationId))

--- a/DotNet/DataAcquisition.Domain/Application/Services/FhirApi/FhirApiService.cs
+++ b/DotNet/DataAcquisition.Domain/Application/Services/FhirApi/FhirApiService.cs
@@ -1,4 +1,8 @@
-﻿using Confluent.Kafka;
+﻿using System.Diagnostics;
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using Confluent.Kafka;
 using DataAcquisition.Domain.Application.Models;
 using Hl7.Fhir.Model;
 using Hl7.Fhir.Rest;
@@ -13,13 +17,10 @@ using LantanaGroup.Link.DataAcquisition.Domain.Infrastructure.Models.Enums;
 using LantanaGroup.Link.DataAcquisition.Domain.Models;
 using LantanaGroup.Link.DataAcquisition.Domain.Settings;
 using LantanaGroup.Link.Shared.Application.Models;
+using LantanaGroup.Link.Shared.Application.Models.Kafka;
 using LantanaGroup.Link.Shared.Application.Models.Telemetry;
 using LantanaGroup.Link.Shared.Application.SerDes;
 using LantanaGroup.Link.Shared.Application.Utilities;
-using System.Diagnostics;
-using System.Net;
-using System.Text;
-using System.Text.Json;
 using DateTime = System.DateTime;
 using ResourceType = Hl7.Fhir.Model.ResourceType;
 using Task = System.Threading.Tasks.Task;
@@ -41,7 +42,7 @@ public class FhirApiService : IFhirApiService
     private readonly IReferenceResourceService _referenceResourceService;
     private readonly IReadFhirCommand _readFhirCommand;
     private readonly ISearchFhirCommand _searchFhirCommand;
-    private readonly IProducer<string, ResourceAcquired> _kafkaProducer;
+    private readonly IProducer<ResourceKey, ResourceAcquired> _kafkaProducer;
 
     public FhirApiService(
         IReferenceResourcesManager referenceResourceManager,
@@ -49,7 +50,7 @@ public class FhirApiService : IFhirApiService
         IReferenceResourceService referenceResourceService,
         ISearchFhirCommand searchFhirCommand,
         IReadFhirCommand readFhirCommand,
-        IProducer<string, ResourceAcquired> kafkaProducer)
+        IProducer<ResourceKey, ResourceAcquired> kafkaProducer)
     {
         _referenceResourceManager = referenceResourceManager;
         _referenceResourcesQueries = referenceResourcesQueries;
@@ -120,7 +121,7 @@ public class FhirApiService : IFhirApiService
             await GenerateResourceAcquiredMessage(new ResourceAcquired
             {
                 Resource = resource,
-                ScheduledReports = new List<Shared.Application.Models.ScheduledReport> { log.ScheduledReport },
+                ScheduledReports = new List<ScheduledReport> { log.ScheduledReport },
                 PatientId = !fhirQuery.IsReference ?? false ? log.PatientId : null,
                 QueryType = log.QueryPhase.ToString(),
                 ReportableEvent = log.ReportableEvent ?? throw new ArgumentNullException(nameof(log.ReportableEvent)),
@@ -230,7 +231,7 @@ public class FhirApiService : IFhirApiService
                     await GenerateResourceAcquiredMessage(new ResourceAcquired
                     {
                         Resource = resource,
-                        ScheduledReports = new List<Shared.Application.Models.ScheduledReport> { log.ScheduledReport },
+                        ScheduledReports = new List<ScheduledReport> { log.ScheduledReport },
                         PatientId = !fhirQuery.IsReference ?? false ? log.PatientId : null,
                         QueryType = log.QueryPhase.ToString(),
                         ReportableEvent = log.ReportableEvent ?? throw new ArgumentNullException(nameof(log.ReportableEvent)),
@@ -311,9 +312,13 @@ public class FhirApiService : IFhirApiService
 
         await _kafkaProducer.ProduceAsync(
             KafkaTopic.ResourceAcquired.ToString(),
-            new Message<string, ResourceAcquired>
+            new Message<ResourceKey, ResourceAcquired>
             {
-                Key = facilityId,
+                Key = new ResourceKey
+                {
+                    FacilityId = facilityId,
+                    CorrelationId = correlationId
+                },
                 Headers = new Headers
                 {
                 new Header(DataAcquisitionConstants.HeaderNames.CorrelationId,

--- a/DotNet/DataAcquisition.Domain/Application/Services/QueryListProcessor.cs
+++ b/DotNet/DataAcquisition.Domain/Application/Services/QueryListProcessor.cs
@@ -17,6 +17,7 @@ using LantanaGroup.Link.DataAcquisition.Domain.Infrastructure.Interfaces;
 using LantanaGroup.Link.DataAcquisition.Domain.Infrastructure.Models.Enums;
 using LantanaGroup.Link.DataAcquisition.Domain.Infrastructure.Models.QueryConfig;
 using LantanaGroup.Link.Shared.Application.Models;
+using LantanaGroup.Link.Shared.Application.Models.Kafka;
 using LantanaGroup.Link.Shared.Application.Models.Telemetry;
 using Microsoft.Extensions.Logging;
 using RequestStatus = LantanaGroup.Link.DataAcquisition.Domain.Infrastructure.Models.Enums.RequestStatus;
@@ -52,7 +53,7 @@ public class QueryListProcessor : IQueryListProcessor
 {
     private readonly ILogger<QueryListProcessor> _logger;
     private readonly IFhirApiService _fhirRepo;
-    private readonly IProducer<string, ResourceAcquired> _kafkaProducer;
+    private readonly IProducer<ResourceKey, ResourceAcquired> _kafkaProducer;
     private readonly IReferenceResourceService _referenceResourceService;
     private readonly ProducerConfig _producerConfig;
     private readonly IDataAcquisitionLogManager _dataAcquisitionLogManager;
@@ -62,7 +63,7 @@ public class QueryListProcessor : IQueryListProcessor
     public QueryListProcessor(
         ILogger<QueryListProcessor> logger,
         IFhirApiService fhirRepo,
-        IProducer<string, ResourceAcquired> kafkaProducer,
+        IProducer<ResourceKey, ResourceAcquired> kafkaProducer,
         IReferenceResourceService referenceResourceService,
         IDataAcquisitionLogManager dataAcquisitionLogManager,
         IDataAcquisitionLogQueries dataAcquisitionLogQueries,

--- a/DotNet/DataAcquisition.Domain/Application/Services/ReferenceResourceService.cs
+++ b/DotNet/DataAcquisition.Domain/Application/Services/ReferenceResourceService.cs
@@ -12,6 +12,7 @@ using LantanaGroup.Link.DataAcquisition.Domain.Application.Queries;
 using LantanaGroup.Link.DataAcquisition.Domain.Application.Serializers;
 using LantanaGroup.Link.DataAcquisition.Domain.Infrastructure.Models.QueryConfig;
 using LantanaGroup.Link.DataAcquisition.Domain.Models;
+using LantanaGroup.Link.Shared.Application.Models.Kafka;
 using LantanaGroup.Link.Shared.Application.Utilities;
 using Microsoft.Extensions.Logging;
 using Task = System.Threading.Tasks.Task;
@@ -46,7 +47,7 @@ public class ReferenceResourceService : IReferenceResourceService
     private readonly ILogger<ReferenceResourceService> _logger;
     private readonly IReferenceResourcesManager _referenceResourcesManager;
     private readonly IReferenceResourcesQueries _referenceResourcesQueries;
-    private readonly IProducer<string, ResourceAcquired> _kafkaProducer;
+    private readonly IProducer<ResourceKey, ResourceAcquired> _kafkaProducer;
     private readonly IDataAcquisitionServiceMetrics _metrics;
     private readonly IDataAcquisitionLogManager _dataAcquisitionLogManager;
     private readonly IDataAcquisitionLogQueries _dataAcquisitionLogQueries;
@@ -57,7 +58,7 @@ public class ReferenceResourceService : IReferenceResourceService
         ILogger<ReferenceResourceService> logger,
         IReferenceResourcesManager referenceResourcesManager,
         IReferenceResourcesQueries referenceResourcesQueries,
-        IProducer<string, ResourceAcquired> kafkaProducer,
+        IProducer<ResourceKey, ResourceAcquired> kafkaProducer,
         IDataAcquisitionServiceMetrics metrics,
         IDataAcquisitionLogManager dataAcquisitionLogManager,
         IDataAcquisitionLogQueries dataAcquisitionLogQueries,

--- a/DotNet/DataAcquisition.Domain/Extensions/GeneralStartupExtensions.cs
+++ b/DotNet/DataAcquisition.Domain/Extensions/GeneralStartupExtensions.cs
@@ -253,7 +253,7 @@ public static class GeneralStartupExtensions
         services.AddTransient<IPatientCensusService, PatientCensusService>();
         services.AddTransient<IReferenceResourceService, ReferenceResourceService>();
         services.AddTransient<IQueryListProcessor, QueryListProcessor>();
-        services.AddTransient<IBundleEventService<string, ResourceAcquired, ResourceAcquiredMessageGenerationRequest>, BundleResourceAcquiredEventService>();
+        services.AddTransient<IBundleEventService<ResourceKey, ResourceAcquired, ResourceAcquiredMessageGenerationRequest>, BundleResourceAcquiredEventService>();
         services.AddTransient<IDataAcquisitionLogService, DataAcquisitionLogService>();
 
         //Data Pull Commands
@@ -281,7 +281,7 @@ public static class GeneralStartupExtensions
         services.RegisterKafkaProducer<string, string>(kafkaConnection, producerConfig);
         services.RegisterKafkaProducer<string, DataAcquisitionRequested>(kafkaConnection, producerConfig);
         services.RegisterKafkaProducer<string, PatientCensusScheduled>(kafkaConnection, producerConfig);
-        services.RegisterKafkaProducer<string, ResourceAcquired>(kafkaConnection, producerConfig);
+        services.RegisterKafkaProducer<ResourceKey, ResourceAcquired>(kafkaConnection, producerConfig);
         services.RegisterKafkaProducer<string, PatientListMessage>(kafkaConnection, producerConfig, null, new IndentedJsonSerializer<PatientListMessage>());
         services.RegisterKafkaProducer<string, AuditEventMessage>(kafkaConnection, producerConfig);
         services.RegisterKafkaProducer<long, ReadyToAcquire>(kafkaConnection, producerConfig);
@@ -291,7 +291,7 @@ public static class GeneralStartupExtensions
         services.AddTransient<IKafkaProducerFactory<string, string>, KafkaProducerFactory<string, string>>();
         services.AddTransient<IKafkaProducerFactory<string, DataAcquisitionRequested>, KafkaProducerFactory<string, DataAcquisitionRequested>>();
         services.AddTransient<IKafkaProducerFactory<string, PatientCensusScheduled>, KafkaProducerFactory<string, PatientCensusScheduled>>();
-        services.AddTransient<IKafkaProducerFactory<string, ResourceAcquired>, KafkaProducerFactory<string, ResourceAcquired>>();
+        services.AddTransient<IKafkaProducerFactory<ResourceKey, ResourceAcquired>, KafkaProducerFactory<ResourceKey, ResourceAcquired>>();
         services.AddTransient<IKafkaProducerFactory<string, PatientListMessage>, KafkaProducerFactory<string, PatientListMessage>>();
         services.AddTransient<IKafkaProducerFactory<long, ReadyToAcquire>, KafkaProducerFactory<long, ReadyToAcquire>>();
 

--- a/DotNet/DataAcquisition/Jobs/AcquisitionProcessingJob.cs
+++ b/DotNet/DataAcquisition/Jobs/AcquisitionProcessingJob.cs
@@ -1,4 +1,6 @@
-﻿using Confluent.Kafka;
+﻿using System.Diagnostics;
+using System.Text;
+using Confluent.Kafka;
 using LantanaGroup.Link.DataAcquisition.Domain.Application.Managers;
 using LantanaGroup.Link.DataAcquisition.Domain.Application.Models.Api.QueryLog;
 using LantanaGroup.Link.DataAcquisition.Domain.Application.Models.Domain;
@@ -7,11 +9,10 @@ using LantanaGroup.Link.DataAcquisition.Domain.Application.Queries;
 using LantanaGroup.Link.DataAcquisition.Domain.Infrastructure.Entities;
 using LantanaGroup.Link.DataAcquisition.Domain.Settings;
 using LantanaGroup.Link.Shared.Application.Models;
+using LantanaGroup.Link.Shared.Application.Models.Kafka;
 using LantanaGroup.Link.Shared.Application.Services.Security;
 using Microsoft.Extensions.Options;
 using Quartz;
-using System.Diagnostics;
-using System.Text;
 using RequestStatus = LantanaGroup.Link.DataAcquisition.Domain.Infrastructure.Models.Enums.RequestStatus;
 using Task = System.Threading.Tasks.Task;
 
@@ -23,7 +24,7 @@ public class AcquisitionProcessingJob : IJob
     private readonly ILogger<AcquisitionProcessingJob> _logger;
     private readonly IServiceScopeFactory _serviceScopeFactory;
     private readonly IProducer<long, ReadyToAcquire> _readyToAcquireProducer;
-    private readonly IProducer<string, ResourceAcquired> _resourceAcquiredProducer;
+    private readonly IProducer<ResourceKey, ResourceAcquired> _resourceAcquiredProducer;
     private readonly AcquisitionWorkerProcessorSettings _settings;
     private const int BatchSize = 25;
 
@@ -31,7 +32,7 @@ public class AcquisitionProcessingJob : IJob
         ILogger<AcquisitionProcessingJob> logger,
         IServiceScopeFactory serviceScopeFactory,
         IProducer<long, ReadyToAcquire> readyToAcquireProducer,
-        IProducer<string, ResourceAcquired> resourceAcquiredProducer,
+        IProducer<ResourceKey, ResourceAcquired> resourceAcquiredProducer,
         IOptions<AcquisitionWorkerProcessorSettings> settings)
     {
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
@@ -342,9 +343,13 @@ public class AcquisitionProcessingJob : IJob
                     
                     await _resourceAcquiredProducer.ProduceAsync(
                         KafkaTopic.ResourceAcquired.ToString(),
-                        new Message<string, ResourceAcquired>
+                        new Message<ResourceKey, ResourceAcquired>
                         {
-                            Key = message.FacilityId,
+                            Key = new ResourceKey
+                            {
+                                FacilityId = message.FacilityId,
+                                CorrelationId = message.CorrelationId
+                            },
                             Headers = headers,
                             Value = message.ResourceAcquired
                         }, cancellationToken);

--- a/DotNet/Normalization/Listeners/ResourceAcquiredListener.cs
+++ b/DotNet/Normalization/Listeners/ResourceAcquiredListener.cs
@@ -1,4 +1,6 @@
-﻿using Confluent.Kafka;
+﻿using System.Text;
+using System.Text.Json;
+using Confluent.Kafka;
 using Confluent.Kafka.Extensions.Diagnostics;
 using Hl7.Fhir.Model;
 using LantanaGroup.Link.Normalization.Application.Models.Exceptions;
@@ -14,11 +16,10 @@ using LantanaGroup.Link.Shared.Application.Error.Exceptions;
 using LantanaGroup.Link.Shared.Application.Error.Interfaces;
 using LantanaGroup.Link.Shared.Application.Interfaces;
 using LantanaGroup.Link.Shared.Application.Models;
+using LantanaGroup.Link.Shared.Application.Models.Kafka;
 using LantanaGroup.Link.Shared.Application.Models.Telemetry;
 using LantanaGroup.Link.Shared.Application.SerDes;
 using LantanaGroup.Link.Shared.Application.Utilities;
-using System.Text;
-using System.Text.Json;
 using Task = System.Threading.Tasks.Task;
 
 namespace LantanaGroup.Link.Normalization.Listeners;
@@ -26,11 +27,11 @@ namespace LantanaGroup.Link.Normalization.Listeners;
 public class ResourceAcquiredListener : BackgroundService
 {
     private readonly ILogger<ResourceAcquiredListener> _logger;
-    private readonly IKafkaConsumerFactory<string, ResourceAcquiredMessage> _consumerFactory;
-    private readonly IProducer<string, ResourceNormalizedMessage> _producer;
-    private readonly IDeadLetterExceptionHandler<string, string> _consumeExceptionHandler;
-    private readonly IDeadLetterExceptionHandler<string, ResourceAcquiredMessage> _deadLetterExceptionHandler;
-    private readonly ITransientExceptionHandler<string, ResourceAcquiredMessage> _transientExceptionHandler;
+    private readonly IKafkaConsumerFactory<ResourceKey, ResourceAcquiredMessage> _consumerFactory;
+    private readonly IProducer<ResourceKey, ResourceNormalizedMessage> _producer;
+    private readonly IDeadLetterExceptionHandler<ResourceKey, string> _consumeExceptionHandler;
+    private readonly IDeadLetterExceptionHandler<ResourceKey, ResourceAcquiredMessage> _deadLetterExceptionHandler;
+    private readonly ITransientExceptionHandler<ResourceKey, ResourceAcquiredMessage> _transientExceptionHandler;
     private bool _cancelled = false;
     private readonly INormalizationServiceMetrics _metrics;
     private readonly IServiceScopeFactory _scopeFactory;
@@ -45,12 +46,12 @@ public class ResourceAcquiredListener : BackgroundService
         ILogger<ResourceAcquiredListener> logger,
         ServiceInformation serviceInformation,
         IServiceScopeFactory scopeFactory,
-        IKafkaConsumerFactory<string, ResourceAcquiredMessage> consumerFactory,
-        IDeadLetterExceptionHandler<string, string> consumeExceptionHandler,
-        IDeadLetterExceptionHandler<string, ResourceAcquiredMessage> deadLetterExceptionHandler,
-        ITransientExceptionHandler<string, ResourceAcquiredMessage> transientExceptionHandler,
+        IKafkaConsumerFactory<ResourceKey, ResourceAcquiredMessage> consumerFactory,
+        IDeadLetterExceptionHandler<ResourceKey, string> consumeExceptionHandler,
+        IDeadLetterExceptionHandler<ResourceKey, ResourceAcquiredMessage> deadLetterExceptionHandler,
+        ITransientExceptionHandler<ResourceKey, ResourceAcquiredMessage> transientExceptionHandler,
         INormalizationServiceMetrics metrics,
-        IProducer<string, ResourceNormalizedMessage> producer,
+        IProducer<ResourceKey, ResourceNormalizedMessage> producer,
         CopyPropertyOperationService copyPropertyOperationService,
         CodeMapOperationService codeMapOperationService,
         ConditionalTransformOperationService conditionalTransformOperationService,
@@ -82,7 +83,7 @@ public class ResourceAcquiredListener : BackgroundService
 
     protected override async Task ExecuteAsync(CancellationToken cancellationToken)
     {
-        await System.Threading.Tasks.Task.Run(() => StartConsumerLoop(cancellationToken), cancellationToken);
+        await Task.Run(() => StartConsumerLoop(cancellationToken), cancellationToken);
     }
 
     private async Task StartConsumerLoop(CancellationToken cancellationToken)
@@ -97,7 +98,7 @@ public class ResourceAcquiredListener : BackgroundService
 
         while (!cancellationToken.IsCancellationRequested && !_cancelled)
         {
-            ConsumeResult<string, ResourceAcquiredMessage>? message = default;
+            ConsumeResult<ResourceKey, ResourceAcquiredMessage>? message = default;
             try
             {                
                 await kafkaConsumer.ConsumeWithInstrumentation(async (result, CancellationToken) =>
@@ -106,7 +107,7 @@ public class ResourceAcquiredListener : BackgroundService
                     {
                         message = result;
 
-                        if (message.Key == null || string.IsNullOrWhiteSpace(message.Key))
+                        if (message.Key == null || string.IsNullOrWhiteSpace(message.Key.FacilityId))
                         {
                             throw new DeadLetterException("Message Key (FacilityId) is null or empty.");
                         }
@@ -215,17 +216,17 @@ public class ResourceAcquiredListener : BackgroundService
                     }
                     catch (DeadLetterException ex)
                     {
-                        _deadLetterExceptionHandler.HandleException(message, ex, message.Key);
+                        _deadLetterExceptionHandler.HandleException(message, ex, message.Key.FacilityId);
                     }
                     catch (TransientException ex)
                     {
-                        _transientExceptionHandler.HandleException(message, ex, message.Key);
+                        _transientExceptionHandler.HandleException(message, ex, message.Key.FacilityId);
                     }
                     catch (Exception ex)
                     {
                         _logger.LogError(ex, $"Failed to process Patient Event.");
 
-                        _transientExceptionHandler.HandleException(message, new TransientException("Normalization Exception thrown: " + ex.Message), message.Message.Key);
+                        _transientExceptionHandler.HandleException(message, new TransientException("Normalization Exception thrown: " + ex.Message), message.Message.Key.FacilityId);
                     }
                     finally
                     {
@@ -244,7 +245,19 @@ public class ResourceAcquiredListener : BackgroundService
                     throw new OperationCanceledException(ex.Error.Reason, ex);
                 }
 
-                string facilityId = Encoding.UTF8.GetString(ex.ConsumerRecord?.Message?.Key ?? []);
+                string facilityId = string.Empty;
+                if (ex.ConsumerRecord?.Message?.Key != null)
+                {
+                    try
+                    {
+                        var key = JsonSerializer.Deserialize<ResourceKey>(ex.ConsumerRecord.Message.Key);
+                        facilityId = key?.FacilityId ?? string.Empty;
+                    }
+                    catch
+                    {
+                        // ignore
+                    }
+                }
 
                 _consumeExceptionHandler.HandleConsumeException(ex, facilityId);
                 TopicPartitionOffset? offset = ex.ConsumerRecord?.TopicPartitionOffset;
@@ -264,7 +277,7 @@ public class ResourceAcquiredListener : BackgroundService
     }
 
 
-    private async Task ProduceResourceNormalizedMessage(ConsumeResult<string, ResourceAcquiredMessage>? message, string facilityId, string correlationId, DomainResource? resource = null)
+    private async Task ProduceResourceNormalizedMessage(ConsumeResult<ResourceKey, ResourceAcquiredMessage>? message, string facilityId, string correlationId, DomainResource? resource = null)
     {
         var serializedResource = JsonSerializer.SerializeToElement(resource, LinkFhirSerializerOptions.ForFhirLenientSerialization);
 
@@ -282,9 +295,13 @@ public class ResourceAcquiredListener : BackgroundService
             ScheduledReports = message.Message.Value.ScheduledReports,
             ReportableEvent = message.Message.Value.ReportableEvent
         };
-        Message<string, ResourceNormalizedMessage> produceMessage = new Message<string, ResourceNormalizedMessage>
+        Message<ResourceKey, ResourceNormalizedMessage> produceMessage = new Message<ResourceKey, ResourceNormalizedMessage>
         {
-            Key = facilityId,
+            Key = new ResourceKey
+            {
+                FacilityId = facilityId,
+                CorrelationId = correlationId
+            },
             Headers = headers,
             Value = resourceNormalizedMessage
         };
@@ -293,7 +310,7 @@ public class ResourceAcquiredListener : BackgroundService
         {
             await _producer.ProduceAsync(KafkaTopic.ResourceNormalized.ToString(), produceMessage);
         }
-        catch (ProduceException<string, ResourceNormalizedMessage> ex)
+        catch (ProduceException<ResourceKey, ResourceNormalizedMessage> ex)
         {
             _logger.LogError(ex, "Failed to produce ResourceNormalized message. FacilityId: {FacilityId}, CorrelationId: {CorrelationId}, FhirResourceType: {fhirResourceType}, ResourceId: {resourceId}", facilityId, correlationId, resource?.TypeName, resource?.Id);
             throw new TransientException($"Failed to produce ResourceNormalized message: {ex.Message}", ex);
@@ -305,16 +322,20 @@ public class ResourceAcquiredListener : BackgroundService
         this._cancelled = true;
     }
 
-    private (string facilityId, string correlationId) ExtractFacilityIdAndCorrelationIdFromMessage(Message<string, ResourceAcquiredMessage> message)
+    private (string facilityId, string correlationId) ExtractFacilityIdAndCorrelationIdFromMessage(Message<ResourceKey, ResourceAcquiredMessage> message)
     {
-        var facilityId = message.Key;
-        var cIBytes = message.Headers.FirstOrDefault(x => x.Key == NormalizationConstants.HeaderNames.CorrelationId)?.GetValueBytes();
+        var facilityId = message.Key.FacilityId;
+        var correlationId = message.Key.CorrelationId;
 
-        if (cIBytes == null || cIBytes.Length == 0)
-            throw new MissingCorrelationIdException();
+        if (string.IsNullOrWhiteSpace(correlationId))
+        {
+            var cIBytes = message.Headers.FirstOrDefault(x => x.Key == NormalizationConstants.HeaderNames.CorrelationId)?.GetValueBytes();
 
+            if (cIBytes == null || cIBytes.Length == 0)
+                throw new MissingCorrelationIdException();
 
-        var correlationId = Encoding.UTF8.GetString(cIBytes);
+            correlationId = Encoding.UTF8.GetString(cIBytes);
+        }
 
         return (facilityId, correlationId);
     }

--- a/DotNet/Normalization/Listeners/ResourceAcquiredListener.cs
+++ b/DotNet/Normalization/Listeners/ResourceAcquiredListener.cs
@@ -216,17 +216,17 @@ public class ResourceAcquiredListener : BackgroundService
                     }
                     catch (DeadLetterException ex)
                     {
-                        _deadLetterExceptionHandler.HandleException(message, ex, message.Key.FacilityId);
+                        _deadLetterExceptionHandler.HandleException(message, ex, message.Key?.FacilityId ?? string.Empty);
                     }
                     catch (TransientException ex)
                     {
-                        _transientExceptionHandler.HandleException(message, ex, message.Key.FacilityId);
+                        _transientExceptionHandler.HandleException(message, ex, message.Key?.FacilityId ?? string.Empty);
                     }
                     catch (Exception ex)
                     {
                         _logger.LogError(ex, $"Failed to process Patient Event.");
 
-                        _transientExceptionHandler.HandleException(message, new TransientException("Normalization Exception thrown: " + ex.Message), message.Message.Key.FacilityId);
+                        _transientExceptionHandler.HandleException(message, new TransientException("Normalization Exception thrown: " + ex.Message), message.Key?.FacilityId ?? string.Empty);
                     }
                     finally
                     {

--- a/DotNet/Normalization/Program.cs
+++ b/DotNet/Normalization/Program.cs
@@ -23,6 +23,7 @@ using LantanaGroup.Link.Shared.Application.Listeners;
 using LantanaGroup.Link.Shared.Application.Middleware;
 using LantanaGroup.Link.Shared.Application.Models;
 using LantanaGroup.Link.Shared.Application.Models.Configs;
+using LantanaGroup.Link.Shared.Application.Models.Kafka;
 using LantanaGroup.Link.Shared.Application.Services;
 using LantanaGroup.Link.Shared.Application.Utilities;
 using LantanaGroup.Link.Shared.Domain.Repositories.Interceptors;
@@ -71,20 +72,21 @@ static void RegisterServices(WebApplicationBuilder builder)
     // For instructions on how to configure Kestrel and gRPC clients on macOS, visit https://go.microsoft.com/fwlink/?linkid=2099682
 
     builder.Services.AddTransient<IKafkaConsumerFactory<string, string>, KafkaConsumerFactory<string, string>>();
-    builder.Services.AddTransient<IKafkaConsumerFactory<string, ResourceAcquiredMessage>, KafkaConsumerFactory<string, ResourceAcquiredMessage>>();
+    builder.Services.AddTransient<IKafkaConsumerFactory<ResourceKey, ResourceAcquiredMessage>, KafkaConsumerFactory<ResourceKey, ResourceAcquiredMessage>>();
 
     builder.Services.AddTransient<IKafkaProducerFactory<string, string>, KafkaProducerFactory<string, string>>();
     builder.Services.AddTransient<IKafkaProducerFactory<string, AuditEventMessage>, KafkaProducerFactory<string, AuditEventMessage>>();
-    builder.Services.AddTransient<IKafkaProducerFactory<string, ResourceAcquiredMessage>, KafkaProducerFactory<string, ResourceAcquiredMessage>>();
-    builder.Services.AddTransient<IKafkaProducerFactory<string, ResourceNormalizedMessage>, KafkaProducerFactory<string, ResourceNormalizedMessage>>();
+    builder.Services.AddTransient<IKafkaProducerFactory<ResourceKey, ResourceAcquiredMessage>, KafkaProducerFactory<ResourceKey, ResourceAcquiredMessage>>();
+    builder.Services.AddTransient<IKafkaProducerFactory<ResourceKey, ResourceNormalizedMessage>, KafkaProducerFactory<ResourceKey, ResourceNormalizedMessage>>();
 
-    builder.Services.RegisterKafkaProducer<string, ResourceNormalizedMessage>(kafkaConnection: builder.Configuration.GetSection(KafkaConstants.SectionName).Get<KafkaConnection>(),
-        config: new ProducerConfig() { CompressionType = CompressionType.Zstd });
+    builder.Services.RegisterKafkaProducer<ResourceKey, ResourceNormalizedMessage>(
+        builder.Configuration.GetSection(KafkaConstants.SectionName).Get<KafkaConnection>(),
+        new ProducerConfig() { CompressionType = CompressionType.Zstd });
     builder.Services.RegisterKafkaProducer<string, AuditEventMessage>(kafkaConnection: builder.Configuration.GetSection(KafkaConstants.SectionName).Get<KafkaConnection>(), new ProducerConfig());
 
-    builder.Services.AddTransient<IDeadLetterExceptionHandler<string, string>, DeadLetterExceptionHandler<string, string>>();
-    builder.Services.AddTransient<IDeadLetterExceptionHandler<string, ResourceAcquiredMessage>, DeadLetterExceptionHandler<string, ResourceAcquiredMessage>>();
-    builder.Services.AddTransient<ITransientExceptionHandler<string, ResourceAcquiredMessage>, TransientExceptionHandler<string, ResourceAcquiredMessage>>();
+    builder.Services.AddTransient<IDeadLetterExceptionHandler<ResourceKey, string>, DeadLetterExceptionHandler<ResourceKey, string>>();
+    builder.Services.AddTransient<IDeadLetterExceptionHandler<ResourceKey, ResourceAcquiredMessage>, DeadLetterExceptionHandler<ResourceKey, ResourceAcquiredMessage>>();
+    builder.Services.AddTransient<ITransientExceptionHandler<ResourceKey, ResourceAcquiredMessage>, TransientExceptionHandler<ResourceKey, ResourceAcquiredMessage>>();
 
     builder.Services.AddTransient<ITenantApiService, TenantApiService>();
 

--- a/DotNet/Normalization/Program.cs
+++ b/DotNet/Normalization/Program.cs
@@ -75,6 +75,7 @@ static void RegisterServices(WebApplicationBuilder builder)
     builder.Services.AddTransient<IKafkaConsumerFactory<ResourceKey, ResourceAcquiredMessage>, KafkaConsumerFactory<ResourceKey, ResourceAcquiredMessage>>();
 
     builder.Services.AddTransient<IKafkaProducerFactory<string, string>, KafkaProducerFactory<string, string>>();
+    builder.Services.AddTransient<IKafkaProducerFactory<ResourceKey, string>, KafkaProducerFactory<ResourceKey, string>>();
     builder.Services.AddTransient<IKafkaProducerFactory<string, AuditEventMessage>, KafkaProducerFactory<string, AuditEventMessage>>();
     builder.Services.AddTransient<IKafkaProducerFactory<ResourceKey, ResourceAcquiredMessage>, KafkaProducerFactory<ResourceKey, ResourceAcquiredMessage>>();
     builder.Services.AddTransient<IKafkaProducerFactory<ResourceKey, ResourceNormalizedMessage>, KafkaProducerFactory<ResourceKey, ResourceNormalizedMessage>>();
@@ -85,8 +86,10 @@ static void RegisterServices(WebApplicationBuilder builder)
     builder.Services.RegisterKafkaProducer<string, AuditEventMessage>(kafkaConnection: builder.Configuration.GetSection(KafkaConstants.SectionName).Get<KafkaConnection>(), new ProducerConfig());
 
     builder.Services.AddTransient<IDeadLetterExceptionHandler<ResourceKey, string>, DeadLetterExceptionHandler<ResourceKey, string>>();
+    builder.Services.AddTransient<IDeadLetterExceptionHandler<string, string>, DeadLetterExceptionHandler<string, string>>();
     builder.Services.AddTransient<IDeadLetterExceptionHandler<ResourceKey, ResourceAcquiredMessage>, DeadLetterExceptionHandler<ResourceKey, ResourceAcquiredMessage>>();
     builder.Services.AddTransient<ITransientExceptionHandler<ResourceKey, ResourceAcquiredMessage>, TransientExceptionHandler<ResourceKey, ResourceAcquiredMessage>>();
+    builder.Services.AddTransient<ITransientExceptionHandler<string, string>, TransientExceptionHandler<string, string>>();
 
     builder.Services.AddTransient<ITenantApiService, TenantApiService>();
 

--- a/DotNet/ServiceTests/IntegrationTests/DataAcquisition/AcquisitionProcessingJobTests.cs
+++ b/DotNet/ServiceTests/IntegrationTests/DataAcquisition/AcquisitionProcessingJobTests.cs
@@ -5,12 +5,13 @@ using LantanaGroup.Link.DataAcquisition.Domain.Application.Models.Kafka;
 using LantanaGroup.Link.DataAcquisition.Domain.Infrastructure.Context;
 using LantanaGroup.Link.DataAcquisition.Domain.Infrastructure.Entities;
 using LantanaGroup.Link.DataAcquisition.Domain.Infrastructure.Models.Enums;
+using LantanaGroup.Link.DataAcquisition.Domain.Settings;
 using LantanaGroup.Link.DataAcquisition.Jobs;
 using LantanaGroup.Link.Shared.Application.Models;
+using LantanaGroup.Link.Shared.Application.Models.Kafka;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using LantanaGroup.Link.DataAcquisition.Domain.Settings;
 using Moq;
 using Quartz;
 using RequestStatus = LantanaGroup.Link.DataAcquisition.Domain.Infrastructure.Models.Enums.RequestStatus;
@@ -71,7 +72,7 @@ public class AcquisitionProcessingJobTests : IClassFixture<DataAcquisitionIntegr
         var log = await logManager.CreateAsync(createLog);
 
         var readyProducer = _fixture.ServiceProvider.GetRequiredService<IProducer<long, ReadyToAcquire>>();
-        var acquiredProducer = _fixture.ServiceProvider.GetRequiredService<IProducer<string, ResourceAcquired>>();
+        var acquiredProducer = _fixture.ServiceProvider.GetRequiredService<IProducer<ResourceKey, ResourceAcquired>>();
         var loggerMock = new Mock<ILogger<AcquisitionProcessingJob>>();
         var scopeFactory = _fixture.ServiceProvider.GetRequiredService<IServiceScopeFactory>();
         var job = new AcquisitionProcessingJob(loggerMock.Object, scopeFactory, readyProducer, acquiredProducer, _settings);
@@ -127,7 +128,7 @@ public class AcquisitionProcessingJobTests : IClassFixture<DataAcquisitionIntegr
         await dbContext.SaveChangesAsync();
 
         var readyProducer = _fixture.ServiceProvider.GetRequiredService<IProducer<long, ReadyToAcquire>>();
-        var acquiredProducer = _fixture.ServiceProvider.GetRequiredService<IProducer<string, ResourceAcquired>>();
+        var acquiredProducer = _fixture.ServiceProvider.GetRequiredService<IProducer<ResourceKey, ResourceAcquired>>();
 
         var loggerMock = new Mock<ILogger<AcquisitionProcessingJob>>();
         var scopeFactory = _fixture.ServiceProvider.GetRequiredService<IServiceScopeFactory>();
@@ -193,7 +194,7 @@ public class AcquisitionProcessingJobTests : IClassFixture<DataAcquisitionIntegr
         await dbContext.SaveChangesAsync();
 
         var readyProducer = _fixture.ServiceProvider.GetRequiredService<IProducer<long, ReadyToAcquire>>();
-        var acquiredProducer = _fixture.ServiceProvider.GetRequiredService<IProducer<string, ResourceAcquired>>();
+        var acquiredProducer = _fixture.ServiceProvider.GetRequiredService<IProducer<ResourceKey, ResourceAcquired>>();
 
         var loggerMock = new Mock<ILogger<AcquisitionProcessingJob>>();
         var scopeFactory = _fixture.ServiceProvider.GetRequiredService<IServiceScopeFactory>();
@@ -278,7 +279,7 @@ public class AcquisitionProcessingJobTests : IClassFixture<DataAcquisitionIntegr
         await dbContext.SaveChangesAsync();
 
         var readyProducer = _fixture.ServiceProvider.GetRequiredService<IProducer<long, ReadyToAcquire>>();
-        var acquiredProducer = _fixture.ServiceProvider.GetRequiredService<IProducer<string, ResourceAcquired>>();
+        var acquiredProducer = _fixture.ServiceProvider.GetRequiredService<IProducer<ResourceKey, ResourceAcquired>>();
 
         var loggerMock = new Mock<ILogger<AcquisitionProcessingJob>>();
         var scopeFactory = _fixture.ServiceProvider.GetRequiredService<IServiceScopeFactory>();
@@ -370,7 +371,7 @@ public class AcquisitionProcessingJobTests : IClassFixture<DataAcquisitionIntegr
         await dbContext.SaveChangesAsync();
 
         var readyProducer = _fixture.ServiceProvider.GetRequiredService<IProducer<long, ReadyToAcquire>>();
-        var acquiredProducer = _fixture.ServiceProvider.GetRequiredService<IProducer<string, ResourceAcquired>>();
+        var acquiredProducer = _fixture.ServiceProvider.GetRequiredService<IProducer<ResourceKey, ResourceAcquired>>();
 
         var loggerMock = new Mock<ILogger<AcquisitionProcessingJob>>();
         var scopeFactory = _fixture.ServiceProvider.GetRequiredService<IServiceScopeFactory>();
@@ -383,8 +384,8 @@ public class AcquisitionProcessingJobTests : IClassFixture<DataAcquisitionIntegr
         _fixture.ResourceAcquiredProducerMock.Verify(
             p => p.ProduceAsync(
             KafkaTopic.ResourceAcquired.ToString(),
-            It.Is<Message<string, ResourceAcquired>>(msg =>
-                msg.Key == facilityId &&
+            It.Is<Message<ResourceKey, ResourceAcquired>>(msg =>
+                msg.Key != null && msg.Key.FacilityId == facilityId && msg.Key.CorrelationId == correlationId &&
                 msg.Value.AcquisitionComplete == true &&
                 msg.Value.ScheduledReports.Any(sr => sr.ReportTrackingId == reportTrackingId)),
             It.IsAny<CancellationToken>()),
@@ -451,7 +452,7 @@ public class AcquisitionProcessingJobTests : IClassFixture<DataAcquisitionIntegr
         await dbContext.SaveChangesAsync();
 
         var readyProducer = _fixture.ServiceProvider.GetRequiredService<IProducer<long, ReadyToAcquire>>();
-        var acquiredProducer = _fixture.ServiceProvider.GetRequiredService<IProducer<string, ResourceAcquired>>();
+        var acquiredProducer = _fixture.ServiceProvider.GetRequiredService<IProducer<ResourceKey, ResourceAcquired>>();
 
         var loggerMock = new Mock<ILogger<AcquisitionProcessingJob>>();
         var scopeFactory = _fixture.ServiceProvider.GetRequiredService<IServiceScopeFactory>();
@@ -584,7 +585,7 @@ public class AcquisitionProcessingJobTests : IClassFixture<DataAcquisitionIntegr
         var totalProcessable = numFacilities * processablePerFacility;
 
         var readyProducer = _fixture.ServiceProvider.GetRequiredService<IProducer<long, ReadyToAcquire>>();
-        var acquiredProducer = _fixture.ServiceProvider.GetRequiredService<IProducer<string, ResourceAcquired>>();
+        var acquiredProducer = _fixture.ServiceProvider.GetRequiredService<IProducer<ResourceKey, ResourceAcquired>>();
 
         var loggerMock = new Mock<ILogger<AcquisitionProcessingJob>>();
         var scopeFactory = _fixture.ServiceProvider.GetRequiredService<IServiceScopeFactory>();
@@ -670,7 +671,7 @@ public class AcquisitionProcessingJobTests : IClassFixture<DataAcquisitionIntegr
         await dbContext.SaveChangesAsync();
 
         var readyProducer = _fixture.ServiceProvider.GetRequiredService<IProducer<long, ReadyToAcquire>>();
-        var acquiredProducer = _fixture.ServiceProvider.GetRequiredService<IProducer<string, ResourceAcquired>>();
+        var acquiredProducer = _fixture.ServiceProvider.GetRequiredService<IProducer<ResourceKey, ResourceAcquired>>();
 
         var loggerMock = new Mock<ILogger<AcquisitionProcessingJob>>();
         var scopeFactory = _fixture.ServiceProvider.GetRequiredService<IServiceScopeFactory>();
@@ -751,7 +752,7 @@ public class AcquisitionProcessingJobTests : IClassFixture<DataAcquisitionIntegr
         await dbContext.SaveChangesAsync();
 
         var readyProducer = _fixture.ServiceProvider.GetRequiredService<IProducer<long, ReadyToAcquire>>();
-        var acquiredProducer = _fixture.ServiceProvider.GetRequiredService<IProducer<string, ResourceAcquired>>();
+        var acquiredProducer = _fixture.ServiceProvider.GetRequiredService<IProducer<ResourceKey, ResourceAcquired>>();
 
         var loggerMock = new Mock<ILogger<AcquisitionProcessingJob>>();
         var scopeFactory = _fixture.ServiceProvider.GetRequiredService<IServiceScopeFactory>();
@@ -830,7 +831,7 @@ public class AcquisitionProcessingJobTests : IClassFixture<DataAcquisitionIntegr
         await dbContext.SaveChangesAsync();
 
         var readyProducer = _fixture.ServiceProvider.GetRequiredService<IProducer<long, ReadyToAcquire>>();
-        var acquiredProducer = _fixture.ServiceProvider.GetRequiredService<IProducer<string, ResourceAcquired>>();
+        var acquiredProducer = _fixture.ServiceProvider.GetRequiredService<IProducer<ResourceKey, ResourceAcquired>>();
 
         var loggerMock = new Mock<ILogger<AcquisitionProcessingJob>>();
         var scopeFactory = _fixture.ServiceProvider.GetRequiredService<IServiceScopeFactory>();
@@ -905,7 +906,7 @@ public class AcquisitionProcessingJobTests : IClassFixture<DataAcquisitionIntegr
         await dbContext.SaveChangesAsync();
 
         var readyProducer = _fixture.ServiceProvider.GetRequiredService<IProducer<long, ReadyToAcquire>>();
-        var acquiredProducer = _fixture.ServiceProvider.GetRequiredService<IProducer<string, ResourceAcquired>>();
+        var acquiredProducer = _fixture.ServiceProvider.GetRequiredService<IProducer<ResourceKey, ResourceAcquired>>();
 
         var loggerMock = new Mock<ILogger<AcquisitionProcessingJob>>();
         var scopeFactory = _fixture.ServiceProvider.GetRequiredService<IServiceScopeFactory>();

--- a/DotNet/ServiceTests/IntegrationTests/DataAcquisition/DataAcquisitionIntegrationTestFixture.cs
+++ b/DotNet/ServiceTests/IntegrationTests/DataAcquisition/DataAcquisitionIntegrationTestFixture.cs
@@ -5,14 +5,15 @@ using LantanaGroup.Link.DataAcquisition.Domain.Application.Models.Kafka;
 using LantanaGroup.Link.DataAcquisition.Domain.Application.Queries;
 using LantanaGroup.Link.DataAcquisition.Domain.Application.Services;
 using LantanaGroup.Link.DataAcquisition.Domain.Application.Validators;
-using LantanaGroup.Link.DataAcquisition.Domain.Settings;
 using LantanaGroup.Link.DataAcquisition.Domain.Infrastructure;
 using LantanaGroup.Link.DataAcquisition.Domain.Infrastructure.Context;
 using LantanaGroup.Link.DataAcquisition.Domain.Infrastructure.Entities;
+using LantanaGroup.Link.DataAcquisition.Domain.Settings;
 using LantanaGroup.Link.Shared.Application.Extensions;
 using LantanaGroup.Link.Shared.Application.Interfaces.Services.Security.Token;
 using LantanaGroup.Link.Shared.Application.Models;
 using LantanaGroup.Link.Shared.Application.Models.Configs;
+using LantanaGroup.Link.Shared.Application.Models.Kafka;
 using LantanaGroup.Link.Shared.Application.Services;
 using LantanaGroup.Link.Shared.Application.Services.Security.Token;
 using LantanaGroup.Link.Shared.Domain.Repositories.Implementations;
@@ -39,12 +40,12 @@ namespace IntegrationTests.DataAcquisition
         private readonly string _dbPath;
 
         public Mock<IProducer<long, ReadyToAcquire>> ReadyToAcquireProducerMock { get; private set; }
-        public Mock<IProducer<string, ResourceAcquired>> ResourceAcquiredProducerMock { get; private set; }
+        public Mock<IProducer<ResourceKey, ResourceAcquired>> ResourceAcquiredProducerMock { get; private set; }
 
         public DataAcquisitionIntegrationTestFixture()
         {
             ReadyToAcquireProducerMock = new Mock<IProducer<long, ReadyToAcquire>>();
-            ResourceAcquiredProducerMock = new Mock<IProducer<string, ResourceAcquired>>();
+            ResourceAcquiredProducerMock = new Mock<IProducer<ResourceKey, ResourceAcquired>>();
 
             _dbPath = Path.Combine(Path.GetTempPath(), $"testdb_{Guid.NewGuid()}.db");
             var sqliteConnectionString = $"Data Source={_dbPath};";
@@ -99,7 +100,7 @@ namespace IntegrationTests.DataAcquisition
 
             // Mock Kafka producers for integration tests
             builder.Services.AddSingleton<IProducer<long, ReadyToAcquire>>(ReadyToAcquireProducerMock.Object);
-            builder.Services.AddSingleton<IProducer<string, ResourceAcquired>>(ResourceAcquiredProducerMock.Object);
+            builder.Services.AddSingleton<IProducer<ResourceKey, ResourceAcquired>>(ResourceAcquiredProducerMock.Object);
 
             builder.Services.Configure<ServiceRegistry>(options =>
             {

--- a/DotNet/ServiceTests/IntegrationTests/DataAcquisition/FhirApiServiceTests.cs
+++ b/DotNet/ServiceTests/IntegrationTests/DataAcquisition/FhirApiServiceTests.cs
@@ -1,4 +1,6 @@
-﻿using DataAcquisition.Domain.Application.Models;
+﻿using System.Net;
+using Confluent.Kafka;
+using DataAcquisition.Domain.Application.Models;
 using Hl7.Fhir.Rest;
 using Hl7.Fhir.Support;
 using LantanaGroup.Link.DataAcquisition.Domain.Application.Managers;
@@ -12,11 +14,9 @@ using LantanaGroup.Link.DataAcquisition.Domain.Application.Services.FhirApi.Comm
 using LantanaGroup.Link.DataAcquisition.Domain.Infrastructure.Models.Enums;
 using LantanaGroup.Link.DataAcquisition.Domain.Models;
 using LantanaGroup.Link.DataAcquisition.Domain.Settings;
+using LantanaGroup.Link.Shared.Application.Models;
+using LantanaGroup.Link.Shared.Application.Models.Kafka;
 using Moq;
-using System.Net;
-using System.Collections.Frozen;
-using System.Collections.Generic;
-using System.Linq;
 using ResourceType = Hl7.Fhir.Model.ResourceType;
 using Task = System.Threading.Tasks.Task;
 
@@ -70,9 +70,9 @@ public class FhirApiServiceTests
         var mockLogQueries = new Mock<IDataAcquisitionLogQueries>();
         mockLogQueries.Setup(q => q.CheckIfReferenceResourceHasBeenSent(
             It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
-            .ThrowsAsync(new System.Exception("DB failure"));
+            .ThrowsAsync(new Exception("DB failure"));
 
-        await Assert.ThrowsAsync<System.Exception>(() =>
+        await Assert.ThrowsAsync<Exception>(() =>
             mockLogQueries.Object.CheckIfReferenceResourceHasBeenSent("ref4", "report4", "fac4", "corr4", CancellationToken.None));
     }
 
@@ -85,7 +85,7 @@ public class FhirApiServiceTests
         var referenceResourceService = new Mock<IReferenceResourceService>();
         var searchFhirCommand = new Mock<ISearchFhirCommand>();
         var readFhirCommand = new Mock<IReadFhirCommand>();
-        var kafkaProducer = new Mock<Confluent.Kafka.IProducer<string, ResourceAcquired>>();
+        var kafkaProducer = new Mock<IProducer<ResourceKey, ResourceAcquired>>();
 
         var service = new FhirApiService(
             referenceResourceManager.Object,
@@ -100,7 +100,7 @@ public class FhirApiServiceTests
 
         // Act: Use reflection to invoke the private InsertDateExtension method
         typeof(FhirApiService)
-            .GetMethod("InsertDateExtension", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)
+            .GetMethod("InsertDateExtension", BindingFlags.NonPublic | BindingFlags.Instance)
             .Invoke(service, new object[] { resource });
 
         // Assert: meta.extension contains the expected extension
@@ -123,7 +123,7 @@ public class FhirApiServiceTests
         var referenceResourceService = new Mock<IReferenceResourceService>();
         var searchFhirCommand = new Mock<ISearchFhirCommand>();
         var readFhirCommand = new Mock<IReadFhirCommand>();
-        var kafkaProducer = new Mock<Confluent.Kafka.IProducer<string, ResourceAcquired>>();
+        var kafkaProducer = new Mock<IProducer<ResourceKey, ResourceAcquired>>();
 
         var service = new FhirApiService(
             referenceResourceManager.Object,
@@ -170,18 +170,18 @@ public class FhirApiServiceTests
         var referenceResourceService = new Mock<IReferenceResourceService>();
         var searchFhirCommand = new Mock<ISearchFhirCommand>();
         var readFhirCommand = new Mock<IReadFhirCommand>();
-        var kafkaProducer = new Mock<Confluent.Kafka.IProducer<string, ResourceAcquired>>();
+        var kafkaProducer = new Mock<IProducer<ResourceKey, ResourceAcquired>>();
 
         // Prepare a shared resource (e.g., Location) with no patient context
-        var location = new Hl7.Fhir.Model.Location
+        var location = new Location
         {
             Id = "loc-1"
         };
-        var bundle = new Hl7.Fhir.Model.Bundle
+        var bundle = new Bundle
         {
-            Entry = new List<Hl7.Fhir.Model.Bundle.EntryComponent>
+            Entry = new List<Bundle.EntryComponent>
             {
-                new Hl7.Fhir.Model.Bundle.EntryComponent { Resource = location }
+                new Bundle.EntryComponent { Resource = location }
             }
         };
 
@@ -197,13 +197,13 @@ public class FhirApiServiceTests
         kafkaProducer
             .Setup(x => x.ProduceAsync(
                 It.IsAny<string>(),
-                It.IsAny<Confluent.Kafka.Message<string, ResourceAcquired>>(),
+                It.IsAny<Message<ResourceKey, ResourceAcquired>>(),
                 It.IsAny<CancellationToken>()))
-            .Callback<string, Confluent.Kafka.Message<string, ResourceAcquired>, CancellationToken>((topic, msg, ct) =>
+            .Callback<string, Message<ResourceKey, ResourceAcquired>, CancellationToken>((topic, msg, ct) =>
             {
                 producedMessage = msg.Value;
             })
-            .ReturnsAsync(new Confluent.Kafka.DeliveryResult<string, ResourceAcquired>());
+            .ReturnsAsync(new DeliveryResult<ResourceKey, ResourceAcquired>());
 
         var service = new FhirApiService(
             referenceResourceManager.Object,
@@ -219,7 +219,7 @@ public class FhirApiServiceTests
             FacilityId = "fac-1",
             CorrelationId = "corr-1",
             QueryPhase = QueryPhase.Initial,
-            ScheduledReport = new LantanaGroup.Link.Shared.Application.Models.ScheduledReport(),
+            ScheduledReport = new ScheduledReport(),
             ReportableEvent = ReportableEvent.Adhoc
         };
 
@@ -236,7 +236,7 @@ public class FhirApiServiceTests
         };
 
         // Act
-        await service.ExecuteSearch(log, fhirQuery, fhirQueryConfig, Hl7.Fhir.Model.ResourceType.Location);
+        await service.ExecuteSearch(log, fhirQuery, fhirQueryConfig, ResourceType.Location);
 
         // Assert: Kafka message was produced and PatientId is null
         Assert.NotNull(producedMessage);
@@ -245,7 +245,7 @@ public class FhirApiServiceTests
 
     }
 
-    private static async IAsyncEnumerable<Hl7.Fhir.Model.Bundle> GetBundleAsync(Hl7.Fhir.Model.Bundle bundle)
+    private static async IAsyncEnumerable<Bundle> GetBundleAsync(Bundle bundle)
     {
         yield return bundle;
         await Task.CompletedTask;

--- a/DotNet/ServiceTests/IntegrationTests/DataAcquisition/PatientDataServiceTests.cs
+++ b/DotNet/ServiceTests/IntegrationTests/DataAcquisition/PatientDataServiceTests.cs
@@ -18,6 +18,7 @@ using LantanaGroup.Link.DataAcquisition.Domain.Infrastructure.Models.Enums;
 using LantanaGroup.Link.DataAcquisition.Domain.Infrastructure.Models.QueryConfig;
 using LantanaGroup.Link.DataAcquisition.Domain.Models;
 using LantanaGroup.Link.Shared.Application.Models;
+using LantanaGroup.Link.Shared.Application.Models.Kafka;
 using LantanaGroup.Link.Shared.Application.Models.Responses;
 using Medallion.Threading;
 using Microsoft.Extensions.Logging;
@@ -38,7 +39,7 @@ public class PatientDataServiceTests
     private readonly Mock<IFhirQueryConfigurationQueries> _mockFhirQueryQueries;
     private readonly Mock<IQueryPlanManager> _mockQueryPlanManager;
     private readonly Mock<IQueryPlanQueries> _mockQueryPlanQueries;
-    private readonly Mock<IProducer<string, ResourceAcquired>> _mockKafkaProducer;
+    private readonly Mock<IProducer<ResourceKey, ResourceAcquired>> _mockKafkaProducer;
     private readonly Mock<IQueryListProcessor> _mockQueryListProcessor;
     private readonly Mock<IReadFhirCommand> _mockReadFhirCommand;
     private readonly Mock<ISearchFhirCommand> _mockSearchFhirCommand;
@@ -61,7 +62,7 @@ public class PatientDataServiceTests
         _mockFhirQueryQueries = new Mock<IFhirQueryConfigurationQueries>();
         _mockQueryPlanManager = new Mock<IQueryPlanManager>();
         _mockQueryPlanQueries = new Mock<IQueryPlanQueries>();
-        _mockKafkaProducer = new Mock<IProducer<string, ResourceAcquired>>();
+        _mockKafkaProducer = new Mock<IProducer<ResourceKey, ResourceAcquired>>();
         _mockQueryListProcessor = new Mock<IQueryListProcessor>();
         _mockReadFhirCommand = new Mock<IReadFhirCommand>();
         _mockSearchFhirCommand = new Mock<ISearchFhirCommand>();
@@ -113,9 +114,9 @@ public class PatientDataServiceTests
             PatientId = "patient-123",
             ReportableEvent = ReportableEvent.Discharge,
             QueryType = "Initial",
-            ScheduledReports = new List<LantanaGroup.Link.Shared.Application.Models.ScheduledReport>
+            ScheduledReports = new List<ScheduledReport>
             {
-                new LantanaGroup.Link.Shared.Application.Models.ScheduledReport
+                new ScheduledReport
                 {
                     ReportTypes = new List<string> { "measure-1" },
                     Frequency = Frequency.Discharge,
@@ -212,9 +213,9 @@ public class PatientDataServiceTests
             PatientId = "patient-123",
             ReportableEvent = ReportableEvent.Discharge,
             QueryType = "Initial",
-            ScheduledReports = new List<LantanaGroup.Link.Shared.Application.Models.ScheduledReport>
+            ScheduledReports = new List<ScheduledReport>
             {
-                new LantanaGroup.Link.Shared.Application.Models.ScheduledReport
+                new ScheduledReport
                 {
                     ReportTypes = new List<string> { "measure-1" },
                     Frequency = Frequency.Discharge,
@@ -320,7 +321,7 @@ public class PatientDataServiceTests
                 QueryType = FhirQueryType.Read,
                 FhirQueryResourceTypes = new List<FhirQueryResourceType>
                 {
-                    new FhirQueryResourceType() { ResourceType = Hl7.Fhir.Model.ResourceType.Patient }
+                    new FhirQueryResourceType() { ResourceType = ResourceType.Patient }
                 },
                 QueryParameters = new List<string>(),
                 ResourceReferenceTypes = new List<ResourceReferenceType>()
@@ -360,7 +361,7 @@ public class PatientDataServiceTests
             .Setup(x => x.ExecuteRead(
                 It.IsAny<DataAcquisitionLogModel>(),
                 It.IsAny<FhirQueryModel>(),
-                It.IsAny<Hl7.Fhir.Model.ResourceType>(),
+                It.IsAny<ResourceType>(),
                 It.IsAny<FhirQueryConfigurationModel>(),
                 cancellationToken))
             .ReturnsAsync(new[] { "Patient/patient-1" });

--- a/DotNet/ServiceTests/IntegrationTests/DataAcquisition/Services/ReferenceResourceServiceTests.cs
+++ b/DotNet/ServiceTests/IntegrationTests/DataAcquisition/Services/ReferenceResourceServiceTests.cs
@@ -1,21 +1,15 @@
-﻿using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-using DataAcquisition.Domain.Application.Models;
-using Hl7.Fhir.Model;
-using IntegrationTests.DataAcquisition;
+﻿using DataAcquisition.Domain.Application.Models;
 using LantanaGroup.Link.DataAcquisition.Domain.Application.Interfaces;
 using LantanaGroup.Link.DataAcquisition.Domain.Application.Managers;
-using LantanaGroup.Link.DataAcquisition.Domain.Application.Models.Api.QueryLog;
-using LantanaGroup.Link.DataAcquisition.Domain.Application.Services;
 using LantanaGroup.Link.DataAcquisition.Domain.Application.Queries;
+using LantanaGroup.Link.DataAcquisition.Domain.Application.Services;
+using LantanaGroup.Link.DataAcquisition.Domain.Infrastructure.Context;
 using LantanaGroup.Link.DataAcquisition.Domain.Infrastructure.Models.Enums;
-using RequestStatusEnum = LantanaGroup.Link.DataAcquisition.Domain.Infrastructure.Models.Enums.RequestStatus;
 using LantanaGroup.Link.Shared.Application.Models;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Moq;
-using Xunit;
+using RequestStatusEnum = LantanaGroup.Link.DataAcquisition.Domain.Infrastructure.Models.Enums.RequestStatus;
 using ResourceType = Hl7.Fhir.Model.ResourceType;
 using Task = System.Threading.Tasks.Task;
 
@@ -63,7 +57,7 @@ namespace IntegrationTests.DataAcquisition.Services
         {
             // Arrange
             using var scope = _fixture.ServiceProvider.CreateScope();
-            var dbContext = scope.ServiceProvider.GetRequiredService<LantanaGroup.Link.DataAcquisition.Domain.Infrastructure.Context.DataAcquisitionDbContext>();
+            var dbContext = scope.ServiceProvider.GetRequiredService<DataAcquisitionDbContext>();
 
             await dbContext.Database.EnsureDeletedAsync();
             await dbContext.Database.EnsureCreatedAsync();

--- a/DotNet/ServiceTests/UnitTests/Normalization/ResourceAcquiredListenerTests.cs
+++ b/DotNet/ServiceTests/UnitTests/Normalization/ResourceAcquiredListenerTests.cs
@@ -1,20 +1,16 @@
-﻿using System.Reflection;
-using System.Text;
-using Confluent.Kafka;
-using Hl7.Fhir.Model;
+﻿using Confluent.Kafka;
 using LantanaGroup.Link.Normalization.Application.Models.Messages;
 using LantanaGroup.Link.Normalization.Application.Services;
 using LantanaGroup.Link.Normalization.Application.Services.Operations;
-using LantanaGroup.Link.Normalization.Application.Settings;
 using LantanaGroup.Link.Normalization.Listeners;
 using LantanaGroup.Link.Shared.Application.Error.Exceptions;
 using LantanaGroup.Link.Shared.Application.Error.Interfaces;
 using LantanaGroup.Link.Shared.Application.Interfaces;
 using LantanaGroup.Link.Shared.Application.Models;
+using LantanaGroup.Link.Shared.Application.Models.Kafka;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Moq;
-using Xunit;
 using Task = System.Threading.Tasks.Task;
 
 namespace UnitTests.Normalization;
@@ -24,12 +20,12 @@ public class ResourceAcquiredListenerTests
     private readonly Mock<ILogger<ResourceAcquiredListener>> _loggerMock;
     private readonly Mock<ServiceInformation> _serviceInformationMock;
     private readonly Mock<IServiceScopeFactory> _scopeFactoryMock;
-    private readonly Mock<IKafkaConsumerFactory<string, ResourceAcquiredMessage>> _consumerFactoryMock;
-    private readonly Mock<IDeadLetterExceptionHandler<string, string>> _consumeExceptionHandlerMock;
-    private readonly Mock<IDeadLetterExceptionHandler<string, ResourceAcquiredMessage>> _deadLetterExceptionHandlerMock;
-    private readonly Mock<ITransientExceptionHandler<string, ResourceAcquiredMessage>> _transientExceptionHandlerMock;
+    private readonly Mock<IKafkaConsumerFactory<ResourceKey, ResourceAcquiredMessage>> _consumerFactoryMock;
+    private readonly Mock<IDeadLetterExceptionHandler<ResourceKey, string>> _consumeExceptionHandlerMock;
+    private readonly Mock<IDeadLetterExceptionHandler<ResourceKey, ResourceAcquiredMessage>> _deadLetterExceptionHandlerMock;
+    private readonly Mock<ITransientExceptionHandler<ResourceKey, ResourceAcquiredMessage>> _transientExceptionHandlerMock;
     private readonly Mock<INormalizationServiceMetrics> _metricsMock;
-    private readonly Mock<IProducer<string, ResourceNormalizedMessage>> _producerMock;
+    private readonly Mock<IProducer<ResourceKey, ResourceNormalizedMessage>> _producerMock;
     private readonly Mock<CopyPropertyOperationService> _copyPropertyOperationServiceMock;
     private readonly Mock<CodeMapOperationService> _codeMapOperationServiceMock;
     private readonly Mock<ConditionalTransformOperationService> _conditionalTransformOperationServiceMock;
@@ -40,12 +36,12 @@ public class ResourceAcquiredListenerTests
         _loggerMock = new Mock<ILogger<ResourceAcquiredListener>>();
         _serviceInformationMock = new Mock<ServiceInformation>();
         _scopeFactoryMock = new Mock<IServiceScopeFactory>();
-        _consumerFactoryMock = new Mock<IKafkaConsumerFactory<string, ResourceAcquiredMessage>>();
-        _consumeExceptionHandlerMock = new Mock<IDeadLetterExceptionHandler<string, string>>();
-        _deadLetterExceptionHandlerMock = new Mock<IDeadLetterExceptionHandler<string, ResourceAcquiredMessage>>();
-        _transientExceptionHandlerMock = new Mock<ITransientExceptionHandler<string, ResourceAcquiredMessage>>();
+        _consumerFactoryMock = new Mock<IKafkaConsumerFactory<ResourceKey, ResourceAcquiredMessage>>();
+        _consumeExceptionHandlerMock = new Mock<IDeadLetterExceptionHandler<ResourceKey, string>>();
+        _deadLetterExceptionHandlerMock = new Mock<IDeadLetterExceptionHandler<ResourceKey, ResourceAcquiredMessage>>();
+        _transientExceptionHandlerMock = new Mock<ITransientExceptionHandler<ResourceKey, ResourceAcquiredMessage>>();
         _metricsMock = new Mock<INormalizationServiceMetrics>();
-        _producerMock = new Mock<IProducer<string, ResourceNormalizedMessage>>();
+        _producerMock = new Mock<IProducer<ResourceKey, ResourceNormalizedMessage>>();
         
         // Mocking services that might not have parameterless constructors or are classes
         _copyPropertyOperationServiceMock = new Mock<CopyPropertyOperationService>(new Mock<ILogger<CopyPropertyOperationService>>().Object, null);
@@ -85,21 +81,21 @@ public class ResourceAcquiredListenerTests
             AcquisitionComplete = false
         };
 
-        var consumeResult = new ConsumeResult<string, ResourceAcquiredMessage>
+        var consumeResult = new ConsumeResult<ResourceKey, ResourceAcquiredMessage>
         {
-            Message = new Message<string, ResourceAcquiredMessage>
+            Message = new Message<ResourceKey, ResourceAcquiredMessage>
             {
-                Key = facilityId,
+                Key = new ResourceKey { FacilityId = facilityId, CorrelationId = correlationId },
                 Value = messageValue
             }
         };
 
-        var produceException = new ProduceException<string, ResourceNormalizedMessage>(
+        var produceException = new ProduceException<ResourceKey, ResourceNormalizedMessage>(
             new Error(ErrorCode.Local_Application, "Test Kafka Error"),
-            new DeliveryResult<string, ResourceNormalizedMessage>());
+            new DeliveryResult<ResourceKey, ResourceNormalizedMessage>());
 
         _producerMock
-            .Setup(p => p.ProduceAsync(It.IsAny<string>(), It.IsAny<Message<string, ResourceNormalizedMessage>>(), It.IsAny<CancellationToken>()))
+            .Setup(p => p.ProduceAsync(It.IsAny<string>(), It.IsAny<Message<ResourceKey, ResourceNormalizedMessage>>(), It.IsAny<CancellationToken>()))
             .ThrowsAsync(produceException);
 
         // Act & Assert
@@ -153,21 +149,21 @@ public class ResourceAcquiredListenerTests
             AcquisitionComplete = true // Typical for null resource
         };
 
-        var consumeResultNull = new ConsumeResult<string, ResourceAcquiredMessage>
+        var consumeResultNull = new ConsumeResult<ResourceKey, ResourceAcquiredMessage>
         {
-            Message = new Message<string, ResourceAcquiredMessage>
+            Message = new Message<ResourceKey, ResourceAcquiredMessage>
             {
-                Key = facilityId,
+                Key = new ResourceKey { FacilityId = facilityId, CorrelationId = correlationId },
                 Value = messageValueNull
             }
         };
 
-        var produceExceptionNull = new ProduceException<string, ResourceNormalizedMessage>(
+        var produceExceptionNull = new ProduceException<ResourceKey, ResourceNormalizedMessage>(
             new Error(ErrorCode.Local_Application, "Test Kafka Error"),
-            new DeliveryResult<string, ResourceNormalizedMessage>());
+            new DeliveryResult<ResourceKey, ResourceNormalizedMessage>());
 
         _producerMock
-            .Setup(p => p.ProduceAsync(It.IsAny<string>(), It.IsAny<Message<string, ResourceNormalizedMessage>>(), It.IsAny<CancellationToken>()))
+            .Setup(p => p.ProduceAsync(It.IsAny<string>(), It.IsAny<Message<ResourceKey, ResourceNormalizedMessage>>(), It.IsAny<CancellationToken>()))
             .ThrowsAsync(produceExceptionNull);
 
         // Act & Assert

--- a/DotNet/Shared/Application/Models/Kafka/ResourceKey.cs
+++ b/DotNet/Shared/Application/Models/Kafka/ResourceKey.cs
@@ -1,7 +1,11 @@
-﻿namespace LantanaGroup.Link.Shared.Application.Models.Kafka;
+﻿using System.Text.Json.Serialization;
+
+namespace LantanaGroup.Link.Shared.Application.Models.Kafka;
 
 public class ResourceKey
 {
+    [JsonPropertyName("facilityId")]
     public string FacilityId { get; set; } = string.Empty;
+    [JsonPropertyName("correlationId")]
     public string CorrelationId { get; set; } = string.Empty;
 }

--- a/DotNet/Shared/Application/Models/Kafka/ResourceKey.cs
+++ b/DotNet/Shared/Application/Models/Kafka/ResourceKey.cs
@@ -1,0 +1,7 @@
+﻿namespace LantanaGroup.Link.Shared.Application.Models.Kafka;
+
+public class ResourceKey
+{
+    public string FacilityId { get; set; } = string.Empty;
+    public string CorrelationId { get; set; } = string.Empty;
+}

--- a/Java/measureeval/src/main/java/com/lantanagroup/link/measureeval/configs/KafkaConfig.java
+++ b/Java/measureeval/src/main/java/com/lantanagroup/link/measureeval/configs/KafkaConfig.java
@@ -9,6 +9,7 @@ import com.lantanagroup.link.measureeval.services.ResourceNormalizedConsumer;
 import com.lantanagroup.link.shared.kafka.AsyncListener;
 import com.lantanagroup.link.shared.kafka.Properties;
 import com.lantanagroup.link.shared.kafka.Topics;
+import com.lantanagroup.link.shared.kafka.records.ResourceKey;
 import io.opentelemetry.instrumentation.kafkaclients.v2_6.TracingConsumerInterceptor;
 import io.opentelemetry.instrumentation.kafkaclients.v2_6.TracingProducerInterceptor;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
@@ -61,10 +62,10 @@ public class KafkaConfig {
     @Bean
     public Deserializer<?> keyDeserializer(ObjectMapper objectMapper) {
         Map<String, Deserializer<?>> deserializers = Map.of(
-                Topics.RESOURCE_ACQUIRED_ERROR, new StringDeserializer(),
-                Topics.RESOURCE_NORMALIZED, new StringDeserializer(),
-                Topics.RESOURCE_NORMALIZED_ERROR, new StringDeserializer(),
-                Topics.RESOURCE_NORMALIZED_RETRY, new StringDeserializer(),
+                Topics.RESOURCE_ACQUIRED_ERROR, new JsonDeserializer<>(ResourceKey.class, objectMapper),
+                Topics.RESOURCE_NORMALIZED, new JsonDeserializer<>(ResourceKey.class, objectMapper),
+                Topics.RESOURCE_NORMALIZED_ERROR, new JsonDeserializer<>(ResourceKey.class, objectMapper),
+                Topics.RESOURCE_NORMALIZED_RETRY, new JsonDeserializer<>(ResourceKey.class, objectMapper),
                 Topics.EVALUATION_REQUESTED, new StringDeserializer(),
                 Topics.EVALUATION_REQUESTED_ERROR, new StringDeserializer(),
                 Topics.EVALUATION_REQUESTED_RETRY, new StringDeserializer());

--- a/Java/measureeval/src/main/java/com/lantanagroup/link/measureeval/services/AbstractResourceConsumer.java
+++ b/Java/measureeval/src/main/java/com/lantanagroup/link/measureeval/services/AbstractResourceConsumer.java
@@ -11,6 +11,7 @@ import com.lantanagroup.link.shared.exceptions.ValidationException;
 import com.lantanagroup.link.shared.kafka.AsyncListener;
 import com.lantanagroup.link.shared.kafka.Headers;
 import com.lantanagroup.link.shared.kafka.Topics;
+import com.lantanagroup.link.shared.kafka.records.ResourceKey;
 import com.lantanagroup.link.shared.utils.DiagnosticNames;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.trace.Span;
@@ -35,7 +36,7 @@ import java.util.stream.Collectors;
 
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
 
-public abstract class AbstractResourceConsumer<T extends AbstractResourceRecord> extends AsyncListener<String, T> {
+public abstract class AbstractResourceConsumer<T extends AbstractResourceRecord> extends AsyncListener<ResourceKey, T> {
     private static final Logger logger = LoggerFactory.getLogger(AbstractResourceConsumer.class);
     private static final Logger performanceLogger =LoggerFactory.getLogger(
             "com.lantanagroup.link.performance." + AbstractResourceConsumer.class.getSimpleName());
@@ -75,7 +76,7 @@ public abstract class AbstractResourceConsumer<T extends AbstractResourceRecord>
     }
 
     @Override
-    protected void process(ConsumerRecord<String, T> record) {
+    protected void process(ConsumerRecord<ResourceKey, T> record) {
         String correlationId = Headers.getCorrelationId(record.headers());
 
         StopWatch totalStopWatch = new StopWatch();
@@ -93,10 +94,11 @@ public abstract class AbstractResourceConsumer<T extends AbstractResourceRecord>
             taskStopWatch.stop();
 
             taskStopWatch.start("validateRecord");
-            String facilityId = record.key();
-            if (facilityId == null || facilityId.isEmpty()) {
+            ResourceKey key = record.key();
+            if (key == null || key.getFacilityId() == null || key.getFacilityId().isEmpty()) {
                 throw new ValidationException("Facility ID is null or empty.");
             }
+            String facilityId = key.getFacilityId();
             T value = record.value();
             if (value.getResource() == null && !value.isAcquisitionComplete()) {
                 throw new ValidationException("Record Resource is null and AcquisitionComplete is false.");
@@ -122,7 +124,7 @@ public abstract class AbstractResourceConsumer<T extends AbstractResourceRecord>
 
             logger.trace("Beginning patient status update");
 
-            PatientReportingEvaluationStatus patientStatus = patientStatusCache.computeIfAbsent(correlationId, key -> {
+            PatientReportingEvaluationStatus patientStatus = patientStatusCache.computeIfAbsent(correlationId, k -> {
                 taskStopWatch.start("retrieveOrCreatePatientStatus");
                 PatientReportingEvaluationStatus _patientStatus = Objects.requireNonNullElseGet(
                         retrievePatientStatus(facilityId, correlationId),

--- a/Java/shared/src/main/java/com/lantanagroup/link/shared/kafka/records/ResourceKey.java
+++ b/Java/shared/src/main/java/com/lantanagroup/link/shared/kafka/records/ResourceKey.java
@@ -1,0 +1,15 @@
+package com.lantanagroup.link.shared.kafka.records;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ResourceKey {
+    private String facilityId;
+    private String correlationId;
+}

--- a/Scripts/build_and_push_and_set.py
+++ b/Scripts/build_and_push_and_set.py
@@ -1,0 +1,186 @@
+﻿"""
+This script automates the process of building, pushing, and optionally deploying Docker images for Link services.
+
+It performs the following steps for each selected service:
+1. Builds the Docker image using the appropriate Dockerfile and context.
+2. Pushes the built image to an Azure Container Registry (ACR).
+3. (Optional) Updates a Kubernetes deployment in a specified namespace with the new image.
+   - Before updating, it retrieves and prints the current image used by the deployment.
+
+Usage:
+    python Scripts/build_and_push_and_set.py --link-acr <ACR_URL> --tag <TAG> [options]
+
+Arguments:
+    --link-acr <ACR_URL>    The URL of the Azure Container Registry (e.g., nhsnlinkprem.azurecr.io).
+                            Can also be set via the LINK_ACR environment variable.
+    --tag <TAG>             The tag to apply to the Docker images (Required).
+    --service <SERVICE>     Specific service to process. Can be specified multiple times.
+    --all-services          Process all recognized services.
+    --kube-namespace <NS>   The Kubernetes namespace where the deployments are located. 
+                            If provided, the script will update the deployments with the new images.
+
+If neither --service nor --all-services is specified, the script will interactively prompt the user for each service.
+
+Recognized services:
+    account, admin-bff, admin-ui, audit, census, dataacq, dataacq-worker,
+    measureeval, normalization, querydispatch, report, submission, tenant,
+    terminology, validation
+"""
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+
+# Define the service mapping based on docker-compose.yml and the requested ACR repo names
+# Map service names (matching docker-compose.yml) to their ACR repo names and Dockerfile paths
+SERVICES = {
+    "account": {"repo": "link-account", "dockerfile": "DotNet/Account/Dockerfile", "context": ".", "deployment": "account-deploy", "container": "account"},
+    "admin-bff": {"repo": "link-admin", "dockerfile": "DotNet/Admin.BFF/Dockerfile", "context": ".", "deployment": "admin-deploy", "container": "admin"},
+    "admin-ui": {"repo": "link-admin-ui", "dockerfile": "Web/Admin.UI/Dockerfile", "context": "Web/Admin.UI", "deployment": "admin-ui-deploy", "container": "admin-ui"},
+    "audit": {"repo": "link-audit", "dockerfile": "DotNet/Audit/Dockerfile", "context": ".", "deployment": "audit-deploy", "container": "audit"},
+    "census": {"repo": "link-census", "dockerfile": "DotNet/Census/Dockerfile", "context": ".", "deployment": "census-deploy", "container": "census"},
+    "dataacq": {"repo": "link-dataacquisition", "dockerfile": "DotNet/DataAcquisition/Dockerfile", "context": ".", "deployment": "data-acquisition-deploy", "container": "data"},
+    "dataacq-worker": {"repo": "link-dataacquisition-worker", "dockerfile": "DotNet/DataAcquisition.AcquisitionWorker/Dockerfile", "context": ".", "deployment": "data-acquisition-worker-deploy", "container": "data-worker"},
+    "measureeval": {"repo": "link-measureeval", "dockerfile": "Java/measureeval/Dockerfile", "context": "Java", "deployment": "measure-deploy", "container": "measure"},
+    "normalization": {"repo": "link-normalization", "dockerfile": "DotNet/Normalization/Dockerfile", "context": ".", "deployment": "normalization-deploy", "container": "normalization"},
+    "querydispatch": {"repo": "link-querydispatch", "dockerfile": "DotNet/QueryDispatch/Dockerfile", "context": ".", "deployment": "query-dispatch-deploy", "container": "query-dispatch"},
+    "report": {"repo": "link-report", "dockerfile": "DotNet/Report/Dockerfile", "context": ".", "deployment": "report-deploy", "container": "report"},
+    "submission": {"repo": "link-submission", "dockerfile": "DotNet/Submission/Dockerfile", "context": ".", "deployment": "submission-deploy", "container": "submission"},
+    "tenant": {"repo": "link-tenant", "dockerfile": "DotNet/Tenant/Dockerfile", "context": ".", "deployment": "tenant-deploy", "container": "tenant"},
+    "terminology": {"repo": "link-terminology", "dockerfile": "DotNet/Terminology/Dockerfile", "context": ".", "deployment": "terminology-deploy", "container": "terminology"},
+    "validation": {"repo": "link-validation", "dockerfile": "Java/validation/Dockerfile", "context": "Java", "deployment": "validation-deploy", "container": "validation"}
+}
+
+def run_command(command):
+    """Runs a shell command and prints its output."""
+    print(f"Executing: {' '.join(command)}")
+    # We use check=True to raise an exception on failure
+    subprocess.run(command, check=True)
+
+def main():
+    parser = argparse.ArgumentParser(description="Build and push Link service Docker images to an Azure Container Registry.")
+    
+    # ACR parameter
+    parser.add_argument("--link-acr", help="The ACR URL (e.g. nhsnlinkprem.azurecr.io). Can also be set via LINK_ACR environment variable.")
+    
+    # Kubernetes parameter
+    parser.add_argument("--kube-namespace", help="The Kubernetes namespace to update images in.")
+    
+    # Service selection
+    parser.add_argument("--service", action="append", help="Specific service to build and push. Can be specified multiple times.")
+    parser.add_argument("--all-services", action="store_true", help="Build and push all services defined in the mapping.")
+    
+    # Tag parameter
+    parser.add_argument("--tag", required=True, help="The tag to apply to the Docker images.")
+    
+    args = parser.parse_args()
+
+    # 1. Determine ACR
+    acr = args.link_acr or os.environ.get("LINK_ACR")
+    if not acr:
+        print("Error: ACR must be specified via --link-acr or the LINK_ACR environment variable.", file=sys.stderr)
+        sys.exit(1)
+
+    # 2. Determine services to process
+    selected_services = []
+    if args.all_services:
+        selected_services = list(SERVICES.keys())
+    elif args.service:
+        for s in args.service:
+            if s in SERVICES:
+                selected_services.append(s)
+            else:
+                print(f"Error: Service '{s}' is not recognized. Recognized services: {', '.join(sorted(SERVICES.keys()))}", file=sys.stderr)
+                sys.exit(1)
+    else:
+        # Prompt user for each service
+        print("No services specified. Please indicate which services to build and push:")
+        for service_name in sorted(SERVICES.keys()):
+            try:
+                response = input(f"Build and push {service_name}? (y/N): ").lower()
+                if response == 'y':
+                    selected_services.append(service_name)
+            except EOFError:
+                break
+
+    if not selected_services:
+        print("No services selected. Exiting.")
+        sys.exit(0)
+
+    # 3. Build and push each service
+    for service_name in selected_services:
+        info = SERVICES[service_name]
+        repo = info["repo"]
+        dockerfile = info["dockerfile"]
+        context = info["context"]
+        
+        # Use backslashes in Dockerfile path if on Windows to match the issue description template
+        # although forward slashes generally work fine with docker CLI.
+        if os.name == 'nt':
+            dockerfile = dockerfile.replace('/', '\\')
+            context = context.replace('/', '\\')
+
+        image_tag = f"{acr}/{repo}:{args.tag}"
+        
+        print(f"\n{'='*60}")
+        print(f"Processing service: {service_name}")
+        print(f"Image: {image_tag}")
+        print(f"{'='*60}")
+        
+        # Build command
+        build_cmd = ["docker", "build", "--tag", image_tag, "-f", dockerfile, context]
+        
+        try:
+            print(f"Building {service_name}...")
+            run_command(build_cmd)
+            
+            print(f"Pushing {service_name}...")
+            push_cmd = ["docker", "push", image_tag]
+            run_command(push_cmd)
+            
+            if args.kube_namespace:
+                deployment = info["deployment"]
+                container = info["container"]
+                
+                print(f"Updating Kubernetes deployment for {service_name}...")
+                
+                # Try to output the current image before updating it
+                try:
+                    get_img_cmd = [
+                        "kubectl", "-n", args.kube_namespace, 
+                        "get", f"deployment/{deployment}", 
+                        "-o", "json"
+                    ]
+                    # We use subprocess.run directly here because we need to capture stdout
+                    result = subprocess.run(get_img_cmd, capture_output=True, text=True)
+                    if result.returncode == 0:
+                        dep_data = json.loads(result.stdout)
+                        containers = dep_data.get("spec", {}).get("template", {}).get("spec", {}).get("containers", [])
+                        current_image = next((c.get("image") for c in containers if c.get("name") == container), "Unknown")
+                        print(f"Current image: {current_image}")
+                    else:
+                        print(f"Note: Could not retrieve current image (deployment/container might not exist yet).")
+                except Exception as e:
+                    print(f"Note: Could not retrieve current image: {e}")
+
+                # Example command: kubectl -n my-namespace set image deployment/my-deployment my-container=repo/my-app:1.2.3
+                kube_cmd = [
+                    "kubectl", "-n", args.kube_namespace, 
+                    "set", "image", f"deployment/{deployment}", 
+                    f"{container}={image_tag}"
+                ]
+                run_command(kube_cmd)
+            
+        except subprocess.CalledProcessError as e:
+            print(f"Error: Command failed for {service_name} with exit code {e.returncode}", file=sys.stderr)
+            sys.exit(1)
+        except Exception as e:
+            print(f"An unexpected error occurred: {e}", file=sys.stderr)
+            sys.exit(1)
+
+    print("\nSuccessfully built and pushed all selected services.")
+
+if __name__ == "__main__":
+    main()

--- a/Tests/BackendE2ETests/AdhocReportingSmokeTest.cs
+++ b/Tests/BackendE2ETests/AdhocReportingSmokeTest.cs
@@ -392,14 +392,14 @@ public sealed class AdhocReportingSmokeTest(ITestOutputHelper output) : IAsyncLi
                 {
                     ["QueryConfigType"] = "Reference",
                     ["ResourceType"] = "Location",
-                    ["OperationType"] = 1,
+                    ["OperationType"] = 2,
                     ["Paged"] = 100
                 },
                 ["3"] = new JObject
                 {
                     ["QueryConfigType"] = "Reference",
                     ["ResourceType"] = "Medication",
-                    ["OperationType"] = 1,
+                    ["OperationType"] = 2,
                     ["Paged"] = 100
                 }
             },
@@ -561,14 +561,14 @@ public sealed class AdhocReportingSmokeTest(ITestOutputHelper output) : IAsyncLi
                 {
                     ["QueryConfigType"] = "Reference",
                     ["ResourceType"] = "Device",
-                    ["OperationType"] = 1,
+                    ["OperationType"] = 2,
                     ["Paged"] = 100
                 },
                 ["7"] = new JObject
                 {
                     ["QueryConfigType"] = "Reference",
                     ["ResourceType"] = "Specimen",
-                    ["OperationType"] = 1,
+                    ["OperationType"] = 2,
                     ["Paged"] = 100
                 }
             }
@@ -633,14 +633,14 @@ public sealed class AdhocReportingSmokeTest(ITestOutputHelper output) : IAsyncLi
                 {
                     ["QueryConfigType"] = "Reference",
                     ["ResourceType"] = "Location",
-                    ["OperationType"] = 1,
+                    ["OperationType"] = 2,
                     ["Paged"] = 100
                 },
                 ["3"] = new JObject
                 {
                     ["QueryConfigType"] = "Reference",
                     ["ResourceType"] = "Medication",
-                    ["OperationType"] = 1,
+                    ["OperationType"] = 2,
                     ["Paged"] = 100
                 }
             },
@@ -802,14 +802,14 @@ public sealed class AdhocReportingSmokeTest(ITestOutputHelper output) : IAsyncLi
                 {
                     ["QueryConfigType"] = "Reference",
                     ["ResourceType"] = "Device",
-                    ["OperationType"] = 1,
+                    ["OperationType"] = 2,
                     ["Paged"] = 100
                 },
                 ["7"] = new JObject
                 {
                     ["QueryConfigType"] = "Reference",
                     ["ResourceType"] = "Specimen",
-                    ["OperationType"] = 1,
+                    ["OperationType"] = 2,
                     ["Paged"] = 100
                 }
             }

--- a/Tests/BackendE2ETests/ApiRequests/AdHocReportApiRequests.cs
+++ b/Tests/BackendE2ETests/ApiRequests/AdHocReportApiRequests.cs
@@ -1,6 +1,7 @@
 ﻿using LantanaGroup.Link.Tests.E2ETests;
 using Newtonsoft.Json.Linq;
 using RestSharp;
+using Xunit;
 using Xunit.Abstractions;
 
 namespace LantanaGroup.Link.Tests.BackendE2ETests.ApiRequests
@@ -62,7 +63,7 @@ namespace LantanaGroup.Link.Tests.BackendE2ETests.ApiRequests
             else
             {
                 output.WriteLine("🔴  Facility was not successfully created. Create_SingleMeasureAdHocTestFacility() - FAILED");
-                Xunit.Assert.Fail();
+                Assert.Fail();
             }
         }
         public void Create_SingleMeasureCensusConfiguration_AdHoc()
@@ -100,12 +101,12 @@ namespace LantanaGroup.Link.Tests.BackendE2ETests.ApiRequests
             if (responseCodeString == "Unauthorized")
             {
                 output.WriteLine("🔴  Census was NOT successfully created. Create_SingleMeasureCensusConfiguration_AdHoc() - Please reauthenticate.");
-                Xunit.Assert.Fail();
+                Assert.Fail();
             }
             else
             {
                 output.WriteLine("🔴  Census was not successfully configured. Create_SingleMeasureCensusConfiguration_AdHoc() - FAILED");
-                Xunit.Assert.Fail();
+                Assert.Fail();
             }
         }
         public void Create_SingleMeasureQueryDispatchConfig_AdHoc()
@@ -148,12 +149,12 @@ namespace LantanaGroup.Link.Tests.BackendE2ETests.ApiRequests
             if (responseCodeString == "ServiceUnavailable")
             {
                 output.WriteLine("🔴  Config was NOT successfully created. Create_SingleMeasureQueryDispatchConfig_AdHoc() - The Service is unavailable, please alert dev team.");
-                Xunit.Assert.Fail();
+                Assert.Fail();
             }
             else
             {
                 output.WriteLine("🔴  Config was not successfully created. Create_SingleMeasureQueryDispatchConfig_AdHoc() - FAILED");
-                Xunit.Assert.Fail();
+                Assert.Fail();
             }
         }
         public void Create_SingleMeasure_FHIRQueryConfigByFacility_AdHoc()
@@ -196,17 +197,17 @@ namespace LantanaGroup.Link.Tests.BackendE2ETests.ApiRequests
             if (responseCodeString == "Unauthorized")
             {
                 output.WriteLine("🔴  Query was NOT successfully configured. Please reauthenticate. Create_SingleMeasure_FHIRQueryConfigByFacility_AdHoc() FAILED");
-                Xunit.Assert.Fail();
+                Assert.Fail();
             }
             if (responseCodeString == "ServiceUnavailable")
             {
                 output.WriteLine("🔴  Query was NOT successfully configured. The Service is unavailable, please alert dev team. Create_SingleMeasure_FHIRQueryConfigByFacility_AdHoc() FAILED");
-                Xunit.Assert.Fail();
+                Assert.Fail();
             }
             else
             {
                 output.WriteLine("🔴  Query was not successfully configured. Create_SingleMeasure_FHIRQueryConfigByFacility_AdHoc() FAILED");
-                Xunit.Assert.Fail();
+                Assert.Fail();
             }
         }
         public void Create_SingleMeasure_MontlhyQueryPlanByFacility_AdHoc()
@@ -254,7 +255,7 @@ namespace LantanaGroup.Link.Tests.BackendE2ETests.ApiRequests
                     ""1"": {
                       ""QueryConfigType"": ""Reference"",
                       ""ResourceType"": ""Location"",
-                      ""OperationType"": 1,
+                      ""OperationType"": 2,
                       ""Paged"": 100
                     }
                   },
@@ -416,19 +417,19 @@ namespace LantanaGroup.Link.Tests.BackendE2ETests.ApiRequests
                     ""7"": {
                       ""QueryConfigType"": ""Reference"",
                       ""ResourceType"": ""Medication"",
-                      ""OperationType"": 1,
+                      ""OperationType"": 2,
                       ""Paged"": 100
                     },
                     ""8"": {
                       ""QueryConfigType"": ""Reference"",
                       ""ResourceType"": ""Specimen"",
-                      ""OperationType"": 1,
+                      ""OperationType"": 2,
                       ""Paged"": 100
                     },
                     ""9"": {
                       ""QueryConfigType"": ""Reference"",
                       ""ResourceType"": ""Device"",
-                      ""OperationType"": 1,
+                      ""OperationType"": 2,
                       ""Paged"": 100
                     }
                   }
@@ -451,17 +452,17 @@ namespace LantanaGroup.Link.Tests.BackendE2ETests.ApiRequests
             if (responseCodeString == "Unauthorized")
             {
                 output.WriteLine("🔴  MONTHLY Query Plan was NOT successfully created. Please reauthenticate. Create_SingleMeasure_MontlhyQueryPlanByFacility_AdHoc() FAILED");
-                Xunit.Assert.Fail();
+                Assert.Fail();
             }
             if (responseCodeString == "ServiceUnavailable")
             {
                 output.WriteLine("🔴 MONTHLY Query Plan was NOT successfully created. The Service is unavailable, please alert dev team. Create_SingleMeasure_MontlhyQueryPlanByFacility_AdHoc() FAILED");
-                Xunit.Assert.Fail();
+                Assert.Fail();
             }
             else
             {
                 output.WriteLine("🔴  MONTHLY Query Plan was not successfully created. Create_SingleMeasure_MontlhyQueryPlanByFacility_AdHoc() FAILED");
-                Xunit.Assert.Fail();
+                Assert.Fail();
             }
         }
         public void Create_SingleMeasure_DischargeQueryPlanByFacility_AdHoc()
@@ -509,7 +510,7 @@ namespace LantanaGroup.Link.Tests.BackendE2ETests.ApiRequests
                     ""1"": {
                       ""QueryConfigType"": ""Reference"",
                       ""ResourceType"": ""Location"",
-                      ""OperationType"": 1,
+                      ""OperationType"": 2,
                       ""Paged"": 100
                     }
                   },
@@ -671,19 +672,19 @@ namespace LantanaGroup.Link.Tests.BackendE2ETests.ApiRequests
                     ""7"": {
                       ""QueryConfigType"": ""Reference"",
                       ""ResourceType"": ""Medication"",
-                      ""OperationType"": 1,
+                      ""OperationType"": 2,
                       ""Paged"": 100
                     },
                     ""8"": {
                       ""QueryConfigType"": ""Reference"",
                       ""ResourceType"": ""Specimen"",
-                      ""OperationType"": 1,
+                      ""OperationType"": 2,
                       ""Paged"": 100
                     },
                     ""9"": {
                       ""QueryConfigType"": ""Reference"",
                       ""ResourceType"": ""Device"",
-                      ""OperationType"": 1,
+                      ""OperationType"": 2,
                       ""Paged"": 100
                     }
                   }
@@ -706,17 +707,17 @@ namespace LantanaGroup.Link.Tests.BackendE2ETests.ApiRequests
             if (responseCodeString == "Unauthorized")
             {
                 output.WriteLine("🔴  Query Plan was NOT successfully created. Please reauthenticate. Create_SingleMeasure_DischargeQueryPlanByFacility_AdHoc() - FAILED");
-                Xunit.Assert.Fail();
+                Assert.Fail();
             }
             if (responseCodeString == "ServiceUnavailable")
             {
                 output.WriteLine("🔴  Query Plan was NOT successfully created. The Service is unavailable, please alert dev team. Create_SingleMeasure_DischargeQueryPlanByFacility_AdHoc() FAILED");
-                Xunit.Assert.Fail();
+                Assert.Fail();
             }
             else
             {
                 output.WriteLine("🔴  DISCHARGE Query Plan was not successfully created. Create_SingleMeasure_DischargeQueryPlanByFacility_AdHoc() FAILED");
-                Xunit.Assert.Fail();
+                Assert.Fail();
             }
         }
         public void Create_SingleMeasureFHIRQueryListByFacility_AdHoc()
@@ -785,17 +786,17 @@ namespace LantanaGroup.Link.Tests.BackendE2ETests.ApiRequests
             if (responseCodeString == "Unauthorized")
             {
                 output.WriteLine("🔴  Query List was NOT successfully created. Please reauthenticate. Create_SingleMeasureFHIRQueryListByFacility_AdHoc() FAILED");
-                Xunit.Assert.Fail();
+                Assert.Fail();
             }
             if (responseCodeString == "ServiceUnavailable")
             {
                 output.WriteLine("🔴  Query List was NOT successfully created. The Service is unavailable, please alert dev team. Create_SingleMeasureFHIRQueryListByFacility_AdHoc() FAILED");
-                Xunit.Assert.Fail();
+                Assert.Fail();
             }
             else
             {
                 output.WriteLine("🔴  Query List was not successfully created. Create_SingleMeasureFHIRQueryListByFacility_AdHoc() FAILED");
-                Xunit.Assert.Fail();
+                Assert.Fail();
             }
         }
         public void Create_SingleMeasureFacilityNormalizationConfig_AdHoc()
@@ -947,17 +948,17 @@ namespace LantanaGroup.Link.Tests.BackendE2ETests.ApiRequests
             if (responseCodeString == "Unauthorized")
             {
                 output.WriteLine("🔴  Normalization Config was NOT successfully scheduled. Please reauthenticate.");
-                Xunit.Assert.Fail();
+                Assert.Fail();
             }
             if (responseCodeString == "ServiceUnavailable")
             {
                 output.WriteLine("🔴  Normalization Config was NOT successfully scheduled. The Service is unavailable, please alert dev team.");
-                Xunit.Assert.Fail();
+                Assert.Fail();
             }
             else
             {
                 output.WriteLine("🔴  Normalization Config was not successfully configured.");
-                Xunit.Assert.Fail();
+                Assert.Fail();
             }
         }    //unused at the moment.
         public void GenerateSingleMeasureAdHocReport_ACH()
@@ -1000,17 +1001,17 @@ namespace LantanaGroup.Link.Tests.BackendE2ETests.ApiRequests
             if (responseCodeString == "Unauthorized")
             {
                 output.WriteLine("🔴  AdHoc Report was NOT successfully scheduled. GenerateSingleMeasureAdHocReport_ACH() - Please reauthenticate.");
-                Xunit.Assert.Fail();
+                Assert.Fail();
             }
             if (responseCodeString == "ServiceUnavailable")
             {
                 output.WriteLine("🔴  AdHoc Report was NOT successfully scheduled. GenerateSingleMeasureAdHocReport_ACH() - The Service is unavailable, please alert dev team.");
-                Xunit.Assert.Fail();
+                Assert.Fail();
             }
             else
             {
                 output.WriteLine("🔴  AdHoc Report was not successfully configured. GenerateSingleMeasureAdHocReport_ACH() - FAILED");
-                Xunit.Assert.Fail();
+                Assert.Fail();
             }
         }
         public void GETSingleMeasureAdHocSubmissionDownloadReport()
@@ -1036,12 +1037,12 @@ namespace LantanaGroup.Link.Tests.BackendE2ETests.ApiRequests
             if (responseCodeString == "Unauthorized")
             {
                 output.WriteLine("🔴  AdHoc report was NOT downloaded. GETSingleMeasureAdHocSubmissionDownloadReport() - Check to make sure you are properly authenticated.");
-                Xunit.Assert.Fail();
+                Assert.Fail();
             }
             if (responseCodeString == "BadRequest")
             {
                 output.WriteLine("🔴  AdHoc report was NOT downloaded. GETSingleMeasureAdHocSubmissionDownloadReport() - Please check the GETSubmissionDownloadReport request");
-                Xunit.Assert.Fail();
+                Assert.Fail();
             }
         }
         public void GETSingleMeasureAdHocFacilityValidationResultsForReport()
@@ -1092,15 +1093,15 @@ namespace LantanaGroup.Link.Tests.BackendE2ETests.ApiRequests
             if (responseCodeString == "Unauthorized")
             {
                 output.WriteLine("[ERROR] The Get Validation Report request was NOT successful. GETSingleMeasureAdHocFacilityValidationResultsForReport() - Authentication failed.");
-                Xunit.Assert.Fail("Unauthorized request.");
+                Assert.Fail("Unauthorized request.");
             }
             if (responseCodeString == "BadRequest")
             {
                 output.WriteLine("[ERROR] The Get Validation Report request was NOT successful. GETSingleMeasureAdHocFacilityValidationResultsForReport() - Please verify the request parameters.");
-                Xunit.Assert.Fail("Bad request.");
+                Assert.Fail("Bad request.");
             }
             output.WriteLine($"[ERROR] Unexpected response: {responseCodeString}");
-            Xunit.Assert.Fail($"Unexpected validation report response: {responseCodeString}");
+            Assert.Fail($"Unexpected validation report response: {responseCodeString}");
         }
         #endregion
     }


### PR DESCRIPTION
### 🛠️ Description of Changes

Update the Kafka message key for the ResourceAcquired and ResourceNormalized topics from a simple string (FacilityId) to a complex ResourceKey object containing both FacilityId and CorrelationId.

### 🧪 Testing Performed

Built and ran in docker compose. Waiting for PR check to confirm smoke test runs successfuly.

### 🧑‍🔬 Unit Testing

- [x] I have written or updated unit tests to cover my changes
- Coverage: 0.0%

### 📓 Documentation Updated

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added composite Kafka message keys containing facility ID and correlation ID for improved event tracking and correlation.

* **Updates**
  * Enhanced message handling in data acquisition, normalization, and measure evaluation services to support composite message keys for better traceability across the event processing pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->