### PR TITLE
LNK-4949: Kafka Topic ResourceAcquired Max Message Size

### DIFF
--- a/topics.txt
+++ b/topics.txt
@@ -37,7 +37,7 @@ ReadyToAcquire-Retry:3:1
 ReportScheduled:3:1
 ReportScheduled-Error:3:1
 ReportScheduled-Retry:3:1
-ResourceAcquired:3:1
+ResourceAcquired:3:1:max.message.bytes=10485760
 ResourceAcquired-Error:3:1
 ResourceAcquired-Retry:3:1
 ResourceNormalized:3:1


### PR DESCRIPTION
Updates the ResourceAcquired Kafka Topic max.message.bytes > 10MBs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated ResourceAcquired topic configuration to include maximum message size parameter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


### 🧑‍🔬 Unit Testing
- Coverage: 0.0%