### PR TITLE
LNK-4957: Fix "Pending Validation" stuck state caused by premature Kafka offset commitment in Validation Service

### DIFF
--- a/Java/validation/src/main/java/com/lantanagroup/link/validation/services/ReadyForValidationConsumer.java
+++ b/Java/validation/src/main/java/com/lantanagroup/link/validation/services/ReadyForValidationConsumer.java
@@ -140,7 +140,16 @@ public class ReadyForValidationConsumer extends AsyncListener<ReadyForValidation
         if (correlationId != null) {
             headers.add(Headers.CORRELATION_ID, Headers.getBytes(correlationId));
         }
-        validationCompleteTemplate.send(new ProducerRecord<>(Topics.VALIDATION_COMPLETE, null, facilityId, value, headers));
+        try {
+            // Use .get() to make the send synchronous and wait for broker confirmation
+            validationCompleteTemplate.send(new ProducerRecord<>(Topics.VALIDATION_COMPLETE, null, facilityId, value, headers)).get();
+        } catch (Exception e) {
+            _logger.error("Failed to send ValidationComplete record for patient {} in report {}: {}",
+                    patientId, reportId, e.getMessage(), e);
+            // Throwing the exception ensures AsyncListener's catch block handles it
+            // (e.g., sending the source record to the Error topic)
+            throw new RuntimeException("Failed to produce ValidationComplete message", e);
+        }
     }
 
     private void produceMetrics(

--- a/Java/validation/src/test/java/com/lantanagroup/link/validation/services/ReadyForValidationConsumerTest.java
+++ b/Java/validation/src/test/java/com/lantanagroup/link/validation/services/ReadyForValidationConsumerTest.java
@@ -1,0 +1,427 @@
+package com.lantanagroup.link.validation.services;
+
+import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.parser.IParser;
+import com.azure.core.util.BinaryData;
+import com.lantanagroup.link.shared.entities.PatientSubmissionModel;
+import com.lantanagroup.link.shared.kafka.Headers;
+import com.lantanagroup.link.shared.services.ReportClient;
+import com.lantanagroup.link.validation.entities.Category;
+import com.lantanagroup.link.validation.entities.Result;
+import com.lantanagroup.link.validation.records.ReadyForValidation;
+import com.lantanagroup.link.validation.records.ValidationComplete;
+import com.lantanagroup.link.validation.repositories.ResultRepository;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.hl7.fhir.r4.model.Bundle;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.listener.ConsumerRecordRecoverer;
+import org.springframework.kafka.support.SendResult;
+
+import java.io.InputStream;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class ReadyForValidationConsumerTest {
+
+    private static final String FACILITY_ID = "facility-1";
+    private static final String PATIENT_ID = "patient-1";
+    private static final String REPORT_ID = "report-1";
+    private static final String CORRELATION_ID = "corr-123";
+    private static final String PAYLOAD_URI =
+            "https://myaccount.blob.core.windows.net/mycontainer/myfile.ndjson";
+    private static final String TOPIC = "ready-for-validation";
+
+    @Mock private FhirContext fhirContext;
+    @Mock private ReportClient reportClient;
+    @Mock private ValidationService validationService;
+    @Mock private CategorizationService categorizationService;
+    @Mock private ResultRepository resultRepository;
+    @Mock private KafkaTemplate<String, ValidationComplete> validationCompleteTemplate;
+    @Mock private ValidationMetrics validationMetrics;
+    @Mock private BlobStorageService blobStorageService;
+    @Mock private ConsumerRecordRecoverer recoverer;
+
+    private ReadyForValidationConsumer consumer;
+    private ReadyForValidationConsumer consumerWithoutBlobStorage;
+
+    private Bundle bundle;
+
+    @BeforeEach
+    @SuppressWarnings("unchecked")
+    void setUp() throws Exception {
+        consumer = new ReadyForValidationConsumer(
+                fhirContext,
+                reportClient,
+                validationService,
+                categorizationService,
+                resultRepository,
+                validationCompleteTemplate,
+                validationMetrics,
+                Optional.of(blobStorageService),
+                recoverer);
+
+        consumerWithoutBlobStorage = new ReadyForValidationConsumer(
+                fhirContext,
+                reportClient,
+                validationService,
+                categorizationService,
+                resultRepository,
+                validationCompleteTemplate,
+                validationMetrics,
+                Optional.empty(),
+                recoverer);
+
+        bundle = new Bundle();
+
+        // Default send stub: succeeds synchronously
+        CompletableFuture<SendResult<String, ValidationComplete>> future = mock(CompletableFuture.class);
+        lenient().when(validationCompleteTemplate.send(any(ProducerRecord.class))).thenReturn(future);
+        lenient().when(future.get()).thenReturn(null);
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    private ConsumerRecord<ReadyForValidation.Key, ReadyForValidation> buildRecord(String payloadUri) {
+        return buildRecord(payloadUri, false);
+    }
+
+    private ConsumerRecord<ReadyForValidation.Key, ReadyForValidation> buildRecord(
+            String payloadUri, boolean withCorrelationId) {
+        ReadyForValidation.Key key = new ReadyForValidation.Key();
+        key.setFacilityId(FACILITY_ID);
+
+        ReadyForValidation value = new ReadyForValidation();
+        value.setPatientId(PATIENT_ID);
+        value.setReportTrackingId(REPORT_ID);
+        value.setPayloadUri(payloadUri);
+
+        ConsumerRecord<ReadyForValidation.Key, ReadyForValidation> record =
+                new ConsumerRecord<>(TOPIC, 0, 0L, key, value);
+
+        if (withCorrelationId) {
+            record.headers().add(Headers.CORRELATION_ID, Headers.getBytes(CORRELATION_ID));
+        }
+        return record;
+    }
+
+    /** Stubs reportClient to return a PatientSubmissionModel containing the shared bundle. */
+    private void stubRestRetrieval() throws Exception {
+        PatientSubmissionModel model = new PatientSubmissionModel();
+        model.setBundle(bundle);
+        when(reportClient.getSubmissionModel(FACILITY_ID, PATIENT_ID, REPORT_ID)).thenReturn(model);
+    }
+
+    /** Creates a Result with the given Category already populated (not null). */
+    private Result resultWithCategories(List<Category> categories) {
+        Result result = new Result();
+        result.setCategories(categories);
+        return result;
+    }
+
+    private Category categoryWithAcceptable(boolean acceptable) {
+        Category category = new Category();
+        category.setId(acceptable ? "acceptable-cat" : "unacceptable-cat");
+        category.setAcceptable(acceptable);
+        return category;
+    }
+
+    // -------------------------------------------------------------------------
+    // Bundle retrieval: Blob Storage
+    // -------------------------------------------------------------------------
+
+    @Test
+    void process_withPayloadUri_downloadsBundleFromBlobStorage() throws Exception {
+        IParser parser = mock(IParser.class);
+        when(fhirContext.newNDJsonParser()).thenReturn(parser);
+        when(parser.parseResource(eq(Bundle.class), (InputStream) any())).thenReturn(bundle);
+        when(blobStorageService.download("myfile.ndjson"))
+                .thenReturn(BinaryData.fromBytes(new byte[0]));
+        when(validationService.validate(bundle)).thenReturn(Collections.emptyList());
+
+        consumer.process(buildRecord(PAYLOAD_URI));
+
+        verify(blobStorageService).download("myfile.ndjson");
+        verify(reportClient, never()).getSubmissionModel(any(), any(), any());
+    }
+
+    @Test
+    void process_withPayloadUri_parsesDownloadedDataAsNdJson() throws Exception {
+        IParser parser = mock(IParser.class);
+        when(fhirContext.newNDJsonParser()).thenReturn(parser);
+        when(parser.parseResource(eq(Bundle.class), (InputStream) any())).thenReturn(bundle);
+        when(blobStorageService.download(anyString()))
+                .thenReturn(BinaryData.fromBytes(new byte[0]));
+        when(validationService.validate(bundle)).thenReturn(Collections.emptyList());
+
+        consumer.process(buildRecord(PAYLOAD_URI));
+
+        verify(parser).parseResource(eq(Bundle.class), (InputStream) any());
+    }
+
+    // -------------------------------------------------------------------------
+    // Bundle retrieval: REST fallback
+    // -------------------------------------------------------------------------
+
+    @Test
+    void process_withNullPayloadUri_fetchesBundleViaRest() throws Exception {
+        stubRestRetrieval();
+        when(validationService.validate(bundle)).thenReturn(Collections.emptyList());
+
+        consumer.process(buildRecord(null));
+
+        verify(reportClient).getSubmissionModel(FACILITY_ID, PATIENT_ID, REPORT_ID);
+        verify(blobStorageService, never()).download(anyString());
+    }
+
+    @Test
+    void process_withPayloadUriButNoBlobService_fetchesBundleViaRest() throws Exception {
+        stubRestRetrieval();
+        when(validationService.validate(bundle)).thenReturn(Collections.emptyList());
+
+        consumerWithoutBlobStorage.process(buildRecord(PAYLOAD_URI));
+
+        verify(reportClient).getSubmissionModel(FACILITY_ID, PATIENT_ID, REPORT_ID);
+        verify(blobStorageService, never()).download(anyString());
+    }
+
+    @Test
+    void process_reportClientThrows_exceptionPropagates() {
+        RuntimeException cause = new RuntimeException("REST error");
+        when(reportClient.getSubmissionModel(FACILITY_ID, PATIENT_ID, REPORT_ID)).thenThrow(cause);
+
+        RuntimeException thrown = assertThrows(RuntimeException.class,
+                () -> consumer.process(buildRecord(null)));
+
+        assertSame(cause, thrown);
+    }
+
+    // -------------------------------------------------------------------------
+    // Validation and persistence
+    // -------------------------------------------------------------------------
+
+    @Test
+    void process_callsValidationServiceWithBundle() throws Exception {
+        stubRestRetrieval();
+        when(validationService.validate(bundle)).thenReturn(Collections.emptyList());
+
+        consumer.process(buildRecord(null));
+
+        verify(validationService).validate(bundle);
+    }
+
+    @Test
+    void process_setsContextFieldsOnEachResult() throws Exception {
+        Result result = resultWithCategories(Collections.emptyList());
+        stubRestRetrieval();
+        when(validationService.validate(bundle)).thenReturn(List.of(result));
+
+        consumer.process(buildRecord(null));
+
+        assertEquals(FACILITY_ID, result.getFacilityId());
+        assertEquals(PATIENT_ID, result.getPatientId());
+        assertEquals(REPORT_ID, result.getReportId());
+    }
+
+    @Test
+    void process_callsCategorizationServiceWithResults() throws Exception {
+        Result result = resultWithCategories(Collections.emptyList());
+        stubRestRetrieval();
+        when(validationService.validate(bundle)).thenReturn(List.of(result));
+
+        consumer.process(buildRecord(null));
+
+        verify(categorizationService).categorize(List.of(result));
+    }
+
+    @Test
+    void process_savesAllResultsToRepository() throws Exception {
+        Result result = resultWithCategories(Collections.emptyList());
+        stubRestRetrieval();
+        when(validationService.validate(bundle)).thenReturn(List.of(result));
+
+        consumer.process(buildRecord(null));
+
+        verify(resultRepository).saveAll(List.of(result));
+    }
+
+    // -------------------------------------------------------------------------
+    // ValidationComplete production
+    // -------------------------------------------------------------------------
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void process_allAcceptableCategories_producesValidationCompleteWithValidTrue() throws Exception {
+        Result result = resultWithCategories(List.of(categoryWithAcceptable(true)));
+        stubRestRetrieval();
+        when(validationService.validate(bundle)).thenReturn(List.of(result));
+
+        ArgumentCaptor<ProducerRecord<String, ValidationComplete>> captor =
+                ArgumentCaptor.forClass(ProducerRecord.class);
+        CompletableFuture<SendResult<String, ValidationComplete>> future = mock(CompletableFuture.class);
+        when(validationCompleteTemplate.send(captor.capture())).thenReturn(future);
+        when(future.get()).thenReturn(null);
+
+        consumer.process(buildRecord(null));
+
+        assertTrue(captor.getValue().value().isValid());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void process_anyUnacceptableCategory_producesValidationCompleteWithValidFalse() throws Exception {
+        Result result = resultWithCategories(List.of(categoryWithAcceptable(false)));
+        stubRestRetrieval();
+        when(validationService.validate(bundle)).thenReturn(List.of(result));
+
+        ArgumentCaptor<ProducerRecord<String, ValidationComplete>> captor =
+                ArgumentCaptor.forClass(ProducerRecord.class);
+        CompletableFuture<SendResult<String, ValidationComplete>> future = mock(CompletableFuture.class);
+        when(validationCompleteTemplate.send(captor.capture())).thenReturn(future);
+        when(future.get()).thenReturn(null);
+
+        consumer.process(buildRecord(null));
+
+        assertFalse(captor.getValue().value().isValid());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void process_noResults_producesValidationCompleteWithValidTrue() throws Exception {
+        stubRestRetrieval();
+        when(validationService.validate(bundle)).thenReturn(Collections.emptyList());
+
+        ArgumentCaptor<ProducerRecord<String, ValidationComplete>> captor =
+                ArgumentCaptor.forClass(ProducerRecord.class);
+        CompletableFuture<SendResult<String, ValidationComplete>> future = mock(CompletableFuture.class);
+        when(validationCompleteTemplate.send(captor.capture())).thenReturn(future);
+        when(future.get()).thenReturn(null);
+
+        consumer.process(buildRecord(null));
+
+        assertTrue(captor.getValue().value().isValid());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void process_validationCompleteContainsPatientIdAndReportId() throws Exception {
+        stubRestRetrieval();
+        when(validationService.validate(bundle)).thenReturn(Collections.emptyList());
+
+        ArgumentCaptor<ProducerRecord<String, ValidationComplete>> captor =
+                ArgumentCaptor.forClass(ProducerRecord.class);
+        CompletableFuture<SendResult<String, ValidationComplete>> future = mock(CompletableFuture.class);
+        when(validationCompleteTemplate.send(captor.capture())).thenReturn(future);
+        when(future.get()).thenReturn(null);
+
+        consumer.process(buildRecord(null));
+
+        ValidationComplete vc = captor.getValue().value();
+        assertEquals(PATIENT_ID, vc.getPatientId());
+        assertEquals(REPORT_ID, vc.getReportTrackingId());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void process_validationCompleteKeyIsSetToFacilityId() throws Exception {
+        stubRestRetrieval();
+        when(validationService.validate(bundle)).thenReturn(Collections.emptyList());
+
+        ArgumentCaptor<ProducerRecord<String, ValidationComplete>> captor =
+                ArgumentCaptor.forClass(ProducerRecord.class);
+        CompletableFuture<SendResult<String, ValidationComplete>> future = mock(CompletableFuture.class);
+        when(validationCompleteTemplate.send(captor.capture())).thenReturn(future);
+        when(future.get()).thenReturn(null);
+
+        consumer.process(buildRecord(null));
+
+        assertEquals(FACILITY_ID, captor.getValue().key());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void process_kafkaSendThrows_throwsRuntimeExceptionWithMessage() throws Exception {
+        stubRestRetrieval();
+        when(validationService.validate(bundle)).thenReturn(Collections.emptyList());
+
+        CompletableFuture<SendResult<String, ValidationComplete>> future = mock(CompletableFuture.class);
+        when(validationCompleteTemplate.send(any(ProducerRecord.class))).thenReturn(future);
+        when(future.get()).thenThrow(new RuntimeException("broker unavailable"));
+
+        RuntimeException thrown = assertThrows(RuntimeException.class,
+                () -> consumer.process(buildRecord(null)));
+
+        assertTrue(thrown.getMessage().contains("Failed to produce ValidationComplete message"));
+    }
+
+    // -------------------------------------------------------------------------
+    // Correlation ID header propagation
+    // -------------------------------------------------------------------------
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void process_withCorrelationId_includesCorrelationIdHeaderInProducedRecord() throws Exception {
+        stubRestRetrieval();
+        when(validationService.validate(bundle)).thenReturn(Collections.emptyList());
+
+        ArgumentCaptor<ProducerRecord<String, ValidationComplete>> captor =
+                ArgumentCaptor.forClass(ProducerRecord.class);
+        CompletableFuture<SendResult<String, ValidationComplete>> future = mock(CompletableFuture.class);
+        when(validationCompleteTemplate.send(captor.capture())).thenReturn(future);
+        when(future.get()).thenReturn(null);
+
+        consumer.process(buildRecord(null, true));
+
+        org.apache.kafka.common.header.Header header =
+                captor.getValue().headers().lastHeader(Headers.CORRELATION_ID);
+        assertNotNull(header, "Expected correlation ID header to be present");
+        assertEquals(CORRELATION_ID, Headers.getString(header.value()));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void process_withoutCorrelationId_doesNotIncludeCorrelationIdHeader() throws Exception {
+        stubRestRetrieval();
+        when(validationService.validate(bundle)).thenReturn(Collections.emptyList());
+
+        ArgumentCaptor<ProducerRecord<String, ValidationComplete>> captor =
+                ArgumentCaptor.forClass(ProducerRecord.class);
+        CompletableFuture<SendResult<String, ValidationComplete>> future = mock(CompletableFuture.class);
+        when(validationCompleteTemplate.send(captor.capture())).thenReturn(future);
+        when(future.get()).thenReturn(null);
+
+        consumer.process(buildRecord(null, false));
+
+        assertNull(captor.getValue().headers().lastHeader(Headers.CORRELATION_ID));
+    }
+
+    // -------------------------------------------------------------------------
+    // Metrics
+    // -------------------------------------------------------------------------
+
+    @Test
+    void process_alwaysRecordsMetrics() throws Exception {
+        stubRestRetrieval();
+        when(validationService.validate(bundle)).thenReturn(Collections.emptyList());
+
+        consumer.process(buildRecord(null));
+
+        verify(validationMetrics).addToValidationCounter(any());
+        verify(validationMetrics).recordValidationDuration(anyLong(), any());
+    }
+}


### PR DESCRIPTION
### 🛠️ Description of Changes

Update the produceValidationCompleteRecord method to block on the send() result. This ensures error logging when the message cannot be produced due to network issues or the kafka broker being offline.

### 🧪 Testing Performed

Verified normal operation. Shut down the Kafka broker and observed the catch block being run.

### 🧑‍🔬 Unit Testing

- [x] I have written or updated unit tests to cover my changes
- Coverage: 100.0%

### 📓 Documentation Updated

None



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced validation completion message delivery reliability by implementing broker confirmation before proceeding.
  * Improved error handling with detailed diagnostic logging for validation failures, ensuring proper error propagation.

* **Tests**
  * Added comprehensive test coverage for validation completion including multiple data source configurations, message semantics, and error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->