### PR TITLE
LNK-4800: fixed the http code for facility not found

### DIFF
--- a/DotNet/ServiceTests/IntegrationTests/Tenant/FacilityControllerTests.cs
+++ b/DotNet/ServiceTests/IntegrationTests/Tenant/FacilityControllerTests.cs
@@ -185,14 +185,14 @@ public class FacilityControllerTests
     }
 
     [Fact]
-    public async Task SoftDeleteFacility_FacilityNotFound_ReturnsBadRequest()
+    public async Task SoftDeleteFacility_FacilityNotFound_ReturnsNotFound()
     {
         var nonExistentFacilityId = Guid.NewGuid().ToString();
 
         var result = await _controller.SoftDeleteFacility(nonExistentFacilityId, CancellationToken.None);
 
-        var badRequestResult = Assert.IsType<BadRequestObjectResult>(result);
-        Assert.Contains("Not Found", badRequestResult.Value?.ToString());
+        var notFoundResult = Assert.IsType<NotFoundObjectResult>(result);
+        Assert.Contains("Not Found", notFoundResult.Value?.ToString());
     }
 
     [Fact]
@@ -219,14 +219,14 @@ public class FacilityControllerTests
     }
 
     [Fact]
-    public async Task RestoreFacility_FacilityNotFound_ReturnsBadRequest()
+    public async Task RestoreFacility_FacilityNotFound_ReturnsNotFound()
     {
         var nonExistentFacilityId = Guid.NewGuid().ToString();
 
         var result = await _controller.RestoreFacility(nonExistentFacilityId, CancellationToken.None);
 
-        var badRequestResult = Assert.IsType<BadRequestObjectResult>(result);
-        Assert.Contains("Not Found", badRequestResult.Value?.ToString());
+        var notFoundResult = Assert.IsType<NotFoundObjectResult>(result);
+        Assert.Contains("Not Found", notFoundResult.Value?.ToString());
     }
 
     [Fact]

