### PR TITLE
LNK-5007: Implement Stalled Processing Logs Reset

### DIFF
--- a/DotNet/DataAcquisition.Domain/Application/Queries/DataAcquisitionLogQueries.cs
+++ b/DotNet/DataAcquisition.Domain/Application/Queries/DataAcquisitionLogQueries.cs
@@ -92,6 +92,8 @@ public interface IDataAcquisitionLogQueries
 
     Task<int> FailStalledQueuedLogsAsync(int stallMinutes, int maxBatches = 20, CancellationToken cancellationToken = default);
 
+    Task<int> ResetStalledProcessingLogsAsync(int stallMinutes, int maxBatches = 20, CancellationToken cancellationToken = default);
+    
     Task<DataAcquisitionLogModel?> UpdateAsync(UpdateDataAcquisitionLogModel updateLog,
         CancellationToken cancellationToken = default);
 }
@@ -432,6 +434,21 @@ public class DataAcquisitionLogQueries : IDataAcquisitionLogQueries
                 .ExecuteUpdateAsync(setters => setters
                     .SetProperty(l => l.Status, RequestStatus.Failed)
                     .SetProperty(l => l.ModifyDate, DateTime.UtcNow),
+                    cancellationToken);
+        });
+    }
+    
+    public async Task<int> ResetStalledProcessingLogsAsync(int stallMinutes, int maxBatches = 20, CancellationToken cancellationToken = default)
+    {
+        var stallThreshold = DateTime.UtcNow.AddMinutes(-stallMinutes);
+
+        return await _deadlockRetryPolicy.ExecuteAsync(async () =>
+        {
+            return await _dbContext.DataAcquisitionLogs
+                .Where(l => l.Status == RequestStatus.Processing && l.ModifyDate <= stallThreshold)
+                .ExecuteUpdateAsync(setters => setters
+                        .SetProperty(l => l.Status, RequestStatus.Pending)
+                        .SetProperty(l => l.ModifyDate, DateTime.UtcNow),
                     cancellationToken);
         });
     }

