### PR TITLE
LNK-4890: Fix Measure Eval's handling of nonexistent patient

### DIFF
--- a/Java/measureeval/src/main/java/com/lantanagroup/link/measureeval/services/AbstractResourceConsumer.java
+++ b/Java/measureeval/src/main/java/com/lantanagroup/link/measureeval/services/AbstractResourceConsumer.java
@@ -230,6 +230,9 @@ public abstract class AbstractResourceConsumer<T extends AbstractResourceRecord>
                     measureReport.setId(UUID.randomUUID().toString());
                 }
             } else {
+                if (value.getQueryType() != QueryType.INITIAL) {
+                    throw new IllegalArgumentException("Unexpected empty bundle during non-initial evaluation");
+                }
                 measureReport = null;
             }
 

--- a/Java/measureeval/src/main/java/com/lantanagroup/link/measureeval/services/AbstractResourceConsumer.java
+++ b/Java/measureeval/src/main/java/com/lantanagroup/link/measureeval/services/AbstractResourceConsumer.java
@@ -223,18 +223,24 @@ public abstract class AbstractResourceConsumer<T extends AbstractResourceRecord>
                 continue;
             }
 
-            MeasureReport measureReport = evaluateMeasureService.evaluateMeasure(value.getQueryType().toString(), patientStatus, report, bundle);
-
-            if (measureReport.getIdPart() == null) {
-                measureReport.setId(UUID.randomUUID().toString());
+            MeasureReport measureReport;
+            if (bundle.hasEntry()) {
+                measureReport = evaluateMeasureService.evaluateMeasure(value.getQueryType().toString(), patientStatus, report, bundle);
+                if (measureReport.getIdPart() == null) {
+                    measureReport.setId(UUID.randomUUID().toString());
+                }
+            } else {
+                measureReport = null;
             }
 
             switch (value.getQueryType()) {
                 case INITIAL -> {
-                    updateReportability(patientStatus, report, measureReport);
+                    boolean reportable = measureReport != null && reportabilityPredicate.test(measureReport);
+                    updateReportability(patientStatus, report, reportable);
 
-                    if (!report.getReportable()) {
-                        measureReportGeneratedProducer.produceMeasureReportGeneratedRecord(patientStatus, report, measureReport, null, null);
+                    if (!reportable) {
+                        String measureReportId = measureReport == null ? UUID.randomUUID().toString() : measureReport.getIdPart();
+                        measureReportGeneratedProducer.produceMeasureReportGeneratedRecord(patientStatus, report, measureReportId, null, null);
                     }
                 }
                 case SUPPLEMENTAL -> blobStorageService.storePatientInBlobStorage(patientStatus, report, measureReport);
@@ -269,8 +275,8 @@ public abstract class AbstractResourceConsumer<T extends AbstractResourceRecord>
     private void updateReportability (
             PatientReportingEvaluationStatus patientStatus,
             PatientReportingEvaluationStatus.Report report,
-            MeasureReport measureReport) {
-        report.setReportable(reportabilityPredicate.test(measureReport));
+            boolean reportable) {
+        report.setReportable(reportable);
         patientStatusRepository.save(patientStatus);
     }
 

--- a/Java/measureeval/src/main/java/com/lantanagroup/link/measureeval/services/BlobStorageService.java
+++ b/Java/measureeval/src/main/java/com/lantanagroup/link/measureeval/services/BlobStorageService.java
@@ -105,7 +105,7 @@ public class BlobStorageService {
         }
 
         // Produce MeasureReportGenerated event
-        this.measureReportGeneratedProducer.produceMeasureReportGeneratedRecord(status, report, measureReport, patientPayloadUri, blobName);
+        this.measureReportGeneratedProducer.produceMeasureReportGeneratedRecord(status, report, measureReport.getIdPart(), patientPayloadUri, blobName);
     }
 
     private List<Resource> normalize(MeasureReport measureReport) {

--- a/Java/measureeval/src/main/java/com/lantanagroup/link/measureeval/services/MeasureReportGeneratedProducer.java
+++ b/Java/measureeval/src/main/java/com/lantanagroup/link/measureeval/services/MeasureReportGeneratedProducer.java
@@ -6,7 +6,6 @@ import com.lantanagroup.link.shared.kafka.Headers;
 import com.lantanagroup.link.shared.kafka.Topics;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.header.internals.RecordHeaders;
-import org.hl7.fhir.r4.model.MeasureReport;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -26,11 +25,11 @@ public class MeasureReportGeneratedProducer {
     public void produceMeasureReportGeneratedRecord (
             PatientReportingEvaluationStatus patientStatus,
             PatientReportingEvaluationStatus.Report report,
-            MeasureReport measureReport,
+            String measureReportId,
             String payloadUri,
             String blobName) {
 
-        if (patientStatus == null || report == null || report.getReportTrackingId() == null || measureReport == null) {
+        if (patientStatus == null || report == null || report.getReportTrackingId() == null || measureReportId == null) {
             throw new IllegalArgumentException("All parameters are required");
         }
 
@@ -52,7 +51,7 @@ public class MeasureReportGeneratedProducer {
         }
 
         MeasureReportGenerated value = new MeasureReportGenerated(
-                measureReport.getIdPart(),
+                measureReportId,
                 patientStatus.getFacilityId(),
                 report.getReportTrackingId(),
                 patientStatus.getPatientId(),

--- a/Java/measureeval/src/test/java/com/lantanagroup/link/measureeval/services/BlobStorageServiceTest.java
+++ b/Java/measureeval/src/test/java/com/lantanagroup/link/measureeval/services/BlobStorageServiceTest.java
@@ -104,7 +104,7 @@ class BlobStorageServiceTest {
         String expectedBlobName = "root/patient-patient1-type1.mr";
         verify(containerClient).getBlobClient(expectedBlobName);
         verify(blobClient).upload(any(BinaryData.class), eq(true));
-        verify(measureReportGeneratedProducer).produceMeasureReportGeneratedRecord(eq(status), eq(report), eq(measureReport), anyString(), eq(expectedBlobName));
+        verify(measureReportGeneratedProducer).produceMeasureReportGeneratedRecord(eq(status), eq(report), eq(measureReport.getIdPart()), anyString(), eq(expectedBlobName));
     }
 
     @Test

--- a/Java/measureeval/src/test/java/com/lantanagroup/link/measureeval/services/ResourceNormalizedConsumerTest.java
+++ b/Java/measureeval/src/test/java/com/lantanagroup/link/measureeval/services/ResourceNormalizedConsumerTest.java
@@ -1,0 +1,118 @@
+package com.lantanagroup.link.measureeval.services;
+
+import com.lantanagroup.link.measureeval.entities.PatientReportingEvaluationStatus;
+import com.lantanagroup.link.measureeval.entities.QueryType;
+import com.lantanagroup.link.measureeval.records.DataAcquisitionRequested;
+import com.lantanagroup.link.measureeval.records.ResourceNormalized;
+import com.lantanagroup.link.measureeval.repositories.PatientReportingEvaluationStatusRepository;
+import com.lantanagroup.link.measureeval.repositories.ResourceRepository;
+import org.hl7.fhir.r4.model.Bundle;
+import org.hl7.fhir.r4.model.MeasureReport;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.listener.ConsumerRecordRecoverer;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.Collections;
+import java.util.function.Predicate;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class ResourceNormalizedConsumerTest {
+
+    @Mock
+    private ResourceRepository resourceRepository;
+
+    @Mock
+    private PatientReportingEvaluationStatusRepository patientStatusRepository;
+
+    @Mock
+    private Predicate<MeasureReport> reportabilityPredicate;
+
+    @Mock
+    private MeasureEvalMetrics measureEvalMetrics;
+
+    @Mock
+    private KafkaTemplate<String, DataAcquisitionRequested> dataAcquisitionRequestedTemplate;
+
+    @Mock
+    private EvaluateMeasureService evaluateMeasureService;
+
+    @Mock
+    private PatientStatusBundler patientStatusBundler;
+
+    @Mock
+    private BlobStorageService blobStorageService;
+
+    @Mock
+    private ConsumerRecordRecoverer recoverer;
+
+    @Mock
+    private MeasureReportGeneratedProducer measureReportGeneratedProducer;
+
+    private AutoCloseable mocks;
+    private ResourceNormalizedConsumer consumer;
+
+    @BeforeEach
+    void setUp() {
+        mocks = MockitoAnnotations.openMocks(this);
+        consumer = new ResourceNormalizedConsumer(
+                resourceRepository,
+                patientStatusRepository,
+                reportabilityPredicate,
+                measureEvalMetrics,
+                dataAcquisitionRequestedTemplate,
+                evaluateMeasureService,
+                patientStatusBundler,
+                blobStorageService,
+                recoverer,
+                measureReportGeneratedProducer);
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        mocks.close();
+    }
+
+    @Test
+    void evaluateMeasures_initialQueryEmptyBundle_doesNotEvaluateAndProducesRecord() {
+        // Arrange
+        ResourceNormalized value = new ResourceNormalized();
+        value.setQueryType(QueryType.INITIAL);
+
+        PatientReportingEvaluationStatus.Report report = new PatientReportingEvaluationStatus.Report();
+        report.setReportable(null);
+        report.setReportTrackingId("tracking-1");
+
+        PatientReportingEvaluationStatus patientStatus = new PatientReportingEvaluationStatus();
+        patientStatus.setFacilityId("facility-1");
+        patientStatus.setCorrelationId("correlation-1");
+        patientStatus.setPatientId("patient-1");
+        patientStatus.setReports(Collections.singletonList(report));
+
+        Bundle bundle = new Bundle();
+
+        when(patientStatusRepository.save(any())).thenReturn(patientStatus);
+
+        // Act & Assert - does not throw
+        assertDoesNotThrow(() ->
+                ReflectionTestUtils.invokeMethod(consumer, "evaluateMeasures", value, patientStatus, bundle)
+        );
+
+        // Assert - evaluateMeasureService.evaluateMeasure was not called
+        verifyNoInteractions(evaluateMeasureService);
+
+        // Assert - report is not reportable
+        assertNotNull(report.getReportable());
+        assertFalse(report.getReportable());
+
+        // Assert - measureReportGeneratedProducer.produceMeasureReportGeneratedRecord was called
+        verify(measureReportGeneratedProducer).produceMeasureReportGeneratedRecord(
+                eq(patientStatus), eq(report), anyString(), isNull(), isNull());
+    }
+}


### PR DESCRIPTION
### 🛠️ Description of Changes

Handle nonexistent patient by producing a non-reportable `MeasureReportGenerated` without actually attempting to evaluate.

### 🧪 Testing Performed

Tested locally with a nonexistent patient ID.

### 🧑‍🔬 Unit Testing

- [X] I have written or updated unit tests to cover my changes
- Coverage: 66.7%

### 📓 Documentation Updated

N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved measure evaluation handling for empty data bundles to prevent unnecessary processing while ensuring accurate record generation for initial query evaluations.

* **Refactor**
  * Streamlined internal identifier management in measure report generation throughout the data processing workflow for improved code maintainability and system consistency. Enhanced efficiency in data flow between components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
