### PR TITLE
LNK-5050: Validation for empty sftp root directories

### DIFF
--- a/DotNet/DataAcquisition.AcquisitionWorker/Services/SftpAcquisitionHandler.cs
+++ b/DotNet/DataAcquisition.AcquisitionWorker/Services/SftpAcquisitionHandler.cs
@@ -339,9 +339,7 @@ public class SftpAcquisitionHandler(
                 log.Id, log.FacilityId, ex.Message);
 
             // InvalidOperationException typically indicates a configuration issue (e.g., missing acquisition config, invalid remote directory)
-            await SetStatusOrLogFailure(
-                () => logManager.SetConfigurationRequiredAsync(log.Id, ex.Message, cancellationToken),
-                log.Id, cancellationToken);
+            await logManager.SetConfigurationRequiredAsync(log.Id, ex.Message, cancellationToken);
 
             return new LogProcessingResult(SessionMayBeUnhealthy: false);
         }
@@ -351,9 +349,7 @@ public class SftpAcquisitionHandler(
             activity?.AddException(ex);
 
             // NotSupportedException indicates an unsupported acquisition type - configuration issue
-            await SetStatusOrLogFailure(
-                () => logManager.SetConfigurationRequiredAsync(log.Id, ex.Message, cancellationToken),
-                log.Id, cancellationToken);
+            await logManager.SetConfigurationRequiredAsync(log.Id, ex.Message, cancellationToken);
 
             return new LogProcessingResult(SessionMayBeUnhealthy: false);
         }
@@ -366,9 +362,7 @@ public class SftpAcquisitionHandler(
             activity?.AddException(ex);
 
             // Use retry logic with exponential backoff
-            await SetStatusOrLogFailure(
-                () => FailLogWithRetryAsync(log, ex.Message, logManager, cancellationToken),
-                log.Id, cancellationToken);
+            await FailLogWithRetryAsync(log, ex.Message, logManager, cancellationToken);
 
             // Check if exception indicates potential session/connection issues
             var sessionMayBeUnhealthy = IsSessionRelatedException(ex);
@@ -411,25 +405,6 @@ public class SftpAcquisitionHandler(
         }
 
         return false;
-    }
-
-    /// <summary>
-    /// Wraps a status-transition call so that if the DB update itself fails,
-    /// the exception is logged instead of propagating out of a catch block
-    /// and leaving the log stuck in Processing state.
-    /// </summary>
-    private async Task SetStatusOrLogFailure(Func<Task> statusTransition, long logId, CancellationToken cancellationToken)
-    {
-        try
-        {
-            await statusTransition();
-        }
-        catch (Exception ex)
-        {
-            logger.LogCritical(ex,
-                "Failed to update status for SFTP acquisition log {LogId}. The log may be stuck in Processing state and require manual intervention.",
-                logId);
-        }
     }
 
     private static List<SftpAcquisitionBenchmark>? GetBenchmarks(SftpBenchmarkCollector? collector)

--- a/DotNet/DataAcquisition.AcquisitionWorker/Services/SftpAcquisitionHandler.cs
+++ b/DotNet/DataAcquisition.AcquisitionWorker/Services/SftpAcquisitionHandler.cs
@@ -338,8 +338,10 @@ public class SftpAcquisitionHandler(
             logger.LogError(ex, "Invalid operation for SFTP acquisition log {LogId} for facility {FacilityId}: {Message}",
                 log.Id, log.FacilityId, ex.Message);
 
-            // InvalidOperationException typically indicates a configuration issue (e.g., missing acquisition config)
-            await logManager.SetConfigurationRequiredAsync(log.Id, ex.Message, cancellationToken);
+            // InvalidOperationException typically indicates a configuration issue (e.g., missing acquisition config, invalid remote directory)
+            await SetStatusOrLogFailure(
+                () => logManager.SetConfigurationRequiredAsync(log.Id, ex.Message, cancellationToken),
+                log.Id, cancellationToken);
 
             return new LogProcessingResult(SessionMayBeUnhealthy: false);
         }
