### PR TITLE
LNK-4797: Duplicate POIs cause errors in ad hoc reports

### DIFF
--- a/DotNet/Normalization/Listeners/ResourceAcquiredListener.cs
+++ b/DotNet/Normalization/Listeners/ResourceAcquiredListener.cs
@@ -226,7 +226,7 @@ public class ResourceAcquiredListener : BackgroundService
                     {
                         _logger.LogError(ex, $"Failed to process Patient Event.");
 
-                        _transientExceptionHandler.HandleException(message, new TransientException("Normalization Exception thrown: " + ex.Message), message.Key?.FacilityId ?? string.Empty);
+                        _transientExceptionHandler.HandleException(message, new TransientException("Normalization Exception thrown: " + ex.Message, ex), message.Key?.FacilityId ?? string.Empty);
                     }
                     finally
                     {

--- a/DotNet/QueryDispatch/Listeners/PatientEventListener.cs
+++ b/DotNet/QueryDispatch/Listeners/PatientEventListener.cs
@@ -169,7 +169,7 @@ namespace LantanaGroup.Link.QueryDispatch.Listeners
 
                                     ProduceAuditEvent(auditValue, consumeResult.Message.Headers);
 
-                                    _deadLetterExceptionHandler.HandleException(consumeResult, new DeadLetterException("Query Dispatch Exception thrown: " + ex.Message), consumeResult.Message.Key);
+                                    _deadLetterExceptionHandler.HandleException(consumeResult, new DeadLetterException("Query Dispatch Exception thrown: " + ex.Message, ex), consumeResult.Message.Key);
                                     _patientEventConsumer.Commit();
 
                                     //continue;

--- a/DotNet/QueryDispatch/Listeners/ReportScheduledEventListener.cs
+++ b/DotNet/QueryDispatch/Listeners/ReportScheduledEventListener.cs
@@ -143,7 +143,7 @@ namespace LantanaGroup.Link.QueryDispatch.Listeners
 
                                     ProduceAuditEvent(auditValue, consumeResult.Message.Headers);
 
-                                    _deadLetterExceptionHandler.HandleException(consumeResult, new DeadLetterException("Query Dispatch Exception thrown: " + ex.Message), consumeResult.Message.Key);
+                                    _deadLetterExceptionHandler.HandleException(consumeResult, new DeadLetterException("Query Dispatch Exception thrown: " + ex.Message, ex), consumeResult.Message.Key);
 
                                     _reportScheduledConsumer.Commit(consumeResult);
                                 }

--- a/DotNet/Report/Listeners/GenerateReportListener.cs
+++ b/DotNet/Report/Listeners/GenerateReportListener.cs
@@ -290,7 +290,9 @@ namespace LantanaGroup.Link.Report.Listeners
                                             await GetPatientList(facilityId, startDate.Value, endDate.Value);
                                     }
 
-                    foreach (var patient in value.PatientIds)
+                    var patientIds = value.PatientIds.Distinct().ToList();
+
+                    foreach (var patient in patientIds)
                     {
                         var newEntry = new ReportEntry()
                         {
@@ -313,7 +315,7 @@ namespace LantanaGroup.Link.Report.Listeners
                         await reportEntryManager.AddAsync(newEntry, cancellationToken);
                     }
 
-                    await _dataAcqProducer.Produce(reportSchedule, value.PatientIds);
+                    await _dataAcqProducer.Produce(reportSchedule, patientIds);
                 }
             }
             catch (DeadLetterException ex)

--- a/DotNet/Report/Listeners/MeasureReportGeneratedListener.cs
+++ b/DotNet/Report/Listeners/MeasureReportGeneratedListener.cs
@@ -120,7 +120,7 @@ namespace LantanaGroup.Link.Report.Listeners
                             }
                             catch (Exception ex)
                             {
-                                _deadLetterExceptionHandler.HandleException(result, new DeadLetterException("Report - MeasureReportGenerated Exception thrown: " + ex.Message), facilityId);
+                                _deadLetterExceptionHandler.HandleException(result, new DeadLetterException("Report - MeasureReportGenerated Exception thrown: " + ex.Message, ex), facilityId);
                             }
                             finally
                             {
@@ -228,7 +228,7 @@ namespace LantanaGroup.Link.Report.Listeners
             }
             catch (Exception ex)
             {
-                throw new DeadLetterException(ex.Message);
+                throw new DeadLetterException(ex.Message, ex);
             }
 
             var elapsed = Stopwatch.GetElapsedTime(startTime);
@@ -270,7 +270,7 @@ namespace LantanaGroup.Link.Report.Listeners
             catch (Exception ex)
             {
                 _logger.LogError(ex, "An error was encountered producing a ReadyForValidation (ReportId = {reportId}, FacilityId = {facilityId}, PatientId = {patientId}).", schedule.Id.SanitizeUntrustedString(), schedule.FacilityId.SanitizeUntrustedString(), messageValue.PatientId.SanitizeUntrustedString());
-                throw new DeadLetterException(ex.Message);
+                throw new DeadLetterException(ex.Message, ex);
             }
 
         }

--- a/DotNet/Report/Listeners/PatientListsAcquiredListener.cs
+++ b/DotNet/Report/Listeners/PatientListsAcquiredListener.cs
@@ -194,7 +194,7 @@ namespace LantanaGroup.Link.Report.Listeners
             }
             catch (Exception ex)
             {
-                _deadLetterExceptionHandler.HandleException(result, new DeadLetterException("Report - PatientListsAcquired Exception thrown: " + ex.Message), facilityId);
+                _deadLetterExceptionHandler.HandleException(result, new DeadLetterException("Report - PatientListsAcquired Exception thrown: " + ex.Message, ex), facilityId);
             }
         }
 

--- a/DotNet/Shared/Application/BaseListener.cs
+++ b/DotNet/Shared/Application/BaseListener.cs
@@ -91,7 +91,7 @@ public abstract class BaseListener<MessageType, ConsumeKeyType, ConsumeValueType
                                 "Unhandled exception in listener for {ServiceName} on topic {Topic}",
                                 ServiceInformation.ServiceConfigName, this.TopicName);
 
-                            TransientExceptionHandler.HandleException(consumeResult, new TransientException($"{ServiceInformation.ServiceConfigName} Exception thrown: " + ex.Message), ExtractFacilityId(consumeResult));
+                            TransientExceptionHandler.HandleException(consumeResult, new TransientException($"{ServiceInformation.ServiceConfigName} Exception thrown: " + ex.Message, ex), ExtractFacilityId(consumeResult));
                         }
                         finally
                         {


### PR DESCRIPTION
### 🛠️ Description of Changes

Updated Report's `GenerateReportRequested` consumer to deduplicate patient IDs before persisting `reportEntry`s or producing `DataAcquisitionRequested`.

### 🧪 Testing Performed

Tested locally by passing duplicate patient IDs in the body of a `POST /api/facility/{id}/AdHocReport`.

### 🧑‍🔬 Unit Testing

- Coverage: 0.0%

N/A

### 📓 Documentation Updated

N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error messages with nested exception details for improved troubleshooting and diagnostics.
  * Added automatic deduplication of duplicate patient IDs during data processing to prevent redundant operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