--- a/DotNet/DataAcquisition.Domain/Application/Queries/DataAcquisitionLogQueries.cs
+++ b/DotNet/DataAcquisition.Domain/Application/Queries/DataAcquisitionLogQueries.cs
@@ -424,33 +424,79 @@ public class DataAcquisitionLogQueries : IDataAcquisitionLogQueries
     public async Task<int> FailStalledQueuedLogsAsync(int stallMinutes, int maxBatches = 20, CancellationToken cancellationToken = default)
     {
         var stallThreshold = DateTime.UtcNow.AddMinutes(-stallMinutes);
+        int totalUpdated = 0;
+        int batchesProcessed = 0;
+        const int BatchSize = 100;
 
-        // High-speed bulk update without fetching entities or using transactions.
-        // This avoids LINQ translation errors with JSON collections and minimizes lock duration.
-        return await _deadlockRetryPolicy.ExecuteAsync(async () =>
+        while (batchesProcessed < maxBatches)
         {
-            return await _dbContext.DataAcquisitionLogs
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var batchIds = await _dbContext.DataAcquisitionLogs
                 .Where(l => l.Status == RequestStatus.Queued && l.ModifyDate <= stallThreshold)
-                .ExecuteUpdateAsync(setters => setters
-                    .SetProperty(l => l.Status, RequestStatus.Failed)
-                    .SetProperty(l => l.ModifyDate, DateTime.UtcNow),
-                    cancellationToken);
-        });
+                .OrderBy(l => l.Id)
+                .Select(l => l.Id)
+                .Take(BatchSize)
+                .ToListAsync(cancellationToken);
+
+            if (batchIds.Count == 0)
+                break;
+
+            totalUpdated += await _deadlockRetryPolicy.ExecuteAsync(async () =>
+            {
+                return await _dbContext.DataAcquisitionLogs
+                    .Where(l => batchIds.Contains(l.Id))
+                    .ExecuteUpdateAsync(setters => setters
+                        .SetProperty(l => l.Status, RequestStatus.Failed)
+                        .SetProperty(l => l.ModifyDate, DateTime.UtcNow),
+                        cancellationToken);
+            });
+
+            batchesProcessed++;
+            if (batchIds.Count < BatchSize)
+                break;
+        }
+
+        return totalUpdated;
     }
     
     public async Task<int> ResetStalledProcessingLogsAsync(int stallMinutes, int maxBatches = 20, CancellationToken cancellationToken = default)
     {
         var stallThreshold = DateTime.UtcNow.AddMinutes(-stallMinutes);
+        int totalUpdated = 0;
+        int batchesProcessed = 0;
+        const int BatchSize = 100;
 
-        return await _deadlockRetryPolicy.ExecuteAsync(async () =>
+        while (batchesProcessed < maxBatches)
         {
-            return await _dbContext.DataAcquisitionLogs
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var batchIds = await _dbContext.DataAcquisitionLogs
                 .Where(l => l.Status == RequestStatus.Processing && l.ModifyDate <= stallThreshold)
-                .ExecuteUpdateAsync(setters => setters
-                        .SetProperty(l => l.Status, RequestStatus.Pending)
-                        .SetProperty(l => l.ModifyDate, DateTime.UtcNow),
-                    cancellationToken);
-        });
+                .OrderBy(l => l.Id)
+                .Select(l => l.Id)
+                .Take(BatchSize)
+                .ToListAsync(cancellationToken);
+
+            if (batchIds.Count == 0)
+                break;
+
+            totalUpdated += await _deadlockRetryPolicy.ExecuteAsync(async () =>
+            {
+                return await _dbContext.DataAcquisitionLogs
+                    .Where(l => batchIds.Contains(l.Id))
+                    .ExecuteUpdateAsync(setters => setters
+                            .SetProperty(l => l.Status, RequestStatus.Pending)
+                            .SetProperty(l => l.ModifyDate, DateTime.UtcNow),
+                        cancellationToken);
+            });
+
+            batchesProcessed++;
+            if (batchIds.Count < BatchSize)
+                break;
+        }
+
+        return totalUpdated;
     }
 
     public async Task<PagedConfigModel<DataAcquisitionLogModel>> SearchAsync(SearchDataAcquisitionLogRequest model,

--- a/DotNet/DataAcquisition.Domain/Settings/AcquisitionWorkerProcessorSettings.cs
+++ b/DotNet/DataAcquisition.Domain/Settings/AcquisitionWorkerProcessorSettings.cs
@@ -13,4 +13,6 @@ public class AcquisitionWorkerProcessorSettings
     public int MaxBatchesPerFacilityPerRun { get; set; } = 40;
     public int MaxBatchesFailStalledPerRun { get; set; } = 20;
     public int TimeBudgetPerRunSeconds { get; set; } = 20;
+    public int StalledQueuedThresholdMinutes { get; set; } = 15;
+    public int StalledProcessingThresholdMinutes { get; set; } = 240;
 }

--- a/DotNet/DataAcquisition/Jobs/AcquisitionProcessingJob.cs
+++ b/DotNet/DataAcquisition/Jobs/AcquisitionProcessingJob.cs
@@ -64,6 +64,11 @@ public class AcquisitionProcessingJob : IJob
                 _logger.LogInformation("Successfully failed {count} stalled queued logs.", failedCount);
             }
         }
+        catch (OperationCanceledException)
+        {
+            _logger.LogInformation("Failing stalled queued logs operation was cancelled.");
+            throw;
+        }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Error occurred while failing stalled queued logs.");
@@ -83,6 +88,11 @@ public class AcquisitionProcessingJob : IJob
             {
                 _logger.LogInformation("Successfully reset {count} stalled processing logs to Pending.", resetCount);
             }
+        }
+        catch (OperationCanceledException)
+        {
+            _logger.LogInformation("Resetting stalled processing logs operation was cancelled.");
+            throw;
         }
         catch (Exception ex)
         {
@@ -104,6 +114,11 @@ public class AcquisitionProcessingJob : IJob
             {
                 await ProcessFacilityPendingLogs(facilityId, stopwatch, cancellationToken);
             });