--- a/DotNet/ServiceTests/IntegrationTests/Tenant/FacilityControllerTests.cs
+++ b/DotNet/ServiceTests/IntegrationTests/Tenant/FacilityControllerTests.cs
@@ -321,6 +321,66 @@ public class FacilityControllerTests
         Assert.Equal(200, objectResult.StatusCode);
     }
 
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task GenerateAdHocReport_EmptyFacilityId_ReturnsBadRequest(string facilityId)
+    {
+        var request = new AdHocReportRequest
+        {
+            ReportTypes = new List<string> { "TestReport" },
+            StartDate = DateTime.UtcNow.AddDays(-1),
+            EndDate = DateTime.UtcNow,
+            PatientIds = new List<string>(),
+            BypassSubmission = false
+        };
+
+        var result = await _controller.GenerateAdHocReport(facilityId, request);
+        var actionResult = result.Result as IActionResult;
+        var badRequestResult = Assert.IsType<BadRequestObjectResult>(actionResult);
+        Assert.Contains("FacilityId must be provided", badRequestResult.Value?.ToString());
+    }
+
+    [Fact]
+    public async Task GenerateAdHocReport_FacilityNotFound_ReturnsNotFound()
+    {
+        var request = new AdHocReportRequest
+        {
+            ReportTypes = new List<string> { "TestReport" },
+            StartDate = DateTime.UtcNow.AddDays(-1),
+            EndDate = DateTime.UtcNow,
+            PatientIds = new List<string>(),
+            BypassSubmission = false
+        };
+
+        var result = await _controller.GenerateAdHocReport(Guid.NewGuid().ToString(), request);
+        var actionResult = result.Result as IActionResult;
+        Assert.IsType<NotFoundObjectResult>(actionResult);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task RegenerateReport_EmptyFacilityId_ReturnsBadRequest(string facilityId)
+    {
+        var request = new RegenerateReportRequest { ReportId = "test-report-id", BypassSubmission = false };
+
+        var result = await _controller.RegenerateReport(facilityId, request);
+        var actionResult = result.Result as IActionResult;
+        var badRequestResult = Assert.IsType<BadRequestObjectResult>(actionResult);
+        Assert.Contains("FacilityId must be provided", badRequestResult.Value?.ToString());
+    }
+
+    [Fact]
+    public async Task RegenerateReport_FacilityNotFound_ReturnsNotFound()
+    {
+        var request = new RegenerateReportRequest { ReportId = "test-report-id", BypassSubmission = false };
+
+        var result = await _controller.RegenerateReport(Guid.NewGuid().ToString(), request);
+        var actionResult = result.Result as IActionResult;
+        Assert.IsType<NotFoundObjectResult>(actionResult);
+    }
+
     private class StubHttpMessageHandler : HttpMessageHandler
     {
         private readonly HttpResponseMessage _response;

--- a/DotNet/Tenant/Controllers/FacilityController.cs
+++ b/DotNet/Tenant/Controllers/FacilityController.cs
@@ -475,8 +475,12 @@ namespace LantanaGroup.Link.Tenant.Controllers
         [HttpPost("{facilityId}/AdHocReport")]
         public async Task<ActionResult<GenerateAdhocReportResponse>> GenerateAdHocReport(string facilityId, AdHocReportRequest request)
         {
-            if (string.IsNullOrEmpty(facilityId) ||
-                await _facilityQueries.GetAsync(facilityId, null, CancellationToken.None) == null)
+            if (string.IsNullOrWhiteSpace(facilityId))
+            {
+                return BadRequest("FacilityId must be provided.");
+            }
+
+            if (await _facilityQueries.GetAsync(facilityId, null, CancellationToken.None) == null)
             {
                 return NotFound("Facility does not exist.");
             }
@@ -569,8 +573,12 @@ namespace LantanaGroup.Link.Tenant.Controllers
         [HttpPost("{facilityId}/RegenerateReport")]
         public async Task<ActionResult<GenerateAdhocReportResponse>> RegenerateReport(string facilityId, RegenerateReportRequest request)
         {
-            if (string.IsNullOrEmpty(facilityId) ||
-                await _facilityQueries.GetAsync(facilityId, null, CancellationToken.None) == null)
+            if (string.IsNullOrWhiteSpace(facilityId))
+            {
+                return BadRequest("FacilityId must be provided.");
+            }
+
+            if (await _facilityQueries.GetAsync(facilityId, null, CancellationToken.None) == null)
             {
                 return NotFound("Facility does not exist.");
             }

--- a/DotNet/Tenant/Controllers/FacilityController.cs
+++ b/DotNet/Tenant/Controllers/FacilityController.cs
@@ -358,7 +358,7 @@ namespace LantanaGroup.Link.Tenant.Controllers
 
             if (existingModel == null)
             {
-                return BadRequest($"Facility with Id: {facilityId} Not Found");
+                return NotFound($"Facility with Id: {facilityId} Not Found");
             }
 
             try
@@ -394,7 +394,7 @@ namespace LantanaGroup.Link.Tenant.Controllers
 
             var existingModel = await _facilityQueries.GetAsync(facilityId, null, cancellationToken);
             if (existingModel == null)
-                return BadRequest($"Facility with Id: {facilityId} Not Found");
+                return NotFound($"Facility with Id: {facilityId} Not Found");
 
             try
             {
@@ -437,7 +437,7 @@ namespace LantanaGroup.Link.Tenant.Controllers
 
             var existingModel = await _facilityQueries.GetAsync(facilityId, null, cancellationToken, includeDeleted: true);
             if (existingModel == null)
-                return BadRequest($"Facility with Id: {facilityId} Not Found");
+                return NotFound($"Facility with Id: {facilityId} Not Found");
 
             try
             {
@@ -478,7 +478,7 @@ namespace LantanaGroup.Link.Tenant.Controllers
             if (string.IsNullOrEmpty(facilityId) ||
                 await _facilityQueries.GetAsync(facilityId, null, CancellationToken.None) == null)
             {
-                return BadRequest("Facility does not exist.");
+                return NotFound("Facility does not exist.");
             }
 
             if (request.ReportTypes == null || request.ReportTypes.Count == 0)
@@ -572,7 +572,7 @@ namespace LantanaGroup.Link.Tenant.Controllers
             if (string.IsNullOrEmpty(facilityId) ||
                 await _facilityQueries.GetAsync(facilityId, null, CancellationToken.None) == null)
             {
-                return BadRequest("Facility does not exist.");
+                return NotFound("Facility does not exist.");
             }
 
             if (string.IsNullOrEmpty(request.ReportId))

--- a/Web/Admin.UI/src/app/components/audit/audit-dashboard/audit-dashboard.component.ts
+++ b/Web/Admin.UI/src/app/components/audit/audit-dashboard/audit-dashboard.component.ts
@@ -76,7 +76,7 @@ export class AuditDashboardComponent implements OnInit {
   facilityFilterOptions: Record<string, string> = {};
   selectedFacilityFilter: string = 'Any';
   selectedServiceFilter: string = 'Any';
-  actionFilterOptions = ["Create", "Update", "Delete", "Query", "Submission"];
+  actionFilterOptions = ["Create", "Update", "Delete", "Query", "Submission","Restore"];
   selectedActionFilter: string = 'Any';
 
   serviceFilterOptions : Record<string, string> = {


### PR DESCRIPTION
### 🛠️ Description of Changes

Adjusted to the proper http code when facility does not exist.

### 🧪 Testing Performed

Tested locally

### 🧑‍🔬 Unit Testing

- [ ] I have written or updated unit tests to cover my changes
- Coverage: 0.0%

### 📓 Documentation Updated

Please update any relevant sections in the project documentation that were impacted by the changes in the PR.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HTTP status code accuracy for facility management operations. Requests to delete, restore, or generate reports for non-existent facilities now correctly return HTTP 404 (Not Found) instead of 400 (Bad Request), providing more precise error signaling to API clients.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->