@@ -349,7 +351,9 @@ public class SftpAcquisitionHandler(
             activity?.AddException(ex);
 
             // NotSupportedException indicates an unsupported acquisition type - configuration issue
-            await logManager.SetConfigurationRequiredAsync(log.Id, ex.Message, cancellationToken);
+            await SetStatusOrLogFailure(
+                () => logManager.SetConfigurationRequiredAsync(log.Id, ex.Message, cancellationToken),
+                log.Id, cancellationToken);
 
             return new LogProcessingResult(SessionMayBeUnhealthy: false);
         }
@@ -362,7 +366,9 @@ public class SftpAcquisitionHandler(
             activity?.AddException(ex);
 
             // Use retry logic with exponential backoff
-            await FailLogWithRetryAsync(log, ex.Message, logManager, cancellationToken);
+            await SetStatusOrLogFailure(
+                () => FailLogWithRetryAsync(log, ex.Message, logManager, cancellationToken),
+                log.Id, cancellationToken);
 
             // Check if exception indicates potential session/connection issues
             var sessionMayBeUnhealthy = IsSessionRelatedException(ex);
@@ -405,6 +411,25 @@ public class SftpAcquisitionHandler(
         }
 
         return false;
+    }
+
+    /// <summary>
+    /// Wraps a status-transition call so that if the DB update itself fails,
+    /// the exception is logged instead of propagating out of a catch block
+    /// and leaving the log stuck in Processing state.
+    /// </summary>
+    private async Task SetStatusOrLogFailure(Func<Task> statusTransition, long logId, CancellationToken cancellationToken)
+    {
+        try
+        {
+            await statusTransition();
+        }
+        catch (Exception ex)
+        {
+            logger.LogCritical(ex,
+                "Failed to update status for SFTP acquisition log {LogId}. The log may be stuck in Processing state and require manual intervention.",
+                logId);
+        }
     }
 
     private static List<SftpAcquisitionBenchmark>? GetBenchmarks(SftpBenchmarkCollector? collector)

