### PR TITLE
LNK-4889: fix resource normalized error

### DIFF
--- a/Java/measureeval/src/main/java/com/lantanagroup/link/measureeval/configs/KafkaConfig.java
+++ b/Java/measureeval/src/main/java/com/lantanagroup/link/measureeval/configs/KafkaConfig.java
@@ -148,6 +148,7 @@ public class KafkaConfig {
 
         Map<Class<?>, Serializer<?>> serializers = Map.of(
                 String.class, new StringSerializer(),
+                ResourceKey.class, new JsonSerializer<>(objectMapper.constructType(ResourceKey.class), objectMapper).noTypeInfo(),
                 Object.class, new JsonSerializer<>(),
                 byte[].class, new ByteArraySerializer()
         );

--- a/Java/measureeval/src/test/java/com/lantanagroup/link/measureeval/configs/KafkaConfigTest.java
+++ b/Java/measureeval/src/test/java/com/lantanagroup/link/measureeval/configs/KafkaConfigTest.java
@@ -1,0 +1,58 @@
+package com.lantanagroup.link.measureeval.configs;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.lantanagroup.link.shared.kafka.records.ResourceKey;
+import org.apache.kafka.common.serialization.Serializer;
+import org.junit.jupiter.api.Test;
+import org.springframework.kafka.support.serializer.DelegatingByTypeSerializer;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class KafkaConfigTest {
+
+    @Test
+    void keySerializer_ShouldHandleResourceKey() {
+        KafkaConfig kafkaConfig = new KafkaConfig();
+        ObjectMapper objectMapper = new ObjectMapper();
+        
+        Serializer<?> serializer = kafkaConfig.keySerializer(objectMapper);
+        
+        assertNotNull(serializer);
+        assertTrue(serializer instanceof DelegatingByTypeSerializer);
+        
+        ResourceKey key = ResourceKey.builder()
+                .facilityId("test-facility")
+                .correlationId("test-correlation")
+                .build();
+        
+        byte[] serialized = ((Serializer<Object>) serializer).serialize("test-topic", key);
+        
+        assertNotNull(serialized);
+        assertTrue(serialized.length > 0);
+        
+        // Verify it can be deserialized back (sanity check of the JSON format)
+        try {
+            ResourceKey deserialized = objectMapper.readValue(serialized, ResourceKey.class);
+            assertEquals(key.getFacilityId(), deserialized.getFacilityId());
+            assertEquals(key.getCorrelationId(), deserialized.getCorrelationId());
+        } catch (Exception e) {
+            fail("Failed to deserialize serialized ResourceKey: " + e.getMessage());
+        }
+    }
+
+    @Test
+    void keySerializer_ShouldHandleString() {
+        KafkaConfig kafkaConfig = new KafkaConfig();
+        ObjectMapper objectMapper = new ObjectMapper();
+        
+        Serializer<?> serializer = kafkaConfig.keySerializer(objectMapper);
+        
+        String key = "test-key";
+        byte[] serialized = ((Serializer<Object>) serializer).serialize("test-topic", key);
+        
+        assertNotNull(serialized);
+        assertEquals(key, new String(serialized));
+    }
+}


### PR DESCRIPTION
### 🛠️ Description of Changes

Fix message key for resource normalized error so that the message produces to the topic.

### 🧪 Testing Performed

Local, e2e testing with cases that cause errors.
<img width="1901" height="739" alt="image" src="https://github.com/user-attachments/assets/f4ba88ad-1c9a-41e0-81cb-5a1cfa25f0f7" />


### 🧑‍🔬 Unit Testing

- [x] I have written or updated unit tests to cover my changes
- Coverage: 100.0%

### 📓 Documentation Updated

n.a



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Kafka configuration to properly handle resource key serialization within the messaging system.

* **Tests**
  * Added comprehensive testing to validate serialization and deserialization of resource keys and message data types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->