+        }
+        catch (OperationCanceledException)
+        {
+            _logger.LogInformation("Processing pending logs operation was cancelled.");
+            throw;
         }
         catch (Exception ex)
         {
@@ -366,6 +381,11 @@ public class AcquisitionProcessingJob : IJob
                         message.CorrelationId,
                         message.ResourceAcquired.ScheduledReports.FirstOrDefault()?.ReportTrackingId?.ToString() ?? "",
                         cancellationToken);
+                }
+                catch (OperationCanceledException)
+                {
+                    _logger.LogInformation("Processing tailing message for facility {facilityId} was cancelled.", message.FacilityId?.SanitizeUntrustedString());
+                    throw;
                 }
                 catch (Exception ex)
                 {

--- a/DotNet/DataAcquisition/Jobs/AcquisitionProcessingJob.cs
+++ b/DotNet/DataAcquisition/Jobs/AcquisitionProcessingJob.cs
@@ -46,6 +46,7 @@ public class AcquisitionProcessingJob : IJob
     {
         var stopwatch = Stopwatch.StartNew();
         await FailStalledQueuedLogs(context.CancellationToken);
+        await ResetStalledProcessingLogs(context.CancellationToken);
         await ProcessPendingLogs(stopwatch, context.CancellationToken);
         await ProcessPendingTailingMessages(context.CancellationToken);
     }
@@ -57,8 +58,7 @@ public class AcquisitionProcessingJob : IJob
             using var scope = _serviceScopeFactory.CreateScope();
             var dataAcquisitionLogQueries = scope.ServiceProvider.GetRequiredService<IDataAcquisitionLogQueries>();
 
-            int failedCount = await dataAcquisitionLogQueries.FailStalledQueuedLogsAsync(15, _settings.MaxBatchesFailStalledPerRun, cancellationToken);
-
+            int failedCount = await dataAcquisitionLogQueries.FailStalledQueuedLogsAsync(_settings.StalledQueuedThresholdMinutes, _settings.MaxBatchesFailStalledPerRun, cancellationToken);
             if (failedCount > 0)
             {
                 _logger.LogInformation("Successfully failed {count} stalled queued logs.", failedCount);
@@ -67,6 +67,26 @@ public class AcquisitionProcessingJob : IJob
         catch (Exception ex)
         {
             _logger.LogError(ex, "Error occurred while failing stalled queued logs.");
+        }
+    }
+    
+    private async Task ResetStalledProcessingLogs(CancellationToken cancellationToken)
+    {
+        try
+        {
+            using var scope = _serviceScopeFactory.CreateScope();
+            var dataAcquisitionLogQueries = scope.ServiceProvider.GetRequiredService<IDataAcquisitionLogQueries>();
+
+            int resetCount = await dataAcquisitionLogQueries.ResetStalledProcessingLogsAsync(_settings.StalledProcessingThresholdMinutes, _settings.MaxBatchesFailStalledPerRun, cancellationToken);
+
+            if (resetCount > 0)
+            {
+                _logger.LogInformation("Successfully reset {count} stalled processing logs to Pending.", resetCount);
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error occurred while resetting stalled processing logs.");
         }
     }
 

--- a/DotNet/ServiceTests/IntegrationTests/DataAcquisition/Queries/DataAcquisitionLogQueriesTests.cs
+++ b/DotNet/ServiceTests/IntegrationTests/DataAcquisition/Queries/DataAcquisitionLogQueriesTests.cs
@@ -8,6 +8,7 @@ using Microsoft.Extensions.DependencyInjection;
 using RequestStatus = LantanaGroup.Link.DataAcquisition.Domain.Infrastructure.Models.Enums.RequestStatus;
 using ResourceType = LantanaGroup.Link.DataAcquisition.Domain.Infrastructure.Models.Enums.ResourceType;
 using Task = System.Threading.Tasks.Task;
+using Microsoft.EntityFrameworkCore;
 
 namespace IntegrationTests.DataAcquisition.Queries;
 
@@ -1327,5 +1328,79 @@ public class DataAcquisitionLogQueriesTests : IClassFixture<DataAcquisitionInteg
         // Refresh recent log from DB
         await dbContext.Entry(recentLog).ReloadAsync();
         Assert.Equal(RequestStatus.Processing, recentLog.Status);
+    }
+
+    [Fact]
+    public async Task FailStalledQueuedLogsAsync_RespectsMaxBatches()
+    {
+        // Arrange
+        using var scope = _fixture.ServiceProvider.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<DataAcquisitionDbContext>();
+
+        // Reset database for this test
+        await dbContext.Database.EnsureDeletedAsync();
+        await dbContext.Database.EnsureCreatedAsync();
+
+        var stallMinutes = 15;
+        var stalledDate = DateTime.UtcNow.AddMinutes(-(stallMinutes + 1));
+
+        // Create 250 stalled logs (BatchSize is 100)
+        var stalledLogs = Enumerable.Range(1, 250).Select(i => new DataAcquisitionLog
+        {
+            FacilityId = "TestFacility",
+            Status = RequestStatus.Queued,
+            ModifyDate = stalledDate
+        }).ToList();
+
+        dbContext.DataAcquisitionLogs.AddRange(stalledLogs);
+        await dbContext.SaveChangesAsync();
+
+        var queries = scope.ServiceProvider.GetRequiredService<IDataAcquisitionLogQueries>();
+
+        // Act - request only 1 batch (should update exactly 100)
+        int rowsAffected = await queries.FailStalledQueuedLogsAsync(stallMinutes, maxBatches: 1);
+
+        // Assert
+        Assert.Equal(100, rowsAffected);
+        
+        var failedCount = await dbContext.DataAcquisitionLogs.CountAsync(l => l.Status == RequestStatus.Failed);
+        Assert.Equal(100, failedCount);
+    }
+
+    [Fact]
+    public async Task ResetStalledProcessingLogsAsync_RespectsMaxBatches()
+    {
+        // Arrange
+        using var scope = _fixture.ServiceProvider.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<DataAcquisitionDbContext>();
+
+        // Reset database for this test
+        await dbContext.Database.EnsureDeletedAsync();
+        await dbContext.Database.EnsureCreatedAsync();
+
+        var stallMinutes = 240;
+        var stalledDate = DateTime.UtcNow.AddMinutes(-(stallMinutes + 1));
+
+        // Create 250 stalled logs (BatchSize is 100)
+        var stalledLogs = Enumerable.Range(1, 250).Select(i => new DataAcquisitionLog
+        {
+            FacilityId = "TestFacility",
+            Status = RequestStatus.Processing,
+            ModifyDate = stalledDate
+        }).ToList();
+
+        dbContext.DataAcquisitionLogs.AddRange(stalledLogs);
+        await dbContext.SaveChangesAsync();
+
+        var queries = scope.ServiceProvider.GetRequiredService<IDataAcquisitionLogQueries>();
+
+        // Act - request only 2 batches (should update exactly 200)
+        int rowsAffected = await queries.ResetStalledProcessingLogsAsync(stallMinutes, maxBatches: 2);
+
+        // Assert
+        Assert.Equal(200, rowsAffected);
+
+        var pendingCount = await dbContext.DataAcquisitionLogs.CountAsync(l => l.Status == RequestStatus.Pending);
+        Assert.Equal(200, pendingCount);
     }
 }