--- a/DotNet/DataAcquisition.Domain/Application/Managers/SftpAcquisitionLogManager.cs
+++ b/DotNet/DataAcquisition.Domain/Application/Managers/SftpAcquisitionLogManager.cs
@@ -307,11 +307,11 @@ public class SftpAcquisitionLogManager(ILogger<SftpAcquisitionLogManager> logger
         if (retryAfter.HasValue)
         {
             log.ScheduledDate = retryAfter.Value.ToUniversalTime();
-            log.Notes.Add($"[{DateTime.UtcNow:O}] Processing failed (attempt {log.RetryAttempts}): {errorMessage}. Retry scheduled for {log.ScheduledDate:O}");
+            log.Notes.Add($"[{DateTime.UtcNow:O}] Processing failed (attempt {log.RetryAttempts}). Retry scheduled for {log.ScheduledDate:O}");
         }
         else
         {
-            log.Notes.Add($"[{DateTime.UtcNow:O}] Processing failed (attempt {log.RetryAttempts}): {errorMessage}");
+            log.Notes.Add($"[{DateTime.UtcNow:O}] Processing failed (attempt {log.RetryAttempts})");
         }
 
         await database.SaveChangesAsync();

--- a/DotNet/DataAcquisition.Domain/Application/Managers/SftpAcquisitionLogManager.cs
+++ b/DotNet/DataAcquisition.Domain/Application/Managers/SftpAcquisitionLogManager.cs
@@ -361,7 +361,6 @@ public class SftpAcquisitionLogManager(ILogger<SftpAcquisitionLogManager> logger
         }
 
         log.Status = RequestStatus.ConfigurationRequired;
-        log.Notes.Add($"[{DateTime.UtcNow:O}] Configuration required: {errorMessage}");
 
         await database.SaveChangesAsync();
         logger.LogWarning("SFTP acquisition log {LogId} marked as configuration required: {Error}", id, errorMessage);

--- a/DotNet/DataAcquisition.Domain/Application/Services/Sftp/SftpSession.cs
+++ b/DotNet/DataAcquisition.Domain/Application/Services/Sftp/SftpSession.cs
@@ -89,6 +89,13 @@ public class SftpSession : ISftpSession
         ObjectDisposedException.ThrowIf(_disposed, this);
         cancellationToken.ThrowIfCancellationRequested();
 
+        // Validate the remote directory path before attempting SFTP operations
+        if (string.IsNullOrWhiteSpace(remoteDirectory))
+        {
+            throw new InvalidOperationException(
+                "Remote directory path is empty. Please configure a valid remote directory path (e.g., '/' for root).");
+        }
+
         // Verify the remote directory exists before attempting to list
         if (!_client.Exists(remoteDirectory))
         {

--- a/DotNet/DataAcquisition.Domain/Application/Validators/SftpConfigurationRequestValidators.cs
+++ b/DotNet/DataAcquisition.Domain/Application/Validators/SftpConfigurationRequestValidators.cs
@@ -15,6 +15,7 @@ public class CreateSftpConfigurationModelValidator : AbstractValidator<CreateSft
         var settings = options.Value.Connection;
 
         RuleFor(x => x.Host)
+            .Cascade(CascadeMode.Stop)
             .NotEmpty()
             .WithMessage("Host is required.")
             .MaximumLength(settings.MaxHostLength)
@@ -27,6 +28,7 @@ public class CreateSftpConfigurationModelValidator : AbstractValidator<CreateSft
             .WithMessage("Port must be between 1 and 65535.");
 
         RuleFor(x => x.RemoteDirectory)
+            .Cascade(CascadeMode.Stop)
             .NotEmpty()
             .WithMessage("Remote directory is required. Use '/' for the root directory.")
             .MaximumLength(settings.MaxRemoteDirectoryLength)
@@ -63,6 +65,7 @@ public class SftpConfigurationModelValidator : AbstractValidator<SftpConfigurati
             .WithMessage("Configuration Id is required.");
 
         RuleFor(x => x.Host)
+            .Cascade(CascadeMode.Stop)
             .NotEmpty()
             .WithMessage("Host is required.")
             .MaximumLength(settings.MaxHostLength)
@@ -75,6 +78,7 @@ public class SftpConfigurationModelValidator : AbstractValidator<SftpConfigurati
             .WithMessage("Port must be between 1 and 65535.");
 
         RuleFor(x => x.RemoteDirectory)
+            .Cascade(CascadeMode.Stop)
             .NotEmpty()
             .WithMessage("Remote directory is required. Use '/' for the root directory.")
             .MaximumLength(settings.MaxRemoteDirectoryLength)
@@ -102,6 +106,7 @@ public class SftpAcquisitionTypeConfigurationValidator : AbstractValidator<SftpA
         var settings = options.Value.Connection;
 
         RuleFor(x => x.RemoteDirectory)
+            .Cascade(CascadeMode.Stop)
             .Must(path => !string.IsNullOrWhiteSpace(path))
             .WithMessage("Acquisition remote directory cannot be empty. Use '/' for the root directory or leave the field blank to inherit from the connection-level directory.")
             .MaximumLength(settings.MaxRemoteDirectoryLength)
@@ -111,6 +116,7 @@ public class SftpAcquisitionTypeConfigurationValidator : AbstractValidator<SftpA
             .When(x => x.RemoteDirectory is not null);
 
         RuleFor(x => x.ProcessedDirectory)
+            .Cascade(CascadeMode.Stop)
             .Must(path => !string.IsNullOrWhiteSpace(path))
             .WithMessage("Processed directory cannot be empty. Provide a valid path or leave the field blank.")
             .MaximumLength(settings.MaxRemoteDirectoryLength)

--- a/DotNet/DataAcquisition.Domain/Application/Validators/SftpConfigurationRequestValidators.cs
+++ b/DotNet/DataAcquisition.Domain/Application/Validators/SftpConfigurationRequestValidators.cs
@@ -1,5 +1,6 @@
 using FluentValidation;
 using LantanaGroup.Link.DataAcquisition.Domain.Application.Models.Api.Configuration;
+using LantanaGroup.Link.DataAcquisition.Domain.Application.Models.Domain;
 using Microsoft.Extensions.Options;
 
 namespace LantanaGroup.Link.DataAcquisition.Domain.Application.Validators;
@@ -26,11 +27,16 @@ public class CreateSftpConfigurationModelValidator : AbstractValidator<CreateSft
             .WithMessage("Port must be between 1 and 65535.");
 
         RuleFor(x => x.RemoteDirectory)
+            .NotEmpty()
+            .WithMessage("Remote directory is required. Use '/' for the root directory.")
             .MaximumLength(settings.MaxRemoteDirectoryLength)
             .WithMessage($"Remote directory path cannot exceed {settings.MaxRemoteDirectoryLength} characters.")
             .Must(SftpConfigurationValidationRules.BeValidRemoteDirectoryPath)
-            .WithMessage("Remote directory path contains invalid characters.")
-            .When(x => !string.IsNullOrEmpty(x.RemoteDirectory));
+            .WithMessage("Remote directory path contains invalid characters.");
+
+        // Validate nested acquisition configurations
+        RuleForEach(x => x.AcquisitionConfigurations)
+            .SetValidator(new SftpAcquisitionTypeConfigurationValidator(options));
 
         RuleFor(x => x.Timeout)
             .Must(timeout => timeout >= TimeSpan.Zero && timeout <= TimeSpan.FromMinutes(settings.MaxTimeoutMinutes))
@@ -69,15 +75,49 @@ public class SftpConfigurationModelValidator : AbstractValidator<SftpConfigurati
             .WithMessage("Port must be between 1 and 65535.");
 
         RuleFor(x => x.RemoteDirectory)
+            .NotEmpty()
+            .WithMessage("Remote directory is required. Use '/' for the root directory.")
             .MaximumLength(settings.MaxRemoteDirectoryLength)
             .WithMessage($"Remote directory path cannot exceed {settings.MaxRemoteDirectoryLength} characters.")
             .Must(SftpConfigurationValidationRules.BeValidRemoteDirectoryPath)
-            .WithMessage("Remote directory path contains invalid characters.")
-            .When(x => !string.IsNullOrEmpty(x.RemoteDirectory));
+            .WithMessage("Remote directory path contains invalid characters.");
+
+        // Validate nested acquisition configurations
+        RuleForEach(x => x.AcquisitionConfigurations)
+            .SetValidator(new SftpAcquisitionTypeConfigurationValidator(options));
 
         RuleFor(x => x.Timeout)
             .Must(timeout => timeout >= TimeSpan.Zero && timeout <= TimeSpan.FromMinutes(settings.MaxTimeoutMinutes))
             .WithMessage($"Timeout must be between 0 and {settings.MaxTimeoutMinutes} minutes.");
+    }
+}
+
+/// <summary>
+/// Validator for SftpAcquisitionTypeConfiguration (nested within SFTP configuration)
+/// </summary>
+public class SftpAcquisitionTypeConfigurationValidator : AbstractValidator<SftpAcquisitionTypeConfiguration>
+{
+    public SftpAcquisitionTypeConfigurationValidator(IOptions<SftpValidationSettings> options)
+    {
+        var settings = options.Value.Connection;
+
+        RuleFor(x => x.RemoteDirectory)
+            .Must(path => !string.IsNullOrWhiteSpace(path))
+            .WithMessage("Acquisition remote directory cannot be empty. Use '/' for the root directory or leave the field blank to inherit from the connection-level directory.")
+            .MaximumLength(settings.MaxRemoteDirectoryLength)
+            .WithMessage($"Acquisition remote directory path cannot exceed {settings.MaxRemoteDirectoryLength} characters.")
+            .Must(SftpConfigurationValidationRules.BeValidRemoteDirectoryPath)
+            .WithMessage("Acquisition remote directory path contains invalid characters.")
+            .When(x => x.RemoteDirectory is not null);
+
+        RuleFor(x => x.ProcessedDirectory)
+            .Must(path => !string.IsNullOrWhiteSpace(path))
+            .WithMessage("Processed directory cannot be empty. Provide a valid path or leave the field blank.")
+            .MaximumLength(settings.MaxRemoteDirectoryLength)
+            .WithMessage($"Processed directory path cannot exceed {settings.MaxRemoteDirectoryLength} characters.")
+            .Must(SftpConfigurationValidationRules.BeValidRemoteDirectoryPath)
+            .WithMessage("Processed directory path contains invalid characters.")
+            .When(x => x.ProcessedDirectory is not null);
     }
 }
 
