### PR TITLE
LNK-5030: Filtering patients in report view doesn't work on some patient ids

### DIFF
--- a/DotNet/ServiceTests/UnitTests/Shared/HtmlInputSanitizerTest.cs
+++ b/DotNet/ServiceTests/UnitTests/Shared/HtmlInputSanitizerTest.cs
@@ -9,6 +9,7 @@ public class HtmlInputSanitizerTest
     [InlineData("<script>alert('XSS');</script>", "")]
     [InlineData("alert('XSS');</script>", "alertXSS")]
     [InlineData("Hello, World!", "Hello World")]
+    [InlineData("Hello, World.", "Hello World.")]
     [InlineData("123-456_789", "123-456_789")]
     [InlineData("!@#$%^&*()", "amp")]       // Sanitizer class converts & to &amp; then regex removes & and ;
     [InlineData("", "")]

--- a/DotNet/Shared/Application/Services/Security/HtmlInputSanitizer.cs
+++ b/DotNet/Shared/Application/Services/Security/HtmlInputSanitizer.cs
@@ -18,7 +18,7 @@ namespace LantanaGroup.Link.Shared.Application.Services.Security
         public static string SanitizeAndRemove(this string input)
         {
             var sanitizedInput = Sanitize(input);
-            sanitizedInput = Regex.Replace(sanitizedInput, @"[^a-zA-Z0-9\-_ ]", string.Empty, RegexOptions.Compiled);
+            sanitizedInput = Regex.Replace(sanitizedInput, @"[^a-zA-Z0-9\-_. ]", string.Empty, RegexOptions.Compiled);
             return sanitizedInput;
         }
     }


### PR DESCRIPTION
### 🛠️ Description of Changes

Update `HtmlInputSanitizer` to permit periods, which is required to avoid munging some valid FHIR IDs.

### 🧪 Testing Performed

Confirmed that, after this fix, searching for a period-containing patient ID in the acquisition log screen worked.

### 🧑‍🔬 Unit Testing

- Coverage: 100.0%

- [X] I have written or updated unit tests to cover my changes

### 📓 Documentation Updated

N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Updated input sanitization to allow periods in user-provided text, enabling proper punctuation in entries. Added test coverage to verify sanitizer behavior with punctuated input.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