--- a/DotNet/ServiceTests/IntegrationTests/DataAcquisition/Queries/DataAcquisitionLogQueriesTests.cs
+++ b/DotNet/ServiceTests/IntegrationTests/DataAcquisition/Queries/DataAcquisitionLogQueriesTests.cs
@@ -1277,4 +1277,55 @@ public class DataAcquisitionLogQueriesTests : IClassFixture<DataAcquisitionInteg
         Assert.Equal(RequestStatus.Queued, recentLog.Status);
         Assert.Single(recentLog.Notes);
     }
+    
+    [Fact]
+    public async Task ResetStalledProcessingLogsAsync_ResetsStalledLogs()
+    {
+        // Arrange
+        using var scope = _fixture.ServiceProvider.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<DataAcquisitionDbContext>();
+
+        // Reset database for this test
+        await dbContext.Database.EnsureDeletedAsync();
+        await dbContext.Database.EnsureCreatedAsync();
+
+        var stallMinutes = 240;
+        var stalledDate = DateTime.UtcNow.AddMinutes(-(stallMinutes + 1));
+        var recentDate = DateTime.UtcNow;
+
+        var stalledLog = new DataAcquisitionLog
+        {
+            FacilityId = "TestFacility",
+            Status = RequestStatus.Processing,
+            ModifyDate = stalledDate,
+            Notes = new List<string> { "Processing started" }
+        };
+
+        var recentLog = new DataAcquisitionLog
+        {
+            FacilityId = "TestFacility",
+            Status = RequestStatus.Processing,
+            ModifyDate = recentDate,
+            Notes = new List<string> { "Processing started" }
+        };
+
+        dbContext.DataAcquisitionLogs.AddRange(stalledLog, recentLog);
+        await dbContext.SaveChangesAsync();
+
+        var queries = scope.ServiceProvider.GetRequiredService<IDataAcquisitionLogQueries>();
+
+        // Act
+        int rowsAffected = await queries.ResetStalledProcessingLogsAsync(stallMinutes);
+
+        // Assert
+        Assert.Equal(1, rowsAffected);
+
+        // Refresh stalled log from DB
+        await dbContext.Entry(stalledLog).ReloadAsync();
+        Assert.Equal(RequestStatus.Pending, stalledLog.Status);
+
+        // Refresh recent log from DB
+        await dbContext.Entry(recentLog).ReloadAsync();
+        Assert.Equal(RequestStatus.Processing, recentLog.Status);
+    }
 }


