### PR TITLE
LNK-4952: Normalization Optimizations (0.5.1 Cherry Pick)

### DIFF
--- a/DotNet/DataAcquisition.Domain/Application/Models/Kafka/ResourceAcquired.cs
+++ b/DotNet/DataAcquisition.Domain/Application/Models/Kafka/ResourceAcquired.cs
@@ -9,6 +9,7 @@ public class ResourceAcquired
     public bool AcquisitionComplete { get; set; } = false;
     public string PatientId { get; set; }
     public string QueryType { get; set; }
+    public string? ResourceType { get; set; }
     public Resource Resource { get; set; }
     public List<ScheduledReport> ScheduledReports { get; set; } = new List<ScheduledReport>();
     public ReportableEvent ReportableEvent { get; set; }

--- a/DotNet/DataAcquisition.Domain/Application/Services/BundleEventService.cs
+++ b/DotNet/DataAcquisition.Domain/Application/Services/BundleEventService.cs
@@ -51,6 +51,7 @@ public class BundleResourceAcquiredEventService : IBundleEventService<ResourceKe
                         Value = new ResourceAcquired
                         {
                             Resource = resource,
+                            ResourceType = resource.TypeName,
                             ScheduledReports = request.scheduledReports,
                             PatientId = RemovePatientId(e.Resource) ? string.Empty : request.patientId,
                             QueryType = request.queryType,

--- a/DotNet/DataAcquisition.Domain/Application/Services/FhirApi/FhirApiService.cs
+++ b/DotNet/DataAcquisition.Domain/Application/Services/FhirApi/FhirApiService.cs
@@ -25,6 +25,7 @@ using LantanaGroup.Link.Shared.Application.Utilities;
 using DateTime = System.DateTime;
 using ResourceType = Hl7.Fhir.Model.ResourceType;
 using Task = System.Threading.Tasks.Task;
+using Hl7.Fhir.Serialization;
 
 namespace LantanaGroup.Link.DataAcquisition.Domain.Application.Services.FhirApi;
 
@@ -125,6 +126,7 @@ public class FhirApiService : IFhirApiService
             await GenerateResourceAcquiredMessage(new ResourceAcquired
             {
                 Resource = resource,
+                ResourceType = resource.TypeName,
                 ScheduledReports = new List<ScheduledReport> { log.ScheduledReport },
                 PatientId = !fhirQuery.IsReference ?? false ? log.PatientId : null,
                 QueryType = log.QueryPhase.ToString(),
@@ -261,6 +263,7 @@ public class FhirApiService : IFhirApiService
                     await GenerateResourceAcquiredMessage(new ResourceAcquired
                     {
                         Resource = resource,
+                        ResourceType = resource.TypeName,
                         ScheduledReports = new List<ScheduledReport> { log.ScheduledReport },
                         PatientId = !fhirQuery.IsReference ?? false ? log.PatientId : null,
                         QueryType = log.QueryPhase.ToString(),

--- a/DotNet/Normalization/Application/Models/Messages/ResourceAcquiredMessage.cs
+++ b/DotNet/Normalization/Application/Models/Messages/ResourceAcquiredMessage.cs
@@ -1,4 +1,5 @@
 ﻿using LantanaGroup.Link.Shared.Application.Models;
+using Microsoft.EntityFrameworkCore.Query.Internal;
 
 namespace LantanaGroup.Link.Normalization.Application.Models.Messages;
 
@@ -7,6 +8,7 @@ public class ResourceAcquiredMessage
     public bool AcquisitionComplete { get; set; } = false;
     public string PatientId { get; set; }
     public string QueryType { get; set; }
+    public string? ResourceType { get; set; }
     public object Resource { get; set; }
     public string ReportableEvent { get; set; }
     public List<ScheduledReport> ScheduledReports { get; set; }

--- a/DotNet/Normalization/Application/Models/Messages/ResourceNormalizedMessage.cs
+++ b/DotNet/Normalization/Application/Models/Messages/ResourceNormalizedMessage.cs
@@ -7,7 +7,7 @@ public class ResourceNormalizedMessage
     public bool AcquisitionComplete { get; set; } = false;
     public string PatientId { get; set; }
     public string QueryType { get; set; }
-    public object Resource { get; set; }
+    public object? Resource { get; set; }
     public List<ScheduledReport> ScheduledReports { get; set; }
     public string ReportableEvent { get; set; }
 }

--- a/DotNet/Normalization/Application/Services/Operations/BaseOperationService.cs
+++ b/DotNet/Normalization/Application/Services/Operations/BaseOperationService.cs
@@ -2,14 +2,14 @@
 using LantanaGroup.Link.Normalization.Application.Models.Operations;
 using LantanaGroup.Link.Shared.Application.Error.Exceptions;
 using System.Collections.Concurrent;
+using System.Runtime.Versioning;
 using Task = System.Threading.Tasks.Task;
 
 namespace LantanaGroup.Link.Normalization.Application.Services.Operations
 {
-    public abstract class BaseOperationService<TOperation> : BackgroundService
+    public abstract class BaseOperationService<TOperation>
         where TOperation : class
     {
-        private readonly ConcurrentQueue<(TOperation Operation, DomainResource Resource, TaskCompletionSource<OperationResult> Result)> _operationQueue = new();
         private readonly TimeSpan _operationTimeout;
         protected readonly ILogger Logger;
 
@@ -19,7 +19,7 @@ namespace LantanaGroup.Link.Normalization.Application.Services.Operations
             _operationTimeout = operationTimeout ?? TimeSpan.FromSeconds(120);
         }
 
-        public async Task<OperationResult> EnqueueOperationAsync(TOperation operation, DomainResource resource)
+        public async Task<OperationResult> ProcessOperationAsync(TOperation operation, DomainResource resource)
         {
             if (operation == null)
                 return OperationResult.Failure("Operation cannot be null.");
@@ -27,55 +27,28 @@ namespace LantanaGroup.Link.Normalization.Application.Services.Operations
             if (resource == null)
                 return OperationResult.Failure("Resource cannot be null.");
 
-            var tcs = new TaskCompletionSource<OperationResult>(TaskCreationOptions.RunContinuationsAsynchronously);
-            _operationQueue.Enqueue((operation, resource, tcs));
+            var result = await ProcessOperation(operation, resource);
 
-            try
-            {
-                return await tcs.Task.WaitAsync(_operationTimeout, CancellationToken.None);
-            }
-            catch (TimeoutException tex)
-            {
-                Logger.LogError(tex, "{OperationType} operation timed out after {Timeout}.", typeof(TOperation).Name, _operationTimeout);
-                return OperationResult.Failure($"{typeof(TOperation).Name} operation timed out after {_operationTimeout}.");
-            }
-        }
-
-        protected override async Task ExecuteAsync(CancellationToken stoppingToken)
-        {
-            while (!stoppingToken.IsCancellationRequested)
-            {
-                var batch = new List<(TOperation Operation, DomainResource Resource, TaskCompletionSource<OperationResult> Result)>();
-                while (_operationQueue.TryDequeue(out var item) && batch.Count < 10)
-                    batch.Add(item);
-
-                foreach (var item in batch)
-                {
-                    var result = await ProcessOperation(item.Operation, item.Resource);
-                    item.Result.SetResult(result);
-                    if (result.SuccessCode != OperationStatus.Success)
-                        Logger.LogError("Failed {OperationType} operation: {ErrorMessage}", typeof(TOperation).Name, result.ErrorMessage);
-                }
-
-                if (batch.Count == 0)
-                    await Task.Delay(100, stoppingToken);
-            }
+            return result;
         }
 
         protected virtual async Task<OperationResult> ProcessOperation(TOperation operation, DomainResource resource)
         {
-            var resourceCopy = resource.DeepCopy() as DomainResource;
-            if (resourceCopy == null)
-                return OperationResult.Failure($"Failed to create a deep copy of the resource of type {resource.GetType().Name}.");
+            //Daniel - 4/2026: Do we need to perform a deep copy? Commented this out for now as it looks like the operations are being applied without it. 
+            //var resourceCopy = resource.DeepCopy() as DomainResource;
+            //if (resourceCopy == null)
+            //    return OperationResult.Failure($"Failed to create a deep copy of the resource of type {resource.GetType().Name}.");
 
             try
             {
-                return await ExecuteOperation(operation, resourceCopy);
+                //return await ExecuteOperation(operation, resourceCopy);
+                return await ExecuteOperation(operation, resource);
             }
             catch (Exception ex)
             {
                 Logger.LogError(ex, "Failed to process {OperationType} operation for resource type {ResourceType}.", typeof(TOperation).Name, resource.TypeName);
-                return OperationResult.Failure($"Failed to process {typeof(TOperation).Name} operation: {ex.Message}", resourceCopy);
+                //return OperationResult.Failure($"Failed to process {typeof(TOperation).Name} operation: {ex.Message}", resourceCopy);
+                return OperationResult.Failure($"Failed to process {typeof(TOperation).Name} operation: {ex.Message}", resource);
             }
         }
 

--- a/DotNet/Normalization/Application/Services/Operations/CodeMapOperatonService.cs
+++ b/DotNet/Normalization/Application/Services/Operations/CodeMapOperatonService.cs
@@ -8,17 +8,21 @@ namespace LantanaGroup.Link.Normalization.Application.Services.Operations
 {
     public class CodeMapOperationService : BaseOperationService<CodeMapOperation>
     {
+        ILogger<CodeMapOperationService> _logger;
+
         public CodeMapOperationService(ILogger<CodeMapOperationService> logger, TimeSpan? operationTimeout = null)
             : base(logger, operationTimeout)
         {
+            _logger = logger;
         }
 
         protected override async Task<OperationResult> ExecuteOperation(CodeMapOperation operation, DomainResource resource)
         {
-            var result = await FhirPathValidator.IsFhirPathValidForResourceType(operation.FhirPath, resource.TypeName);
+            //Daniel - 4/2026: I don't think we need this per execution. We should probably move a check like this in the Rest API and validate that it's a valid path.             
+            //var result = await FhirPathValidator.IsFhirPathValidForResourceType(operation.FhirPath, resource.TypeName);
 
-            if (!result.IsValid)
-                return OperationResult.Failure($"Invalid target FHIRPath expression: {operation.FhirPath}. {result.ErrorMessage}", resource);
+            //if (!result.IsValid)
+            //    return OperationResult.Failure($"Invalid target FHIRPath expression: {operation.FhirPath}. {result.ErrorMessage}", resource);
 
             var sources = resource.Select(operation.FhirPath);
 
@@ -55,7 +59,10 @@ namespace LantanaGroup.Link.Normalization.Application.Services.Operations
             }
 
             if (anyUpdated)
+            {
+                _logger.LogDebug("Applying Code Map Operation (ResourceType: {type}, ResourceId: {resourceId})", resource.TypeName, resource.Id);
                 return OperationResult.Success(resource);
+            }
             else
                 return OperationResult.NoAction("No code maps applied.", resource);
         }

--- a/DotNet/Normalization/Application/Services/Operations/ConditionalTransformationOperationService.cs
+++ b/DotNet/Normalization/Application/Services/Operations/ConditionalTransformationOperationService.cs
@@ -11,9 +11,12 @@ namespace LantanaGroup.Link.Normalization.Application.Services.Operations
 {
     public class ConditionalTransformOperationService : BaseOperationService<ConditionalTransformOperation>
     {
+        ILogger<ConditionalTransformOperationService> _logger;
+
         public ConditionalTransformOperationService(ILogger<ConditionalTransformOperationService> logger, TimeSpan? operationTimeout = null)
             : base(logger, operationTimeout)
         {
+            _logger = logger;
         }
 
         protected override async Task<OperationResult> ExecuteOperation(ConditionalTransformOperation operation, DomainResource resource)
@@ -34,6 +37,11 @@ namespace LantanaGroup.Link.Normalization.Application.Services.Operations
             }
 
             var result = await SetTransformValue(resource, operation.TargetFhirPath, operation.TargetValue);
+
+            if (result.SuccessCode == OperationStatus.Success) {
+                _logger.LogDebug("Applying Conditional Transform Operation (ResourceType: {type}, ResourceId: {resourceId})", resource.TypeName, resource.Id);
+            }
+
             return result;
         }
 

--- a/DotNet/Normalization/Application/Services/Operations/CopyLocationOperation.cs
+++ b/DotNet/Normalization/Application/Services/Operations/CopyLocationOperation.cs
@@ -11,9 +11,12 @@ namespace LantanaGroup.Link.Normalization.Application.Services.Operations
 {
     public class CopyLocationOperationService : BaseOperationService<CopyLocationOperation>
     {
+        ILogger<CopyLocationOperationService> _logger;
+
         public CopyLocationOperationService(ILogger<CopyLocationOperationService> logger, TimeSpan? operationTimeout = null)
             : base(logger, operationTimeout)
         {
+            _logger = logger;
         }
 
         protected override async Task<OperationResult> ExecuteOperation(CopyLocationOperation operation, DomainResource resource)
@@ -22,6 +25,8 @@ namespace LantanaGroup.Link.Normalization.Application.Services.Operations
             {
                 return OperationResult.Failure($"Resource must be a Location");
             }
+
+            _logger.LogDebug("Applying Copy Location Operation (ResourceType: {type}, ResourceId: {resourceId})", resource.TypeName, resource.Id);
 
             Location location = (Location)resource;
 

--- a/DotNet/Normalization/Application/Services/Operations/CopyPropertyOperationService.cs
+++ b/DotNet/Normalization/Application/Services/Operations/CopyPropertyOperationService.cs
@@ -10,14 +10,23 @@ namespace LantanaGroup.Link.Normalization.Application.Services.Operations
 {
     public class CopyPropertyOperationService : BaseOperationService<CopyPropertyOperation>
     {
+        ILogger<CopyPropertyOperationService> _logger;
+
         public CopyPropertyOperationService(ILogger<CopyPropertyOperationService> logger, TimeSpan? operationTimeout = null)
             : base(logger, operationTimeout)
         {
+            _logger = logger;
         }
 
         protected override async Task<OperationResult> ExecuteOperation(CopyPropertyOperation operation, DomainResource resource)
         {
-            return await CopyFhirPathValue(resource, operation.SourceFhirPath, operation.TargetFhirPath);
+            var result = await CopyFhirPathValue(resource, operation.SourceFhirPath, operation.TargetFhirPath);
+
+            if (result.SuccessCode == OperationStatus.Success) {
+                _logger.LogDebug("Copy Property Operation (ResourceType: {type}, ResourceId: {resourceId})", resource.TypeName, resource.Id);
+            }
+
+            return result;
         }
 
         private async Task<OperationResult> CopyFhirPathValue(DomainResource resource, string sourceFhirPath, string targetFhirPath)

--- a/DotNet/Normalization/Controllers/OperationsController.cs
+++ b/DotNet/Normalization/Controllers/OperationsController.cs
@@ -360,10 +360,10 @@ namespace LantanaGroup.Link.Normalization.Controllers
 
                 var result = model.Operation.OperationType switch
                 {
-                    OperationType.CopyProperty => await _copyPropertyOperationService.EnqueueOperationAsync((CopyPropertyOperation)operationImplementation, domainResource),
-                    OperationType.CodeMap => await _codeMapOperationService.EnqueueOperationAsync((CodeMapOperation)operationImplementation, domainResource),
-                    OperationType.ConditionalTransform => await _conditionalTransformOperationService.EnqueueOperationAsync((ConditionalTransformOperation)operationImplementation, domainResource),
-                    OperationType.CopyLocation => await _copyLocationOperationService.EnqueueOperationAsync((CopyLocationOperation)operationImplementation, domainResource),
+                    OperationType.CopyProperty => await _copyPropertyOperationService.ProcessOperationAsync((CopyPropertyOperation)operationImplementation, domainResource),
+                    OperationType.CodeMap => await _codeMapOperationService.ProcessOperationAsync((CodeMapOperation)operationImplementation, domainResource),
+                    OperationType.ConditionalTransform => await _conditionalTransformOperationService.ProcessOperationAsync((ConditionalTransformOperation)operationImplementation, domainResource),
+                    OperationType.CopyLocation => await _copyLocationOperationService.ProcessOperationAsync((CopyLocationOperation)operationImplementation, domainResource),
                     _ => null
                 };
 
@@ -407,10 +407,10 @@ namespace LantanaGroup.Link.Normalization.Controllers
 
                 var result = operation.OperationType switch
                 {
-                    OperationType.CopyProperty => await _copyPropertyOperationService.EnqueueOperationAsync((CopyPropertyOperation)operation, domainResource),
-                    OperationType.CodeMap => await _codeMapOperationService.EnqueueOperationAsync((CodeMapOperation)operation, domainResource),
-                    OperationType.ConditionalTransform => await _conditionalTransformOperationService.EnqueueOperationAsync((ConditionalTransformOperation)operation, domainResource),
-                    OperationType.CopyLocation => await _copyLocationOperationService.EnqueueOperationAsync((CopyLocationOperation)operation, domainResource),
+                    OperationType.CopyProperty => await _copyPropertyOperationService.ProcessOperationAsync((CopyPropertyOperation)operation, domainResource),
+                    OperationType.CodeMap => await _codeMapOperationService.ProcessOperationAsync((CodeMapOperation)operation, domainResource),
+                    OperationType.ConditionalTransform => await _conditionalTransformOperationService.ProcessOperationAsync((ConditionalTransformOperation)operation, domainResource),
+                    OperationType.CopyLocation => await _copyLocationOperationService.ProcessOperationAsync((CopyLocationOperation)operation, domainResource),
                     _ => null
                 };
 

--- a/DotNet/Normalization/Domain/Queries/OperationSequenceQueries.cs
+++ b/DotNet/Normalization/Domain/Queries/OperationSequenceQueries.cs
@@ -1,7 +1,9 @@
-﻿using LantanaGroup.Link.Normalization.Application.Models.Operations.Business;
+﻿using AngleSharp;
+using LantanaGroup.Link.Normalization.Application.Models.Operations.Business;
 using LantanaGroup.Link.Normalization.Application.Models.Operations.Business.Query;
 using LantanaGroup.Link.Normalization.Domain.Entities;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Caching.Memory;
 
 namespace LantanaGroup.Link.Normalization.Domain.Queries
 {
@@ -9,16 +11,21 @@ namespace LantanaGroup.Link.Normalization.Domain.Queries
     {
         Task<OperationSequenceModel> Get(string resourceType, string? facilityId);
         Task<List<OperationSequenceModel>> Search(OperationSequenceSearchModel model);
+        void ClearCache(OperationSequenceSearchModel model);
     }
 
     public class OperationSequenceQueries : IOperationSequenceQueries
     {
         private readonly IDatabase _database;
         private readonly NormalizationDbContext _dbContext;
-        public OperationSequenceQueries(IDatabase database, NormalizationDbContext dbContext)
+        private readonly IMemoryCache _cache;
+        private readonly TimeSpan _cacheTtl = TimeSpan.FromSeconds(60);
+
+        public OperationSequenceQueries(IDatabase database, NormalizationDbContext dbContext, IMemoryCache cache) 
         {
             _database = database;
             _dbContext = dbContext;
+            _cache = cache;
         }
 
         public async Task<OperationSequenceModel> Get(string FacilityId, Guid id)
@@ -39,88 +46,104 @@ namespace LantanaGroup.Link.Normalization.Domain.Queries
             })).Single();
         }
 
+        private static (string? FacilityId, string? ResourceType, Guid? ResourceTypeId) BuildCacheKey(OperationSequenceSearchModel model) => (model.FacilityId, model.ResourceType, model.ResourceTypeId);
+
         public async Task<List<OperationSequenceModel>> Search(OperationSequenceSearchModel model)
         {
-            var query = from o in _dbContext.OperationSequences
-                        where o.FacilityId == model.FacilityId
-                        select new OperationSequenceModel()
+            //Daniel - 4/2026: Temporarily adding queried configs into memory cache to reduce the amount of queries made to the database.
+            var cacheKey = BuildCacheKey(model);
+            var cacheResult = _cache.GetOrCreate(cacheKey, entry =>
+            {
+                entry.AbsoluteExpirationRelativeToNow = _cacheTtl;
+
+                IQueryable<OperationSequenceModel> query = 
+                    from o in _dbContext.OperationSequences
+                    where o.FacilityId == model.FacilityId
+                    select new OperationSequenceModel()
+                    {
+                        Id = o.Id,
+                        FacilityId = o.FacilityId,
+                        Sequence = o.Sequence.HasValue ? o.Sequence.Value : default,
+                        ModifyDate = o.ModifyDate,
+                        CreateDate = o.CreateDate,
+                        OperationResourceType = new OperationResourceTypeModel()
                         {
-                            Id = o.Id,
-                            FacilityId = o.FacilityId,
-                            Sequence = o.Sequence.HasValue ? o.Sequence.Value : default,
-                            ModifyDate = o.ModifyDate,
-                            CreateDate = o.CreateDate,
+                            Id = o.OperationResourceTypeId,
+                            OperationId = o.OperationResourceType.OperationId,
+                            ResourceTypeId = o.OperationResourceType.ResourceTypeId,
+                            Operation = new OperationModel()
+                            {
+                                Id = o.OperationResourceType.OperationId,
+                                FacilityId = o.OperationResourceType.Operation.FacilityId,
+                                Name = o.OperationResourceType.Operation.Name,
+                                Description = o.OperationResourceType.Operation.Description,
+                                IsDisabled = o.OperationResourceType.Operation.IsDisabled,
+                                ModifyDate = o.OperationResourceType.Operation.ModifyDate,
+                                OperationJson = o.OperationResourceType.Operation.OperationJson,
+                                OperationType = o.OperationResourceType.Operation.OperationType,
+                                CreateDate = o.OperationResourceType.Operation.CreateDate,
+                            },
+                            Resource = new ResourceModel()
+                            {
+                                ResourceTypeId = o.OperationResourceType.ResourceType.Id,
+                                ResourceName = o.OperationResourceType.ResourceType.Name
+                            }
+                        },
+                        VendorPresets = o.OperationResourceType.VendorVersionOperationPresets.Select(vp => new VendorVersionOperationPresetModel()
+                        {
+                            Id = vp.Id,
+                            VendorVersionId = vp.VendorVersionId,
+                            OperationResourceTypeId = vp.OperationResourceTypeId,
                             OperationResourceType = new OperationResourceTypeModel()
                             {
-                                Id = o.OperationResourceTypeId,
-                                OperationId = o.OperationResourceType.OperationId,
-                                ResourceTypeId = o.OperationResourceType.ResourceTypeId,
                                 Operation = new OperationModel()
                                 {
-                                    Id = o.OperationResourceType.OperationId,
-                                    FacilityId = o.OperationResourceType.Operation.FacilityId,
-                                    Name = o.OperationResourceType.Operation.Name,
-                                    Description = o.OperationResourceType.Operation.Description,
-                                    IsDisabled = o.OperationResourceType.Operation.IsDisabled,
-                                    ModifyDate = o.OperationResourceType.Operation.ModifyDate,
-                                    OperationJson = o.OperationResourceType.Operation.OperationJson,
-                                    OperationType = o.OperationResourceType.Operation.OperationType,
-                                    CreateDate = o.OperationResourceType.Operation.CreateDate,
+                                    Id = vp.OperationResourceType.Operation.Id,
+                                    Name = vp.OperationResourceType.Operation.Name,
+                                    Description = vp.OperationResourceType.Operation.Description,
+                                    OperationJson = vp.OperationResourceType.Operation.OperationJson,
+                                    OperationType = vp.OperationResourceType.Operation.OperationType
                                 },
                                 Resource = new ResourceModel()
                                 {
-                                    ResourceTypeId = o.OperationResourceType.ResourceType.Id,
-                                    ResourceName = o.OperationResourceType.ResourceType.Name
+                                    ResourceName = vp.OperationResourceType.ResourceType.Name,
+                                    ResourceTypeId = vp.OperationResourceType.ResourceType.Id
                                 }
                             },
-                            VendorPresets = o.OperationResourceType.VendorVersionOperationPresets.Select(vp => new VendorVersionOperationPresetModel()
+                            VendorVersion = new VendorVersionModel()
                             {
-                                Id = vp.Id,
-                                VendorVersionId = vp.VendorVersionId,
-                                OperationResourceTypeId = vp.OperationResourceTypeId,
-                                OperationResourceType = new OperationResourceTypeModel()
+                                Id = vp.VendorVersion.Id,
+                                VendorId = vp.VendorVersion.VendorId,
+                                Version = vp.VendorVersion.Version,
+                                Vendor = new VendorModel()
                                 {
-                                    Operation = new OperationModel()
-                                    {
-                                        Id = vp.OperationResourceType.Operation.Id,
-                                        Name = vp.OperationResourceType.Operation.Name,
-                                        Description = vp.OperationResourceType.Operation.Description,
-                                        OperationJson = vp.OperationResourceType.Operation.OperationJson,
-                                        OperationType = vp.OperationResourceType.Operation.OperationType
-                                    },
-                                    Resource = new ResourceModel()
-                                    {
-                                        ResourceName = vp.OperationResourceType.ResourceType.Name,
-                                        ResourceTypeId = vp.OperationResourceType.ResourceType.Id
-                                    }
-                                },
-                                VendorVersion = new VendorVersionModel()
-                                {
-                                    Id = vp.VendorVersion.Id,
-                                    VendorId = vp.VendorVersion.VendorId,
-                                    Version = vp.VendorVersion.Version,
-                                    Vendor = new VendorModel()
-                                    {
-                                        Id = vp.VendorVersion.Vendor.Id,
-                                        Name = vp.VendorVersion.Vendor.Name
-                                    }
-                                },
-                                CreateDate = vp.CreateDate,
-                                ModifyDate = vp.ModifyDate
-                            }).ToList()
-                        };
+                                    Id = vp.VendorVersion.Vendor.Id,
+                                    Name = vp.VendorVersion.Vendor.Name
+                                }
+                            },
+                            CreateDate = vp.CreateDate,
+                            ModifyDate = vp.ModifyDate
+                        }).ToList()
+                    };
 
-            if (!string.IsNullOrEmpty(model.ResourceType))
-            {
-                query = query.Where(q => q.OperationResourceType.Resource.ResourceName == model.ResourceType);
-            }
+                if (!string.IsNullOrEmpty(model.ResourceType))
+                {
+                    query = query.Where(q => q.OperationResourceType.Resource.ResourceName == model.ResourceType);
+                }
 
-            if (model.ResourceTypeId.HasValue)
-            {
-                query = query.Where(q => q.OperationResourceType.Resource.ResourceTypeId == model.ResourceTypeId);
-            }
+                if (model.ResourceTypeId.HasValue)
+                {
+                    query = query.Where(q => q.OperationResourceType.Resource.ResourceTypeId == model.ResourceTypeId);
+                }
 
-            return await query.ToListAsync();
+                return query.ToList();
+            });
+
+            return cacheResult;
+        }
+
+        public void ClearCache(OperationSequenceSearchModel model) {
+            _cache.Remove(model.FacilityId + model.ResourceType);
         }
     }
 }

--- a/DotNet/Normalization/Listeners/ResourceAcquiredListener.cs
+++ b/DotNet/Normalization/Listeners/ResourceAcquiredListener.cs
@@ -1,6 +1,4 @@
-﻿using System.Text;
-using System.Text.Json;
-using Confluent.Kafka;
+﻿using Confluent.Kafka;
 using Confluent.Kafka.Extensions.Diagnostics;
 using Hl7.Fhir.Model;
 using LantanaGroup.Link.Normalization.Application.Models.Exceptions;
@@ -20,6 +18,10 @@ using LantanaGroup.Link.Shared.Application.Models.Kafka;
 using LantanaGroup.Link.Shared.Application.Models.Telemetry;
 using LantanaGroup.Link.Shared.Application.SerDes;
 using LantanaGroup.Link.Shared.Application.Utilities;
+using Microsoft.OpenApi.Writers;
+using OpenTelemetry.Resources;
+using System.Text;
+using System.Text.Json;
 using Task = System.Threading.Tasks.Task;
 
 namespace LantanaGroup.Link.Normalization.Listeners;
@@ -107,7 +109,7 @@ public class ResourceAcquiredListener : BackgroundService
                     {
                         message = result;
 
-                        if (message.Key == null || string.IsNullOrWhiteSpace(message.Key.FacilityId))
+                        if (message.Message.Key == null || string.IsNullOrWhiteSpace(message.Message.Key.FacilityId))
                         {
                             throw new DeadLetterException("Message Key (FacilityId) is null or empty.");
                         }
@@ -142,77 +144,84 @@ public class ResourceAcquiredListener : BackgroundService
                         {
                             _logger.LogInformation("Acquisition Complete tail message received. Producing message for measure eval.");
 
-                            await ProduceResourceNormalizedMessage(message, messageMetaData.facilityId, messageMetaData.correlationId, null);
+                            await ProduceResourceNormalizedMessage(message, messageMetaData.facilityId, messageMetaData.correlationId, message.Message.Value.Resource);
                             return;
                         }
 
-                        DomainResource resource;
-                        try
+                        using (var scope = _scopeFactory.CreateScope())
                         {
-                            resource = DeserializeResource(message.Message.Value.Resource);
-                        }
-                        catch (Exception ex)
-                        {
-                            if (ex is JsonException || ex is NotSupportedException)
+                            var operationSequenceQueries = scope.ServiceProvider.GetRequiredService<IOperationSequenceQueries>();
+
+                            var sequences = await operationSequenceQueries.Search(new OperationSequenceSearchModel()
                             {
-                                throw new TransientException("Failed to deserialize resource.", ex);
-                            }
+                                FacilityId = messageMetaData.facilityId,
+                                ResourceType = message.Message.Value.ResourceType,
+                            });
 
-                            throw new DeadLetterException("Failed to deserialize resource.", ex);
-                        }
-
-                        var operationSequenceQueries = _scopeFactory.CreateScope().ServiceProvider.GetRequiredService<IOperationSequenceQueries>();
-
-                        var sequences = await operationSequenceQueries.Search(new OperationSequenceSearchModel()
-                        {
-                            FacilityId = messageMetaData.facilityId,
-                            ResourceType = resource.TypeName,
-                        });
-
-                        if (sequences != null && sequences.Count > 0)
-                        {
-                            sequences.Sort((a, b) => a.Sequence.CompareTo(b.Sequence));
-
-                            foreach (var sequence in sequences)
+                            if (sequences != null && sequences.Count > 0)
                             {
-                                var dbEntity = sequence.OperationResourceType.Operation;
-
-                                var operation = OperationHelper.GetOperation(dbEntity.OperationType, dbEntity.OperationJson);
-
-                                if (operation == null)
+                                DomainResource resource;
+                                try
                                 {
-                                    throw new TransientException("Operation Data Entity found, but the operation failed to deserialize");
+                                    resource = DeserializeResource(message.Message.Value.Resource);
+                                }
+                                catch (Exception ex)
+                                {
+                                    if (ex is JsonException || ex is NotSupportedException)
+                                    {
+                                        throw new TransientException("Failed to deserialize resource.", ex);
+                                    }
+
+                                    throw new DeadLetterException("Failed to deserialize resource.", ex);
                                 }
 
-                                var operationResult = operation.OperationType switch
-                                {
-                                    OperationType.CopyProperty => await _copyPropertyOperationService.EnqueueOperationAsync((CopyPropertyOperation)operation, resource),
-                                    OperationType.CodeMap => await _codeMapOperationService.EnqueueOperationAsync((CodeMapOperation)operation, resource),
-                                    OperationType.ConditionalTransform => await _conditionalTransformOperationService.EnqueueOperationAsync((ConditionalTransformOperation)operation, resource),
-                                    OperationType.CopyLocation => await _copyLocationOperationService.EnqueueOperationAsync((CopyLocationOperation)operation, resource),
-                                    _ => null
-                                };
+                                sequences.Sort((a, b) => a.Sequence.CompareTo(b.Sequence));
 
-                                if (operationResult != null && operationResult.SuccessCode != OperationStatus.Failure)
+                                foreach (var sequence in sequences)
                                 {
-                                    resource = operationResult.Resource;
+                                    var dbEntity = sequence.OperationResourceType.Operation;
 
-                                    _metrics.IncrementResourceNormalizedCounter(new List<KeyValuePair<string, object?>>() {
+                                    var operation = OperationHelper.GetOperation(dbEntity.OperationType, dbEntity.OperationJson);
+
+                                    if (operation == null)
+                                    {
+                                        throw new TransientException("Operation Data Entity found, but the operation failed to deserialize");
+                                    }
+
+                                    var operationResult = operation.OperationType switch
+                                    {
+                                        OperationType.CopyProperty => await _copyPropertyOperationService.ProcessOperationAsync((CopyPropertyOperation)operation, resource),
+                                        OperationType.CodeMap => await _codeMapOperationService.ProcessOperationAsync((CodeMapOperation)operation, resource),
+                                        OperationType.ConditionalTransform => await _conditionalTransformOperationService.ProcessOperationAsync((ConditionalTransformOperation)operation, resource),
+                                        OperationType.CopyLocation => await _copyLocationOperationService.ProcessOperationAsync((CopyLocationOperation)operation, resource),
+                                        _ => null
+                                    };
+
+                                    if (operationResult != null && operationResult.SuccessCode != OperationStatus.Failure)
+                                    {
+                                        resource = operationResult.Resource;
+
+                                        _metrics.IncrementResourceNormalizedCounter(new List<KeyValuePair<string, object?>>() {
                                         new KeyValuePair<string, object?>(DiagnosticNames.FacilityId, messageMetaData.facilityId),
                                         new KeyValuePair<string, object?>(DiagnosticNames.CorrelationId, messageMetaData.correlationId),
                                         new KeyValuePair<string, object?>(DiagnosticNames.PatientId, message.Message.Value.PatientId),
                                         new KeyValuePair<string, object?>(DiagnosticNames.Resource, resource.TypeName),
                                         new KeyValuePair<string, object?>(DiagnosticNames.QueryType, message.Message.Value.QueryType),
                                         new KeyValuePair<string, object?>(DiagnosticNames.NormalizationOperation, operation.OperationType.ToString())});
+                                    }
+                                    else
+                                    {
+                                        _logger.LogWarning("Normalization Operation Failed ({FacilityId}, {CorrelationId}, {OperationType}): {ErrorMessage}", messageMetaData.facilityId, messageMetaData.correlationId, operation.OperationType, operationResult?.ErrorMessage ?? "No Operation Result Error Message");
+                                    }
                                 }
-                                else
-                                {
-                                    _logger.LogWarning("Normalization Operation Failed ({FacilityId}, {CorrelationId}, {OperationType}): {ErrorMessage}", messageMetaData.facilityId, messageMetaData.correlationId, operation.OperationType, operationResult?.ErrorMessage ?? "No Operation Result Error Message");
-                                }
+
+                                await ProduceResourceNormalizedMessage(message, messageMetaData.facilityId, messageMetaData.correlationId, resource);
+                            }
+                            else
+                            {
+                                await ProduceResourceNormalizedMessage(message, messageMetaData.facilityId, messageMetaData.correlationId, message.Message.Value.Resource);
                             }
                         }
-
-                        await ProduceResourceNormalizedMessage(message, messageMetaData.facilityId, messageMetaData.correlationId, resource);
                     }
                     catch (DeadLetterException ex)
                     {
@@ -277,10 +286,8 @@ public class ResourceAcquiredListener : BackgroundService
     }
 
 
-    private async Task ProduceResourceNormalizedMessage(ConsumeResult<ResourceKey, ResourceAcquiredMessage>? message, string facilityId, string correlationId, DomainResource? resource = null)
+    private async Task ProduceResourceNormalizedMessage(ConsumeResult<ResourceKey, ResourceAcquiredMessage>? message, string facilityId, string correlationId, object? resource)
     {
-        var serializedResource = JsonSerializer.SerializeToElement(resource, LinkFhirSerializerOptions.ForFhirLenientSerialization);
-
         var headers = new Headers
         {
             new Header(NormalizationConstants.HeaderNames.CorrelationId, Encoding.UTF8.GetBytes(correlationId))
@@ -290,7 +297,7 @@ public class ResourceAcquiredListener : BackgroundService
         {
             AcquisitionComplete = message.Message.Value.AcquisitionComplete,
             PatientId = message.Message.Value.PatientId ?? "",
-            Resource = serializedResource,
+            Resource = resource,
             QueryType = message.Message.Value.QueryType,
             ScheduledReports = message.Message.Value.ScheduledReports,
             ReportableEvent = message.Message.Value.ReportableEvent
@@ -308,11 +315,11 @@ public class ResourceAcquiredListener : BackgroundService
 
         try
         {
-            await _producer.ProduceAsync(KafkaTopic.ResourceNormalized.ToString(), produceMessage);
+            _producer.Produce(KafkaTopic.ResourceNormalized.ToString(), produceMessage);
         }
         catch (ProduceException<ResourceKey, ResourceNormalizedMessage> ex)
         {
-            _logger.LogError(ex, "Failed to produce ResourceNormalized message. FacilityId: {FacilityId}, CorrelationId: {CorrelationId}, FhirResourceType: {fhirResourceType}, ResourceId: {resourceId}", facilityId, correlationId, resource?.TypeName, resource?.Id);
+            _logger.LogError(ex, "Failed to produce ResourceNormalized message. FacilityId: {FacilityId}, CorrelationId: {CorrelationId}, ResourceAcquired Partition: {Partition}, ResourceAcquired Offset: {Offset}", facilityId, correlationId, message.Partition.Value, message.Offset.Value);
             throw new TransientException($"Failed to produce ResourceNormalized message: {ex.Message}", ex);
         }
     }

--- a/DotNet/Normalization/Listeners/ResourceAcquiredListener.cs
+++ b/DotNet/Normalization/Listeners/ResourceAcquiredListener.cs
@@ -315,7 +315,7 @@ public class ResourceAcquiredListener : BackgroundService
 
         try
         {
-            _producer.Produce(KafkaTopic.ResourceNormalized.ToString(), produceMessage);
+            await _producer.ProduceAsync(KafkaTopic.ResourceNormalized.ToString(), produceMessage);
         }
         catch (ProduceException<ResourceKey, ResourceNormalizedMessage> ex)
         {

--- a/DotNet/Normalization/Program.cs
+++ b/DotNet/Normalization/Program.cs
@@ -1,6 +1,6 @@
-using System.Reflection;
 using Confluent.Kafka;
 using HealthChecks.UI.Client;
+using Hl7.Fhir.Model.CdsHooks;
 using LantanaGroup.Link.Normalization.Application.Models.Messages;
 using LantanaGroup.Link.Normalization.Application.Services;
 using LantanaGroup.Link.Normalization.Application.Services.Operations;
@@ -33,10 +33,12 @@ using LantanaGroup.Link.Shared.Settings;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Diagnostics.HealthChecks;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Caching.Memory;
 using Microsoft.OpenApi.Models;
 using Serilog;
 using Serilog.Enrichers.Span;
 using Serilog.Exceptions;
+using System.Reflection;
 using AuditEventMessage = LantanaGroup.Link.Shared.Application.Models.Kafka.AuditEventMessage;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -99,6 +101,11 @@ static void RegisterServices(WebApplicationBuilder builder)
 
     builder.Services.AddHttpClient();
     builder.Services.AddProblemDetails();
+
+    builder.Services.AddMemoryCache();
+
+    var provider = builder.Services.BuildServiceProvider();
+    var cache = provider.GetRequiredService<IMemoryCache>();
 
     // Add Link Security
     bool allowAnonymousAccess = builder.Configuration.GetValue<bool>("Authentication:EnableAnonymousAccess");
@@ -188,17 +195,10 @@ static void RegisterServices(WebApplicationBuilder builder)
     builder.Services.AddTransient<RetryJob>();
 
     builder.Services.AddSingleton<CopyPropertyOperationService>();
-    builder.Services.AddHostedService(provider => provider.GetRequiredService<CopyPropertyOperationService>());
-
     builder.Services.AddSingleton<CodeMapOperationService>();
-    builder.Services.AddHostedService(provider => provider.GetRequiredService<CodeMapOperationService>());
-
     builder.Services.AddSingleton<ConditionalTransformOperationService>();
-    builder.Services.AddHostedService(provider => provider.GetRequiredService<ConditionalTransformOperationService>());
-
     builder.Services.AddSingleton<CopyLocationOperationService>();
-    builder.Services.AddHostedService(provider => provider.GetRequiredService<CopyLocationOperationService>());
-
+    
     if (consumerSettings != null && !consumerSettings.DisableConsumer)
     {
         builder.Services.AddHostedService<ResourceAcquiredListener>();

--- a/DotNet/ServiceTests/IntegrationTests/Normalization/NormalizationIntegrationTestFixture.cs
+++ b/DotNet/ServiceTests/IntegrationTests/Normalization/NormalizationIntegrationTestFixture.cs
@@ -7,6 +7,7 @@ using LantanaGroup.Link.Normalization.Domain.Repositories;
 using LantanaGroup.Link.Shared.Domain.Repositories.Interfaces;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using ResourceType = LantanaGroup.Link.Normalization.Domain.Entities.ResourceType;
@@ -39,16 +40,9 @@ namespace IntegrationTests.Normalization
 
                     // Register CopyPropertyOperationService as a singleton and hosted service
                     services.AddSingleton<CopyPropertyOperationService>();
-                    services.AddHostedService(provider => provider.GetRequiredService<CopyPropertyOperationService>());
-
                     services.AddSingleton<CopyLocationOperationService>();
-                    services.AddHostedService(provider => provider.GetRequiredService<CopyLocationOperationService>());
-
                     services.AddSingleton<CodeMapOperationService>();
-                    services.AddHostedService(provider => provider.GetRequiredService<CodeMapOperationService>());
-
                     services.AddSingleton<ConditionalTransformOperationService>();
-                    services.AddHostedService(provider => provider.GetRequiredService<ConditionalTransformOperationService>());
 
                     // Register other services
                     services.AddScoped<IEntityRepository<Operation>, OperationRepository>();
@@ -69,6 +63,11 @@ namespace IntegrationTests.Normalization
                     services.AddScoped<IOperationSequenceQueries, OperationSequenceQueries>();
                     services.AddScoped<IVendorQueries, VendorQueries>();
                     services.AddScoped<IResourceQueries, ResourceQueries>();
+
+                    services.AddMemoryCache();
+
+                    var provider = services.BuildServiceProvider();
+                    var cache = provider.GetRequiredService<IMemoryCache>();
                 })
                 .Build();
 

--- a/DotNet/ServiceTests/IntegrationTests/Normalization/OperationServiceTests.cs
+++ b/DotNet/ServiceTests/IntegrationTests/Normalization/OperationServiceTests.cs
@@ -89,7 +89,7 @@ namespace IntegrationTests.Normalization
             Assert.NotNull(copyOperation.SourceFhirPath);
             Assert.NotNull(copyOperation.TargetFhirPath);
 
-            var operationResult = await _copyOperationService.EnqueueOperationAsync(copyOperation, location);
+            var operationResult = await _copyOperationService.ProcessOperationAsync(copyOperation, location);
             Assert.Equal(OperationStatus.Success, operationResult.SuccessCode);
 
             var modifiedLocation = (Location)operationResult.Resource;
@@ -145,7 +145,7 @@ namespace IntegrationTests.Normalization
             Assert.NotNull(copyOperation.SourceFhirPath);
             Assert.NotNull(copyOperation.TargetFhirPath);
 
-            var operationResult = await _copyOperationService.EnqueueOperationAsync(copyOperation, location);
+            var operationResult = await _copyOperationService.ProcessOperationAsync(copyOperation, location);
             Assert.Equal(OperationStatus.Success, operationResult.SuccessCode);
 
             var modifiedLocation = (Location)operationResult.Resource;
@@ -201,7 +201,7 @@ namespace IntegrationTests.Normalization
             Assert.NotNull(copyOperation.SourceFhirPath);
             Assert.NotNull(copyOperation.TargetFhirPath);
 
-            var operationResult = await _copyOperationService.EnqueueOperationAsync(copyOperation, resource);
+            var operationResult = await _copyOperationService.ProcessOperationAsync(copyOperation, resource);
             Assert.Equal(OperationStatus.Success, operationResult.SuccessCode);
 
             var modifiedResource = (Patient)operationResult.Resource;
@@ -257,7 +257,7 @@ namespace IntegrationTests.Normalization
             Assert.NotNull(copyOperation.SourceFhirPath);
             Assert.NotNull(copyOperation.TargetFhirPath);
 
-            var operationResult = await _copyOperationService.EnqueueOperationAsync(copyOperation, resource);
+            var operationResult = await _copyOperationService.ProcessOperationAsync(copyOperation, resource);
             Assert.Equal(OperationStatus.Success, operationResult.SuccessCode);
 
             var modifiedResource = (Observation)operationResult.Resource;
@@ -319,7 +319,7 @@ namespace IntegrationTests.Normalization
             Assert.NotNull(copyOperation.SourceFhirPath);
             Assert.NotNull(copyOperation.TargetFhirPath);
 
-            var operationResult = await _copyOperationService.EnqueueOperationAsync(copyOperation, resource);
+            var operationResult = await _copyOperationService.ProcessOperationAsync(copyOperation, resource);
             Assert.Equal(OperationStatus.Success, operationResult.SuccessCode);
 
             var modifiedResource = (Patient)operationResult.Resource;
@@ -381,7 +381,7 @@ namespace IntegrationTests.Normalization
             Assert.NotNull(copyOperation.SourceFhirPath);
             Assert.NotNull(copyOperation.TargetFhirPath);
 
-            var operationResult = await _copyOperationService.EnqueueOperationAsync(copyOperation, resource);
+            var operationResult = await _copyOperationService.ProcessOperationAsync(copyOperation, resource);
             Assert.Equal(OperationStatus.Success, operationResult.SuccessCode);
 
             var modifiedResource = (MedicationRequest)operationResult.Resource;
@@ -445,7 +445,7 @@ namespace IntegrationTests.Normalization
             Assert.NotNull(copyOperation.SourceFhirPath);
             Assert.NotNull(copyOperation.TargetFhirPath);
 
-            var operationResult = await _copyOperationService.EnqueueOperationAsync(copyOperation, resource);
+            var operationResult = await _copyOperationService.ProcessOperationAsync(copyOperation, resource);
             Assert.Equal(OperationStatus.Success, operationResult.SuccessCode);
 
             var modifiedResource = (Condition)operationResult.Resource;
@@ -510,7 +510,7 @@ namespace IntegrationTests.Normalization
             Assert.NotNull(copyOperation.SourceFhirPath);
             Assert.NotNull(copyOperation.TargetFhirPath);
 
-            var operationResult = await _copyOperationService.EnqueueOperationAsync(copyOperation, resource);
+            var operationResult = await _copyOperationService.ProcessOperationAsync(copyOperation, resource);
             Assert.Equal(OperationStatus.Success, operationResult.SuccessCode);
 
             var modifiedResource = (Encounter)operationResult.Resource;
@@ -574,7 +574,7 @@ namespace IntegrationTests.Normalization
             Assert.NotNull(copyOperation.SourceFhirPath);
             Assert.NotNull(copyOperation.TargetFhirPath);
 
-            var operationResult = await _copyOperationService.EnqueueOperationAsync(copyOperation, resource);
+            var operationResult = await _copyOperationService.ProcessOperationAsync(copyOperation, resource);
             Assert.Equal(OperationStatus.Success, operationResult.SuccessCode);
 
             var modifiedResource = (Patient)operationResult.Resource;
@@ -638,7 +638,7 @@ namespace IntegrationTests.Normalization
             Assert.NotNull(copyOperation.SourceFhirPath);
             Assert.NotNull(copyOperation.TargetFhirPath);
 
-            var operationResult = await _copyOperationService.EnqueueOperationAsync(copyOperation, resource);
+            var operationResult = await _copyOperationService.ProcessOperationAsync(copyOperation, resource);
             Assert.Equal(OperationStatus.Success, operationResult.SuccessCode);
 
             var modifiedResource = (MedicationRequest)operationResult.Resource;
@@ -704,7 +704,7 @@ namespace IntegrationTests.Normalization
             Assert.NotNull(copyOperation.SourceFhirPath);
             Assert.NotNull(copyOperation.TargetFhirPath);
 
-            var operationResult = await _copyOperationService.EnqueueOperationAsync(copyOperation, resource);
+            var operationResult = await _copyOperationService.ProcessOperationAsync(copyOperation, resource);
             Assert.Equal(OperationStatus.Success, operationResult.SuccessCode);
 
             var modifiedResource = (AllergyIntolerance)operationResult.Resource;
@@ -771,7 +771,7 @@ namespace IntegrationTests.Normalization
             Assert.NotNull(copyOperation.SourceFhirPath);
             Assert.NotNull(copyOperation.TargetFhirPath);
 
-            var operationResult = await _copyOperationService.EnqueueOperationAsync(copyOperation, resource);
+            var operationResult = await _copyOperationService.ProcessOperationAsync(copyOperation, resource);
             Assert.Equal(OperationStatus.Success, operationResult.SuccessCode);
 
             var modifiedResource = (DiagnosticReport)operationResult.Resource;
@@ -855,7 +855,7 @@ namespace IntegrationTests.Normalization
                 Assert.NotNull(copyOperation.TargetFhirPath);
 
                 fetchedOperations.Add(copyOperation);
-                tasks.Add(_copyOperationService.EnqueueOperationAsync(copyOperation, resource));
+                tasks.Add(_copyOperationService.ProcessOperationAsync(copyOperation, resource));
             }
 
             var results = await Task.WhenAll(tasks);
@@ -955,7 +955,7 @@ namespace IntegrationTests.Normalization
                 Assert.Fail("No encounter resource found");
             }
             // Act: Execute the operation
-            var operationResult = await _codeMapOperationService.EnqueueOperationAsync(codeMapOperation, encounter);
+            var operationResult = await _codeMapOperationService.ProcessOperationAsync(codeMapOperation, encounter);
             Assert.Equal(OperationStatus.Success, operationResult.SuccessCode);
 
             // Assert: Verify the mapping
@@ -1036,7 +1036,7 @@ namespace IntegrationTests.Normalization
             }
 
             // Act: Execute the operation
-            var operationResult = await _codeMapOperationService.EnqueueOperationAsync(codeMapOperation, encounter);
+            var operationResult = await _codeMapOperationService.ProcessOperationAsync(codeMapOperation, encounter);
             Assert.Equal(OperationStatus.Success, operationResult.SuccessCode);
 
             // Assert: Verify the mapping
@@ -1122,7 +1122,7 @@ namespace IntegrationTests.Normalization
             var originalClass = encounter.Class.DeepCopy() as Coding;
 
             // Act: Execute the operation
-            var operationResult = await _codeMapOperationService.EnqueueOperationAsync(codeMapOperation, encounter);
+            var operationResult = await _codeMapOperationService.ProcessOperationAsync(codeMapOperation, encounter);
             Assert.Equal(OperationStatus.NoAction, operationResult.SuccessCode);
 
             // Assert: Verify no changes were made
@@ -1203,7 +1203,7 @@ namespace IntegrationTests.Normalization
             }
 
             // Act: Execute the operation
-            var operationResult = await _codeMapOperationService.EnqueueOperationAsync(codeMapOperation, observation);
+            var operationResult = await _codeMapOperationService.ProcessOperationAsync(codeMapOperation, observation);
             Assert.Equal(OperationStatus.Success, operationResult.SuccessCode);
 
             // Assert: Verify the mapping
@@ -1287,7 +1287,7 @@ namespace IntegrationTests.Normalization
             }
 
             // Act: Execute the operation
-            var operationResult = await _codeMapOperationService.EnqueueOperationAsync(codeMapOperation, condition);
+            var operationResult = await _codeMapOperationService.ProcessOperationAsync(codeMapOperation, condition);
             Assert.Equal(OperationStatus.Success, operationResult.SuccessCode);
 
             // Assert: Verify the mapping
@@ -1353,7 +1353,7 @@ namespace IntegrationTests.Normalization
             string text = File.ReadAllText(resourcePath);
             var resource = parser.Parse<Encounter>(text);
 
-            var operationResult = await _conditionalTransformService.EnqueueOperationAsync(transformOperation, resource);
+            var operationResult = await _conditionalTransformService.ProcessOperationAsync(transformOperation, resource);
             if (operationResult.SuccessCode != OperationStatus.Success)
             {
                 _output.WriteLine(operationResult.ErrorMessage);
@@ -1417,8 +1417,8 @@ namespace IntegrationTests.Normalization
             string text = File.ReadAllText(resourcePath);
             var resource = parser.Parse<Encounter>(text);
 
-            var operationResult = await _conditionalTransformService.EnqueueOperationAsync(transformOperation, resource);
-
+            var operationResult = await _conditionalTransformService.ProcessOperationAsync(transformOperation, resource);
+            
             Assert.Equal(OperationStatus.NoAction, operationResult.SuccessCode);
             Assert.Contains("Condition was not met", operationResult.ErrorMessage);
 
@@ -1479,7 +1479,7 @@ namespace IntegrationTests.Normalization
             string text = File.ReadAllText(resourcePath);
             var resource = parser.Parse<Encounter>(text);
 
-            var operationResult = await _conditionalTransformService.EnqueueOperationAsync(transformOperation, resource);
+            var operationResult = await _conditionalTransformService.ProcessOperationAsync(transformOperation, resource);
             Assert.Equal(OperationStatus.Success, operationResult.SuccessCode);
 
             var modifiedResource = (Encounter)operationResult.Resource;
@@ -1539,8 +1539,8 @@ namespace IntegrationTests.Normalization
             string text = File.ReadAllText(resourcePath);
             var resource = parser.Parse<Encounter>(text);
 
-            var operationResult = await _conditionalTransformService.EnqueueOperationAsync(transformOperation, resource);
-
+            var operationResult = await _conditionalTransformService.ProcessOperationAsync(transformOperation, resource);
+            
             Assert.Equal(OperationStatus.NoAction, operationResult.SuccessCode);
             Assert.Contains("Condition was not met", operationResult.ErrorMessage);
 
@@ -1601,7 +1601,7 @@ namespace IntegrationTests.Normalization
             string text = File.ReadAllText(resourcePath);
             var resource = parser.Parse<Encounter>(text);
 
-            var operationResult = await _conditionalTransformService.EnqueueOperationAsync(transformOperation, resource);
+            var operationResult = await _conditionalTransformService.ProcessOperationAsync(transformOperation, resource);
             Assert.Equal(OperationStatus.Success, operationResult.SuccessCode);
 
             var modifiedResource = (Encounter)operationResult.Resource;
@@ -1661,8 +1661,8 @@ namespace IntegrationTests.Normalization
             string text = File.ReadAllText(resourcePath);
             var resource = parser.Parse<Encounter>(text);
 
-            var operationResult = await _conditionalTransformService.EnqueueOperationAsync(transformOperation, resource);
-
+            var operationResult = await _conditionalTransformService.ProcessOperationAsync(transformOperation, resource);
+            
             Assert.Equal(OperationStatus.NoAction, operationResult.SuccessCode);
             Assert.Contains("Condition was not met", operationResult.ErrorMessage);
 
@@ -1723,7 +1723,7 @@ namespace IntegrationTests.Normalization
             string text = File.ReadAllText(resourcePath);
             var resource = parser.Parse<Encounter>(text);
 
-            var operationResult = await _conditionalTransformService.EnqueueOperationAsync(transformOperation, resource);
+            var operationResult = await _conditionalTransformService.ProcessOperationAsync(transformOperation, resource);
             Assert.Equal(OperationStatus.Success, operationResult.SuccessCode);
 
             var modifiedResource = (Encounter)operationResult.Resource;
@@ -1783,8 +1783,8 @@ namespace IntegrationTests.Normalization
             string text = File.ReadAllText(resourcePath);
             var resource = parser.Parse<Encounter>(text);
 
-            var operationResult = await _conditionalTransformService.EnqueueOperationAsync(transformOperation, resource);
-
+            var operationResult = await _conditionalTransformService.ProcessOperationAsync(transformOperation, resource);
+            
             Assert.Equal(OperationStatus.NoAction, operationResult.SuccessCode);
             Assert.Contains("Condition was not met", operationResult.ErrorMessage);
 
@@ -1845,7 +1845,7 @@ namespace IntegrationTests.Normalization
             string text = File.ReadAllText(resourcePath);
             var resource = parser.Parse<Encounter>(text);
 
-            var operationResult = await _conditionalTransformService.EnqueueOperationAsync(transformOperation, resource);
+            var operationResult = await _conditionalTransformService.ProcessOperationAsync(transformOperation, resource);
             Assert.Equal(OperationStatus.Success, operationResult.SuccessCode);
 
             var modifiedResource = (Encounter)operationResult.Resource;
@@ -1905,8 +1905,8 @@ namespace IntegrationTests.Normalization
             string text = File.ReadAllText(resourcePath);
             var resource = parser.Parse<Encounter>(text);
 
-            var operationResult = await _conditionalTransformService.EnqueueOperationAsync(transformOperation, resource);
-
+            var operationResult = await _conditionalTransformService.ProcessOperationAsync(transformOperation, resource);
+            
             Assert.Equal(OperationStatus.NoAction, operationResult.SuccessCode);
             Assert.Contains("Condition was not met", operationResult.ErrorMessage);
 
@@ -1967,7 +1967,7 @@ namespace IntegrationTests.Normalization
             string text = File.ReadAllText(resourcePath);
             var resource = parser.Parse<Encounter>(text);
 
-            var operationResult = await _conditionalTransformService.EnqueueOperationAsync(transformOperation, resource);
+            var operationResult = await _conditionalTransformService.ProcessOperationAsync(transformOperation, resource);
             Assert.Equal(OperationStatus.Success, operationResult.SuccessCode);
 
             var modifiedResource = (Encounter)operationResult.Resource;
@@ -2027,8 +2027,8 @@ namespace IntegrationTests.Normalization
             string text = File.ReadAllText(resourcePath);
             var resource = parser.Parse<Encounter>(text);
 
-            var operationResult = await _conditionalTransformService.EnqueueOperationAsync(transformOperation, resource);
-
+            var operationResult = await _conditionalTransformService.ProcessOperationAsync(transformOperation, resource);
+            
             Assert.Equal(OperationStatus.NoAction, operationResult.SuccessCode);
             Assert.Contains("Condition was not met", operationResult.ErrorMessage);
 
@@ -2089,7 +2089,7 @@ namespace IntegrationTests.Normalization
             string text = File.ReadAllText(resourcePath);
             var resource = parser.Parse<Encounter>(text);
 
-            var operationResult = await _conditionalTransformService.EnqueueOperationAsync(transformOperation, resource);
+            var operationResult = await _conditionalTransformService.ProcessOperationAsync(transformOperation, resource);
             Assert.Equal(OperationStatus.Success, operationResult.SuccessCode);
 
             var modifiedResource = (Encounter)operationResult.Resource;
@@ -2149,8 +2149,8 @@ namespace IntegrationTests.Normalization
             string text = File.ReadAllText(resourcePath);
             var resource = parser.Parse<Encounter>(text);
 
-            var operationResult = await _conditionalTransformService.EnqueueOperationAsync(transformOperation, resource);
-
+            var operationResult = await _conditionalTransformService.ProcessOperationAsync(transformOperation, resource);
+            
             Assert.Equal(OperationStatus.NoAction, operationResult.SuccessCode);
             Assert.Contains("Condition was not met", operationResult.ErrorMessage);
 
@@ -2211,7 +2211,7 @@ namespace IntegrationTests.Normalization
             string text = File.ReadAllText(resourcePath);
             var resource = parser.Parse<Encounter>(text);
 
-            var operationResult = await _conditionalTransformService.EnqueueOperationAsync(transformOperation, resource);
+            var operationResult = await _conditionalTransformService.ProcessOperationAsync(transformOperation, resource);
             Assert.Equal(OperationStatus.Success, operationResult.SuccessCode);
 
             var modifiedResource = (Encounter)operationResult.Resource;
@@ -2271,8 +2271,8 @@ namespace IntegrationTests.Normalization
             string text = File.ReadAllText(resourcePath);
             var resource = parser.Parse<Encounter>(text);
 
-            var operationResult = await _conditionalTransformService.EnqueueOperationAsync(transformOperation, resource);
-
+            var operationResult = await _conditionalTransformService.ProcessOperationAsync(transformOperation, resource);
+            
             Assert.Equal(OperationStatus.NoAction, operationResult.SuccessCode);
             Assert.Contains("Condition was not met", operationResult.ErrorMessage);
 
@@ -2333,7 +2333,7 @@ namespace IntegrationTests.Normalization
             string text = File.ReadAllText(resourcePath);
             var resource = parser.Parse<Observation>(text);
 
-            var operationResult = await _conditionalTransformService.EnqueueOperationAsync(transformOperation, resource);
+            var operationResult = await _conditionalTransformService.ProcessOperationAsync(transformOperation, resource);
             Assert.Equal(OperationStatus.Success, operationResult.SuccessCode);
 
             var modifiedResource = (Observation)operationResult.Resource;
@@ -2393,7 +2393,7 @@ namespace IntegrationTests.Normalization
             string text = File.ReadAllText(resourcePath);
             var resource = parser.Parse<Observation>(text);
 
-            var operationResult = await _conditionalTransformService.EnqueueOperationAsync(transformOperation, resource);
+            var operationResult = await _conditionalTransformService.ProcessOperationAsync(transformOperation, resource);
 
             Assert.Equal(OperationStatus.NoAction, operationResult.SuccessCode);
             Assert.Contains("Condition was not met", operationResult.ErrorMessage);
@@ -2453,7 +2453,7 @@ namespace IntegrationTests.Normalization
 
             Assert.NotNull(copyOperation);
 
-            var operationResult = await _copyLocationOperationService.EnqueueOperationAsync(copyOperation, location);
+            var operationResult = await _copyLocationOperationService.ProcessOperationAsync(copyOperation, location);
             Assert.Equal(OperationStatus.Success, operationResult.SuccessCode);
 
             var modifiedLocation = (Location)operationResult.Resource;

--- a/DotNet/ServiceTests/IntegrationTests/Normalization/OperationTests.cs
+++ b/DotNet/ServiceTests/IntegrationTests/Normalization/OperationTests.cs
@@ -446,7 +446,8 @@ namespace IntegrationTests.Normalization
             var result = await operationManager.DeleteOperationSequence(deleteModel);
 
             Assert.True(result);
-            var searched = await operationSequenceQueries.Search(new OperationSequenceSearchModel { FacilityId = facilityId, ResourceType = "Patient" });
+            operationSequenceQueries.ClearCache(new OperationSequenceSearchModel { ResourceTypeId = opId, FacilityId = facilityId, ResourceType = "Patient" });
+            var searched = await operationSequenceQueries.Search(new OperationSequenceSearchModel { ResourceTypeId = opId, FacilityId = facilityId, ResourceType = "Patient" });
             Assert.Empty(searched);
         }
 


### PR DESCRIPTION
🛠️ Description of Changes

The following optimizations have been made to the Normalization service:

- Data Acquisition will now add Resource Type to the value of ResourceAcquired events. This allows for the Normalization service to not de-serialize each consumed resource. Instead, it will only perform de-serializations if there is an operation to perform for the consumed resource type.
- Added local memory caching when attempting to perform searches for an operation. This will reduce the amount of queries made to the database. This is intended to be a temporary fix for 0.5.1.
- Removed normalization operation enqueuing.
- Added info logging when a normalization operation is being applied to a resource.

🧪 Testing Performed

Local testing was done to ensure that configured operations are being applied after the updates to Normalization.

🧑‍🔬 Unit Testing

Integration tests for Normalization have been updated and are all passing.

📓 Documentation Updated

N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Resource type information now included in acquired resource messages
  * In-memory caching implemented for operation sequences with 60-second TTL

* **Improvements**
  * Operations now execute synchronously instead of background queueing
  * Enhanced debug logging added throughout normalization service operations

* **Bug Fixes**
  * Corrected resource payload references in message listeners

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


### 🧑‍🔬 Unit Testing
- Coverage: 0.0%