@@ -140,7 +180,7 @@ public static class SftpConfigurationValidationRules
     public static bool BeValidRemoteDirectoryPath(string? path)
     {
         if (string.IsNullOrWhiteSpace(path))
-            return true; // Empty path is allowed
+            return false;
 
         return !path.Any(c => InvalidPathChars.Contains(c));
     }

--- a/Web/Admin.UI/src/app/components/data-acquisition/sftp-config-form/sftp-config-form.component.html
+++ b/Web/Admin.UI/src/app/components/data-acquisition/sftp-config-form/sftp-config-form.component.html
@@ -40,7 +40,10 @@
           <mat-icon>close</mat-icon>
         </button>
       }
-      <mat-hint>Path to the directory containing census files (optional)</mat-hint>
+      @if (!viewOnly && remoteDirectoryControl.hasError('required')) {
+        <mat-error>Remote directory is <strong>required</strong>. Use '/' for the root directory.</mat-error>
+      }
+      <mat-hint>Path to the directory on the SFTP server (use '/' for root)</mat-hint>
     </mat-form-field>
   </div>
 
@@ -125,6 +128,9 @@
               <mat-label>Remote Directory</mat-label>
               <input matInput formControlName="remoteDirectory" [readonly]="viewOnly"
                      placeholder="/path/to/files">