### PR DESCRIPTION
### 🛠️ Description of Changes

This PR introduces a mechanism to identify and handle "stalled" data acquisition logs within the AcquisitionProcessingJob. This ensures that logs which have been stuck in a transient state (Queued or Processing) for too long are either failed or reset to allow for reprocessing.
• Stalled Queued Logs: Added FailStalledQueuedLogsAsync to DataAcquisitionLogQueries to bulk-update logs stuck in Queued status beyond a configured threshold to Failed.
• Stalled Processing Logs: Added ResetStalledProcessingLogsAsync to DataAcquisitionLogQueries to bulk-update logs stuck in Processing status beyond a configured threshold back to Pending.
• Job Execution: Updated AcquisitionProcessingJob to execute these cleanup tasks at the beginning of each run.
• Bulk Updates: Utilized ExecuteUpdateAsync for high-performance bulk updates, bypassing entity tracking and minimizing database lock duration.
• Retry Logic: Applied _deadlockRetryPolicy to both new query methods to improve resilience against database deadlocks.

### 🧪 Testing Performed

• Verified that AcquisitionProcessingJob correctly calls the new cleanup methods.
• Validated that FailStalledQueuedLogsAsync updates only the logs that meet the status (Queued) and time threshold criteria.
• Validated that ResetStalledProcessingLogsAsync updates only the logs that meet the status (Processing) and time threshold criteria.
• Integration tests were updated/added in DataAcquisitionLogQueriesTests.cs (e.g., ResetStalledProcessingLogsAsync_ResetsStalledLogs).

### 🧑‍🔬 Unit Testing

- Coverage: 0.0%

• [x] I have written or updated unit tests to cover my changes

### 📓 Documentation Updated

• N/A (The changes are internal to the data acquisition processing logic and do not affect external API contracts).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic detection and recovery for data acquisition logs stuck in processing state; affected logs are reset to pending for reprocessing.

* **Configuration**
  * Introduced configurable thresholds for stalled log detection: queued logs (default 15 minutes) and processing logs (default 240 minutes).

* **Tests**
  * Added integration tests for stalled log recovery functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