+              @if (!viewOnly && config.get('remoteDirectory')?.hasError('blank')) {
+                <mat-error>Remote directory cannot be blank. Provide a valid path or clear the field.</mat-error>
+              }
               <mat-hint>Directory for this acquisition type (optional, defaults to connection's remote directory)</mat-hint>
             </mat-form-field>
 
@@ -132,6 +138,9 @@
               <mat-label>Processed Directory</mat-label>
               <input matInput formControlName="processedDirectory" [readonly]="viewOnly"
                      placeholder="/path/to/processed">
+              @if (!viewOnly && config.get('processedDirectory')?.hasError('blank')) {
+                <mat-error>Processed directory cannot be blank. Provide a valid path or clear the field.</mat-error>
+              }
               <mat-hint>Move files here after processing (optional, recommended for audit trail)</mat-hint>
             </mat-form-field>
 

--- a/Web/Admin.UI/src/app/components/data-acquisition/sftp-config-form/sftp-config-form.component.ts
+++ b/Web/Admin.UI/src/app/components/data-acquisition/sftp-config-form/sftp-config-form.component.ts
@@ -1,10 +1,12 @@
 import { Component, EventEmitter, Input, OnChanges, OnInit, Output, SimpleChanges } from '@angular/core';
 import {
+  AbstractControl,
   FormArray,
   FormBuilder,
   FormControl,
   FormGroup,
   ReactiveFormsModule,
+  ValidationErrors,
   Validators
 } from '@angular/forms';
 import { MatButtonModule } from '@angular/material/button';
@@ -80,7 +82,7 @@ export class SftpConfigFormComponent implements OnInit, OnChanges {
       facilityId: this.fb.control('', Validators.required),
       host: this.fb.control('', Validators.required),
       port: this.fb.control(22, [Validators.required, Validators.min(1), Validators.max(65535)]),
-      remoteDirectory: this.fb.control(''),
+      remoteDirectory: this.fb.control('/', Validators.required),
       timeout: this.fb.control('00:01:00', Validators.required),
       removeAfterProcessing: this.fb.control(false),
       enableBenchmarking: this.fb.control(false),
@@ -100,7 +102,7 @@ export class SftpConfigFormComponent implements OnInit, OnChanges {
       this.hostControl.updateValueAndValidity();
       this.portControl.setValue(this.item.port);
       this.portControl.updateValueAndValidity();
-      this.remoteDirectoryControl.setValue(this.item.remoteDirectory || '');
+      this.remoteDirectoryControl.setValue(this.item.remoteDirectory || '/');
       this.remoteDirectoryControl.updateValueAndValidity();
       this.timeoutControl.setValue(this.item.timeout);
       this.timeoutControl.updateValueAndValidity();
@@ -148,7 +150,7 @@ export class SftpConfigFormComponent implements OnInit, OnChanges {
       this.hostControl.updateValueAndValidity();
       this.portControl.setValue(this.item.port);
       this.portControl.updateValueAndValidity();
-      this.remoteDirectoryControl.setValue(this.item.remoteDirectory || '');
+      this.remoteDirectoryControl.setValue(this.item.remoteDirectory || '/');
       this.remoteDirectoryControl.updateValueAndValidity();
       this.timeoutControl.setValue(this.item.timeout);
       this.timeoutControl.updateValueAndValidity();
@@ -279,11 +281,22 @@ export class SftpConfigFormComponent implements OnInit, OnChanges {
     return this.fb.group({
       acquisitionType: [config?.acquisitionType || SftpAcquisitionType.Census, Validators.required],
       subType: [config?.subType || SftpAcquisitionSubType.None, Validators.required],
-      remoteDirectory: [config?.remoteDirectory || ''],
-      processedDirectory: [config?.processedDirectory || ''],
+      remoteDirectory: [config?.remoteDirectory || '', SftpConfigFormComponent.notBlankValidator],
+      processedDirectory: [config?.processedDirectory || '', SftpConfigFormComponent.notBlankValidator],
       fileNamePattern: [config?.fileNamePattern || ''],
       parsingConfiguration: [config?.parsingConfiguration || null]
     });
+  }
+
+  /**
+   * Validator that allows empty (inherits from parent) but rejects whitespace-only values.
+   */
+  static notBlankValidator(control: AbstractControl): ValidationErrors | null {
+    const value = control.value;
+    if (typeof value === 'string' && value.length > 0 && value.trim().length === 0) {
+      return { blank: true };
+    }
+    return null;
   }
 
   addAcquisitionConfiguration(): void {
@@ -300,7 +313,7 @@ export class SftpConfigFormComponent implements OnInit, OnChanges {
   }
 
   clearRemoteDirectory(): void {
-    this.remoteDirectoryControl.setValue('');
+    this.remoteDirectoryControl.setValue('/');
     this.remoteDirectoryControl.updateValueAndValidity();
   }
 
@@ -310,12 +323,16 @@ export class SftpConfigFormComponent implements OnInit, OnChanges {
         organizationId: this.facilityIdControl.value,
         host: this.hostControl.value,
         port: this.portControl.value,
-        remoteDirectory: this.remoteDirectoryControl.value || undefined,
+        remoteDirectory: this.remoteDirectoryControl.value,
         timeout: this.timeoutControl.value,
         removeAfterProcessing: this.removeAfterProcessingControl.value,
         authenticationProtocol: 'Basic',
         enableBenchmarking: this.enableBenchmarkingControl.value,
-        acquisitionConfigurations: this.acquisitionConfigurationsArray.value
+        acquisitionConfigurations: this.acquisitionConfigurationsArray.value.map((ac: any) => ({
+          ...ac,
+          remoteDirectory: ac.remoteDirectory || undefined,
+          processedDirectory: ac.processedDirectory || undefined
+        }))
       };
 
       // Add credentials if provided


### PR DESCRIPTION
### 🛠️ Description of Changes

Added validation for empty SFTP root directories, added logic to move… status of a SFTP log into configuration required if this issue were to arise

### 🧪 Testing Performed

Local testing, screen shots added to the defect ticket.

### 🧑‍🔬 Unit Testing

- [ ] I have written or updated unit tests to cover my changes
- Coverage: 0.0%

### 📓 Documentation Updated

Please update any relevant sections in the project documentation that were impacted by the changes in the PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced validation and error feedback for SFTP directory configuration fields with real-time validation messages

* **Bug Fixes**
  * Remote Directory is now a required field (previously optional) with "/" as the default path
  * Strengthened directory path validation to reject empty strings and whitespace-only values

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
