### PR TITLE
LNK-5079: Optimize Scheduled Report Table

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -47,7 +47,7 @@ jobs:
         run: echo "run_job=${{ steps.should.outputs.run_job }}"
 
   docker-build-and-run:    
-    name: Adhoc Report Test with Docker Compose
+    name: Smoke Test with Docker Compose
     runs-on: [docker-16core-64gb]
     timeout-minutes: 15
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -47,7 +47,7 @@ jobs:
         run: echo "run_job=${{ steps.should.outputs.run_job }}"
 
   docker-build-and-run:    
-    name: Smoke Test with Docker Compose
+    name: Adhoc Report Test with Docker Compose
     runs-on: [docker-16core-64gb]
     timeout-minutes: 15
 

--- a/DotNet/Automation.Link/Helpers/PipelineSummarySnapshotBuilder.cs
+++ b/DotNet/Automation.Link/Helpers/PipelineSummarySnapshotBuilder.cs
@@ -301,7 +301,14 @@ public class PipelineSummarySnapshotBuilder
             .Where(s => string.Equals(s.Status, "Completed", StringComparison.OrdinalIgnoreCase)
                         || string.Equals(s.Status, "Skipped", StringComparison.OrdinalIgnoreCase))
             .Sum(s => s.Count);
-        var dataAcqComplete = dataAcqTotalLogs > 0 && dataAcqTerminalLogs == dataAcqTotalLogs;
+
+        // DA is complete when all logs reached a terminal state.
+        // For regenerated reports there are zero DA logs (data is reused from the
+        // prior report). In that case, if downstream stages have already progressed
+        // (entries with measure reports exist), DA is implicitly complete.
+        var dataAcqExplicitlyComplete = dataAcqTotalLogs > 0 && dataAcqTerminalLogs == dataAcqTotalLogs;
+        var dataAcqImplicitlyComplete = dataAcqTotalLogs == 0 && entries.Any(e => e.MeasureReports.Count > 0);
+        var dataAcqComplete = dataAcqExplicitlyComplete || dataAcqImplicitlyComplete;
         var measureComplete = measureResources > 0;
 
         var hasValidationOutcome = entries.Any(e =>

--- a/DotNet/Automation.Link/Helpers/ProgressMonitor.cs
+++ b/DotNet/Automation.Link/Helpers/ProgressMonitor.cs
@@ -15,6 +15,7 @@ public class ProgressMonitor
     private readonly PipelineProgressTracker? _progressTracker;
     private readonly PipelineDataReader _reader;
     private readonly LokiScraper? _lokiScraper;
+    private readonly bool _expectsDataAcquisition;
 
     private string? _lastScheduleStatus;
     private int _lastReportEntryCount;
@@ -43,6 +44,7 @@ public class ProgressMonitor
         _output = output;
         _lokiScraper = lokiScraper;
         _reader = reader;
+        _expectsDataAcquisition = expectsDataAcquisition;
         _progressTracker = expectedPatientCount > 0
             ? new PipelineProgressTracker(output, expectedPatientCount, reader, expectsDataAcquisition)
             : null;
@@ -59,7 +61,10 @@ public class ProgressMonitor
         var hasCriticalFailure = false;
 
         hasCriticalFailure |= await CheckReportProgress(facilityId, reportId);
-        hasCriticalFailure |= await CheckDataAcquisitionProgress(facilityId, reportId);
+        if (_expectsDataAcquisition)
+        {
+            hasCriticalFailure |= await CheckDataAcquisitionProgress(facilityId, reportId);
+        }
 
         if (_progressTracker != null)
         {

--- a/DotNet/Automation.Link/Services/ReportApiHelper.cs
+++ b/DotNet/Automation.Link/Services/ReportApiHelper.cs
@@ -82,14 +82,14 @@ public class ReportApiHelper
         var timeoutLabel = hardTimeout == TimeSpan.MaxValue ? "no timeout" : $"hard timeout={hardTimeout.TotalSeconds:F0}s";
 
         // -------------------------------------------------------------------
-        //  Phase 1: Wait for MeasureReportsGenerated milestone
-        //  The pipeline must complete DA → Normalization → MeasureEval before
-        //  submission can happen. Do not burn submission poll retries before
-        //  this milestone is reached.
+        //  Phase 1: Wait for ReportEntriesCreated milestone
+        //  Start schedule polling as soon as report entries exist, instead of
+        //  waiting for downstream milestones that can be noisy during
+        //  regenerate/no-data-acquisition scenarios.
         // -------------------------------------------------------------------
         if (diagnostics != null)
         {
-            var milestoneToAwait = "MeasureReportsGenerated";
+            var milestoneToAwait = "ReportEntriesCreated";
             _output.WriteLine($"Waiting for pipeline milestone '{milestoneToAwait}' before polling submission (reportId={reportId}, {timeoutLabel})...");
 
             var milestoneReached = false;

--- a/DotNet/Automation.UI/Services/AutomationRunManager.cs
+++ b/DotNet/Automation.UI/Services/AutomationRunManager.cs
@@ -1,8 +1,6 @@
 ﻿using Automation.UI.Models;
-using Automation.UI.Models;
 using Automation.UI.Services.Persistence;
 using LantanaGroup.Automation;
-using LantanaGroup.Automation.Generation;
 using LantanaGroup.Link.Automation.Link;
 using LantanaGroup.Link.Automation.Link.Configuration;
 using LantanaGroup.Link.Automation.Link.Helpers;

--- a/DotNet/Automation.UI/Services/RunSnapshotOrchestrator.cs
+++ b/DotNet/Automation.UI/Services/RunSnapshotOrchestrator.cs
@@ -89,18 +89,32 @@ public sealed class RunSnapshotOrchestrator : BackgroundService
     /// </summary>
     public async Task UpdateRunAsync(Guid runId, string facilityId, string reportId, CancellationToken ct = default)
     {
-        // Stop existing poller
+        // 1. Stop the existing poller FIRST so it cannot write stale domain data
+        //    after we clear snapshots. StopAsync awaits the current poll cycle, so
+        //    after this returns the old poller is guaranteed idle.
         if (_activePollers.TryRemove(runId, out var existingHandle))
         {
             await existingHandle.StopAsync();
-            _logger.LogInformation("Stopped existing poller for run {RunId} before re-registration", runId);
+            _logger.LogInformation("Stopped existing poller for run {RunId} before context switch", runId);
         }
 
-        // Clear old domain data so stale first-report data doesn't bleed through
+        // 2. Now safe to update meta and clear stale domain snapshots — no writer
+        //    can re-populate them with old-report data.
         await _store.UpdateRunMetaAsync(runId, facilityId, reportId, ct);
 
-        // The next reconciliation cycle will pick up the updated meta and start a new poller.
-        _logger.LogInformation("Updated run {RunId} to track new report {ReportId}", runId, reportId);
+        // 3. Immediately start a new poller bound to the regenerated report so the
+        //    UI doesn't have to wait up to 2s for the next reconciliation cycle.
+        var meta = new RunSnapshotMeta
+        {
+            RunId = runId,
+            FacilityId = facilityId,
+            ReportId = reportId,
+            StartedAt = DateTimeOffset.UtcNow,
+            IsActive = true
+        };
+        StartPoller(meta, ct);
+
+        _logger.LogInformation("Updated run {RunId} to track new report {ReportId} and started new poller", runId, reportId);
     }
 
     /// <summary>
@@ -145,6 +159,25 @@ public sealed class RunSnapshotOrchestrator : BackgroundService
                 {
                     await completedHandle.StopAsync();
                     _logger.LogWarning("Restarting completed poller task for still-active run {RunId}", meta.RunId);
+                }
+            }
+
+            // If run identifiers changed (e.g., regenerate switched to a new reportId),
+            // force a poller restart so snapshots cannot oscillate between contexts.
+            if (_activePollers.TryGetValue(meta.RunId, out existingHandle)
+                && (!string.Equals(existingHandle.FacilityId, meta.FacilityId, StringComparison.Ordinal)
+                    || !string.Equals(existingHandle.ReportId, meta.ReportId, StringComparison.Ordinal)))
+            {
+                if (_activePollers.TryRemove(meta.RunId, out var staleHandle))
+                {
+                    await staleHandle.StopAsync();
+                    _logger.LogInformation(
+                        "Restarting poller for run {RunId} due to context change (facility: {OldFacility}->{NewFacility}, report: {OldReport}->{NewReport})",
+                        meta.RunId,
+                        staleHandle.FacilityId,
+                        meta.FacilityId,
+                        staleHandle.ReportId,
+                        meta.ReportId);
                 }
             }
 
@@ -215,6 +248,8 @@ public sealed class RunSnapshotOrchestrator : BackgroundService
         IServiceScope scope,
         StoreBackedServicePoller poller)
     {
+        public string FacilityId => poller.FacilityId;
+        public string ReportId => poller.ReportId;
         public bool IsCompleted => pollerTask.IsCompleted;
 
         public Task FinalPollAsync() => poller.FinalPollAsync();

--- a/DotNet/Automation.UI/Services/StoreBackedServicePoller.cs
+++ b/DotNet/Automation.UI/Services/StoreBackedServicePoller.cs
@@ -31,6 +31,9 @@ public sealed class StoreBackedServicePoller
         _logger = logger;
     }
 
+    public string FacilityId => _meta.FacilityId;
+    public string ReportId => _meta.ReportId;
+
     public async Task RunAsync(CancellationToken ct)
     {
         if (!Guid.TryParse(_meta.ReportId, out var scheduleId))
@@ -159,9 +162,8 @@ public sealed class StoreBackedServicePoller
     {
         var summary = await _reader.GetDataAcquisitionReportSummaryAsync(_meta.ReportId);
 
-        if (summary == null)
-            return;
-
+        // Always write — even when null — so stale data from a prior report
+        // (e.g., before regeneration cleared snapshots) is overwritten.
         await _store.SetDomainAsync(_meta.RunId, "acquisitionSummary", summary, ct);
     }
 

--- a/DotNet/DataAcquisition.Domain/Application/Managers/DataAcquisitionLogManager.cs
+++ b/DotNet/DataAcquisition.Domain/Application/Managers/DataAcquisitionLogManager.cs
@@ -1,4 +1,4 @@
-using DataAcquisition.Domain.Application.Models;
+﻿using DataAcquisition.Domain.Application.Models;
 using LantanaGroup.Link.DataAcquisition.Domain.Application.Models.Api.QueryLog;
 using LantanaGroup.Link.DataAcquisition.Domain.Application.Models.Api.Requests;
 using LantanaGroup.Link.DataAcquisition.Domain.Application.Models.Domain;
@@ -82,32 +82,37 @@ public class DataAcquisitionLogManager : IDataAcquisitionLogManager
         activity?.SetTag(DiagnosticNames.FacilityId, model.FacilityId);
         activity?.SetTag(DiagnosticNames.CorrelationId, model.CorrelationId);
 
-        if (model.ScheduledReport == null)
-        {
-            throw new ArgumentNullException("Required property ScheduledReport must not be null");
-        }
+        ScheduledReportEntity? scheduledReportEntity = null;
+        var reportTrackingId = model.ScheduledReport?.ReportTrackingId;
 
-        // Find-or-create the normalised ScheduledReportEntity row.
-        var scheduledReportEntity = await _dbContext.ScheduledReports
-            .FirstOrDefaultAsync(
-                sr => sr.ReportTrackingId == model.ScheduledReport.ReportTrackingId,
-                cancellationToken);
-
-        if (scheduledReportEntity == null)
+        if (!string.IsNullOrWhiteSpace(reportTrackingId))
         {
-            scheduledReportEntity = new ScheduledReportEntity
+            // Find-or-create the normalised ScheduledReportEntity row.
+            scheduledReportEntity = await _dbContext.ScheduledReports
+                .FirstOrDefaultAsync(
+                    sr => sr.ReportTrackingId == reportTrackingId,
+                    cancellationToken);
+
+            if (scheduledReportEntity == null)
             {
-                ReportTrackingId = model.ScheduledReport.ReportTrackingId!,
-                Frequency = model.ScheduledReport.Frequency,
-                StartDate = model.ScheduledReport.StartDate,
-                EndDate = model.ScheduledReport.EndDate,
-                ReportTypes = model.ScheduledReport.ReportTypes != null
-                    ? string.Join(",", model.ScheduledReport.ReportTypes)
-                    : null,
-                CreateDate = DateTime.UtcNow,
-            };
-            _dbContext.ScheduledReports.Add(scheduledReportEntity);
-            await _dbContext.SaveChangesAsync(cancellationToken);
+                scheduledReportEntity = new ScheduledReportEntity
+                {
+                    ReportTrackingId = reportTrackingId,
+                    Frequency = model.ScheduledReport!.Frequency,
+                    StartDate = model.ScheduledReport.StartDate,
+                    EndDate = model.ScheduledReport.EndDate,
+                    ReportTypes = model.ScheduledReport.ReportTypes != null
+                        ? string.Join(",", model.ScheduledReport.ReportTypes)
+                        : null,
+                    CreateDate = DateTime.UtcNow,
+                };
+                _dbContext.ScheduledReports.Add(scheduledReportEntity);
+                await _dbContext.SaveChangesAsync(cancellationToken);
+            }
+        }
+        else if (!model.IsCensus)
+        {
+            throw new ArgumentNullException("Required property ScheduledReport.ReportTrackingId must not be null or empty for non-census logs");
         }
 
         var log = new DataAcquisitionLog
@@ -140,12 +145,12 @@ public class DataAcquisitionLogManager : IDataAcquisitionLogManager
                     ResourceType = r.ResourceType,
                 }).ToList()
             }).ToList(),
-            ScheduledReportId = scheduledReportEntity.Id,
+            ScheduledReportId = scheduledReportEntity?.Id,
             CompletionDate = null,
             CompletionTimeMilliseconds = null,
-            ReportTrackingId = model.ScheduledReport.ReportTrackingId,
-            ReportStartDate = model.ScheduledReport.StartDate,
-            ReportEndDate = model.ScheduledReport.EndDate,
+            ReportTrackingId = model.ScheduledReport?.ReportTrackingId,
+            ReportStartDate = model.ScheduledReport?.StartDate,
+            ReportEndDate = model.ScheduledReport?.EndDate,
             ExecutionDate = model.ExecutionDate,
             CorrelationId = model.CorrelationId,
             TraceId = model.TraceId,

--- a/DotNet/DataAcquisition.Domain/Application/Managers/DataAcquisitionLogManager.cs
+++ b/DotNet/DataAcquisition.Domain/Application/Managers/DataAcquisitionLogManager.cs
@@ -78,6 +78,13 @@ public class DataAcquisitionLogManager : IDataAcquisitionLogManager
 
     public async Task<DataAcquisitionLogModel> CreateAsync(CreateDataAcquisitionLogModel model, CancellationToken cancellationToken = default)
     {
+        ArgumentNullException.ThrowIfNull(model);
+
+        if (string.IsNullOrWhiteSpace(model.FacilityId))
+        {
+            throw new ArgumentNullException(nameof(model.FacilityId));
+        }
+
         using var activity = ServiceActivitySource.Instance.StartActivity("DataAcquisitionLogManager.CreateAsync");
         activity?.SetTag(DiagnosticNames.FacilityId, model.FacilityId);
         activity?.SetTag(DiagnosticNames.CorrelationId, model.CorrelationId);

--- a/DotNet/DataAcquisition.Domain/Application/Managers/DataAcquisitionLogManager.cs
+++ b/DotNet/DataAcquisition.Domain/Application/Managers/DataAcquisitionLogManager.cs
@@ -82,37 +82,15 @@ public class DataAcquisitionLogManager : IDataAcquisitionLogManager
         activity?.SetTag(DiagnosticNames.FacilityId, model.FacilityId);
         activity?.SetTag(DiagnosticNames.CorrelationId, model.CorrelationId);
 
-        ScheduledReportEntity? scheduledReportEntity = null;
-        var reportTrackingId = model.ScheduledReport?.ReportTrackingId;
-
-        if (!string.IsNullOrWhiteSpace(reportTrackingId))
+        Guid? reportTrackingId = null;
+        if (!string.IsNullOrWhiteSpace(model.ReportTrackingId))
         {
-            // Find-or-create the normalised ScheduledReportEntity row.
-            scheduledReportEntity = await _dbContext.ScheduledReports
-                .FirstOrDefaultAsync(
-                    sr => sr.ReportTrackingId == reportTrackingId,
-                    cancellationToken);
-
-            if (scheduledReportEntity == null)
+            if (!Guid.TryParse(model.ReportTrackingId, out var parsedReportTrackingId))
             {
-                scheduledReportEntity = new ScheduledReportEntity
-                {
-                    ReportTrackingId = reportTrackingId,
-                    Frequency = model.ScheduledReport!.Frequency,
-                    StartDate = model.ScheduledReport.StartDate,
-                    EndDate = model.ScheduledReport.EndDate,
-                    ReportTypes = model.ScheduledReport.ReportTypes != null
-                        ? string.Join(",", model.ScheduledReport.ReportTypes)
-                        : null,
-                    CreateDate = DateTime.UtcNow,
-                };
-                _dbContext.ScheduledReports.Add(scheduledReportEntity);
-                await _dbContext.SaveChangesAsync(cancellationToken);
+                throw new ArgumentException("ReportTrackingId must be a valid GUID.", nameof(model.ReportTrackingId));
             }
-        }
-        else if (!model.IsCensus)
-        {
-            throw new ArgumentNullException("Required property ScheduledReport.ReportTrackingId must not be null or empty for non-census logs");
+
+            reportTrackingId = parsedReportTrackingId;
         }
 
         var log = new DataAcquisitionLog
@@ -145,12 +123,9 @@ public class DataAcquisitionLogManager : IDataAcquisitionLogManager
                     ResourceType = r.ResourceType,
                 }).ToList()
             }).ToList(),
-            ScheduledReportId = scheduledReportEntity?.Id,
             CompletionDate = null,
             CompletionTimeMilliseconds = null,
-            ReportTrackingId = model.ScheduledReport?.ReportTrackingId,
-            ReportStartDate = model.ScheduledReport?.StartDate,
-            ReportEndDate = model.ScheduledReport?.EndDate,
+            ReportTrackingId = reportTrackingId,
             ExecutionDate = model.ExecutionDate,
             CorrelationId = model.CorrelationId,
             TraceId = model.TraceId,
@@ -270,13 +245,18 @@ public class DataAcquisitionLogManager : IDataAcquisitionLogManager
             throw new ArgumentNullException(nameof(reportTrackingId), "Report tracking ID cannot be null or empty.");
         }
 
+        if (!Guid.TryParse(reportTrackingId, out var reportTrackingGuid))
+        {
+            throw new ArgumentException("Report tracking ID must be a valid GUID.", nameof(reportTrackingId));
+        }
+
         int totalUpdated = 0;
         int updated;
 
         do
         {
             updated = await _dbContext.DataAcquisitionLogs
-                .Where(l => l.ReportTrackingId == reportTrackingId && !l.IsDeleted)
+                .Where(l => l.ReportTrackingId == reportTrackingGuid && !l.IsDeleted)
                 .Take(SoftDeleteBatchSize)
                 .ExecuteUpdateAsync(setters => setters
                     .SetProperty(l => l.IsDeleted, true)
@@ -300,13 +280,18 @@ public class DataAcquisitionLogManager : IDataAcquisitionLogManager
             throw new ArgumentNullException(nameof(reportTrackingId), "Report tracking ID cannot be null or empty.");
         }
 
+        if (!Guid.TryParse(reportTrackingId, out var reportTrackingGuid))
+        {
+            throw new ArgumentException("Report tracking ID must be a valid GUID.", nameof(reportTrackingId));
+        }
+
         int totalUpdated = 0;
         int updated;
 
         do
         {
             updated = await _dbContext.DataAcquisitionLogs
-                .Where(l => l.ReportTrackingId == reportTrackingId && l.IsDeleted)
+                .Where(l => l.ReportTrackingId == reportTrackingGuid && l.IsDeleted)
                 .Take(SoftDeleteBatchSize)
                 .ExecuteUpdateAsync(setters => setters
                     .SetProperty(l => l.IsDeleted, false)
@@ -472,7 +457,16 @@ public class DataAcquisitionLogManager : IDataAcquisitionLogManager
             query = query.Where(l => l.PatientId == filter.PatientId);
 
         if (!string.IsNullOrEmpty(filter.ReportTrackingId))
-            query = query.Where(l => l.ReportTrackingId == filter.ReportTrackingId);
+        {
+            if (Guid.TryParse(filter.ReportTrackingId, out var filterReportTrackingGuid))
+            {
+                query = query.Where(l => l.ReportTrackingId == filterReportTrackingGuid);
+            }
+            else
+            {
+                query = query.Where(_ => false);
+            }
+        }
 
         if (!string.IsNullOrEmpty(filter.ResourceId))
             query = query.Where(l => l.ResourceIds.Any(r => r.ResourceId == filter.ResourceId));
@@ -539,13 +533,18 @@ public class DataAcquisitionLogManager : IDataAcquisitionLogManager
         activity?.SetTag(DiagnosticNames.CorrelationId, correlationId);
         activity?.SetTag(DiagnosticNames.ReportTrackingId, reportTrackingId);
 
+        if (!Guid.TryParse(reportTrackingId, out var reportTrackingGuid))
+        {
+            throw new ArgumentException("Report tracking ID must be a valid GUID.", nameof(reportTrackingId));
+        }
+
         if (logIds == null || logIds.Count == 0) return;
 
         var updated = await _dbContext.DataAcquisitionLogs
             .Where(l => logIds.Contains(l.Id)
                 && l.FacilityId == facilityId
                 && l.CorrelationId == correlationId
-                && l.ReportTrackingId == reportTrackingId)
+                && l.ReportTrackingId == reportTrackingGuid)
             .ExecuteUpdateAsync(setters => setters
                 .SetProperty(l => l.TailSent, true)
                 .SetProperty(l => l.ModifyDate, DateTime.UtcNow),
@@ -806,7 +805,7 @@ public class DataAcquisitionLogManager : IDataAcquisitionLogManager
                 l.TraceId,
                 ScheduledReport = l.ScheduledReportEntity != null ? new ScheduledReport
                 {
-                    ReportTrackingId = l.ScheduledReportEntity.ReportTrackingId,
+                    ReportTrackingId = l.ScheduledReportEntity.ReportTrackingId.ToString(),
                     Frequency = l.ScheduledReportEntity.Frequency,
                     StartDate = DateTime.SpecifyKind(l.ScheduledReportEntity.StartDate, DateTimeKind.Utc),
                     EndDate = DateTime.SpecifyKind(l.ScheduledReportEntity.EndDate, DateTimeKind.Utc),

--- a/DotNet/DataAcquisition.Domain/Application/Managers/DataAcquisitionLogManager.cs
+++ b/DotNet/DataAcquisition.Domain/Application/Managers/DataAcquisitionLogManager.cs
@@ -812,7 +812,7 @@ public class DataAcquisitionLogManager : IDataAcquisitionLogManager
                 l.TraceId,
                 ScheduledReport = l.ScheduledReportEntity != null ? new ScheduledReport
                 {
-                    ReportTrackingId = l.ScheduledReportEntity.ReportTrackingId.ToString(),
+                    ReportTrackingId = l.ScheduledReportEntity.ReportTrackingId.ToString().ToLower(),
                     Frequency = l.ScheduledReportEntity.Frequency,
                     StartDate = DateTime.SpecifyKind(l.ScheduledReportEntity.StartDate, DateTimeKind.Utc),
                     EndDate = DateTime.SpecifyKind(l.ScheduledReportEntity.EndDate, DateTimeKind.Utc),

--- a/DotNet/DataAcquisition.Domain/Application/Managers/ScheduledReportManager.cs
+++ b/DotNet/DataAcquisition.Domain/Application/Managers/ScheduledReportManager.cs
@@ -1,0 +1,97 @@
+﻿using LantanaGroup.Link.DataAcquisition.Domain.Infrastructure.Context;
+using LantanaGroup.Link.DataAcquisition.Domain.Infrastructure.Entities;
+using LantanaGroup.Link.Shared.Application.Models;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace LantanaGroup.Link.DataAcquisition.Domain.Application.Managers;
+
+public interface IScheduledReportManager
+{
+    /// <summary>
+    /// Ensures a <see cref="ScheduledReportEntity"/> row exists for the given
+    /// <paramref name="report"/>. If a row with a matching <c>ReportTrackingId</c>
+    /// already exists it is returned as-is; otherwise a new row is inserted.
+    ///
+    /// This method is safe to call concurrently from multiple processes — it catches
+    /// the unique-constraint violation that occurs when two workers race to insert
+    /// the same <c>ReportTrackingId</c> and falls back to a read.
+    /// </summary>
+    Task<ScheduledReportEntity> EnsureCreatedAsync(ScheduledReport report, CancellationToken cancellationToken = default);
+}
+
+public class ScheduledReportManager : IScheduledReportManager
+{
+    private readonly DataAcquisitionDbContext _dbContext;
+    private readonly ILogger<ScheduledReportManager> _logger;
+
+    public ScheduledReportManager(DataAcquisitionDbContext dbContext, ILogger<ScheduledReportManager> logger)
+    {
+        _dbContext = dbContext ?? throw new ArgumentNullException(nameof(dbContext));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<ScheduledReportEntity> EnsureCreatedAsync(ScheduledReport report, CancellationToken cancellationToken = default)
+    {
+        if (report == null)
+            throw new ArgumentNullException(nameof(report));
+
+        if (string.IsNullOrWhiteSpace(report.ReportTrackingId))
+            throw new ArgumentException("ReportTrackingId must not be null or empty.", nameof(report));
+
+        if (!Guid.TryParse(report.ReportTrackingId, out var reportTrackingId))
+            throw new ArgumentException("ReportTrackingId must be a valid GUID.", nameof(report));
+
+        // Fast path — row already exists (PK lookup).
+        var existing = await _dbContext.ScheduledReports
+            .FindAsync(new object[] { reportTrackingId }, cancellationToken);
+
+        if (existing != null)
+            return existing;
+
+        // Slow path — insert, handling the race where another process inserts first.
+        var entity = new ScheduledReportEntity
+        {
+            ReportTrackingId = reportTrackingId,
+            Frequency = report.Frequency,
+            StartDate = report.StartDate,
+            EndDate = report.EndDate,
+            ReportTypes = report.ReportTypes != null
+                ? string.Join(",", report.ReportTypes)
+                : null,
+            CreateDate = DateTime.UtcNow,
+        };
+
+        _dbContext.ScheduledReports.Add(entity);
+
+        try
+        {
+            await _dbContext.SaveChangesAsync(cancellationToken);
+            return entity;
+        }
+        catch (DbUpdateException ex) when (IsUniqueConstraintViolation(ex))
+        {
+            _logger.LogDebug(
+                ex,
+                "Concurrent insert for ReportTrackingId={ReportTrackingId} — falling back to read.",
+                report.ReportTrackingId);
+
+            // Detach the failed entity so the DbContext is clean.
+            _dbContext.Entry(entity).State = EntityState.Detached;
+
+            // The other process won the race — read their row.
+            return await _dbContext.ScheduledReports
+                .FindAsync(new object[] { reportTrackingId }, cancellationToken)
+                ?? throw new InvalidOperationException(
+                    $"ScheduledReport with ReportTrackingId={reportTrackingId} not found after concurrent insert.");
+        }
+    }
+
+    private static bool IsUniqueConstraintViolation(DbUpdateException ex)
+    {
+        // SQL Server error 2601 = unique index violation, 2627 = unique constraint violation.
+        var message = ex.InnerException?.Message ?? ex.Message;
+        return message.Contains("2601") || message.Contains("2627")
+            || message.Contains("UNIQUE constraint", StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/DotNet/DataAcquisition.Domain/Application/Models/Api/QueryLog/DataAcquisitionLogModel.cs
+++ b/DotNet/DataAcquisition.Domain/Application/Models/Api/QueryLog/DataAcquisitionLogModel.cs
@@ -1,4 +1,4 @@
-using System.ComponentModel.DataAnnotations;
+﻿using System.ComponentModel.DataAnnotations;
 using DataAcquisition.Domain.Application.Models;
 using LantanaGroup.Link.DataAcquisition.Domain.Application.Models.Api.Configuration;
 using LantanaGroup.Link.DataAcquisition.Domain.Application.Models.Api.QueryLog;
@@ -56,7 +56,7 @@ public class DataAcquisitionLogModel
             IsCensus = log.IsCensus,
             PatientId = log.PatientId,
             ReportableEvent = log.ReportableEvent,
-            ReportTrackingId = log.ReportTrackingId,
+            ReportTrackingId = log.ReportTrackingId != null ? log.ReportTrackingId.ToString() : null,
             CorrelationId = log.CorrelationId,
             FhirVersion = log.FhirVersion,
             QueryType = log.QueryType,
@@ -98,7 +98,7 @@ public class DataAcquisitionLogModel
             ScheduledReport = log.ScheduledReportEntity != null
                 ? new ScheduledReport
                 {
-                    ReportTrackingId = log.ScheduledReportEntity.ReportTrackingId,
+                    ReportTrackingId = log.ScheduledReportEntity.ReportTrackingId.ToString(),
                     Frequency = log.ScheduledReportEntity.Frequency,
                     StartDate = DateTime.SpecifyKind(log.ScheduledReportEntity.StartDate, DateTimeKind.Utc),
                     EndDate = DateTime.SpecifyKind(log.ScheduledReportEntity.EndDate, DateTimeKind.Utc),

--- a/DotNet/DataAcquisition.Domain/Application/Models/Api/QueryLog/DataAcquisitionLogModel.cs
+++ b/DotNet/DataAcquisition.Domain/Application/Models/Api/QueryLog/DataAcquisitionLogModel.cs
@@ -74,6 +74,9 @@ public class DataAcquisitionLogModel
                 QueryParameters = q.QueryParameters,
                 Paged = q.Paged,
                 DataAcquisitionLogId = q.DataAcquisitionLogId,
+                CensusTimeFrame = q.CensusTimeFrame,
+                CensusPatientStatus = q.CensusPatientStatus,
+                CensusListId = q.CensusListId,
                 ResourceReferenceTypes = q.ResourceReferenceTypes != null ? q.ResourceReferenceTypes.Select(rt => new ResourceReferenceTypeModel
                 {
                     Id = rt.Id,

--- a/DotNet/DataAcquisition.Domain/Application/Models/Api/QueryLog/DataAcquisitionLogModel.cs
+++ b/DotNet/DataAcquisition.Domain/Application/Models/Api/QueryLog/DataAcquisitionLogModel.cs
@@ -56,7 +56,7 @@ public class DataAcquisitionLogModel
             IsCensus = log.IsCensus,
             PatientId = log.PatientId,
             ReportableEvent = log.ReportableEvent,
-            ReportTrackingId = log.ReportTrackingId != null ? log.ReportTrackingId.ToString() : null,
+            ReportTrackingId = log.ReportTrackingId?.ToString().ToLowerInvariant(),
             CorrelationId = log.CorrelationId,
             FhirVersion = log.FhirVersion,
             QueryType = log.QueryType,
@@ -101,7 +101,7 @@ public class DataAcquisitionLogModel
             ScheduledReport = log.ScheduledReportEntity != null
                 ? new ScheduledReport
                 {
-                    ReportTrackingId = log.ScheduledReportEntity.ReportTrackingId.ToString(),
+                    ReportTrackingId = log.ScheduledReportEntity.ReportTrackingId.ToString().ToLowerInvariant(),
                     Frequency = log.ScheduledReportEntity.Frequency,
                     StartDate = DateTime.SpecifyKind(log.ScheduledReportEntity.StartDate, DateTimeKind.Utc),
                     EndDate = DateTime.SpecifyKind(log.ScheduledReportEntity.EndDate, DateTimeKind.Utc),

--- a/DotNet/DataAcquisition.Domain/Application/Models/CreateDataAcquisitionLogModel.cs
+++ b/DotNet/DataAcquisition.Domain/Application/Models/CreateDataAcquisitionLogModel.cs
@@ -1,10 +1,8 @@
 ﻿using LantanaGroup.Link.DataAcquisition.Domain.Application.Models.Api.Configuration;
 using LantanaGroup.Link.DataAcquisition.Domain.Infrastructure.Models.Enums;
-using LantanaGroup.Link.Shared.Application.Models.Integration.DataAcquisition;
-using RequestStatus = LantanaGroup.Link.Shared.Application.Models.Integration.DataAcquisition.RequestStatus;
-using QueryPhase = LantanaGroup.Link.Shared.Application.Models.Integration.DataAcquisition.QueryPhase;
 using FhirQueryType = LantanaGroup.Link.Shared.Application.Models.Integration.DataAcquisition.FhirQueryType;
-using LantanaGroup.Link.Shared.Application.Models;
+using QueryPhase = LantanaGroup.Link.Shared.Application.Models.Integration.DataAcquisition.QueryPhase;
+using RequestStatus = LantanaGroup.Link.Shared.Application.Models.Integration.DataAcquisition.RequestStatus;
 
 namespace DataAcquisition.Domain.Application.Models
 {
@@ -24,7 +22,7 @@ namespace DataAcquisition.Domain.Application.Models
         public DateTime? ExecutionDate { get; set; }
         public string? TraceId { get; set; }
         public List<string> Notes { get; set; } = new List<string>();
-        public ScheduledReport? ScheduledReport { get; set; }
+        public string? ReportTrackingId { get; set; }
         public int? SiblingCount { get; set; }
     }
 }

--- a/DotNet/DataAcquisition.Domain/Application/Models/CreateDataAcquisitionLogModel.cs
+++ b/DotNet/DataAcquisition.Domain/Application/Models/CreateDataAcquisitionLogModel.cs
@@ -1,4 +1,4 @@
-using LantanaGroup.Link.DataAcquisition.Domain.Application.Models.Api.Configuration;
+﻿using LantanaGroup.Link.DataAcquisition.Domain.Application.Models.Api.Configuration;
 using LantanaGroup.Link.DataAcquisition.Domain.Infrastructure.Models.Enums;
 using LantanaGroup.Link.Shared.Application.Models.Integration.DataAcquisition;
 using RequestStatus = LantanaGroup.Link.Shared.Application.Models.Integration.DataAcquisition.RequestStatus;
@@ -24,7 +24,7 @@ namespace DataAcquisition.Domain.Application.Models
         public DateTime? ExecutionDate { get; set; }
         public string? TraceId { get; set; }
         public List<string> Notes { get; set; } = new List<string>();
-        public required ScheduledReport ScheduledReport { get; set; }
+        public ScheduledReport? ScheduledReport { get; set; }
         public int? SiblingCount { get; set; }
     }
 }

--- a/DotNet/DataAcquisition.Domain/Application/Queries/DataAcquisitionLogQueries.cs
+++ b/DotNet/DataAcquisition.Domain/Application/Queries/DataAcquisitionLogQueries.cs
@@ -173,7 +173,7 @@ public class DataAcquisitionLogQueries : IDataAcquisitionLogQueries
                 IsCensus = l.IsCensus,
                 PatientId = l.PatientId,
                 ReportableEvent = l.ReportableEvent,
-                ReportTrackingId = l.ReportTrackingId,
+                ReportTrackingId = l.ReportTrackingId != null ? l.ReportTrackingId.ToString() : null,
                 CorrelationId = l.CorrelationId,
                 FhirVersion = l.FhirVersion,
                 QueryType = l.QueryType,
@@ -216,7 +216,7 @@ public class DataAcquisitionLogQueries : IDataAcquisitionLogQueries
                 Notes = null,
                 ScheduledReport = l.ScheduledReportEntity != null ? new ScheduledReport
                 {
-                    ReportTrackingId = l.ScheduledReportEntity.ReportTrackingId,
+                    ReportTrackingId = l.ScheduledReportEntity.ReportTrackingId.ToString(),
                     Frequency = l.ScheduledReportEntity.Frequency,
                     StartDate = DateTime.SpecifyKind(l.ScheduledReportEntity.StartDate, DateTimeKind.Utc),
                     EndDate = DateTime.SpecifyKind(l.ScheduledReportEntity.EndDate, DateTimeKind.Utc),
@@ -251,9 +251,7 @@ public class DataAcquisitionLogQueries : IDataAcquisitionLogQueries
                     !log.TailSent &&
                     log.Status != null && completedOrFailedStatuses.Contains(log.Status.Value) &&
                     log.ReportTrackingId != null &&
-                    log.CorrelationId != null &&
-                    log.ReportStartDate != null &&
-                    log.ReportEndDate != null)
+                    log.CorrelationId != null)
                 .GroupBy(log => new
                 {
                     log.FacilityId,
@@ -264,7 +262,7 @@ public class DataAcquisitionLogQueries : IDataAcquisitionLogQueries
                 .Select(g => new
                 {
                     Key = g.Key,
-                    EarliestStart = g.Min(x => x.ReportStartDate)
+                    EarliestStart = g.Min(x => x.ScheduledReportEntity != null ? x.ScheduledReportEntity.StartDate : DateTime.MaxValue)
                 })
                 .OrderBy(x => x.EarliestStart)
                 .Take(100)
@@ -309,7 +307,7 @@ public class DataAcquisitionLogQueries : IDataAcquisitionLogQueries
                         log.ReportableEvent,
                         ScheduledReport = log.ScheduledReportEntity != null ? new ScheduledReport
                         {
-                            ReportTrackingId = log.ScheduledReportEntity.ReportTrackingId,
+                            ReportTrackingId = log.ScheduledReportEntity.ReportTrackingId.ToString(),
                             Frequency = log.ScheduledReportEntity.Frequency,
                             StartDate = DateTime.SpecifyKind(log.ScheduledReportEntity.StartDate, DateTimeKind.Utc),
                             EndDate = DateTime.SpecifyKind(log.ScheduledReportEntity.EndDate, DateTimeKind.Utc),
@@ -317,8 +315,6 @@ public class DataAcquisitionLogQueries : IDataAcquisitionLogQueries
                                 ? log.ScheduledReportEntity.ReportTypes.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries).ToList()
                                 : new List<string>()
                         } : null,
-                        log.ReportStartDate,
-                        log.ReportEndDate
                     })
                     .ToListAsync(cancellationToken);
 
@@ -472,7 +468,7 @@ public class DataAcquisitionLogQueries : IDataAcquisitionLogQueries
                         RetryAttempts = log.RetryAttempts,
                         Status = log.Status,
                         IsDeleted = log.IsDeleted,
-                        ReportTrackingId = log.ReportTrackingId
+                        ReportTrackingId = log.ReportTrackingId != null ? log.ReportTrackingId.ToString() : null
                     };
                 }).ToList();
             }
@@ -507,7 +503,7 @@ public class DataAcquisitionLogQueries : IDataAcquisitionLogQueries
                 IsCensus = l.IsCensus,
                 PatientId = l.PatientId,
                 ReportableEvent = l.ReportableEvent,
-                ReportTrackingId = l.ReportTrackingId,
+                ReportTrackingId = l.ReportTrackingId != null ? l.ReportTrackingId.ToString() : null,
                 CorrelationId = l.CorrelationId,
                 FhirVersion = l.FhirVersion,
                 QueryType = l.QueryType,
@@ -544,8 +540,13 @@ public class DataAcquisitionLogQueries : IDataAcquisitionLogQueries
         using var activity = ServiceActivitySource.Instance.StartActivity("DataAcquisitionLogQueries.GetDataAcquisitionLogStatisticsByReportAsync");
         activity?.SetTag(DiagnosticNames.ReportId, reportId);
 
+        if (!Guid.TryParse(reportId, out var reportTrackingIdGuid))
+        {
+            throw new ArgumentException("Report ID must be a valid GUID.", nameof(reportId));
+        }
+
         var baseQuery = _dbContext.DataAcquisitionLogs.AsNoTracking()
-            .Where(l => l.ReportTrackingId == reportId && !l.IsDeleted);
+            .Where(l => l.ReportTrackingId == reportTrackingIdGuid && !l.IsDeleted);
 
         // Scalar aggregates in a single DB pass
         var totals = await baseQuery
@@ -713,9 +714,14 @@ public class DataAcquisitionLogQueries : IDataAcquisitionLogQueries
             throw new ArgumentNullException(nameof(reportId), "Report ID cannot be null or empty.");
         }
 
+        if (!Guid.TryParse(reportId, out var reportTrackingIdGuid))
+        {
+            throw new ArgumentException("Report ID must be a valid GUID.", nameof(reportId));
+        }
+
         var query = _dbContext.DataAcquisitionLogs
             .AsNoTracking()
-            .Where(log => log.ReportTrackingId == reportId);
+            .Where(log => log.ReportTrackingId == reportTrackingIdGuid);
 
         if (!string.IsNullOrWhiteSpace(patientId))
         {
@@ -753,10 +759,13 @@ public class DataAcquisitionLogQueries : IDataAcquisitionLogQueries
         if (string.IsNullOrWhiteSpace(correlationId))
             throw new ArgumentNullException(nameof(correlationId), "Correlation ID cannot be null or empty.");
 
+        if (!Guid.TryParse(reportTrackingId, out var reportTrackingIdGuid))
+            throw new ArgumentException("Report Tracking ID must be a valid GUID.", nameof(reportTrackingId));
+
         return await _dbContext.DataAcquisitionLogResourceIds
             .AnyAsync(r =>
                 r.ResourceId == referenceId
-                && r.DataAcquisitionLog.ReportTrackingId == reportTrackingId
+                && r.DataAcquisitionLog.ReportTrackingId == reportTrackingIdGuid
                 && r.DataAcquisitionLog.FacilityId == facilityId
                 && r.DataAcquisitionLog.CorrelationId == correlationId,
                 cancellationToken);
@@ -798,7 +807,14 @@ public class DataAcquisitionLogQueries : IDataAcquisitionLogQueries
 
         if (!string.IsNullOrEmpty(model.ReportTrackingId))
         {
-            query = query.Where(log => log.ReportTrackingId == model.ReportTrackingId);
+            if (Guid.TryParse(model.ReportTrackingId, out var parsedReportTrackingId))
+            {
+                query = query.Where(log => log.ReportTrackingId == parsedReportTrackingId);
+            }
+            else
+            {
+                query = query.Where(_ => false);
+            }
         }
 
         if (model.QueryPhase.HasValue)
@@ -879,7 +895,7 @@ public class DataAcquisitionLogQueries : IDataAcquisitionLogQueries
                         IsCensus = log.IsCensus,
                         PatientId = log.PatientId,
                         ReportableEvent = log.ReportableEvent,
-                        ReportTrackingId = log.ReportTrackingId,
+                        ReportTrackingId = log.ReportTrackingId != null ? log.ReportTrackingId.ToString() : null,
                         CorrelationId = log.CorrelationId,
                         FhirVersion = log.FhirVersion,
                         QueryType = log.QueryType,
@@ -894,7 +910,7 @@ public class DataAcquisitionLogQueries : IDataAcquisitionLogQueries
                         Notes = null,
                         ScheduledReport = log.ScheduledReportEntity != null ? new ScheduledReport
                         {
-                            ReportTrackingId = log.ScheduledReportEntity.ReportTrackingId,
+                            ReportTrackingId = log.ScheduledReportEntity.ReportTrackingId.ToString(),
                             Frequency = log.ScheduledReportEntity.Frequency,
                             StartDate = DateTime.SpecifyKind(log.ScheduledReportEntity.StartDate, DateTimeKind.Utc),
                             EndDate = DateTime.SpecifyKind(log.ScheduledReportEntity.EndDate, DateTimeKind.Utc),

--- a/DotNet/DataAcquisition.Domain/Application/Queries/DataAcquisitionLogQueries.cs
+++ b/DotNet/DataAcquisition.Domain/Application/Queries/DataAcquisitionLogQueries.cs
@@ -173,7 +173,7 @@ public class DataAcquisitionLogQueries : IDataAcquisitionLogQueries
                 IsCensus = l.IsCensus,
                 PatientId = l.PatientId,
                 ReportableEvent = l.ReportableEvent,
-                ReportTrackingId = l.ReportTrackingId != null ? l.ReportTrackingId.ToString() : null,
+                ReportTrackingId = l.ReportTrackingId != null ? l.ReportTrackingId.ToString().ToLower() : null,
                 CorrelationId = l.CorrelationId,
                 FhirVersion = l.FhirVersion,
                 QueryType = l.QueryType,
@@ -216,7 +216,7 @@ public class DataAcquisitionLogQueries : IDataAcquisitionLogQueries
                 Notes = null,
                 ScheduledReport = l.ScheduledReportEntity != null ? new ScheduledReport
                 {
-                    ReportTrackingId = l.ScheduledReportEntity.ReportTrackingId.ToString(),
+                    ReportTrackingId = l.ScheduledReportEntity.ReportTrackingId.ToString().ToLower(),
                     Frequency = l.ScheduledReportEntity.Frequency,
                     StartDate = DateTime.SpecifyKind(l.ScheduledReportEntity.StartDate, DateTimeKind.Utc),
                     EndDate = DateTime.SpecifyKind(l.ScheduledReportEntity.EndDate, DateTimeKind.Utc),
@@ -307,7 +307,7 @@ public class DataAcquisitionLogQueries : IDataAcquisitionLogQueries
                         log.ReportableEvent,
                         ScheduledReport = log.ScheduledReportEntity != null ? new ScheduledReport
                         {
-                            ReportTrackingId = log.ScheduledReportEntity.ReportTrackingId.ToString(),
+                            ReportTrackingId = log.ScheduledReportEntity.ReportTrackingId.ToString().ToLower(),
                             Frequency = log.ScheduledReportEntity.Frequency,
                             StartDate = DateTime.SpecifyKind(log.ScheduledReportEntity.StartDate, DateTimeKind.Utc),
                             EndDate = DateTime.SpecifyKind(log.ScheduledReportEntity.EndDate, DateTimeKind.Utc),
@@ -468,7 +468,7 @@ public class DataAcquisitionLogQueries : IDataAcquisitionLogQueries
                         RetryAttempts = log.RetryAttempts,
                         Status = log.Status,
                         IsDeleted = log.IsDeleted,
-                        ReportTrackingId = log.ReportTrackingId != null ? log.ReportTrackingId.ToString() : null
+                        ReportTrackingId = log.ReportTrackingId != null ? log.ReportTrackingId.ToString().ToLower() : null
                     };
                 }).ToList();
             }
@@ -503,7 +503,7 @@ public class DataAcquisitionLogQueries : IDataAcquisitionLogQueries
                 IsCensus = l.IsCensus,
                 PatientId = l.PatientId,
                 ReportableEvent = l.ReportableEvent,
-                ReportTrackingId = l.ReportTrackingId != null ? l.ReportTrackingId.ToString() : null,
+                ReportTrackingId = l.ReportTrackingId != null ? l.ReportTrackingId.ToString().ToLower() : null,
                 CorrelationId = l.CorrelationId,
                 FhirVersion = l.FhirVersion,
                 QueryType = l.QueryType,
@@ -895,7 +895,7 @@ public class DataAcquisitionLogQueries : IDataAcquisitionLogQueries
                         IsCensus = log.IsCensus,
                         PatientId = log.PatientId,
                         ReportableEvent = log.ReportableEvent,
-                        ReportTrackingId = log.ReportTrackingId != null ? log.ReportTrackingId.ToString() : null,
+                        ReportTrackingId = log.ReportTrackingId != null ? log.ReportTrackingId.ToString().ToLower() : null,
                         CorrelationId = log.CorrelationId,
                         FhirVersion = log.FhirVersion,
                         QueryType = log.QueryType,
@@ -910,7 +910,7 @@ public class DataAcquisitionLogQueries : IDataAcquisitionLogQueries
                         Notes = null,
                         ScheduledReport = log.ScheduledReportEntity != null ? new ScheduledReport
                         {
-                            ReportTrackingId = log.ScheduledReportEntity.ReportTrackingId.ToString(),
+                            ReportTrackingId = log.ScheduledReportEntity.ReportTrackingId.ToString().ToLower(),
                             Frequency = log.ScheduledReportEntity.Frequency,
                             StartDate = DateTime.SpecifyKind(log.ScheduledReportEntity.StartDate, DateTimeKind.Utc),
                             EndDate = DateTime.SpecifyKind(log.ScheduledReportEntity.EndDate, DateTimeKind.Utc),

--- a/DotNet/DataAcquisition.Domain/Application/Services/PatientCensusService.cs
+++ b/DotNet/DataAcquisition.Domain/Application/Services/PatientCensusService.cs
@@ -1,4 +1,4 @@
-using Confluent.Kafka;
+﻿using Confluent.Kafka;
 using DataAcquisition.Domain.Application.Models;
 using Hl7.Fhir.Model;
 using Hl7.Fhir.Utility;
@@ -153,7 +153,7 @@ public class PatientCensusService : IPatientCensusService
                 ExecutionDate = DateTime.UtcNow,
                 Priority = AcquisitionPriority.Normal,
                 IsCensus = true,
-                ScheduledReport = new ScheduledReport()
+                ScheduledReport = null
             };
 
             facilityConfig.EHRPatientLists.ForEach(x =>

--- a/DotNet/DataAcquisition.Domain/Application/Services/PatientCensusService.cs
+++ b/DotNet/DataAcquisition.Domain/Application/Services/PatientCensusService.cs
@@ -153,7 +153,6 @@ public class PatientCensusService : IPatientCensusService
                 ExecutionDate = DateTime.UtcNow,
                 Priority = AcquisitionPriority.Normal,
                 IsCensus = true,
-                ScheduledReport = null
             };
 
             facilityConfig.EHRPatientLists.ForEach(x =>

--- a/DotNet/DataAcquisition.Domain/Application/Services/PatientDataService.cs
+++ b/DotNet/DataAcquisition.Domain/Application/Services/PatientDataService.cs
@@ -1,4 +1,4 @@
-using Confluent.Kafka;
+ï»¿using Confluent.Kafka;
 using DataAcquisition.Domain.Application.Models;
 using Hl7.Fhir.Model;
 using LantanaGroup.Link.DataAcquisition.Domain.Application.Factories;
@@ -66,6 +66,7 @@ public class PatientDataService : IPatientDataService
     private readonly IFhirApiService _fhirApiService;
     private readonly IDistributedSemaphoreProvider _distributedSemaphoreProvider;
     private readonly IPatientCensusService _patientCensusService;
+    private readonly IScheduledReportManager _scheduledReportManager;
 
     public PatientDataService(
         IDatabase database,
@@ -79,7 +80,8 @@ public class PatientDataService : IPatientDataService
         IFhirApiService fhirApiService,
         IDistributedSemaphoreProvider distributedSemaphoreProvider,
         IServiceProvider serviceProvider,
-        IPatientCensusService patientCensusService)
+        IPatientCensusService patientCensusService,
+        IScheduledReportManager scheduledReportManager)
     {
         _database = database ?? throw new ArgumentNullException(nameof(database));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
@@ -98,6 +100,7 @@ public class PatientDataService : IPatientDataService
         _dataAcquisitionLogQueries = dataAcquisitionLogQueries ??
                                      throw new ArgumentNullException(nameof(dataAcquisitionLogQueries));
         _fhirApiService = fhirApiService ?? throw new ArgumentNullException(nameof(fhirApiService));
+        _scheduledReportManager = scheduledReportManager ?? throw new ArgumentNullException(nameof(scheduledReportManager));
         _distributedSemaphoreProvider = distributedSemaphoreProvider ??
                                         throw new ArgumentNullException(nameof(distributedSemaphoreProvider));
         _patientCensusService = patientCensusService ?? throw new ArgumentNullException(nameof(patientCensusService));
@@ -248,6 +251,12 @@ public class PatientDataService : IPatientDataService
 
             foreach (var schedReport in request.ConsumeResult.Message.Value.ScheduledReports)
             {
+                // Ensure the ScheduledReport row exists (concurrency-safe, deduplicated by ReportTrackingId).
+                if (!string.IsNullOrWhiteSpace(schedReport.ReportTrackingId))
+                {
+                    await _scheduledReportManager.EnsureCreatedAsync(schedReport, cancellationToken);
+                }
+
                 if (request.QueryPlanType == QueryPlanType.Initial)
                 {
                     var priority = schedReport.Frequency == Frequency.Daily
@@ -270,7 +279,7 @@ public class PatientDataService : IPatientDataService
                                 QueryType = FhirQueryType.Read,
                                 QueryPhase =
                                     QueryPhaseUtilities.ToDomain(request.ConsumeResult.Message.Value.QueryType),
-                                ScheduledReport = schedReport,
+                                ReportTrackingId = schedReport.ReportTrackingId,
                                 TraceId = traceAndSpanDelimited,
                                 FhirQuery = new List<CreateFhirQueryModel>
                                 {
@@ -329,7 +338,7 @@ public class PatientDataService : IPatientDataService
                 }
             }
 
-            // All logs committed — stamp the sibling count so workers know the full set exists.
+            // All logs committed â€” stamp the sibling count so workers know the full set exists.
             if (totalLogsCreated > 0)
             {
                 var queryPhase = QueryPhaseUtilities.ToDomain(request.ConsumeResult.Value.QueryType);
@@ -360,7 +369,7 @@ public class PatientDataService : IPatientDataService
         //1. get log
         var log = await _dataAcquisitionLogQueries.GetAsync(request.logId, cancellationToken);
 
-        // Read facility config once — reused by the happy path and all error handlers
+        // Read facility config once â€” reused by the happy path and all error handlers
         FhirQueryConfigurationModel? fhirQueryConfiguration = null;
 
         try
@@ -462,7 +471,7 @@ public class PatientDataService : IPatientDataService
                     $"Log with ID {log.Id} is not in a queued state. Current status: {log.Status}");
             }
 
-            //2. atomically update to "Processing" — single DB write, no follow-up UpdateAsync needed
+            //2. atomically update to "Processing" â€” single DB write, no follow-up UpdateAsync needed
             var allowedStatuses = new List<RequestStatus> { RequestStatus.Queued };
             if (request.ignoreStatusConstraint && log.Status.HasValue)
             {

--- a/DotNet/DataAcquisition.Domain/Application/Services/QueryListProcessor.cs
+++ b/DotNet/DataAcquisition.Domain/Application/Services/QueryListProcessor.cs
@@ -1,4 +1,4 @@
-using System.Diagnostics;
+﻿using System.Diagnostics;
 using Confluent.Kafka;
 using DataAcquisition.Domain.Application.Models;
 using Hl7.Fhir.Model;
@@ -219,7 +219,7 @@ public class QueryListProcessor : IQueryListProcessor
             {
                 // Reference resources are now fetched inline during normal log
                 // processing (in ProcessReferences). No separate log is needed.
-                _logger.LogDebug("Skipping separate log creation for reference query {ResourceType} � references are resolved inline.", ((ReferenceQueryConfig)queryConfig).ResourceType);
+                _logger.LogDebug("Skipping separate log creation for reference query {ResourceType} — references are resolved inline.", ((ReferenceQueryConfig)queryConfig).ResourceType);
             }
         }
 
@@ -245,7 +245,7 @@ public class QueryListProcessor : IQueryListProcessor
             FhirVersion = "R4",
             QueryPhase = QueryPhaseUtilities.ToDomain(request.QueryPlanType.ToString()),
             Status = RequestStatus.Pending,
-            ScheduledReport = scheduledReport,
+            ReportTrackingId = scheduledReport.ReportTrackingId,
             ExecutionDate = DateTime.UtcNow,
             FhirQuery = [fhirQuery],
             TraceId = traceAndSpanDelimited ?? string.Empty,

--- a/DotNet/DataAcquisition.Domain/Extensions/GeneralStartupExtensions.cs
+++ b/DotNet/DataAcquisition.Domain/Extensions/GeneralStartupExtensions.cs
@@ -241,6 +241,7 @@ public static class GeneralStartupExtensions
         services.AddTransient<IReferenceResourcesManager, ReferenceResourcesManager>();
         services.AddTransient<IFhirQueryManager, FhirQueryManager>();
         services.AddTransient<IDataAcquisitionLogManager, DataAcquisitionLogManager>();
+        services.AddTransient<IScheduledReportManager, ScheduledReportManager>();
         services.AddTransient<ISftpAcquisitionLogManager, SftpAcquisitionLogManager>();
         services.AddTransient<ISftpConfigurationManager, SftpConfigurationManager>();
     }

--- a/DotNet/DataAcquisition.Domain/Infrastructure/Context/DataAcquisitionDbContext.cs
+++ b/DotNet/DataAcquisition.Domain/Infrastructure/Context/DataAcquisitionDbContext.cs
@@ -1,4 +1,4 @@
-using AppAny.Quartz.EntityFrameworkCore.Migrations;
+﻿using AppAny.Quartz.EntityFrameworkCore.Migrations;
 using AppAny.Quartz.EntityFrameworkCore.Migrations.SqlServer;
 using LantanaGroup.Link.DataAcquisition.Domain.Application.Models.Domain;
 using LantanaGroup.Link.DataAcquisition.Domain.Application.Serializers;
@@ -161,6 +161,12 @@ public class DataAcquisitionDbContext : DbContext
                 .HasPrincipalKey(x => x.Id)
                 .OnDelete(DeleteBehavior.Cascade);
 
+            entity.HasOne(x => x.ScheduledReportEntity)
+                .WithMany(x => x.DataAcquisitionLogs)
+                .HasForeignKey(x => x.ReportTrackingId)
+                .HasPrincipalKey(x => x.ReportTrackingId)
+                .OnDelete(DeleteBehavior.SetNull);
+
             entity.Property(d => d.Status)
                 .HasConversion(new EnumToStringConverter<RequestStatus>())
                 .HasMaxLength(50);
@@ -226,9 +232,9 @@ public class DataAcquisitionDbContext : DbContext
                 .HasDatabaseName("IX_DataAcquisitionLogs_FacilityId_IsDeleted")
                 .HasFilter("[IsDeleted] = 1");
 
-            entity.HasIndex(e => new { e.TailSent, e.FacilityId, e.ReportTrackingId, e.CorrelationId, e.ReportStartDate, e.ReportEndDate, e.QueryPhase })
+            entity.HasIndex(e => new { e.TailSent, e.FacilityId, e.ReportTrackingId, e.CorrelationId, e.QueryPhase })
                 .HasDatabaseName("IX_DataAcquisitionLogs_Tailing_Optimization")
-                .HasFilter("[TailSent] = 0 AND [ReportTrackingId] IS NOT NULL AND [CorrelationId] IS NOT NULL AND [ReportStartDate] IS NOT NULL AND [ReportEndDate] IS NOT NULL");
+                .HasFilter("[TailSent] = 0 AND [ReportTrackingId] IS NOT NULL AND [CorrelationId] IS NOT NULL");
 
             entity.HasIndex(e => new { e.TailSent, e.SiblingCount, e.FacilityId, e.CorrelationId, e.QueryPhase, e.Status })
                 .HasDatabaseName("IX_DataAcquisitionLogs_InlineTail")
@@ -276,11 +282,7 @@ public class DataAcquisitionDbContext : DbContext
         //-------------------ScheduledReportEntity-------------------
         modelBuilder.Entity<ScheduledReportEntity>(entity =>
         {
-            entity.Property(e => e.Id).ValueGeneratedOnAdd();
-
-            entity.HasIndex(e => e.ReportTrackingId)
-                .IsUnique()
-                .HasDatabaseName("UX_ScheduledReports_ReportTrackingId");
+            entity.HasKey(e => e.ReportTrackingId);
 
             entity.Property(e => e.Frequency)
                 .HasConversion(new EnumToStringConverter<Frequency>());

--- a/DotNet/DataAcquisition.Domain/Infrastructure/Context/DataAcquisitionDbContext.cs
+++ b/DotNet/DataAcquisition.Domain/Infrastructure/Context/DataAcquisitionDbContext.cs
@@ -251,6 +251,36 @@ public class DataAcquisitionDbContext : DbContext
                     nameof(DataAcquisitionLog.CompletionTimeMilliseconds)
                 );
 
+            // Covers GetTailingMessages Phase-1 query (filters !TailSent, checks Status, groups by facility/tracking/correlation/phase).
+            entity.HasIndex(e => new { e.TailSent, e.Status })
+                .HasDatabaseName("IX_DataAcquisitionLogs_TailSent_Status")
+                .IncludeProperties(
+                    nameof(DataAcquisitionLog.FacilityId),
+                    nameof(DataAcquisitionLog.ReportTrackingId),
+                    nameof(DataAcquisitionLog.CorrelationId),
+                    nameof(DataAcquisitionLog.QueryPhase),
+                    nameof(DataAcquisitionLog.TraceId),
+                    nameof(DataAcquisitionLog.PatientId),
+                    nameof(DataAcquisitionLog.ReportableEvent)
+                );
+
+            // Covers default UI pagination on (IsDeleted, Id DESC).
+            entity.HasIndex(e => new { e.IsDeleted, e.Id })
+                .HasDatabaseName("IX_DataAcquisitionLogs_IsDeleted_Id")
+                .IncludeProperties(
+                    nameof(DataAcquisitionLog.Priority),
+                    nameof(DataAcquisitionLog.FacilityId),
+                    nameof(DataAcquisitionLog.PatientId),
+                    nameof(DataAcquisitionLog.ReportTrackingId),
+                    nameof(DataAcquisitionLog.FhirVersion),
+                    nameof(DataAcquisitionLog.QueryType),
+                    nameof(DataAcquisitionLog.QueryPhase),
+                    nameof(DataAcquisitionLog.ExecutionDate),
+                    nameof(DataAcquisitionLog.CreateDate),
+                    nameof(DataAcquisitionLog.RetryAttempts),
+                    nameof(DataAcquisitionLog.Status)
+                );
+
             });
 
             //-------------------DataAcquisitionLogResourceId-------------------

--- a/DotNet/DataAcquisition.Domain/Infrastructure/Entities/DataAcquisitionLog.cs
+++ b/DotNet/DataAcquisition.Domain/Infrastructure/Entities/DataAcquisitionLog.cs
@@ -1,12 +1,10 @@
+﻿using LantanaGroup.Link.DataAcquisition.Domain.Application.Models.Api.Configuration;
+using LantanaGroup.Link.DataAcquisition.Domain.Infrastructure.Models.Enums;
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
-using LantanaGroup.Link.DataAcquisition.Domain.Application.Models.Api.Configuration;
-using LantanaGroup.Link.DataAcquisition.Domain.Infrastructure.Models.Enums;
-using LantanaGroup.Link.Shared.Application.Models.Integration.DataAcquisition;
-using RequestStatus = LantanaGroup.Link.Shared.Application.Models.Integration.DataAcquisition.RequestStatus;
-using QueryPhase = LantanaGroup.Link.Shared.Application.Models.Integration.DataAcquisition.QueryPhase;
 using FhirQueryType = LantanaGroup.Link.Shared.Application.Models.Integration.DataAcquisition.FhirQueryType;
-using LantanaGroup.Link.Shared.Application.Models;
+using QueryPhase = LantanaGroup.Link.Shared.Application.Models.Integration.DataAcquisition.QueryPhase;
+using RequestStatus = LantanaGroup.Link.Shared.Application.Models.Integration.DataAcquisition.RequestStatus;
 
 namespace LantanaGroup.Link.DataAcquisition.Domain.Infrastructure.Entities;
 
@@ -43,9 +41,7 @@ public class DataAcquisitionLog
 
     public long? CompletionTimeMilliseconds { get; set; }
 
-    public long? ScheduledReportId { get; set; }
-
-    [ForeignKey("ScheduledReportId")]
+    [ForeignKey("ReportTrackingId")]
     public virtual ScheduledReportEntity? ScheduledReportEntity { get; set; }
 
     public bool IsCensus { get; set; } = false;
@@ -56,12 +52,7 @@ public class DataAcquisitionLog
 
     public bool IsDeleted { get; set; } = false;
 
-    [MaxLength(128)]
-    public string? ReportTrackingId { get; set; }
-
-    public DateTime? ReportEndDate { get; set; }
-
-    public DateTime? ReportStartDate { get; set; }
+    public Guid? ReportTrackingId { get; set; }
 
     [StringLength(64)]
     public string? TraceId { get; set; }

--- a/DotNet/DataAcquisition.Domain/Infrastructure/Entities/ScheduledReportEntity.cs
+++ b/DotNet/DataAcquisition.Domain/Infrastructure/Entities/ScheduledReportEntity.cs
@@ -1,5 +1,5 @@
-﻿using System.ComponentModel.DataAnnotations;
-using LantanaGroup.Link.Shared.Application.Models;
+﻿using LantanaGroup.Link.Shared.Application.Models;
+using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
 
 namespace LantanaGroup.Link.DataAcquisition.Domain.Infrastructure.Entities;
@@ -13,11 +13,7 @@ namespace LantanaGroup.Link.DataAcquisition.Domain.Infrastructure.Entities;
 public class ScheduledReportEntity
 {
     [Key]
-    public long Id { get; set; }
-
-    [Required]
-    [MaxLength(256)]
-    public string ReportTrackingId { get; set; } = null!;
+    public Guid ReportTrackingId { get; set; }
 
     [Required]
     public Frequency Frequency { get; set; }

--- a/DotNet/DataAcquisition.Domain/Migrations/20260418000000_PerformanceTuningCollapsed.cs
+++ b/DotNet/DataAcquisition.Domain/Migrations/20260418000000_PerformanceTuningCollapsed.cs
@@ -548,9 +548,6 @@ namespace DataAcquisition.Domain.Migrations
             migrationBuilder.DropTable(name: "DataAcquisitionLogResourceIds");
             migrationBuilder.DropTable(name: "DataAcquisitionLogNotes");
 
-            // Drop junction table
-            migrationBuilder.DropTable(name: "DataAcquisitionLogReferenceResource");
-
             // Restore ReferenceResources: unique index → non-unique, re-add FK column
             migrationBuilder.DropIndex(
                 name: "IX_ReferenceResources_Facility_Type_ResourceId",
@@ -600,6 +597,9 @@ namespace DataAcquisition.Domain.Migrations
                     GROUP BY [ReferenceResourceId]
                 ) j ON rr.[Id] = j.[ReferenceResourceId];
             ");
+
+            // Drop junction table (after data has been restored from it)
+            migrationBuilder.DropTable(name: "DataAcquisitionLogReferenceResource");
 
             // RCSI off
             migrationBuilder.Sql(@"

--- a/DotNet/DataAcquisition.Domain/Migrations/20260505000000_NaturalKeyScheduledReport.Designer.cs
+++ b/DotNet/DataAcquisition.Domain/Migrations/20260505000000_NaturalKeyScheduledReport.Designer.cs
@@ -1258,7 +1258,8 @@ namespace DataAcquisition.Domain.Migrations
                 {
                     b.HasOne("LantanaGroup.Link.DataAcquisition.Domain.Infrastructure.Entities.ScheduledReportEntity", "ScheduledReportEntity")
                         .WithMany("DataAcquisitionLogs")
-                        .HasForeignKey("ReportTrackingId");
+                        .HasForeignKey("ReportTrackingId")
+                        .OnDelete(DeleteBehavior.SetNull);
 
                     b.Navigation("ScheduledReportEntity");
                 });

--- a/DotNet/DataAcquisition.Domain/Migrations/20260505000000_NaturalKeyScheduledReport.Designer.cs
+++ b/DotNet/DataAcquisition.Domain/Migrations/20260505000000_NaturalKeyScheduledReport.Designer.cs
@@ -700,6 +700,16 @@ namespace DataAcquisition.Domain.Migrations
                         .HasDatabaseName("IX_DataAcquisitionLogs_Tailing_Optimization")
                         .HasFilter("[TailSent] = 0 AND [ReportTrackingId] IS NOT NULL AND [CorrelationId] IS NOT NULL");
 
+                    SqlServerIndexBuilderExtensions.IncludeProperties(b.HasIndex("TailSent", "Status"), new[] { "FacilityId", "ReportTrackingId", "CorrelationId", "QueryPhase", "TraceId", "PatientId", "ReportableEvent" });
+
+                    b.HasIndex("TailSent", "Status")
+                        .HasDatabaseName("IX_DataAcquisitionLogs_TailSent_Status");
+
+                    b.HasIndex("IsDeleted", "Id")
+                        .HasDatabaseName("IX_DataAcquisitionLogs_IsDeleted_Id");
+
+                    SqlServerIndexBuilderExtensions.IncludeProperties(b.HasIndex("IsDeleted", "Id"), new[] { "Priority", "FacilityId", "PatientId", "ReportTrackingId", "FhirVersion", "QueryType", "QueryPhase", "ExecutionDate", "CreateDate", "RetryAttempts", "Status" });
+
                     b.ToTable("DataAcquisitionLog");
                 });
 

--- a/DotNet/DataAcquisition.Domain/Migrations/20260505000000_NaturalKeyScheduledReport.Designer.cs
+++ b/DotNet/DataAcquisition.Domain/Migrations/20260505000000_NaturalKeyScheduledReport.Designer.cs
@@ -4,6 +4,7 @@ using LantanaGroup.Link.DataAcquisition.Domain.Infrastructure.Context;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace DataAcquisition.Domain.Migrations
 {
     [DbContext(typeof(DataAcquisitionDbContext))]
-    partial class DataAcquisitionDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260505000000_NaturalKeyScheduledReport")]
+    partial class NaturalKeyScheduledReport
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -1032,7 +1035,6 @@ namespace DataAcquisition.Domain.Migrations
             modelBuilder.Entity("LantanaGroup.Link.DataAcquisition.Domain.Infrastructure.Entities.ScheduledReportEntity", b =>
                 {
                     b.Property<Guid>("ReportTrackingId")
-                        .ValueGeneratedOnAdd()
                         .HasColumnType("uniqueidentifier");
 
                     b.Property<DateTime>("CreateDate")

--- a/DotNet/DataAcquisition.Domain/Migrations/20260505000000_NaturalKeyScheduledReport.cs
+++ b/DotNet/DataAcquisition.Domain/Migrations/20260505000000_NaturalKeyScheduledReport.cs
@@ -1,0 +1,302 @@
+﻿using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace DataAcquisition.Domain.Migrations
+{
+    /// <summary>
+    /// Promotes ReportTrackingId to the natural primary key of ScheduledReports and
+    /// makes DataAcquisitionLog.ReportTrackingId the FK, eliminating the synthetic
+    /// bigint Id / ScheduledReportId indirection.
+    ///
+    /// Also removes the redundant ReportStartDate / ReportEndDate columns from
+    /// DataAcquisitionLog (dates live in ScheduledReports via the FK).
+    ///
+    /// Migration steps:
+    ///   1. Backfill orphaned ReportTrackingId values into ScheduledReports.
+    ///   2. Drop all indexes and the FK that reference the old ScheduledReportId / Id columns.
+    ///   3. Drop ScheduledReportId column from DataAcquisitionLog.
+    ///   4. Drop the Id PK from ScheduledReports, create new PK on ReportTrackingId.
+    ///   5. Drop the old Id column from ScheduledReports.
+    ///   6. Create the FK: DataAcquisitionLog.ReportTrackingId → ScheduledReports.ReportTrackingId.
+    ///   7. Drop ReportStartDate / ReportEndDate columns.
+    ///   8. Recreate indexes to match the new schema.
+    /// </summary>
+    public partial class NaturalKeyScheduledReport : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            // 1) Backfill orphan scheduled reports from legacy logs.
+            migrationBuilder.Sql(@"
+                INSERT INTO [ScheduledReports] ([ReportTrackingId], [Frequency], [StartDate], [EndDate], [ReportTypes], [CreateDate])
+                SELECT
+                    dal.[ReportTrackingId],
+                    'Adhoc',
+                    COALESCE(dal.[ReportStartDate], '1900-01-01'),
+                    COALESCE(dal.[ReportEndDate],   '1900-01-01'),
+                    NULL,
+                    GETUTCDATE()
+                FROM (
+                    SELECT [ReportTrackingId], [ReportStartDate], [ReportEndDate],
+                           ROW_NUMBER() OVER (PARTITION BY [ReportTrackingId] ORDER BY [Id]) AS rn
+                    FROM [DataAcquisitionLog]
+                    WHERE [ReportTrackingId] IS NOT NULL
+                ) dal
+                WHERE dal.rn = 1
+                  AND NOT EXISTS (
+                      SELECT 1 FROM [ScheduledReports] sr
+                      WHERE sr.[ReportTrackingId] = dal.[ReportTrackingId]
+                  );
+            ");
+
+            // 2) Validate all non-null ReportTrackingIds are GUIDs before conversion.
+            migrationBuilder.Sql(@"
+                IF EXISTS (
+                    SELECT 1
+                    FROM [DataAcquisitionLog]
+                    WHERE [ReportTrackingId] IS NOT NULL
+                      AND TRY_CONVERT(uniqueidentifier, [ReportTrackingId]) IS NULL)
+                BEGIN
+                    THROW 50001, 'DataAcquisitionLog contains non-GUID ReportTrackingId values. Migration aborted.', 1;
+                END
+
+                IF EXISTS (
+                    SELECT 1
+                    FROM [ScheduledReports]
+                    WHERE [ReportTrackingId] IS NOT NULL
+                      AND TRY_CONVERT(uniqueidentifier, [ReportTrackingId]) IS NULL)
+                BEGIN
+                    THROW 50002, 'ScheduledReports contains non-GUID ReportTrackingId values. Migration aborted.', 1;
+                END
+            ");
+
+            // 3) Drop dependent constraints/indexes using old ScheduledReportId or ReportTrackingId(string) shape.
+            migrationBuilder.Sql(@"
+                DECLARE @fkName sysname;
+                SELECT TOP 1 @fkName = fk.[name]
+                FROM sys.foreign_keys fk
+                INNER JOIN sys.foreign_key_columns fkc ON fk.object_id = fkc.constraint_object_id
+                INNER JOIN sys.columns c ON fkc.parent_object_id = c.object_id AND fkc.parent_column_id = c.column_id
+                WHERE fk.parent_object_id = OBJECT_ID('DataAcquisitionLog')
+                  AND fk.referenced_object_id = OBJECT_ID('ScheduledReports')
+                  AND c.[name] = 'ScheduledReportId';
+
+                IF @fkName IS NOT NULL
+                    EXEC('ALTER TABLE [DataAcquisitionLog] DROP CONSTRAINT [' + @fkName + ']');
+
+                IF EXISTS (SELECT 1 FROM sys.indexes WHERE object_id = OBJECT_ID('DataAcquisitionLog') AND name = 'IX_DataAcquisitionLog_ScheduledReportId')
+                    DROP INDEX [IX_DataAcquisitionLog_ScheduledReportId] ON [DataAcquisitionLog];
+
+                IF EXISTS (SELECT 1 FROM sys.indexes WHERE object_id = OBJECT_ID('DataAcquisitionLog') AND name = 'IX_DataAcquisitionLogs_Tailing_Optimization')
+                    DROP INDEX [IX_DataAcquisitionLogs_Tailing_Optimization] ON [DataAcquisitionLog];
+
+                IF EXISTS (SELECT 1 FROM sys.indexes WHERE object_id = OBJECT_ID('DataAcquisitionLog') AND name = 'IX_DataAcquisitionLogs_ReportTrackingId_IsDeleted')
+                    DROP INDEX [IX_DataAcquisitionLogs_ReportTrackingId_IsDeleted] ON [DataAcquisitionLog];
+
+                IF EXISTS (SELECT 1 FROM sys.indexes WHERE object_id = OBJECT_ID('DataAcquisitionLog') AND name = 'IX_DataAcquisitionLogs_Facility_Status_ExecutionDate_Id')
+                    DROP INDEX [IX_DataAcquisitionLogs_Facility_Status_ExecutionDate_Id] ON [DataAcquisitionLog];
+
+                IF EXISTS (SELECT 1 FROM sys.indexes WHERE object_id = OBJECT_ID('DataAcquisitionLog') AND name = 'IX_DataAcquisitionLogs_Paging_Default')
+                    DROP INDEX [IX_DataAcquisitionLogs_Paging_Default] ON [DataAcquisitionLog];
+
+                IF EXISTS (SELECT 1 FROM sys.indexes WHERE object_id = OBJECT_ID('ScheduledReports') AND name = 'UX_ScheduledReports_ReportTrackingId')
+                    DROP INDEX [UX_ScheduledReports_ReportTrackingId] ON [ScheduledReports];
+            ");
+
+            // 4) Remove old ScheduledReportId indirection.
+            migrationBuilder.DropColumn(name: "ScheduledReportId", table: "DataAcquisitionLog");
+
+            // 5) Promote ScheduledReports.ReportTrackingId to PK and convert to uniqueidentifier.
+            migrationBuilder.Sql(@"
+                ALTER TABLE [ScheduledReports] DROP CONSTRAINT [PK_ScheduledReports];
+                ALTER TABLE [ScheduledReports] DROP COLUMN [Id];
+                ALTER TABLE [ScheduledReports] ALTER COLUMN [ReportTrackingId] uniqueidentifier NOT NULL;
+                ALTER TABLE [ScheduledReports] ADD CONSTRAINT [PK_ScheduledReports] PRIMARY KEY CLUSTERED ([ReportTrackingId]);
+            ");
+
+            // 6) Convert DataAcquisitionLog.ReportTrackingId to uniqueidentifier.
+            migrationBuilder.Sql(@"
+                ALTER TABLE [DataAcquisitionLog] ALTER COLUMN [ReportTrackingId] uniqueidentifier NULL;
+            ");
+
+            // 7) Add natural-key FK.
+            migrationBuilder.Sql(@"
+                ALTER TABLE [DataAcquisitionLog]
+                    ADD CONSTRAINT [FK_DataAcquisitionLog_ScheduledReports_ReportTrackingId]
+                    FOREIGN KEY ([ReportTrackingId])
+                    REFERENCES [ScheduledReports] ([ReportTrackingId])
+                    ON DELETE SET NULL;
+            ");
+
+            // 8) Drop legacy date columns.
+            migrationBuilder.Sql(@"
+                DECLARE @dfName1 sysname;
+                SELECT @dfName1 = dc.[name]
+                FROM sys.default_constraints dc
+                INNER JOIN sys.columns c ON dc.parent_object_id = c.object_id AND dc.parent_column_id = c.column_id
+                WHERE dc.parent_object_id = OBJECT_ID('DataAcquisitionLog') AND c.[name] = 'ReportStartDate';
+                IF @dfName1 IS NOT NULL EXEC('ALTER TABLE [DataAcquisitionLog] DROP CONSTRAINT [' + @dfName1 + ']');
+
+                DECLARE @dfName2 sysname;
+                SELECT @dfName2 = dc.[name]
+                FROM sys.default_constraints dc
+                INNER JOIN sys.columns c ON dc.parent_object_id = c.object_id AND dc.parent_column_id = c.column_id
+                WHERE dc.parent_object_id = OBJECT_ID('DataAcquisitionLog') AND c.[name] = 'ReportEndDate';
+                IF @dfName2 IS NOT NULL EXEC('ALTER TABLE [DataAcquisitionLog] DROP CONSTRAINT [' + @dfName2 + ']');
+            ");
+
+            migrationBuilder.DropColumn(name: "ReportStartDate", table: "DataAcquisitionLog");
+            migrationBuilder.DropColumn(name: "ReportEndDate",   table: "DataAcquisitionLog");
+
+            // 9) Recreate indexes in final shape.
+            migrationBuilder.CreateIndex(
+                name: "IX_DataAcquisitionLogs_Paging_Default",
+                table: "DataAcquisitionLog",
+                columns: new[] { "ExecutionDate", "Id" },
+                descending: new[] { true, true })
+                .Annotation("SqlServer:Include", new[] {
+                    "Priority", "FacilityId", "IsCensus", "PatientId", "ReportableEvent",
+                    "ReportTrackingId", "CorrelationId", "TraceId", "FhirVersion", "QueryType",
+                    "QueryPhase", "Status", "RetryAttempts", "CompletionDate", "CompletionTimeMilliseconds"
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_DataAcquisitionLogs_Facility_Status_ExecutionDate_Id",
+                table: "DataAcquisitionLog",
+                columns: new[] { "FacilityId", "Status", "ExecutionDate", "Id" })
+                .Annotation("SqlServer:Include", new[] {
+                    "Priority", "IsCensus", "PatientId", "ReportableEvent", "ReportTrackingId",
+                    "CorrelationId", "FhirVersion", "QueryType", "QueryPhase", "TraceId",
+                    "RetryAttempts", "CompletionDate", "CompletionTimeMilliseconds"
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_DataAcquisitionLogs_ReportTrackingId_IsDeleted",
+                table: "DataAcquisitionLog",
+                columns: new[] { "ReportTrackingId", "IsDeleted" })
+                .Annotation("SqlServer:Include", new[] { "PatientId", "Status", "RetryAttempts", "CompletionTimeMilliseconds" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_DataAcquisitionLogs_Tailing_Optimization",
+                table: "DataAcquisitionLog",
+                columns: new[] { "TailSent", "FacilityId", "ReportTrackingId", "CorrelationId", "QueryPhase" },
+                filter: "[TailSent] = 0 AND [ReportTrackingId] IS NOT NULL AND [CorrelationId] IS NOT NULL");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_DataAcquisitionLog_ReportTrackingId",
+                table: "DataAcquisitionLog",
+                column: "ReportTrackingId");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql(@"
+                IF EXISTS (SELECT 1 FROM sys.foreign_keys WHERE name = 'FK_DataAcquisitionLog_ScheduledReports_ReportTrackingId')
+                    ALTER TABLE [DataAcquisitionLog] DROP CONSTRAINT [FK_DataAcquisitionLog_ScheduledReports_ReportTrackingId];
+
+                IF EXISTS (SELECT 1 FROM sys.indexes WHERE object_id = OBJECT_ID('DataAcquisitionLog') AND name = 'IX_DataAcquisitionLog_ReportTrackingId')
+                    DROP INDEX [IX_DataAcquisitionLog_ReportTrackingId] ON [DataAcquisitionLog];
+
+                IF EXISTS (SELECT 1 FROM sys.indexes WHERE object_id = OBJECT_ID('DataAcquisitionLog') AND name = 'IX_DataAcquisitionLogs_Tailing_Optimization')
+                    DROP INDEX [IX_DataAcquisitionLogs_Tailing_Optimization] ON [DataAcquisitionLog];
+
+                IF EXISTS (SELECT 1 FROM sys.indexes WHERE object_id = OBJECT_ID('DataAcquisitionLog') AND name = 'IX_DataAcquisitionLogs_ReportTrackingId_IsDeleted')
+                    DROP INDEX [IX_DataAcquisitionLogs_ReportTrackingId_IsDeleted] ON [DataAcquisitionLog];
+
+                IF EXISTS (SELECT 1 FROM sys.indexes WHERE object_id = OBJECT_ID('DataAcquisitionLog') AND name = 'IX_DataAcquisitionLogs_Facility_Status_ExecutionDate_Id')
+                    DROP INDEX [IX_DataAcquisitionLogs_Facility_Status_ExecutionDate_Id] ON [DataAcquisitionLog];
+
+                IF EXISTS (SELECT 1 FROM sys.indexes WHERE object_id = OBJECT_ID('DataAcquisitionLog') AND name = 'IX_DataAcquisitionLogs_Paging_Default')
+                    DROP INDEX [IX_DataAcquisitionLogs_Paging_Default] ON [DataAcquisitionLog];
+
+                ALTER TABLE [DataAcquisitionLog] ALTER COLUMN [ReportTrackingId] nvarchar(128) NULL;
+
+                ALTER TABLE [ScheduledReports] DROP CONSTRAINT [PK_ScheduledReports];
+                ALTER TABLE [ScheduledReports] ALTER COLUMN [ReportTrackingId] nvarchar(256) NOT NULL;
+                ALTER TABLE [ScheduledReports] ADD [Id] bigint IDENTITY(1,1) NOT NULL;
+                ALTER TABLE [ScheduledReports] ADD CONSTRAINT [PK_ScheduledReports] PRIMARY KEY CLUSTERED ([Id]);
+
+                CREATE UNIQUE NONCLUSTERED INDEX [UX_ScheduledReports_ReportTrackingId]
+                    ON [ScheduledReports] ([ReportTrackingId]);
+            ");
+
+            // Re-add ScheduledReportId column and backfill
+            migrationBuilder.AddColumn<long>(
+                name: "ScheduledReportId",
+                table: "DataAcquisitionLog",
+                type: "bigint",
+                nullable: true);
+
+            migrationBuilder.Sql(@"
+                UPDATE dal
+                SET dal.[ScheduledReportId] = sr.[Id]
+                FROM [DataAcquisitionLog] dal
+                INNER JOIN [ScheduledReports] sr ON dal.[ReportTrackingId] = sr.[ReportTrackingId]
+                WHERE dal.[ReportTrackingId] IS NOT NULL;
+            ");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_DataAcquisitionLog_ScheduledReportId",
+                table: "DataAcquisitionLog",
+                column: "ScheduledReportId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_DataAcquisitionLog_ScheduledReports_ScheduledReportId",
+                table: "DataAcquisitionLog",
+                column: "ScheduledReportId",
+                principalTable: "ScheduledReports",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.SetNull);
+
+            // Re-add date columns
+            migrationBuilder.AddColumn<DateTime>(
+                name: "ReportStartDate", table: "DataAcquisitionLog", type: "datetime2", nullable: true);
+            migrationBuilder.AddColumn<DateTime>(
+                name: "ReportEndDate",   table: "DataAcquisitionLog", type: "datetime2", nullable: true);
+
+            migrationBuilder.Sql(@"
+                UPDATE dal
+                SET dal.[ReportStartDate] = sr.[StartDate],
+                    dal.[ReportEndDate]   = sr.[EndDate]
+                FROM [DataAcquisitionLog] dal
+                INNER JOIN [ScheduledReports] sr ON dal.[ScheduledReportId] = sr.[Id]
+                WHERE dal.[ScheduledReportId] IS NOT NULL;
+            ");
+
+            // Recreate original tailing index
+            migrationBuilder.CreateIndex(
+                name: "IX_DataAcquisitionLogs_Tailing_Optimization",
+                table: "DataAcquisitionLog",
+                columns: new[] { "TailSent", "FacilityId", "ReportTrackingId", "CorrelationId", "ReportStartDate", "ReportEndDate", "QueryPhase" },
+                filter: "[TailSent] = 0 AND [ReportTrackingId] IS NOT NULL AND [CorrelationId] IS NOT NULL AND [ReportStartDate] IS NOT NULL AND [ReportEndDate] IS NOT NULL");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_DataAcquisitionLogs_ReportTrackingId_IsDeleted",
+                table: "DataAcquisitionLog",
+                columns: new[] { "ReportTrackingId", "IsDeleted" })
+                .Annotation("SqlServer:Include", new[] { "PatientId", "Status", "RetryAttempts", "CompletionTimeMilliseconds" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_DataAcquisitionLogs_Facility_Status_ExecutionDate_Id",
+                table: "DataAcquisitionLog",
+                columns: new[] { "FacilityId", "Status", "ExecutionDate", "Id" })
+                .Annotation("SqlServer:Include", new[] {
+                    "Priority", "IsCensus", "PatientId", "ReportableEvent", "ReportTrackingId",
+                    "CorrelationId", "FhirVersion", "QueryType", "QueryPhase", "TraceId",
+                    "RetryAttempts", "CompletionDate", "CompletionTimeMilliseconds"
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_DataAcquisitionLogs_Paging_Default",
+                table: "DataAcquisitionLog",
+                columns: new[] { "ExecutionDate", "Id" },
+                descending: new[] { true, true })
+                .Annotation("SqlServer:Include", new[] {
+                    "Priority", "FacilityId", "IsCensus", "PatientId", "ReportableEvent",
+                    "ReportTrackingId", "CorrelationId", "TraceId", "FhirVersion", "QueryType",
+                    "QueryPhase", "Status", "RetryAttempts", "CompletionDate", "CompletionTimeMilliseconds"
+                });
+        }
+    }
+}

--- a/DotNet/DataAcquisition.Domain/Migrations/20260505000000_NaturalKeyScheduledReport.cs
+++ b/DotNet/DataAcquisition.Domain/Migrations/20260505000000_NaturalKeyScheduledReport.cs
@@ -69,6 +69,16 @@ namespace DataAcquisition.Domain.Migrations
                 BEGIN
                     THROW 50002, 'ScheduledReports contains non-GUID ReportTrackingId values. Migration aborted.', 1;
                 END
+
+                IF EXISTS (
+                    SELECT 1
+                    FROM [ScheduledReports]
+                    WHERE [ReportTrackingId] IS NOT NULL
+                    GROUP BY TRY_CONVERT(uniqueidentifier, [ReportTrackingId])
+                    HAVING COUNT(*) > 1)
+                BEGIN
+                    THROW 50003, 'ScheduledReports contains duplicate ReportTrackingId values after GUID normalization. Migration aborted.', 1;
+                END
             ");
 
             // 3) Drop dependent constraints/indexes using old ScheduledReportId or ReportTrackingId(string) shape.

--- a/DotNet/DataAcquisition.Domain/Migrations/20260505000000_NaturalKeyScheduledReport.cs
+++ b/DotNet/DataAcquisition.Domain/Migrations/20260505000000_NaturalKeyScheduledReport.cs
@@ -100,6 +100,12 @@ namespace DataAcquisition.Domain.Migrations
                 IF EXISTS (SELECT 1 FROM sys.indexes WHERE object_id = OBJECT_ID('DataAcquisitionLog') AND name = 'IX_DataAcquisitionLogs_Paging_Default')
                     DROP INDEX [IX_DataAcquisitionLogs_Paging_Default] ON [DataAcquisitionLog];
 
+                IF EXISTS (SELECT 1 FROM sys.indexes WHERE object_id = OBJECT_ID('DataAcquisitionLog') AND name = 'IX_DataAcquisitionLogs_TailSent_Status')
+                    DROP INDEX [IX_DataAcquisitionLogs_TailSent_Status] ON [DataAcquisitionLog];
+
+                IF EXISTS (SELECT 1 FROM sys.indexes WHERE object_id = OBJECT_ID('DataAcquisitionLog') AND name = 'IX_DataAcquisitionLogs_IsDeleted_Id')
+                    DROP INDEX [IX_DataAcquisitionLogs_IsDeleted_Id] ON [DataAcquisitionLog];
+
                 IF EXISTS (SELECT 1 FROM sys.indexes WHERE object_id = OBJECT_ID('ScheduledReports') AND name = 'UX_ScheduledReports_ReportTrackingId')
                     DROP INDEX [UX_ScheduledReports_ReportTrackingId] ON [ScheduledReports];
             ");
@@ -187,6 +193,28 @@ namespace DataAcquisition.Domain.Migrations
                 name: "IX_DataAcquisitionLog_ReportTrackingId",
                 table: "DataAcquisitionLog",
                 column: "ReportTrackingId");
+
+            // Recreate IX_DataAcquisitionLogs_TailSent_Status with updated INCLUDE list
+            // (removed ScheduledReportId, ReportStartDate, ReportEndDate — those columns no longer exist).
+            migrationBuilder.CreateIndex(
+                name: "IX_DataAcquisitionLogs_TailSent_Status",
+                table: "DataAcquisitionLog",
+                columns: new[] { "TailSent", "Status" })
+                .Annotation("SqlServer:Include", new[] {
+                    "FacilityId", "ReportTrackingId", "CorrelationId",
+                    "QueryPhase", "TraceId", "PatientId", "ReportableEvent"
+                });
+
+            // Recreate IX_DataAcquisitionLogs_IsDeleted_Id (ReportTrackingId column type changed to uniqueidentifier).
+            migrationBuilder.CreateIndex(
+                name: "IX_DataAcquisitionLogs_IsDeleted_Id",
+                table: "DataAcquisitionLog",
+                columns: new[] { "IsDeleted", "Id" })
+                .Annotation("SqlServer:Include", new[] {
+                    "Priority", "FacilityId", "PatientId", "ReportTrackingId",
+                    "FhirVersion", "QueryType", "QueryPhase",
+                    "ExecutionDate", "CreateDate", "RetryAttempts", "Status"
+                });
         }
 
         protected override void Down(MigrationBuilder migrationBuilder)
@@ -209,6 +237,12 @@ namespace DataAcquisition.Domain.Migrations
 
                 IF EXISTS (SELECT 1 FROM sys.indexes WHERE object_id = OBJECT_ID('DataAcquisitionLog') AND name = 'IX_DataAcquisitionLogs_Paging_Default')
                     DROP INDEX [IX_DataAcquisitionLogs_Paging_Default] ON [DataAcquisitionLog];
+
+                IF EXISTS (SELECT 1 FROM sys.indexes WHERE object_id = OBJECT_ID('DataAcquisitionLog') AND name = 'IX_DataAcquisitionLogs_TailSent_Status')
+                    DROP INDEX [IX_DataAcquisitionLogs_TailSent_Status] ON [DataAcquisitionLog];
+
+                IF EXISTS (SELECT 1 FROM sys.indexes WHERE object_id = OBJECT_ID('DataAcquisitionLog') AND name = 'IX_DataAcquisitionLogs_IsDeleted_Id')
+                    DROP INDEX [IX_DataAcquisitionLogs_IsDeleted_Id] ON [DataAcquisitionLog];
 
                 ALTER TABLE [DataAcquisitionLog] ALTER COLUMN [ReportTrackingId] nvarchar(128) NULL;
 
@@ -296,6 +330,28 @@ namespace DataAcquisition.Domain.Migrations
                     "Priority", "FacilityId", "IsCensus", "PatientId", "ReportableEvent",
                     "ReportTrackingId", "CorrelationId", "TraceId", "FhirVersion", "QueryType",
                     "QueryPhase", "Status", "RetryAttempts", "CompletionDate", "CompletionTimeMilliseconds"
+                });
+
+            // Recreate IX_DataAcquisitionLogs_TailSent_Status (originally created in PerformanceTuningCollapsed)
+            migrationBuilder.CreateIndex(
+                name: "IX_DataAcquisitionLogs_TailSent_Status",
+                table: "DataAcquisitionLog",
+                columns: new[] { "TailSent", "Status" })
+                .Annotation("SqlServer:Include", new[] {
+                    "FacilityId", "ReportTrackingId", "CorrelationId",
+                    "ReportStartDate", "ReportEndDate", "QueryPhase",
+                    "TraceId", "PatientId", "ReportableEvent", "ScheduledReportId"
+                });
+
+            // Recreate IX_DataAcquisitionLogs_IsDeleted_Id (originally created in PerformanceTuningCollapsed)
+            migrationBuilder.CreateIndex(
+                name: "IX_DataAcquisitionLogs_IsDeleted_Id",
+                table: "DataAcquisitionLog",
+                columns: new[] { "IsDeleted", "Id" })
+                .Annotation("SqlServer:Include", new[] {
+                    "Priority", "FacilityId", "PatientId", "ReportTrackingId",
+                    "FhirVersion", "QueryType", "QueryPhase",
+                    "ExecutionDate", "CreateDate", "RetryAttempts", "Status"
                 });
         }
     }

--- a/DotNet/DataAcquisition.Domain/Migrations/DataAcquisitionDbContextModelSnapshot.cs
+++ b/DotNet/DataAcquisition.Domain/Migrations/DataAcquisitionDbContextModelSnapshot.cs
@@ -697,6 +697,16 @@ namespace DataAcquisition.Domain.Migrations
                         .HasDatabaseName("IX_DataAcquisitionLogs_Tailing_Optimization")
                         .HasFilter("[TailSent] = 0 AND [ReportTrackingId] IS NOT NULL AND [CorrelationId] IS NOT NULL");
 
+                    SqlServerIndexBuilderExtensions.IncludeProperties(b.HasIndex("TailSent", "Status"), new[] { "FacilityId", "ReportTrackingId", "CorrelationId", "QueryPhase", "TraceId", "PatientId", "ReportableEvent" });
+
+                    b.HasIndex("TailSent", "Status")
+                        .HasDatabaseName("IX_DataAcquisitionLogs_TailSent_Status");
+
+                    b.HasIndex("IsDeleted", "Id")
+                        .HasDatabaseName("IX_DataAcquisitionLogs_IsDeleted_Id");
+
+                    SqlServerIndexBuilderExtensions.IncludeProperties(b.HasIndex("IsDeleted", "Id"), new[] { "Priority", "FacilityId", "PatientId", "ReportTrackingId", "FhirVersion", "QueryType", "QueryPhase", "ExecutionDate", "CreateDate", "RetryAttempts", "Status" });
+
                     b.ToTable("DataAcquisitionLog");
                 });
 

--- a/DotNet/DataAcquisition.Domain/Migrations/DataAcquisitionDbContextModelSnapshot.cs
+++ b/DotNet/DataAcquisition.Domain/Migrations/DataAcquisitionDbContextModelSnapshot.cs
@@ -1256,7 +1256,8 @@ namespace DataAcquisition.Domain.Migrations
                 {
                     b.HasOne("LantanaGroup.Link.DataAcquisition.Domain.Infrastructure.Entities.ScheduledReportEntity", "ScheduledReportEntity")
                         .WithMany("DataAcquisitionLogs")
-                        .HasForeignKey("ReportTrackingId");
+                        .HasForeignKey("ReportTrackingId")
+                        .OnDelete(DeleteBehavior.SetNull);
 
                     b.Navigation("ScheduledReportEntity");
                 });

--- a/DotNet/Report/KafkaProducers/DataAcquisitionRequestedProducer.cs
+++ b/DotNet/Report/KafkaProducers/DataAcquisitionRequestedProducer.cs
@@ -1,4 +1,4 @@
-using Confluent.Kafka;
+﻿using Confluent.Kafka;
 using LantanaGroup.Link.Report.Data;
 using LantanaGroup.Link.Report.Models;
 using LantanaGroup.Link.Shared.Application.Models;

--- a/DotNet/ServiceTests/IntegrationTests/DataAcquisition/AcquisitionProcessingJobTests.cs
+++ b/DotNet/ServiceTests/IntegrationTests/DataAcquisition/AcquisitionProcessingJobTests.cs
@@ -4,11 +4,6 @@ using LantanaGroup.Link.DataAcquisition.Domain.Application.Managers;
 using LantanaGroup.Link.DataAcquisition.Domain.Application.Models.Kafka;
 using LantanaGroup.Link.DataAcquisition.Domain.Infrastructure.Context;
 using LantanaGroup.Link.DataAcquisition.Domain.Infrastructure.Entities;
-using LantanaGroup.Link.DataAcquisition.Domain.Infrastructure.Models.Enums;
-using LantanaGroup.Link.Shared.Application.Models.Integration.DataAcquisition;
-using RequestStatus = LantanaGroup.Link.Shared.Application.Models.Integration.DataAcquisition.RequestStatus;
-using QueryPhase = LantanaGroup.Link.Shared.Application.Models.Integration.DataAcquisition.QueryPhase;
-using FhirQueryType = LantanaGroup.Link.Shared.Application.Models.Integration.DataAcquisition.FhirQueryType;
 using LantanaGroup.Link.DataAcquisition.Domain.Settings;
 using LantanaGroup.Link.DataAcquisition.Jobs;
 using LantanaGroup.Link.Shared.Application.Models;
@@ -19,6 +14,9 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Moq;
 using Quartz;
+using FhirQueryType = LantanaGroup.Link.Shared.Application.Models.Integration.DataAcquisition.FhirQueryType;
+using RequestStatus = LantanaGroup.Link.Shared.Application.Models.Integration.DataAcquisition.RequestStatus;
+using ScheduledFrequency = LantanaGroup.Link.Shared.Application.Models.Frequency;
 using Task = System.Threading.Tasks.Task;
 
 namespace IntegrationTests.DataAcquisition;
@@ -63,7 +61,7 @@ public class AcquisitionProcessingJobTests
         dbContext.ScheduledReports.Add(new ScheduledReportEntity
         {
             ReportTrackingId = reportTrackingId,
-            Frequency = Frequency.Adhoc,
+            Frequency = ScheduledFrequency.Adhoc,
             StartDate = DateTime.UtcNow.AddDays(-1),
             EndDate = DateTime.UtcNow
         });
@@ -407,7 +405,7 @@ public class AcquisitionProcessingJobTests
         dbContext.ScheduledReports.Add(new ScheduledReportEntity
         {
             ReportTrackingId = reportTrackingId,
-            Frequency = Frequency.Adhoc,
+            Frequency = ScheduledFrequency.Adhoc,
             StartDate = DateTime.UtcNow.AddDays(-1),
             EndDate = DateTime.UtcNow
         });

--- a/DotNet/ServiceTests/IntegrationTests/DataAcquisition/AcquisitionProcessingJobTests.cs
+++ b/DotNet/ServiceTests/IntegrationTests/DataAcquisition/AcquisitionProcessingJobTests.cs
@@ -44,7 +44,7 @@ public class AcquisitionProcessingJobTests
 
         var testTag = Guid.NewGuid().ToString("N");
         var facilityId = $"TestFacility_{testTag}";
-        var reportTrackingId = $"TestReportId_{testTag}";
+        Guid reportTrackingId = Guid.NewGuid();
 
         using var scope = _fixture.ServiceProvider.CreateScope();
         var dbContext = scope.ServiceProvider.GetRequiredService<DataAcquisitionDbContext>();
@@ -67,11 +67,7 @@ public class AcquisitionProcessingJobTests
             Status = RequestStatus.Pending,
             CorrelationId = Guid.NewGuid().ToString(),
             PatientId = "Patient/123",
-            ScheduledReport = new ScheduledReport {
-                ReportTrackingId = reportTrackingId,
-                StartDate = DateTime.UtcNow.AddDays(-1),
-                EndDate = DateTime.UtcNow
-            }
+            ReportTrackingId = reportTrackingId.ToString()
         };
 
         var log = await logManager.CreateAsync(createLog);
@@ -108,7 +104,7 @@ public class AcquisitionProcessingJobTests
 
         var testTag = Guid.NewGuid().ToString("N");
         var missingConfigFacilityId = $"MissingConfigFacility_{testTag}";
-        var reportTrackingId = $"TestReportId_{testTag}";
+        Guid reportTrackingId = Guid.NewGuid();
 
         using var scope = _fixture.ServiceProvider.CreateScope();
         var dbContext = scope.ServiceProvider.GetRequiredService<DataAcquisitionDbContext>();
@@ -122,8 +118,6 @@ public class AcquisitionProcessingJobTests
             CorrelationId = Guid.NewGuid().ToString(),
             ReportTrackingId = reportTrackingId,
             PatientId = "Patient/123",
-            ReportStartDate = DateTime.UtcNow.AddDays(-1),
-            ReportEndDate = DateTime.UtcNow,
             ScheduledReportEntity = new ScheduledReportEntity {
                 ReportTrackingId = reportTrackingId,
                 StartDate = DateTime.UtcNow.AddDays(-1),
@@ -171,7 +165,7 @@ public class AcquisitionProcessingJobTests
 
         var testTag = Guid.NewGuid().ToString("N");
         var missingConfigFacilityId = $"MissingConfigFacility_{testTag}";
-        var reportTrackingId = $"TestReportId_{testTag}";
+        Guid reportTrackingId = Guid.NewGuid();
 
         using var scope = _fixture.ServiceProvider.CreateScope();
         var dbContext = scope.ServiceProvider.GetRequiredService<DataAcquisitionDbContext>();
@@ -185,8 +179,6 @@ public class AcquisitionProcessingJobTests
             CorrelationId = Guid.NewGuid().ToString(),
             ReportTrackingId = reportTrackingId,
             PatientId = "Patient/456",
-            ReportStartDate = DateTime.UtcNow.AddDays(-1),
-            ReportEndDate = DateTime.UtcNow,
             ScheduledReportEntity = new ScheduledReportEntity
             {
                 ReportTrackingId = reportTrackingId,
@@ -228,7 +220,7 @@ public class AcquisitionProcessingJobTests
 
         var testTag = Guid.NewGuid().ToString("N");
         var facilityId = $"TestFacility_{testTag}";
-        var reportTrackingId = $"TestReportId_{testTag}";
+        Guid reportTrackingId = Guid.NewGuid();
 
         using var scope = _fixture.ServiceProvider.CreateScope();
         var dbContext = scope.ServiceProvider.GetRequiredService<DataAcquisitionDbContext>();
@@ -250,8 +242,6 @@ public class AcquisitionProcessingJobTests
             CorrelationId = Guid.NewGuid().ToString(),
             ReportTrackingId = reportTrackingId,
             PatientId = "Patient/123",
-            ReportStartDate = DateTime.UtcNow.AddDays(-1),
-            ReportEndDate = DateTime.UtcNow,
             ScheduledReportEntity = new ScheduledReportEntity {
                 ReportTrackingId = reportTrackingId,
                 StartDate = DateTime.UtcNow.AddDays(-1),
@@ -294,8 +284,8 @@ public class AcquisitionProcessingJobTests
 
         var testTag = Guid.NewGuid().ToString("N");
         var facilityId = $"TestFacility_{testTag}";
-        var reportTrackingId1 = $"TestReportId_1_{testTag}";
-        var reportTrackingId2 = $"TestReportId_2_{testTag}";
+        Guid reportTrackingId1 = Guid.NewGuid();
+        Guid reportTrackingId2 = Guid.NewGuid();
 
         using var scope = _fixture.ServiceProvider.CreateScope();
         var dbContext = scope.ServiceProvider.GetRequiredService<DataAcquisitionDbContext>();
@@ -318,8 +308,6 @@ public class AcquisitionProcessingJobTests
             CorrelationId = Guid.NewGuid().ToString(),
             ReportTrackingId = reportTrackingId1,
             PatientId = "Patient/123",
-            ReportStartDate = DateTime.UtcNow.AddDays(-1),
-            ReportEndDate = DateTime.UtcNow,
             ScheduledReportEntity = new ScheduledReportEntity {
                 ReportTrackingId = reportTrackingId1,
                 StartDate = DateTime.UtcNow.AddDays(-1),
@@ -336,8 +324,6 @@ public class AcquisitionProcessingJobTests
             CorrelationId = Guid.NewGuid().ToString(),
             ReportTrackingId = reportTrackingId2,
             PatientId = "Patient/123",
-            ReportStartDate = DateTime.UtcNow.AddDays(-1),
-            ReportEndDate = DateTime.UtcNow,
             ScheduledReportEntity = new ScheduledReportEntity {
                 ReportTrackingId = reportTrackingId2,
                 StartDate = DateTime.UtcNow.AddDays(-1),
@@ -394,7 +380,7 @@ public class AcquisitionProcessingJobTests
 
         var testTag = Guid.NewGuid().ToString("N");
         var facilityId = $"TestFacility_{testTag}";
-        var reportTrackingId = $"TestReportId_{testTag}";
+        Guid reportTrackingId = Guid.NewGuid();
 
         using var scope = _fixture.ServiceProvider.CreateScope();
         var dbContext = scope.ServiceProvider.GetRequiredService<DataAcquisitionDbContext>();
@@ -500,7 +486,7 @@ public class AcquisitionProcessingJobTests
 
             for (int i = 1; i <= logsPerFacility; i++)
             {
-                var reportTrackingId = $"Report{f}_{i}_{testTag}";
+                Guid reportTrackingId = Guid.NewGuid();
 
                 var log = new DataAcquisitionLog
                 {
@@ -509,8 +495,6 @@ public class AcquisitionProcessingJobTests
                     CorrelationId = Guid.NewGuid().ToString(),
                     ReportTrackingId = reportTrackingId,
                     PatientId = $"Patient/{i}",
-                    ReportStartDate = DateTime.UtcNow.AddDays(-1),
-                    ReportEndDate = DateTime.UtcNow,
                     ScheduledReportEntity = new ScheduledReportEntity {
                         ReportTrackingId = reportTrackingId,
                         StartDate = DateTime.UtcNow.AddDays(-1),
@@ -563,6 +547,9 @@ public class AcquisitionProcessingJobTests
         var testTag = Guid.NewGuid().ToString("N");
         const int numFacilities = 3;
         const int pendingPerFacility = 30; const int failedRetryablePerFacility = 20; const int failedMaxRetriesPerFacility = 10; var facilities = new List<string>();
+        var pendingLogsByFacility = new Dictionary<string, List<DataAcquisitionLog>>();
+        var retryableLogsByFacility = new Dictionary<string, List<DataAcquisitionLog>>();
+        var maxRetryLogsByFacility = new Dictionary<string, List<DataAcquisitionLog>>();
 
         using var setupScope = _fixture.ServiceProvider.CreateScope();
         var dbContext = setupScope.ServiceProvider.GetRequiredService<DataAcquisitionDbContext>();
@@ -572,6 +559,9 @@ public class AcquisitionProcessingJobTests
         {
             var facilityId = $"Facility{f}_{testTag}";
             facilities.Add(facilityId);
+            pendingLogsByFacility[facilityId] = new List<DataAcquisitionLog>();
+            retryableLogsByFacility[facilityId] = new List<DataAcquisitionLog>();
+            maxRetryLogsByFacility[facilityId] = new List<DataAcquisitionLog>();
 
             var config = new FhirQueryConfiguration
             {
@@ -584,7 +574,7 @@ public class AcquisitionProcessingJobTests
 
             for (int i = 1; i <= pendingPerFacility; i++)
             {
-                var reportTrackingId = $"Pending{f}_{i}_{testTag}";
+                Guid reportTrackingId = Guid.NewGuid();
                 var log = new DataAcquisitionLog
                 {
                     FacilityId = facilityId,
@@ -592,8 +582,6 @@ public class AcquisitionProcessingJobTests
                     CorrelationId = Guid.NewGuid().ToString(),
                     ReportTrackingId = reportTrackingId,
                     PatientId = $"Patient/{i}",
-                    ReportStartDate = DateTime.UtcNow.AddDays(-1),
-                    ReportEndDate = DateTime.UtcNow,
                     ScheduledReportEntity = new ScheduledReportEntity {
                         ReportTrackingId = reportTrackingId,
                         StartDate = DateTime.UtcNow.AddDays(-1),
@@ -602,11 +590,12 @@ public class AcquisitionProcessingJobTests
                 };
 
                 dbContext.DataAcquisitionLogs.Add(log);
+                pendingLogsByFacility[facilityId].Add(log);
             }
 
             for (int i = 1; i <= failedRetryablePerFacility; i++)
             {
-                var reportTrackingId = $"FailedRetry{f}_{i}_{testTag}";
+                Guid reportTrackingId = Guid.NewGuid();
                 var log = new DataAcquisitionLog
                 {
                     FacilityId = facilityId,
@@ -615,8 +604,6 @@ public class AcquisitionProcessingJobTests
                     CorrelationId = Guid.NewGuid().ToString(),
                     ReportTrackingId = reportTrackingId,
                     PatientId = $"Patient/{i + pendingPerFacility}",
-                    ReportStartDate = DateTime.UtcNow.AddDays(-1),
-                    ReportEndDate = DateTime.UtcNow,
                     ScheduledReportEntity = new ScheduledReportEntity {
                         ReportTrackingId = reportTrackingId,
                         StartDate = DateTime.UtcNow.AddDays(-1),
@@ -625,11 +612,12 @@ public class AcquisitionProcessingJobTests
                 };
 
                 dbContext.DataAcquisitionLogs.Add(log);
+                retryableLogsByFacility[facilityId].Add(log);
             }
 
             for (int i = 1; i <= failedMaxRetriesPerFacility; i++)
             {
-                var reportTrackingId = $"MaxRetry{f}_{i}_{testTag}";
+                Guid reportTrackingId = Guid.NewGuid();
                 var log = new DataAcquisitionLog
                 {
                     FacilityId = facilityId,
@@ -638,8 +626,6 @@ public class AcquisitionProcessingJobTests
                     CorrelationId = Guid.NewGuid().ToString(),
                     ReportTrackingId = reportTrackingId,
                     PatientId = $"Patient/{i + pendingPerFacility + failedRetryablePerFacility}",
-                    ReportStartDate = DateTime.UtcNow.AddDays(-1),
-                    ReportEndDate = DateTime.UtcNow,
                     ScheduledReportEntity = new ScheduledReportEntity {
                         ReportTrackingId = reportTrackingId,
                         StartDate = DateTime.UtcNow.AddDays(-1),
@@ -647,6 +633,7 @@ public class AcquisitionProcessingJobTests
                     }
                 };
                 dbContext.DataAcquisitionLogs.Add(log);
+                maxRetryLogsByFacility[facilityId].Add(log);
             }
         }
         await dbContext.SaveChangesAsync();
@@ -683,17 +670,20 @@ public class AcquisitionProcessingJobTests
 
             Assert.Equal(pendingPerFacility + failedRetryablePerFacility + failedMaxRetriesPerFacility, allLogs.Count);
 
-            var pendingLogs = allLogs.Where(l => l.ReportTrackingId.StartsWith("Pending") && l.ReportTrackingId.EndsWith($"_{testTag}")).ToList();
+            var pendingLogIds = pendingLogsByFacility[facilityId].Select(l => l.Id).ToHashSet();
+            var pendingLogs = allLogs.Where(l => pendingLogIds.Contains(l.Id)).ToList();
             Assert.All(pendingLogs, log => Assert.Equal(RequestStatus.Ready, log.Status));
 
-            var retryableLogs = allLogs.Where(l => l.ReportTrackingId.StartsWith("FailedRetry") && l.ReportTrackingId.EndsWith($"_{testTag}")).ToList();
+            var retryableLogIds = retryableLogsByFacility[facilityId].Select(l => l.Id).ToHashSet();
+            var retryableLogs = allLogs.Where(l => retryableLogIds.Contains(l.Id)).ToList();
             Assert.All(retryableLogs, log =>
             {
                 Assert.Equal(RequestStatus.Ready, log.Status);
                 Assert.Equal(1, log.RetryAttempts);
             });
 
-            var maxRetryLogs = allLogs.Where(l => l.ReportTrackingId.StartsWith("MaxRetry") && l.ReportTrackingId.EndsWith($"_{testTag}")).ToList();
+            var maxRetryLogIds = maxRetryLogsByFacility[facilityId].Select(l => l.Id).ToHashSet();
+            var maxRetryLogs = allLogs.Where(l => maxRetryLogIds.Contains(l.Id)).ToList();
             Assert.All(maxRetryLogs, log => Assert.Equal(RequestStatus.MaxRetriesReached, log.Status));
         }
     }
@@ -706,7 +696,7 @@ public class AcquisitionProcessingJobTests
 
         var testTag = Guid.NewGuid().ToString("N");
         var facilityId = $"TestFacility_{testTag}";
-        var reportTrackingId = $"TestReportId_{testTag}";
+        Guid reportTrackingId = Guid.NewGuid();
 
         using var scope = _fixture.ServiceProvider.CreateScope();
         var dbContext = scope.ServiceProvider.GetRequiredService<DataAcquisitionDbContext>();
@@ -730,8 +720,6 @@ public class AcquisitionProcessingJobTests
             CorrelationId = Guid.NewGuid().ToString(),
             ReportTrackingId = reportTrackingId,
             PatientId = "Patient/123",
-            ReportStartDate = DateTime.UtcNow.AddDays(-1),
-            ReportEndDate = DateTime.UtcNow,
             ScheduledReportEntity = new ScheduledReportEntity {
                 ReportTrackingId = reportTrackingId,
                 StartDate = DateTime.UtcNow.AddDays(-1),
@@ -774,7 +762,7 @@ public class AcquisitionProcessingJobTests
 
         var testTag = Guid.NewGuid().ToString("N");
         var facilityId = $"TestFacility_{testTag}";
-        var reportTrackingId = $"TestReportId_{testTag}";
+        Guid reportTrackingId = Guid.NewGuid();
 
         using var scope = _fixture.ServiceProvider.CreateScope();
         var dbContext = scope.ServiceProvider.GetRequiredService<DataAcquisitionDbContext>();
@@ -812,8 +800,6 @@ public class AcquisitionProcessingJobTests
             CorrelationId = Guid.NewGuid().ToString(),
             ReportTrackingId = reportTrackingId,
             PatientId = "Patient/123",
-            ReportStartDate = DateTime.UtcNow.AddDays(-1),
-            ReportEndDate = DateTime.UtcNow,
             ScheduledReportEntity = new ScheduledReportEntity {
                 ReportTrackingId = reportTrackingId,
                 StartDate = DateTime.UtcNow.AddDays(-1),
@@ -856,7 +842,7 @@ public class AcquisitionProcessingJobTests
 
         var testTag = Guid.NewGuid().ToString("N");
         var facilityId = $"TestFacility_{testTag}";
-        var reportTrackingId = $"TestReportId_{testTag}";
+        Guid reportTrackingId = Guid.NewGuid();
 
         using var scope = _fixture.ServiceProvider.CreateScope();
         var dbContext = scope.ServiceProvider.GetRequiredService<DataAcquisitionDbContext>();
@@ -892,8 +878,6 @@ public class AcquisitionProcessingJobTests
             CorrelationId = Guid.NewGuid().ToString(),
             ReportTrackingId = reportTrackingId,
             PatientId = "Patient/123",
-            ReportStartDate = DateTime.UtcNow.AddDays(-1),
-            ReportEndDate = DateTime.UtcNow,
             ScheduledReportEntity = new ScheduledReportEntity {
                 ReportTrackingId = reportTrackingId,
                 StartDate = DateTime.UtcNow.AddDays(-1),
@@ -936,7 +920,7 @@ public class AcquisitionProcessingJobTests
 
         var testTag = Guid.NewGuid().ToString("N");
         var facilityId = $"TestFacility_{testTag}";
-        var reportTrackingId = $"TestReportId_{testTag}";
+        Guid reportTrackingId = Guid.NewGuid();
 
         using var scope = _fixture.ServiceProvider.CreateScope();
         var dbContext = scope.ServiceProvider.GetRequiredService<DataAcquisitionDbContext>();
@@ -968,8 +952,6 @@ public class AcquisitionProcessingJobTests
             CorrelationId = Guid.NewGuid().ToString(),
             ReportTrackingId = reportTrackingId,
             PatientId = "Patient/123",
-            ReportStartDate = DateTime.UtcNow.AddDays(-1),
-            ReportEndDate = DateTime.UtcNow,
             ScheduledReportEntity = new ScheduledReportEntity {
                 ReportTrackingId = reportTrackingId,
                 StartDate = DateTime.UtcNow.AddDays(-1),

--- a/DotNet/ServiceTests/IntegrationTests/DataAcquisition/AcquisitionProcessingJobTests.cs
+++ b/DotNet/ServiceTests/IntegrationTests/DataAcquisition/AcquisitionProcessingJobTests.cs
@@ -1,4 +1,4 @@
-using Confluent.Kafka;
+﻿using Confluent.Kafka;
 using DataAcquisition.Domain.Application.Models;
 using LantanaGroup.Link.DataAcquisition.Domain.Application.Managers;
 using LantanaGroup.Link.DataAcquisition.Domain.Application.Models.Kafka;
@@ -59,6 +59,14 @@ public class AcquisitionProcessingJobTests
             MaxAcquisitionPullTime = null
         };
         dbContext.FhirQueryConfigurations.Add(config);
+
+        dbContext.ScheduledReports.Add(new ScheduledReportEntity
+        {
+            ReportTrackingId = reportTrackingId,
+            Frequency = Frequency.Adhoc,
+            StartDate = DateTime.UtcNow.AddDays(-1),
+            EndDate = DateTime.UtcNow
+        });
 
         var createLog = new CreateDataAcquisitionLogModel
         {
@@ -395,6 +403,14 @@ public class AcquisitionProcessingJobTests
             MaxRetries = 2
         };
         dbContext.FhirQueryConfigurations.Add(config);
+
+        dbContext.ScheduledReports.Add(new ScheduledReportEntity
+        {
+            ReportTrackingId = reportTrackingId,
+            Frequency = Frequency.Adhoc,
+            StartDate = DateTime.UtcNow.AddDays(-1),
+            EndDate = DateTime.UtcNow
+        });
 
         var log1 = new DataAcquisitionLog
         {

--- a/DotNet/ServiceTests/IntegrationTests/DataAcquisition/Controllers/LogControllerTests.cs
+++ b/DotNet/ServiceTests/IntegrationTests/DataAcquisition/Controllers/LogControllerTests.cs
@@ -14,6 +14,7 @@ using FhirQueryType = LantanaGroup.Link.Shared.Application.Models.Integration.Da
 using LantanaGroup.Link.DataAcquisition.Domain.Models;
 using LantanaGroup.Link.Shared.Application.Enums;
 using LantanaGroup.Link.Shared.Application.Interfaces.Models;
+using LantanaGroup.Link.Shared.Application.Models;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;

--- a/DotNet/ServiceTests/IntegrationTests/DataAcquisition/Controllers/LogControllerTests.cs
+++ b/DotNet/ServiceTests/IntegrationTests/DataAcquisition/Controllers/LogControllerTests.cs
@@ -7,20 +7,18 @@ using LantanaGroup.Link.DataAcquisition.Domain.Application.Services;
 using LantanaGroup.Link.DataAcquisition.Domain.Infrastructure.Context;
 using LantanaGroup.Link.DataAcquisition.Domain.Infrastructure.Entities;
 using LantanaGroup.Link.DataAcquisition.Domain.Infrastructure.Models.Enums;
-using LantanaGroup.Link.Shared.Application.Models.Integration.DataAcquisition;
-using RequestStatus = LantanaGroup.Link.Shared.Application.Models.Integration.DataAcquisition.RequestStatus;
-using QueryPhase = LantanaGroup.Link.Shared.Application.Models.Integration.DataAcquisition.QueryPhase;
-using FhirQueryType = LantanaGroup.Link.Shared.Application.Models.Integration.DataAcquisition.FhirQueryType;
 using LantanaGroup.Link.DataAcquisition.Domain.Models;
 using LantanaGroup.Link.Shared.Application.Enums;
 using LantanaGroup.Link.Shared.Application.Interfaces.Models;
-using LantanaGroup.Link.Shared.Application.Models;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Moq;
 using System.Net;
+using QueryPhase = LantanaGroup.Link.Shared.Application.Models.Integration.DataAcquisition.QueryPhase;
+using RequestStatus = LantanaGroup.Link.Shared.Application.Models.Integration.DataAcquisition.RequestStatus;
+using ScheduledFrequency = LantanaGroup.Link.Shared.Application.Models.Frequency;
 using Task = System.Threading.Tasks.Task;
 
 namespace IntegrationTests.DataAcquisition.Controllers;
@@ -73,7 +71,7 @@ public class LogControllerTests
         dbContext.ScheduledReports.Add(new ScheduledReportEntity
         {
             ReportTrackingId = reportTrackingId,
-            Frequency = Frequency.Adhoc,
+            Frequency = ScheduledFrequency.Adhoc,
             StartDate = DateTime.UtcNow.AddDays(-1),
             EndDate = DateTime.UtcNow
         });

--- a/DotNet/ServiceTests/IntegrationTests/DataAcquisition/Controllers/LogControllerTests.cs
+++ b/DotNet/ServiceTests/IntegrationTests/DataAcquisition/Controllers/LogControllerTests.cs
@@ -69,6 +69,13 @@ public class LogControllerTests
             QueryPhase = QueryPhase.Initial,
             Priority = AcquisitionPriority.Normal
         };
+        dbContext.ScheduledReports.Add(new ScheduledReportEntity
+        {
+            ReportTrackingId = reportTrackingId,
+            Frequency = Frequency.Adhoc,
+            StartDate = DateTime.UtcNow.AddDays(-1),
+            EndDate = DateTime.UtcNow
+        });
         dbContext.DataAcquisitionLogs.Add(log);
         await dbContext.SaveChangesAsync();
 

--- a/DotNet/ServiceTests/IntegrationTests/DataAcquisition/Controllers/LogControllerTests.cs
+++ b/DotNet/ServiceTests/IntegrationTests/DataAcquisition/Controllers/LogControllerTests.cs
@@ -1,4 +1,4 @@
-using LantanaGroup.Link.DataAcquisition.Controllers;
+﻿using LantanaGroup.Link.DataAcquisition.Controllers;
 using LantanaGroup.Link.DataAcquisition.Domain.Application.Managers;
 using LantanaGroup.Link.DataAcquisition.Domain.Application.Models.Api.QueryLog;
 using LantanaGroup.Link.DataAcquisition.Domain.Application.Models.Http;
@@ -52,7 +52,7 @@ public class LogControllerTests
         // Arrange
         var tag = Guid.NewGuid().ToString("N");
         var facilityId = $"TestFacility_{tag}";
-        var reportTrackingId = $"TestReportId_{tag}";
+        var reportTrackingId = Guid.NewGuid();
 
         using var scope = _fixture.ServiceProvider.CreateScope();
         var dbContext = scope.ServiceProvider.GetRequiredService<DataAcquisitionDbContext>();
@@ -66,8 +66,6 @@ public class LogControllerTests
             CorrelationId = Guid.NewGuid().ToString(),
             ReportTrackingId = reportTrackingId,
             PatientId = "Patient/123",
-            ReportStartDate = DateTime.UtcNow.AddDays(-1),
-            ReportEndDate = DateTime.UtcNow,
             QueryPhase = QueryPhase.Initial,
             Priority = AcquisitionPriority.Normal
         };

--- a/DotNet/ServiceTests/IntegrationTests/DataAcquisition/Managers/DataAcquisitionLogManagerTests.cs
+++ b/DotNet/ServiceTests/IntegrationTests/DataAcquisition/Managers/DataAcquisitionLogManagerTests.cs
@@ -53,11 +53,21 @@ public class DataAcquisitionLogManagerTests
 
         var manager = CreateManager(scope);
         var queries = _fixture.ServiceProvider.CreateScope().ServiceProvider.GetRequiredService<IDataAcquisitionLogQueries>();
+        var reportTrackingId = Guid.NewGuid();
+        dbContext.ScheduledReports.Add(new ScheduledReportEntity
+        {
+            ReportTrackingId = reportTrackingId,
+            Frequency = Frequency.Adhoc,
+            StartDate = DateTime.UtcNow.AddDays(-1),
+            EndDate = DateTime.UtcNow
+        });
+        await dbContext.SaveChangesAsync();
+
         var createModel = new CreateDataAcquisitionLogModel
         {
             FacilityId = "TestFacility",
             CorrelationId = Guid.NewGuid().ToString(),
-            ReportTrackingId = "TestReport",
+            ReportTrackingId = reportTrackingId.ToString(),
             QueryPhase = QueryPhase.Initial,
             QueryType = FhirQueryType.Read,
             Status = RequestStatus.Pending,
@@ -223,6 +233,14 @@ public class DataAcquisitionLogManagerTests
 
         using var scope = _fixture.ServiceProvider.CreateScope();
         var dbContext = scope.ServiceProvider.GetRequiredService<DataAcquisitionDbContext>();
+
+        dbContext.ScheduledReports.Add(new ScheduledReportEntity
+        {
+            ReportTrackingId = reportTrackingId,
+            Frequency = Frequency.Adhoc,
+            StartDate = DateTime.UtcNow.AddDays(-1),
+            EndDate = DateTime.UtcNow
+        });
 
 
         var log1 = new DataAcquisitionLog
@@ -573,6 +591,21 @@ public class DataAcquisitionLogManagerTests
 
         var matchReportTrackingId = Guid.NewGuid();
         var noMatchReportTrackingId = Guid.NewGuid();
+        dbContext.ScheduledReports.AddRange(
+            new ScheduledReportEntity
+            {
+                ReportTrackingId = matchReportTrackingId,
+                Frequency = Frequency.Adhoc,
+                StartDate = DateTime.UtcNow.AddDays(-1),
+                EndDate = DateTime.UtcNow
+            },
+            new ScheduledReportEntity
+            {
+                ReportTrackingId = noMatchReportTrackingId,
+                Frequency = Frequency.Adhoc,
+                StartDate = DateTime.UtcNow.AddDays(-1),
+                EndDate = DateTime.UtcNow
+            });
         var match = new DataAcquisitionLog { FacilityId = "F1", ReportTrackingId = matchReportTrackingId, Status = RequestStatus.Pending, CreateDate = DateTime.UtcNow.AddHours(-48) };
         var noMatch = new DataAcquisitionLog { FacilityId = "F1", ReportTrackingId = noMatchReportTrackingId, Status = RequestStatus.Pending, CreateDate = DateTime.UtcNow.AddHours(-48) };
         dbContext.DataAcquisitionLogs.AddRange(match, noMatch);

--- a/DotNet/ServiceTests/IntegrationTests/DataAcquisition/Managers/DataAcquisitionLogManagerTests.cs
+++ b/DotNet/ServiceTests/IntegrationTests/DataAcquisition/Managers/DataAcquisitionLogManagerTests.cs
@@ -9,16 +9,15 @@ using LantanaGroup.Link.DataAcquisition.Domain.Infrastructure;
 using LantanaGroup.Link.DataAcquisition.Domain.Infrastructure.Context;
 using LantanaGroup.Link.DataAcquisition.Domain.Infrastructure.Entities;
 using LantanaGroup.Link.DataAcquisition.Domain.Infrastructure.Models.Enums;
-using LantanaGroup.Link.Shared.Application.Models.Integration.DataAcquisition;
-using RequestStatus = LantanaGroup.Link.Shared.Application.Models.Integration.DataAcquisition.RequestStatus;
-using QueryPhase = LantanaGroup.Link.Shared.Application.Models.Integration.DataAcquisition.QueryPhase;
-using FhirQueryType = LantanaGroup.Link.Shared.Application.Models.Integration.DataAcquisition.FhirQueryType;
-using LantanaGroup.Link.Shared.Application.Models;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Moq;
+using FhirQueryType = LantanaGroup.Link.Shared.Application.Models.Integration.DataAcquisition.FhirQueryType;
+using QueryPhase = LantanaGroup.Link.Shared.Application.Models.Integration.DataAcquisition.QueryPhase;
+using RequestStatus = LantanaGroup.Link.Shared.Application.Models.Integration.DataAcquisition.RequestStatus;
 using ResourceType = Hl7.Fhir.Model.ResourceType;
+using ScheduledFrequency = LantanaGroup.Link.Shared.Application.Models.Frequency;
 using Task = System.Threading.Tasks.Task;
 
 namespace IntegrationTests.DataAcquisition.Managers;
@@ -57,7 +56,7 @@ public class DataAcquisitionLogManagerTests
         dbContext.ScheduledReports.Add(new ScheduledReportEntity
         {
             ReportTrackingId = reportTrackingId,
-            Frequency = Frequency.Adhoc,
+            Frequency = ScheduledFrequency.Adhoc,
             StartDate = DateTime.UtcNow.AddDays(-1),
             EndDate = DateTime.UtcNow
         });
@@ -237,7 +236,7 @@ public class DataAcquisitionLogManagerTests
         dbContext.ScheduledReports.Add(new ScheduledReportEntity
         {
             ReportTrackingId = reportTrackingId,
-            Frequency = Frequency.Adhoc,
+            Frequency = ScheduledFrequency.Adhoc,
             StartDate = DateTime.UtcNow.AddDays(-1),
             EndDate = DateTime.UtcNow
         });
@@ -595,14 +594,14 @@ public class DataAcquisitionLogManagerTests
             new ScheduledReportEntity
             {
                 ReportTrackingId = matchReportTrackingId,
-                Frequency = Frequency.Adhoc,
+                Frequency = ScheduledFrequency.Adhoc,
                 StartDate = DateTime.UtcNow.AddDays(-1),
                 EndDate = DateTime.UtcNow
             },
             new ScheduledReportEntity
             {
                 ReportTrackingId = noMatchReportTrackingId,
-                Frequency = Frequency.Adhoc,
+                Frequency = ScheduledFrequency.Adhoc,
                 StartDate = DateTime.UtcNow.AddDays(-1),
                 EndDate = DateTime.UtcNow
             });

--- a/DotNet/ServiceTests/IntegrationTests/DataAcquisition/Managers/DataAcquisitionLogManagerTests.cs
+++ b/DotNet/ServiceTests/IntegrationTests/DataAcquisition/Managers/DataAcquisitionLogManagerTests.cs
@@ -1,4 +1,4 @@
-using DataAcquisition.Domain.Application.Models;
+﻿using DataAcquisition.Domain.Application.Models;
 using LantanaGroup.Link.DataAcquisition.Domain.Application.Managers;
 using LantanaGroup.Link.DataAcquisition.Domain.Application.Models;
 using LantanaGroup.Link.DataAcquisition.Domain.Application.Models.Api.QueryLog;
@@ -57,7 +57,7 @@ public class DataAcquisitionLogManagerTests
         {
             FacilityId = "TestFacility",
             CorrelationId = Guid.NewGuid().ToString(),
-            ScheduledReport = new ScheduledReport { ReportTrackingId = "TestReport", StartDate = DateTime.UtcNow.AddDays(-1), EndDate = DateTime.UtcNow },
+            ReportTrackingId = "TestReport",
             QueryPhase = QueryPhase.Initial,
             QueryType = FhirQueryType.Read,
             Status = RequestStatus.Pending,
@@ -114,7 +114,6 @@ public class DataAcquisitionLogManagerTests
         var createModel = new CreateDataAcquisitionLogModel()
         {
             FacilityId = null!,
-            ScheduledReport = null!,
             QueryType = FhirQueryType.Read,
             Status = RequestStatus.Pending,
             QueryPhase = QueryPhase.Initial
@@ -137,7 +136,7 @@ public class DataAcquisitionLogManagerTests
             FacilityId = "TestFacility",
             Status = RequestStatus.Pending,
             CorrelationId = Guid.NewGuid().ToString(),
-            ScheduledReportEntity = new ScheduledReportEntity { ReportTrackingId = "TestReport", StartDate = DateTime.UtcNow.AddDays(-1), EndDate = DateTime.UtcNow }
+            ScheduledReportEntity = new ScheduledReportEntity { ReportTrackingId = Guid.NewGuid(), StartDate = DateTime.UtcNow.AddDays(-1), EndDate = DateTime.UtcNow }
         };
         dbContext.DataAcquisitionLogs.Add(log);
         await dbContext.SaveChangesAsync();
@@ -220,7 +219,7 @@ public class DataAcquisitionLogManagerTests
         var tag = Guid.NewGuid().ToString("N");
         var facilityId = $"TestFacility_{tag}";
         var correlationId = $"TestCorr_{tag}";
-        var reportTrackingId = $"TestReport_{tag}";
+        var reportTrackingId = Guid.NewGuid();
 
         using var scope = _fixture.ServiceProvider.CreateScope();
         var dbContext = scope.ServiceProvider.GetRequiredService<DataAcquisitionDbContext>();
@@ -247,7 +246,7 @@ public class DataAcquisitionLogManagerTests
         var logIds = new List<long> { log1.Id, log2.Id };
 
         // Act
-        await manager.UpdateTailFlagForFacilityCorrelationIdReportTrackingId(logIds, facilityId, correlationId, reportTrackingId);
+        await manager.UpdateTailFlagForFacilityCorrelationIdReportTrackingId(logIds, facilityId, correlationId, reportTrackingId.ToString());
 
         // Assert
         using var assertScope = _fixture.ServiceProvider.CreateScope();
@@ -270,7 +269,7 @@ public class DataAcquisitionLogManagerTests
         var logIds = new List<long> { 999 };
 
         // Act & Assert
-        await Assert.ThrowsAsync<NotFoundException>(() => manager.UpdateTailFlagForFacilityCorrelationIdReportTrackingId(logIds, "TestFacility", "TestCorr", "TestReport"));
+        await Assert.ThrowsAsync<NotFoundException>(() => manager.UpdateTailFlagForFacilityCorrelationIdReportTrackingId(logIds, "TestFacility", "TestCorr", Guid.NewGuid().ToString()));
     }
 
     // ==================== CancelBulkAsync Tests ====================
@@ -572,8 +571,10 @@ public class DataAcquisitionLogManagerTests
         await dbContext.Database.EnsureDeletedAsync();
         await dbContext.Database.EnsureCreatedAsync();
 
-        var match = new DataAcquisitionLog { FacilityId = "F1", ReportTrackingId = "RPT-001", Status = RequestStatus.Pending, CreateDate = DateTime.UtcNow.AddHours(-48) };
-        var noMatch = new DataAcquisitionLog { FacilityId = "F1", ReportTrackingId = "RPT-002", Status = RequestStatus.Pending, CreateDate = DateTime.UtcNow.AddHours(-48) };
+        var matchReportTrackingId = Guid.NewGuid();
+        var noMatchReportTrackingId = Guid.NewGuid();
+        var match = new DataAcquisitionLog { FacilityId = "F1", ReportTrackingId = matchReportTrackingId, Status = RequestStatus.Pending, CreateDate = DateTime.UtcNow.AddHours(-48) };
+        var noMatch = new DataAcquisitionLog { FacilityId = "F1", ReportTrackingId = noMatchReportTrackingId, Status = RequestStatus.Pending, CreateDate = DateTime.UtcNow.AddHours(-48) };
         dbContext.DataAcquisitionLogs.AddRange(match, noMatch);
         await dbContext.SaveChangesAsync();
 
@@ -581,7 +582,7 @@ public class DataAcquisitionLogManagerTests
 
         // Act
         var (requested, cancelled) = await manager.CancelByFilterAsync(
-            new SearchDataAcquisitionLogRequest { ReportTrackingId = "RPT-001" }, 24);
+            new SearchDataAcquisitionLogRequest { ReportTrackingId = matchReportTrackingId.ToString() }, 24);
 
         // Assert
         Assert.Equal(1, requested);

--- a/DotNet/ServiceTests/IntegrationTests/DataAcquisition/Queries/DataAcquisitionLogQueriesTests.cs
+++ b/DotNet/ServiceTests/IntegrationTests/DataAcquisition/Queries/DataAcquisitionLogQueriesTests.cs
@@ -3,7 +3,6 @@ using LantanaGroup.Link.DataAcquisition.Domain.Application.Models.Api.Requests;
 using LantanaGroup.Link.DataAcquisition.Domain.Application.Queries;
 using LantanaGroup.Link.DataAcquisition.Domain.Infrastructure.Context;
 using LantanaGroup.Link.DataAcquisition.Domain.Infrastructure.Entities;
-using LantanaGroup.Link.Shared.Application.Models.Integration.DataAcquisition;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using FhirQueryType = LantanaGroup.Link.Shared.Application.Models.Integration.DataAcquisition.FhirQueryType;
@@ -33,7 +32,7 @@ public class DataAcquisitionLogQueriesTests
 
         var tag = Guid.NewGuid().ToString("N");
         var facilityId = $"Eligible_{tag}";
-        var reportTrackingId = $"Report_{tag}";
+        var reportTrackingId = Guid.NewGuid();
         var scheduledReport = new ScheduledReportEntity
         {
             ReportTrackingId = reportTrackingId,
@@ -43,30 +42,41 @@ public class DataAcquisitionLogQueriesTests
 
         var pendingLog = new DataAcquisitionLog
         {
-            FhirVersion = "test", TraceId = Guid.NewGuid().ToString(),
-            FacilityId = facilityId, Status = RequestStatus.Pending,
-            CorrelationId = Guid.NewGuid().ToString(), ReportTrackingId = reportTrackingId,
-            PatientId = "Patient/123", ReportStartDate = DateTime.UtcNow.AddDays(-1), ReportEndDate = DateTime.UtcNow,
+            FhirVersion = "test",
+            TraceId = Guid.NewGuid().ToString(),
+            FacilityId = facilityId,
+            Status = RequestStatus.Pending,
+            CorrelationId = Guid.NewGuid().ToString(),
+            ReportTrackingId = reportTrackingId,
+            PatientId = "Patient/123",
             ScheduledReportEntity = scheduledReport
         };
         dbContext.DataAcquisitionLogs.Add(pendingLog);
 
         var failedLog = new DataAcquisitionLog
         {
-            FhirVersion = "test", TraceId = Guid.NewGuid().ToString(),
-            FacilityId = facilityId, Status = RequestStatus.Failed, RetryAttempts = 5,
-            CorrelationId = Guid.NewGuid().ToString(), ReportTrackingId = reportTrackingId,
-            PatientId = "Patient/123", ReportStartDate = DateTime.UtcNow.AddDays(-1), ReportEndDate = DateTime.UtcNow,
+            FhirVersion = "test",
+            TraceId = Guid.NewGuid().ToString(),
+            FacilityId = facilityId,
+            Status = RequestStatus.Failed,
+            RetryAttempts = 5,
+            CorrelationId = Guid.NewGuid().ToString(),
+            ReportTrackingId = reportTrackingId,
+            PatientId = "Patient/123",
             ScheduledReportEntity = scheduledReport
         };
         dbContext.DataAcquisitionLogs.Add(failedLog);
 
         var ineligibleLog = new DataAcquisitionLog
         {
-            FhirVersion = "test", TraceId = Guid.NewGuid().ToString(),
-            FacilityId = facilityId, Status = RequestStatus.MaxRetriesReached, RetryAttempts = 10,
-            CorrelationId = Guid.NewGuid().ToString(), ReportTrackingId = reportTrackingId,
-            PatientId = "Patient/123", ReportStartDate = DateTime.UtcNow.AddDays(-1), ReportEndDate = DateTime.UtcNow,
+            FhirVersion = "test",
+            TraceId = Guid.NewGuid().ToString(),
+            FacilityId = facilityId,
+            Status = RequestStatus.MaxRetriesReached,
+            RetryAttempts = 10,
+            CorrelationId = Guid.NewGuid().ToString(),
+            ReportTrackingId = reportTrackingId,
+            PatientId = "Patient/123",
             ScheduledReportEntity = scheduledReport
         };
         dbContext.DataAcquisitionLogs.Add(ineligibleLog);
@@ -95,37 +105,52 @@ public class DataAcquisitionLogQueriesTests
 
         var correlationId = Guid.NewGuid().ToString();
         var facilityId = $"Tail_{Guid.NewGuid():N}";
-        var reportTrackingId = $"TailReport_{Guid.NewGuid():N}";
+        var reportTrackingId = Guid.NewGuid();
 
         var ScheduledReportEntity = new ScheduledReportEntity { ReportTrackingId = reportTrackingId, StartDate = DateTime.UtcNow.AddDays(-1), EndDate = DateTime.UtcNow };
-        var startDate = DateTime.UtcNow.AddDays(-1);
-        var endDate = DateTime.UtcNow;
 
         var log1 = new DataAcquisitionLog
         {
-            FhirVersion = "test", TraceId = Guid.NewGuid().ToString(),
-            FacilityId = facilityId, CorrelationId = correlationId, ReportTrackingId = reportTrackingId,
-            Status = RequestStatus.Completed, TailSent = false, QueryPhase = QueryPhase.Initial,
-            PatientId = "Patient/123", ReportStartDate = startDate, ReportEndDate = endDate, ScheduledReportEntity = ScheduledReportEntity
+            FhirVersion = "test",
+            TraceId = Guid.NewGuid().ToString(),
+            FacilityId = facilityId,
+            CorrelationId = correlationId,
+            ReportTrackingId = reportTrackingId,
+            Status = RequestStatus.Completed,
+            TailSent = false,
+            QueryPhase = QueryPhase.Initial,
+            PatientId = "Patient/123",
+            ScheduledReportEntity = ScheduledReportEntity
         };
         dbContext.DataAcquisitionLogs.Add(log1);
 
         var log2 = new DataAcquisitionLog
         {
-            FhirVersion = "test", TraceId = Guid.NewGuid().ToString(),
-            FacilityId = facilityId, CorrelationId = correlationId, ReportTrackingId = reportTrackingId,
-            Status = RequestStatus.Completed, TailSent = false, QueryPhase = QueryPhase.Initial,
-            PatientId = "Patient/123", ReportStartDate = startDate, ReportEndDate = endDate, ScheduledReportEntity = ScheduledReportEntity
+            FhirVersion = "test",
+            TraceId = Guid.NewGuid().ToString(),
+            FacilityId = facilityId,
+            CorrelationId = correlationId,
+            ReportTrackingId = reportTrackingId,
+            Status = RequestStatus.Completed,
+            TailSent = false,
+            QueryPhase = QueryPhase.Initial,
+            PatientId = "Patient/123",
+            ScheduledReportEntity = ScheduledReportEntity
         };
         dbContext.DataAcquisitionLogs.Add(log2);
 
         // Incomplete log prevents tailing for this group
         var incompleteLog = new DataAcquisitionLog
         {
-            FhirVersion = "test", TraceId = Guid.NewGuid().ToString(),
-            FacilityId = facilityId, CorrelationId = correlationId, ReportTrackingId = reportTrackingId,
-            Status = RequestStatus.Pending, QueryPhase = QueryPhase.Initial,
-            PatientId = "Patient/123", ReportStartDate = startDate, ReportEndDate = endDate, ScheduledReportEntity = ScheduledReportEntity
+            FhirVersion = "test",
+            TraceId = Guid.NewGuid().ToString(),
+            FacilityId = facilityId,
+            CorrelationId = correlationId,
+            ReportTrackingId = reportTrackingId,
+            Status = RequestStatus.Pending,
+            QueryPhase = QueryPhase.Initial,
+            PatientId = "Patient/123",
+            ScheduledReportEntity = ScheduledReportEntity
         };
         dbContext.DataAcquisitionLogs.Add(incompleteLog);
 
@@ -147,27 +172,37 @@ public class DataAcquisitionLogQueriesTests
 
         var correlationId = Guid.NewGuid().ToString();
         var facilityId = $"TailMixed_{Guid.NewGuid():N}";
-        var reportTrackingId = $"TailMixedReport_{Guid.NewGuid():N}";
+        var reportTrackingId = Guid.NewGuid();
 
         var ScheduledReportEntity = new ScheduledReportEntity { ReportTrackingId = reportTrackingId, StartDate = DateTime.UtcNow.AddDays(-1), EndDate = DateTime.UtcNow };
-        var startDate = DateTime.UtcNow.AddDays(-1);
-        var endDate = DateTime.UtcNow;
 
         var log1 = new DataAcquisitionLog
         {
-            FhirVersion = "test", TraceId = Guid.NewGuid().ToString(),
-            FacilityId = facilityId, CorrelationId = correlationId, ReportTrackingId = reportTrackingId,
-            Status = RequestStatus.Completed, TailSent = false, QueryPhase = QueryPhase.Initial,
-            PatientId = "Patient/123", ReportStartDate = startDate, ReportEndDate = endDate, ScheduledReportEntity = ScheduledReportEntity
+            FhirVersion = "test",
+            TraceId = Guid.NewGuid().ToString(),
+            FacilityId = facilityId,
+            CorrelationId = correlationId,
+            ReportTrackingId = reportTrackingId,
+            Status = RequestStatus.Completed,
+            TailSent = false,
+            QueryPhase = QueryPhase.Initial,
+            PatientId = "Patient/123",
+            ScheduledReportEntity = ScheduledReportEntity
         };
         dbContext.DataAcquisitionLogs.Add(log1);
 
         var log2 = new DataAcquisitionLog
         {
-            FhirVersion = "test", TraceId = Guid.NewGuid().ToString(),
-            FacilityId = facilityId, CorrelationId = correlationId, ReportTrackingId = reportTrackingId,
-            Status = RequestStatus.Completed, TailSent = false, QueryPhase = QueryPhase.Initial,
-            PatientId = "Patient/123", ReportStartDate = startDate, ReportEndDate = endDate, ScheduledReportEntity = ScheduledReportEntity
+            FhirVersion = "test",
+            TraceId = Guid.NewGuid().ToString(),
+            FacilityId = facilityId,
+            CorrelationId = correlationId,
+            ReportTrackingId = reportTrackingId,
+            Status = RequestStatus.Completed,
+            TailSent = false,
+            QueryPhase = QueryPhase.Initial,
+            PatientId = "Patient/123",
+            ScheduledReportEntity = ScheduledReportEntity
         };
         dbContext.DataAcquisitionLogs.Add(log2);
 
@@ -192,16 +227,21 @@ public class DataAcquisitionLogQueriesTests
 
         var correlationId = Guid.NewGuid().ToString();
         var facilityId = $"TailCompleted_{Guid.NewGuid():N}";
-        var reportTrackingId = $"TailCompReport_{Guid.NewGuid():N}";
+        var reportTrackingId = Guid.NewGuid();
 
         var ScheduledReportEntity = new ScheduledReportEntity { ReportTrackingId = reportTrackingId, StartDate = DateTime.UtcNow.AddDays(-1), EndDate = DateTime.UtcNow };
 
         var log1 = new DataAcquisitionLog
         {
-            FhirVersion = "test", TraceId = Guid.NewGuid().ToString(),
-            FacilityId = facilityId, CorrelationId = correlationId, ReportTrackingId = reportTrackingId,
-            Status = RequestStatus.Completed, TailSent = false, QueryPhase = QueryPhase.Initial,
-            PatientId = "Patient/123", ReportStartDate = DateTime.UtcNow.AddDays(-1), ReportEndDate = DateTime.UtcNow,
+            FhirVersion = "test",
+            TraceId = Guid.NewGuid().ToString(),
+            FacilityId = facilityId,
+            CorrelationId = correlationId,
+            ReportTrackingId = reportTrackingId,
+            Status = RequestStatus.Completed,
+            TailSent = false,
+            QueryPhase = QueryPhase.Initial,
+            PatientId = "Patient/123",
             ScheduledReportEntity = ScheduledReportEntity
         };
         dbContext.DataAcquisitionLogs.Add(log1);
@@ -228,11 +268,14 @@ public class DataAcquisitionLogQueriesTests
 
         var log = new DataAcquisitionLog
         {
-            FhirVersion = "test", TraceId = Guid.NewGuid().ToString(),
-            FacilityId = facilityId, Status = RequestStatus.Completed,
-            CorrelationId = Guid.NewGuid().ToString(), ReportTrackingId = $"Report_{tag}",
-            PatientId = "Patient/123", ReportStartDate = DateTime.UtcNow.AddDays(-1), ReportEndDate = DateTime.UtcNow,
-            ScheduledReportEntity = new ScheduledReportEntity { ReportTrackingId = $"Report_{tag}", StartDate = DateTime.UtcNow.AddDays(-1), EndDate = DateTime.UtcNow },
+            FhirVersion = "test",
+            TraceId = Guid.NewGuid().ToString(),
+            FacilityId = facilityId,
+            Status = RequestStatus.Completed,
+            CorrelationId = Guid.NewGuid().ToString(),
+            ReportTrackingId = Guid.NewGuid(),
+            PatientId = "Patient/123",
+            ScheduledReportEntity = new ScheduledReportEntity { ReportTrackingId = Guid.NewGuid(), StartDate = DateTime.UtcNow.AddDays(-1), EndDate = DateTime.UtcNow },
             FhirQueries = new List<FhirQuery>
             {
                 new FhirQuery { MeasureId = "test", FacilityId = facilityId, QueryType = FhirQueryType.Read, FhirQueryResourceTypes = new List<FhirQueryResourceType> { new FhirQueryResourceType() { ResourceType = Hl7.Fhir.Model.ResourceType.Patient } } }
@@ -260,14 +303,17 @@ public class DataAcquisitionLogQueriesTests
         var correlationId = Guid.NewGuid().ToString();
         var tag = Guid.NewGuid().ToString("N");
         var facilityId = $"SearchStatus_{tag}";
-        var reportTrackingId = $"Report_{tag}";
+        var reportTrackingId = Guid.NewGuid();
 
         var log = new DataAcquisitionLog
         {
-            FhirVersion = "test", TraceId = Guid.NewGuid().ToString(),
-            FacilityId = facilityId, CorrelationId = correlationId, ReportTrackingId = reportTrackingId,
-            Status = RequestStatus.Completed, PatientId = "Patient/123",
-            ReportStartDate = DateTime.UtcNow.AddDays(-1), ReportEndDate = DateTime.UtcNow,
+            FhirVersion = "test",
+            TraceId = Guid.NewGuid().ToString(),
+            FacilityId = facilityId,
+            CorrelationId = correlationId,
+            ReportTrackingId = reportTrackingId,
+            Status = RequestStatus.Completed,
+            PatientId = "Patient/123",
             ScheduledReportEntity = new ScheduledReportEntity { ReportTrackingId = reportTrackingId, StartDate = DateTime.UtcNow.AddDays(-1), EndDate = DateTime.UtcNow },
             FhirQueries = new List<FhirQuery>
             {
@@ -288,7 +334,7 @@ public class DataAcquisitionLogQueriesTests
         var result = (await queries.SearchAsync(new SearchDataAcquisitionLogRequest
         {
             FacilityId = facilityId,
-            ReportTrackingId = reportTrackingId,
+            ReportTrackingId = reportTrackingId.ToString(),
             CorrelationId = correlationId
         })).Records.FirstOrDefault();
 
@@ -307,21 +353,27 @@ public class DataAcquisitionLogQueriesTests
 
         var log1 = new DataAcquisitionLog
         {
-            FhirVersion = "test", TraceId = Guid.NewGuid().ToString(),
-            FacilityId = facilityId, Status = RequestStatus.Completed,
-            CorrelationId = Guid.NewGuid().ToString(), ReportTrackingId = $"Report1_{tag}",
-            PatientId = "Patient/123", ReportStartDate = DateTime.UtcNow.AddDays(-1), ReportEndDate = DateTime.UtcNow,
-            ScheduledReportEntity = new ScheduledReportEntity { ReportTrackingId = $"Report1_{tag}", StartDate = DateTime.UtcNow.AddDays(-1), EndDate = DateTime.UtcNow }
+            FhirVersion = "test",
+            TraceId = Guid.NewGuid().ToString(),
+            FacilityId = facilityId,
+            Status = RequestStatus.Completed,
+            CorrelationId = Guid.NewGuid().ToString(),
+            ReportTrackingId = Guid.NewGuid(),
+            PatientId = "Patient/123",
+            ScheduledReportEntity = new ScheduledReportEntity { ReportTrackingId = Guid.NewGuid(), StartDate = DateTime.UtcNow.AddDays(-1), EndDate = DateTime.UtcNow }
         };
         dbContext.DataAcquisitionLogs.Add(log1);
 
         var log2 = new DataAcquisitionLog
         {
-            FhirVersion = "test", TraceId = Guid.NewGuid().ToString(),
-            FacilityId = facilityId, Status = RequestStatus.Pending,
-            CorrelationId = Guid.NewGuid().ToString(), ReportTrackingId = $"Report2_{tag}",
-            PatientId = "Patient/456", ReportStartDate = DateTime.UtcNow.AddDays(-1), ReportEndDate = DateTime.UtcNow,
-            ScheduledReportEntity = new ScheduledReportEntity { ReportTrackingId = $"Report2_{tag}", StartDate = DateTime.UtcNow.AddDays(-1), EndDate = DateTime.UtcNow }
+            FhirVersion = "test",
+            TraceId = Guid.NewGuid().ToString(),
+            FacilityId = facilityId,
+            Status = RequestStatus.Pending,
+            CorrelationId = Guid.NewGuid().ToString(),
+            ReportTrackingId = Guid.NewGuid(),
+            PatientId = "Patient/456",
+            ScheduledReportEntity = new ScheduledReportEntity { ReportTrackingId = Guid.NewGuid(), StartDate = DateTime.UtcNow.AddDays(-1), EndDate = DateTime.UtcNow }
         };
         dbContext.DataAcquisitionLogs.Add(log2);
 
@@ -350,11 +402,14 @@ public class DataAcquisitionLogQueriesTests
 
         var log = new DataAcquisitionLog
         {
-            FhirVersion = "test", TraceId = Guid.NewGuid().ToString(),
-            FacilityId = facilityId, Status = RequestStatus.Completed,
-            CorrelationId = Guid.NewGuid().ToString(), ReportTrackingId = $"Report_{tag}",
-            PatientId = "Patient/123", ReportStartDate = DateTime.UtcNow.AddDays(-1), ReportEndDate = DateTime.UtcNow,
-            ScheduledReportEntity = new ScheduledReportEntity { ReportTrackingId = $"Report_{tag}", StartDate = DateTime.UtcNow.AddDays(-1), EndDate = DateTime.UtcNow },
+            FhirVersion = "test",
+            TraceId = Guid.NewGuid().ToString(),
+            FacilityId = facilityId,
+            Status = RequestStatus.Completed,
+            CorrelationId = Guid.NewGuid().ToString(),
+            ReportTrackingId = Guid.NewGuid(),
+            PatientId = "Patient/123",
+            ScheduledReportEntity = new ScheduledReportEntity { ReportTrackingId = Guid.NewGuid(), StartDate = DateTime.UtcNow.AddDays(-1), EndDate = DateTime.UtcNow },
             FhirQueries = new List<FhirQuery>()
             {
                 new FhirQuery
@@ -402,11 +457,14 @@ public class DataAcquisitionLogQueriesTests
 
         var log = new DataAcquisitionLog
         {
-            FhirVersion = "test", TraceId = Guid.NewGuid().ToString(),
-            FacilityId = facilityId, Status = RequestStatus.Completed,
-            CorrelationId = correlationId, ReportTrackingId = $"Report_{tag}",
-            PatientId = "Patient/123", ReportStartDate = DateTime.UtcNow.AddDays(-1), ReportEndDate = DateTime.UtcNow,
-            ScheduledReportEntity = new ScheduledReportEntity { ReportTrackingId = $"Report_{tag}", StartDate = DateTime.UtcNow.AddDays(-1), EndDate = DateTime.UtcNow },
+            FhirVersion = "test",
+            TraceId = Guid.NewGuid().ToString(),
+            FacilityId = facilityId,
+            Status = RequestStatus.Completed,
+            CorrelationId = correlationId,
+            ReportTrackingId = Guid.NewGuid(),
+            PatientId = "Patient/123",
+            ScheduledReportEntity = new ScheduledReportEntity { ReportTrackingId = Guid.NewGuid(), StartDate = DateTime.UtcNow.AddDays(-1), EndDate = DateTime.UtcNow },
             FhirQueries = new List<FhirQuery>()
             {
                 new FhirQuery
@@ -450,16 +508,21 @@ public class DataAcquisitionLogQueriesTests
         var dbContext = scope.ServiceProvider.GetRequiredService<DataAcquisitionDbContext>();
 
         var tag = Guid.NewGuid().ToString("N");
-        var reportTrackingId = $"StatReport_{tag}";
+        var reportTrackingId = Guid.NewGuid();
         var facilityId = $"Stat_{tag}";
 
         var log1 = new DataAcquisitionLog
         {
-            FhirVersion = "test", TraceId = Guid.NewGuid().ToString(),
-            FacilityId = facilityId, Status = RequestStatus.Completed,
-            CorrelationId = Guid.NewGuid().ToString(), ReportTrackingId = reportTrackingId,
-            PatientId = "Patient/123", ReportStartDate = DateTime.UtcNow.AddDays(-1), ReportEndDate = DateTime.UtcNow,
-            CompletionTimeMilliseconds = 100, QueryPhase = QueryPhase.Initial, QueryType = FhirQueryType.Read,
+            FhirVersion = "test",
+            TraceId = Guid.NewGuid().ToString(),
+            FacilityId = facilityId,
+            Status = RequestStatus.Completed,
+            CorrelationId = Guid.NewGuid().ToString(),
+            ReportTrackingId = reportTrackingId,
+            PatientId = "Patient/123",
+            CompletionTimeMilliseconds = 100,
+            QueryPhase = QueryPhase.Initial,
+            QueryType = FhirQueryType.Read,
             ScheduledReportEntity = new ScheduledReportEntity { ReportTrackingId = reportTrackingId, StartDate = DateTime.UtcNow.AddDays(-1), EndDate = DateTime.UtcNow },
             ResourceIds = new List<DataAcquisitionLogResourceId> { new() { ResourceId = "Patient/123" } },
             FhirQueries = new List<FhirQuery>
@@ -472,7 +535,7 @@ public class DataAcquisitionLogQueriesTests
 
         var queries = scope.ServiceProvider.GetRequiredService<IDataAcquisitionLogQueries>();
 
-        var statistics = await queries.GetDataAcquisitionLogStatisticsByReportAsync(reportTrackingId);
+        var statistics = await queries.GetDataAcquisitionLogStatisticsByReportAsync(reportTrackingId.ToString());
 
         Assert.NotNull(statistics);
         Assert.Equal(1, statistics.TotalLogs);
@@ -489,16 +552,21 @@ public class DataAcquisitionLogQueriesTests
         var dbContext = scope.ServiceProvider.GetRequiredService<DataAcquisitionDbContext>();
 
         var tag = Guid.NewGuid().ToString("N");
-        var reportTrackingId = $"StatCompleted_{tag}";
+        var reportTrackingId = Guid.NewGuid();
         var facilityId = $"StatComp_{tag}";
 
         var log = new DataAcquisitionLog
         {
-            FhirVersion = "test", TraceId = Guid.NewGuid().ToString(),
-            FacilityId = facilityId, Status = RequestStatus.Completed,
-            CorrelationId = Guid.NewGuid().ToString(), ReportTrackingId = reportTrackingId,
-            PatientId = "Patient/123", ReportStartDate = DateTime.UtcNow.AddDays(-1), ReportEndDate = DateTime.UtcNow,
-            CompletionTimeMilliseconds = 150, QueryPhase = QueryPhase.Initial, QueryType = FhirQueryType.Read,
+            FhirVersion = "test",
+            TraceId = Guid.NewGuid().ToString(),
+            FacilityId = facilityId,
+            Status = RequestStatus.Completed,
+            CorrelationId = Guid.NewGuid().ToString(),
+            ReportTrackingId = reportTrackingId,
+            PatientId = "Patient/123",
+            CompletionTimeMilliseconds = 150,
+            QueryPhase = QueryPhase.Initial,
+            QueryType = FhirQueryType.Read,
             ScheduledReportEntity = new ScheduledReportEntity { ReportTrackingId = reportTrackingId, StartDate = DateTime.UtcNow.AddDays(-1), EndDate = DateTime.UtcNow },
             ResourceIds = new List<DataAcquisitionLogResourceId>(),
             FhirQueries = new List<FhirQuery>
@@ -511,7 +579,7 @@ public class DataAcquisitionLogQueriesTests
 
         var queries = scope.ServiceProvider.GetRequiredService<IDataAcquisitionLogQueries>();
 
-        var statistics = await queries.GetDataAcquisitionLogStatisticsByReportAsync(reportTrackingId);
+        var statistics = await queries.GetDataAcquisitionLogStatisticsByReportAsync(reportTrackingId.ToString());
 
         Assert.NotNull(statistics);
         Assert.Equal(1, statistics.TotalLogs);
@@ -527,16 +595,19 @@ public class DataAcquisitionLogQueriesTests
 
         var tag = Guid.NewGuid().ToString("N");
         var facilityId = $"RefSent_{tag}";
-        var reportTrackingId = $"Report_{tag}";
+        var reportTrackingId = Guid.NewGuid();
         var correlationId = Guid.NewGuid().ToString();
         var referenceId = $"Patient/{tag}";
 
         var log = new DataAcquisitionLog
         {
-            FhirVersion = "test", TraceId = Guid.NewGuid().ToString(),
-            FacilityId = facilityId, CorrelationId = correlationId, ReportTrackingId = reportTrackingId,
-            Status = RequestStatus.Completed, PatientId = "Patient/123",
-            ReportStartDate = DateTime.UtcNow.AddDays(-1), ReportEndDate = DateTime.UtcNow,
+            FhirVersion = "test",
+            TraceId = Guid.NewGuid().ToString(),
+            FacilityId = facilityId,
+            CorrelationId = correlationId,
+            ReportTrackingId = reportTrackingId,
+            Status = RequestStatus.Completed,
+            PatientId = "Patient/123",
             ResourceIds = new List<DataAcquisitionLogResourceId> { new() { ResourceId = referenceId } },
             ScheduledReportEntity = new ScheduledReportEntity { ReportTrackingId = reportTrackingId, StartDate = DateTime.UtcNow.AddDays(-1), EndDate = DateTime.UtcNow }
         };
@@ -545,7 +616,7 @@ public class DataAcquisitionLogQueriesTests
 
         var queries = scope.ServiceProvider.GetRequiredService<IDataAcquisitionLogQueries>();
 
-        var hasBeenSent = await queries.CheckIfReferenceResourceHasBeenSent(referenceId, reportTrackingId, facilityId, correlationId);
+        var hasBeenSent = await queries.CheckIfReferenceResourceHasBeenSent(referenceId, reportTrackingId.ToString(), facilityId, correlationId);
 
         Assert.True(hasBeenSent);
     }
@@ -559,36 +630,45 @@ public class DataAcquisitionLogQueriesTests
         var tag = Guid.NewGuid().ToString("N");
         var facility1 = $"Fac1_{tag}";
         var facility2 = $"Fac2_{tag}";
-        var reportTrackingId1 = $"Report1_{tag}";
-        var reportTrackingId2 = $"Report2_{tag}";
-        var reportTrackingId3 = $"Report3_{tag}";
+        var reportTrackingId1 = Guid.NewGuid();
+        var reportTrackingId2 = Guid.NewGuid();
+        var reportTrackingId3 = Guid.NewGuid();
 
         var log1 = new DataAcquisitionLog
         {
-            FhirVersion = "test", TraceId = Guid.NewGuid().ToString(),
-            FacilityId = facility1, Status = RequestStatus.Pending,
-            CorrelationId = Guid.NewGuid().ToString(), ReportTrackingId = reportTrackingId1,
-            PatientId = "Patient/123", ReportStartDate = DateTime.UtcNow.AddDays(-1), ReportEndDate = DateTime.UtcNow,
+            FhirVersion = "test",
+            TraceId = Guid.NewGuid().ToString(),
+            FacilityId = facility1,
+            Status = RequestStatus.Pending,
+            CorrelationId = Guid.NewGuid().ToString(),
+            ReportTrackingId = reportTrackingId1,
+            PatientId = "Patient/123",
             ScheduledReportEntity = new ScheduledReportEntity { ReportTrackingId = reportTrackingId1, StartDate = DateTime.UtcNow.AddDays(-1), EndDate = DateTime.UtcNow }
         };
         dbContext.DataAcquisitionLogs.Add(log1);
 
         var log2 = new DataAcquisitionLog
         {
-            FhirVersion = "test", TraceId = Guid.NewGuid().ToString(),
-            FacilityId = facility2, Status = RequestStatus.Failed,
-            CorrelationId = Guid.NewGuid().ToString(), ReportTrackingId = reportTrackingId2,
-            PatientId = "Patient/123", ReportStartDate = DateTime.UtcNow.AddDays(-1), ReportEndDate = DateTime.UtcNow,
+            FhirVersion = "test",
+            TraceId = Guid.NewGuid().ToString(),
+            FacilityId = facility2,
+            Status = RequestStatus.Failed,
+            CorrelationId = Guid.NewGuid().ToString(),
+            ReportTrackingId = reportTrackingId2,
+            PatientId = "Patient/123",
             ScheduledReportEntity = new ScheduledReportEntity { ReportTrackingId = reportTrackingId2, StartDate = DateTime.UtcNow.AddDays(-1), EndDate = DateTime.UtcNow }
         };
         dbContext.DataAcquisitionLogs.Add(log2);
 
         var log3 = new DataAcquisitionLog
         {
-            FhirVersion = "test", TraceId = Guid.NewGuid().ToString(),
-            FacilityId = facility1, Status = RequestStatus.Failed,
-            CorrelationId = Guid.NewGuid().ToString(), ReportTrackingId = reportTrackingId3,
-            PatientId = "Patient/123", ReportStartDate = DateTime.UtcNow.AddDays(-1), ReportEndDate = DateTime.UtcNow,
+            FhirVersion = "test",
+            TraceId = Guid.NewGuid().ToString(),
+            FacilityId = facility1,
+            Status = RequestStatus.Failed,
+            CorrelationId = Guid.NewGuid().ToString(),
+            ReportTrackingId = reportTrackingId3,
+            PatientId = "Patient/123",
             ScheduledReportEntity = new ScheduledReportEntity { ReportTrackingId = reportTrackingId3, StartDate = DateTime.UtcNow.AddDays(-1), EndDate = DateTime.UtcNow }
         };
         dbContext.DataAcquisitionLogs.Add(log3);
@@ -617,11 +697,14 @@ public class DataAcquisitionLogQueriesTests
         {
             var log = new DataAcquisitionLog
             {
-                FhirVersion = "test", TraceId = Guid.NewGuid().ToString(),
-                FacilityId = facilityId, Status = RequestStatus.Pending,
-                CorrelationId = Guid.NewGuid().ToString(), ReportTrackingId = $"Report{i}_{tag}",
-                PatientId = "Patient/123", ReportStartDate = DateTime.UtcNow.AddDays(-1), ReportEndDate = DateTime.UtcNow,
-                ScheduledReportEntity = new ScheduledReportEntity { ReportTrackingId = $"Report{i}_{tag}", StartDate = DateTime.UtcNow.AddDays(-1), EndDate = DateTime.UtcNow }
+                FhirVersion = "test",
+                TraceId = Guid.NewGuid().ToString(),
+                FacilityId = facilityId,
+                Status = RequestStatus.Pending,
+                CorrelationId = Guid.NewGuid().ToString(),
+                ReportTrackingId = Guid.NewGuid(),
+                PatientId = "Patient/123",
+                ScheduledReportEntity = new ScheduledReportEntity { ReportTrackingId = Guid.NewGuid(), StartDate = DateTime.UtcNow.AddDays(-1), EndDate = DateTime.UtcNow }
             };
             dbContext.DataAcquisitionLogs.Add(log);
         }

--- a/DotNet/ServiceTests/IntegrationTests/DataAcquisition/Services/PatientCensusServiceTests.cs
+++ b/DotNet/ServiceTests/IntegrationTests/DataAcquisition/Services/PatientCensusServiceTests.cs
@@ -1,0 +1,565 @@
+﻿using Confluent.Kafka;
+using DataAcquisition.Domain.Application.Models;
+using LantanaGroup.Link.DataAcquisition.Domain.Application.Interfaces;
+using LantanaGroup.Link.DataAcquisition.Domain.Application.Managers;
+using LantanaGroup.Link.DataAcquisition.Domain.Application.Models.Domain;
+using LantanaGroup.Link.DataAcquisition.Domain.Application.Queries;
+using LantanaGroup.Link.DataAcquisition.Domain.Application.Services;
+using LantanaGroup.Link.DataAcquisition.Domain.Application.Services.FhirApi.Commands;
+using LantanaGroup.Link.DataAcquisition.Domain.Infrastructure;
+using LantanaGroup.Link.DataAcquisition.Domain.Infrastructure.Context;
+using LantanaGroup.Link.DataAcquisition.Domain.Infrastructure.Entities;
+using LantanaGroup.Link.DataAcquisition.Domain.Infrastructure.Models;
+using LantanaGroup.Link.DataAcquisition.Domain.Infrastructure.Models.Enums;
+using LantanaGroup.Link.DataAcquisition.Domain.Models;
+using LantanaGroup.Link.Shared.Application.Models.Kafka;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Moq;
+using FhirQueryType = LantanaGroup.Link.Shared.Application.Models.Integration.DataAcquisition.FhirQueryType;
+using RequestStatus = LantanaGroup.Link.Shared.Application.Models.Integration.DataAcquisition.RequestStatus;
+using ResourceType = Hl7.Fhir.Model.ResourceType;
+using Task = System.Threading.Tasks.Task;
+
+namespace IntegrationTests.DataAcquisition.Services;
+
+[Collection("DataAcquisitionIntegrationTests")]
+[Trait("Category", "IntegrationTests")]
+public class PatientCensusServiceTests
+{
+    private readonly DataAcquisitionIntegrationTestFixture _fixture;
+
+    public PatientCensusServiceTests(DataAcquisitionIntegrationTestFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    /// <summary>
+    /// Builds a standard set of 6 EHR patient lists covering all TimeFrame × ListType combinations.
+    /// </summary>
+    private static List<EhrPatientList> BuildStandardEhrPatientLists(string idPrefix)
+    {
+        return
+        [
+            new EhrPatientList { FhirId = $"{idPrefix}-admit-lt24", Status = ListType.Admit, TimeFrame = TimeFrame.LessThan24Hours },
+            new EhrPatientList { FhirId = $"{idPrefix}-admit-24-48", Status = ListType.Admit, TimeFrame = TimeFrame.Between24To48Hours },
+            new EhrPatientList { FhirId = $"{idPrefix}-admit-gt48", Status = ListType.Admit, TimeFrame = TimeFrame.MoreThan48Hours },
+            new EhrPatientList { FhirId = $"{idPrefix}-discharge-lt24", Status = ListType.Discharge, TimeFrame = TimeFrame.LessThan24Hours },
+            new EhrPatientList { FhirId = $"{idPrefix}-discharge-24-48", Status = ListType.Discharge, TimeFrame = TimeFrame.Between24To48Hours },
+            new EhrPatientList { FhirId = $"{idPrefix}-discharge-gt48", Status = ListType.Discharge, TimeFrame = TimeFrame.MoreThan48Hours },
+        ];
+    }
+
+    /// <summary>
+    /// Seeds FhirListConfiguration + FhirQueryConfiguration into the DB.
+    /// Returns the facilityId for reference.
+    /// </summary>
+    private async Task SeedFhirListAndQueryConfigAsync(DataAcquisitionDbContext dbContext, string facilityId, string fhirBaseUrl = "http://localhost/fhir")
+    {
+        var listConfig = new FhirListConfiguration
+        {
+            Id = Guid.NewGuid(),
+            FacilityId = facilityId,
+            FhirBaseServerUrl = fhirBaseUrl,
+            EHRPatientLists = BuildStandardEhrPatientLists(facilityId),
+        };
+        dbContext.FhirListConfigurations.Add(listConfig);
+
+        var queryConfig = new FhirQueryConfiguration
+        {
+            Id = Guid.NewGuid(),
+            FacilityId = facilityId,
+            FhirServerBaseUrl = fhirBaseUrl,
+        };
+        dbContext.FhirQueryConfigurations.Add(queryConfig);
+
+        await dbContext.SaveChangesAsync();
+    }
+
+    /// <summary>
+    /// Seeds an SftpConfiguration with census acquisition configs for the facility.
+    /// </summary>
+    private async Task SeedSftpCensusConfigAsync(DataAcquisitionDbContext dbContext, string facilityId)
+    {
+        dbContext.SftpConfigurations.Add(new SftpConfiguration
+        {
+            Id = Guid.NewGuid(),
+            OrganizationId = facilityId,
+            Host = "sftp.example.com",
+            Port = 22,
+            AcquisitionConfigurations =
+            [
+                new SftpAcquisitionTypeConfiguration
+                {
+                    AcquisitionType = SftpAcquisitionType.Census,
+                    SubType = SftpAcquisitionSubType.CernerCCLExtract,
+                    RemoteDirectory = "/census",
+                    FileNamePattern = "census_*.dat",
+                },
+            ],
+        });
+
+        await dbContext.SaveChangesAsync();
+    }
+
+    private PatientCensusService CreateService(
+        IServiceScope scope,
+        Mock<IReadFhirCommand>? readFhirCommandMock = null,
+        Mock<IProducer<string, PatientListMessage>>? kafkaProducerMock = null)
+    {
+        var logManager = scope.ServiceProvider.GetRequiredService<IDataAcquisitionLogManager>();
+        var fhirListQueries = scope.ServiceProvider.GetRequiredService<IFhirQueryListConfigurationQueries>();
+        var fhirQueryConfigQueries = scope.ServiceProvider.GetRequiredService<IFhirQueryConfigurationQueries>();
+        var sftpConfigQueries = new SftpConfigurationQueries(scope.ServiceProvider.GetRequiredService<DataAcquisitionDbContext>());
+        var sftpLogManager = new SftpAcquisitionLogManager(
+            new Mock<ILogger<SftpAcquisitionLogManager>>().Object,
+            scope.ServiceProvider.GetRequiredService<IDatabase>(),
+            scope.ServiceProvider.GetRequiredService<DataAcquisitionDbContext>());
+
+        return new PatientCensusService(
+            new Mock<ILogger<PatientCensusService>>().Object,
+            new Mock<IAuthenticationRetrievalService>().Object,
+            fhirListQueries,
+            fhirQueryConfigQueries,
+            (readFhirCommandMock ?? new Mock<IReadFhirCommand>()).Object,
+            logManager,
+            (kafkaProducerMock ?? new Mock<IProducer<string, PatientListMessage>>()).Object,
+            sftpConfigQueries,
+            sftpLogManager);
+    }
+
+    // ─────────────────────────────────────────────────────────────────
+    //  CreateLog – FHIR List path
+    // ─────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task CreateLog_FhirListPath_CreatesLogWith6Queries()
+    {
+        using var scope = _fixture.ServiceProvider.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<DataAcquisitionDbContext>();
+        var tag = Guid.NewGuid().ToString("N")[..8];
+        var facilityId = $"CensusTest_FhirList_{tag}";
+
+        await SeedFhirListAndQueryConfigAsync(dbContext, facilityId);
+
+        var service = CreateService(scope);
+
+        await service.CreateLog(facilityId, CancellationToken.None);
+
+        var log = await dbContext.DataAcquisitionLogs
+            .Include(l => l.FhirQueries)
+                .ThenInclude(q => q.FhirQueryResourceTypes)
+            .Where(l => l.FacilityId == facilityId && l.IsCensus)
+            .SingleOrDefaultAsync();
+
+        Assert.NotNull(log);
+        Assert.Equal(RequestStatus.Pending, log.Status);
+        Assert.True(log.IsCensus);
+        Assert.Equal(6, log.FhirQueries.Count);
+
+        foreach (var fq in log.FhirQueries)
+        {
+            Assert.Equal(FhirQueryType.Read, fq.QueryType);
+            Assert.NotNull(fq.CensusTimeFrame);
+            Assert.NotNull(fq.CensusPatientStatus);
+            Assert.False(string.IsNullOrWhiteSpace(fq.CensusListId));
+            Assert.Contains(fq.FhirQueryResourceTypes, rt => rt.ResourceType == ResourceType.List);
+        }
+    }
+
+    [Fact]
+    public async Task CreateLog_FhirListPath_Throws_WhenFhirListConfigMissing()
+    {
+        using var scope = _fixture.ServiceProvider.CreateScope();
+        var tag = Guid.NewGuid().ToString("N")[..8];
+        var facilityId = $"CensusTest_NoConfig_{tag}";
+
+        var service = CreateService(scope);
+
+        var ex = await Assert.ThrowsAsync<Exception>(
+            () => service.CreateLog(facilityId, CancellationToken.None));
+        Assert.Contains("Missing census configuration", ex.Message);
+    }
+
+    [Fact]
+    public async Task CreateLog_FhirListPath_Throws_WhenFhirQueryConfigMissing()
+    {
+        using var scope = _fixture.ServiceProvider.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<DataAcquisitionDbContext>();
+        var tag = Guid.NewGuid().ToString("N")[..8];
+        var facilityId = $"CensusTest_NoQueryCfg_{tag}";
+
+        dbContext.FhirListConfigurations.Add(new FhirListConfiguration
+        {
+            Id = Guid.NewGuid(),
+            FacilityId = facilityId,
+            FhirBaseServerUrl = "http://localhost/fhir",
+            EHRPatientLists = BuildStandardEhrPatientLists(facilityId),
+        });
+        await dbContext.SaveChangesAsync();
+
+        var service = CreateService(scope);
+
+        var ex = await Assert.ThrowsAsync<Exception>(
+            () => service.CreateLog(facilityId, CancellationToken.None));
+        Assert.Contains("Missing FHIR query configuration", ex.Message);
+    }
+
+    // ─────────────────────────────────────────────────────────────────
+    //  CreateLog – SFTP Census path
+    // ─────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task CreateLog_SftpCensusPath_CreatesSftpLogAndSkipsFhirList()
+    {
+        using var scope = _fixture.ServiceProvider.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<DataAcquisitionDbContext>();
+        var tag = Guid.NewGuid().ToString("N")[..8];
+        var facilityId = $"CensusTest_Sftp_{tag}";
+
+        await SeedSftpCensusConfigAsync(dbContext, facilityId);
+
+        var service = CreateService(scope);
+
+        await service.CreateLog(facilityId, CancellationToken.None);
+
+        // Verify SFTP log was created
+        var sftpLogs = await dbContext.SftpAcquisitionLogs
+            .Where(l => l.FacilityId == facilityId)
+            .ToListAsync();
+        Assert.Single(sftpLogs);
+        Assert.Equal(SftpAcquisitionType.Census, sftpLogs[0].AcquisitionType);
+        Assert.Equal(SftpAcquisitionSubType.CernerCCLExtract, sftpLogs[0].SubType);
+        Assert.Equal(RequestStatus.Pending, sftpLogs[0].Status);
+
+        // Verify no FHIR DataAcquisitionLog was created for this facility
+        var daLogs = await dbContext.DataAcquisitionLogs
+            .Where(l => l.FacilityId == facilityId)
+            .ToListAsync();
+        Assert.Empty(daLogs);
+    }
+
+    [Fact]
+    public async Task CreateLog_SftpConfigExists_ButNoCensusAcq_FallsThroughToFhirList()
+    {
+        using var scope = _fixture.ServiceProvider.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<DataAcquisitionDbContext>();
+        var tag = Guid.NewGuid().ToString("N")[..8];
+        var facilityId = $"CensusTest_SftpNoCensus_{tag}";
+
+        // Seed SFTP config with only Resources type (no Census)
+        dbContext.SftpConfigurations.Add(new SftpConfiguration
+        {
+            Id = Guid.NewGuid(),
+            OrganizationId = facilityId,
+            Host = "sftp.example.com",
+            Port = 22,
+            AcquisitionConfigurations =
+            [
+                new SftpAcquisitionTypeConfiguration
+                {
+                    AcquisitionType = SftpAcquisitionType.Resources,
+                    SubType = SftpAcquisitionSubType.None,
+                },
+            ],
+        });
+        await dbContext.SaveChangesAsync();
+
+        await SeedFhirListAndQueryConfigAsync(dbContext, facilityId);
+
+        var service = CreateService(scope);
+
+        await service.CreateLog(facilityId, CancellationToken.None);
+
+        // Should have fallen through to FHIR List path
+        var daLog = await dbContext.DataAcquisitionLogs
+            .Include(l => l.FhirQueries)
+            .Where(l => l.FacilityId == facilityId && l.IsCensus)
+            .SingleOrDefaultAsync();
+        Assert.NotNull(daLog);
+        Assert.Equal(6, daLog.FhirQueries.Count);
+
+        // No SFTP census log should exist
+        var sftpLogs = await dbContext.SftpAcquisitionLogs
+            .Where(l => l.FacilityId == facilityId)
+            .ToListAsync();
+        Assert.Empty(sftpLogs);
+    }
+
+    // ─────────────────────────────────────────────────────────────────
+    //  RetrieveListData
+    // ─────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task RetrieveListData_NullLog_ThrowsArgumentNullException()
+    {
+        using var scope = _fixture.ServiceProvider.CreateScope();
+        var service = CreateService(scope);
+
+        await Assert.ThrowsAsync<ArgumentNullException>(
+            () => service.RetrieveListData(null!, false, CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task RetrieveListData_WrongQueryCount_ThrowsArgumentException()
+    {
+        using var scope = _fixture.ServiceProvider.CreateScope();
+        var service = CreateService(scope);
+
+        var log = new DataAcquisitionLogModel
+        {
+            FacilityId = "SomeFacility",
+            FhirQuery = [new FhirQueryModel()], // only 1, not 6
+        };
+
+        await Assert.ThrowsAsync<ArgumentException>(
+            () => service.RetrieveListData(log, false, CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task RetrieveListData_SuccessfulFhirRead_ReturnsPatientIds_UpdatesLog_ProducesKafka()
+    {
+        using var scope = _fixture.ServiceProvider.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<DataAcquisitionDbContext>();
+        var logManager = scope.ServiceProvider.GetRequiredService<IDataAcquisitionLogManager>();
+        var logQueries = scope.ServiceProvider.GetRequiredService<IDataAcquisitionLogQueries>();
+        var tag = Guid.NewGuid().ToString("N")[..8];
+        var facilityId = $"CensusTest_Retrieve_{tag}";
+
+        await SeedFhirListAndQueryConfigAsync(dbContext, facilityId);
+
+        // ── Create census log via service (CreateLog) so the DB is fully consistent.
+        var service = CreateService(scope);
+        await service.CreateLog(facilityId, CancellationToken.None);
+
+        var logEntity = await dbContext.DataAcquisitionLogs
+            .Include(l => l.FhirQueries)
+                .ThenInclude(q => q.FhirQueryResourceTypes)
+            .Where(l => l.FacilityId == facilityId && l.IsCensus)
+            .SingleAsync();
+
+        var logModel = DataAcquisitionLogModel.FromDomain(logEntity);
+
+        // ── Prepare mock that returns a FHIR List with patient entries.
+        var readFhirMock = new Mock<IReadFhirCommand>();
+        readFhirMock
+            .Setup(r => r.ExecuteAsync(It.IsAny<ReadFhirCommandRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((ReadFhirCommandRequest req, CancellationToken _) =>
+            {
+                var fhirList = new List
+                {
+                    Id = req.resourceId,
+                    Entry =
+                    [
+                        new List.EntryComponent { Item = new ResourceReference($"Patient/PT-{req.resourceId}-1") },
+                        new List.EntryComponent { Item = new ResourceReference($"Patient/PT-{req.resourceId}-2") },
+                    ],
+                };
+                return fhirList;
+            });
+
+        var kafkaProducerMock = new Mock<IProducer<string, PatientListMessage>>();
+        kafkaProducerMock
+            .Setup(p => p.ProduceAsync(
+                It.IsAny<string>(),
+                It.IsAny<Message<string, PatientListMessage>>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new DeliveryResult<string, PatientListMessage>());
+
+        var retrieveService = CreateService(scope, readFhirMock, kafkaProducerMock);
+
+        // Act
+        var results = await retrieveService.RetrieveListData(logModel, triggerMessage: true, CancellationToken.None);
+
+        // Assert — 6 lists, each with 2 patients
+        Assert.Equal(6, results.Count);
+        Assert.All(results, r =>
+        {
+            Assert.Equal(2, r.PatientIds.Count);
+            Assert.All(r.PatientIds, pid => Assert.StartsWith("PT-", pid));
+        });
+
+        // Assert — log updated to Completed in DB
+        var updatedLog = await logQueries.GetAsync(logEntity.Id);
+        Assert.Equal(RequestStatus.Completed, updatedLog!.Status);
+        Assert.NotNull(updatedLog.CompletionDate);
+        Assert.True(updatedLog.CompletionTimeMilliseconds >= 0);
+
+        // Assert — Kafka message produced exactly once
+        kafkaProducerMock.Verify(p => p.ProduceAsync(
+            It.Is<string>(topic => topic == "PatientListsAcquired"),
+            It.Is<Message<string, PatientListMessage>>(m =>
+                m.Key == facilityId &&
+                m.Value.PatientLists.Count == 6),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task RetrieveListData_FhirReadFails_MarksLogFailed_ThrowsWhenTriggerMessage()
+    {
+        using var scope = _fixture.ServiceProvider.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<DataAcquisitionDbContext>();
+        var logQueries = scope.ServiceProvider.GetRequiredService<IDataAcquisitionLogQueries>();
+        var tag = Guid.NewGuid().ToString("N")[..8];
+        var facilityId = $"CensusTest_Fail_{tag}";
+
+        await SeedFhirListAndQueryConfigAsync(dbContext, facilityId);
+
+        var service = CreateService(scope);
+        await service.CreateLog(facilityId, CancellationToken.None);
+
+        var logEntity = await dbContext.DataAcquisitionLogs
+            .Include(l => l.FhirQueries)
+                .ThenInclude(q => q.FhirQueryResourceTypes)
+            .Where(l => l.FacilityId == facilityId && l.IsCensus)
+            .SingleAsync();
+        var logModel = DataAcquisitionLogModel.FromDomain(logEntity);
+
+        // FHIR call always throws
+        var readFhirMock = new Mock<IReadFhirCommand>();
+        readFhirMock
+            .Setup(r => r.ExecuteAsync(It.IsAny<ReadFhirCommandRequest>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new TimeoutException("FHIR server timed out"));
+
+        var failService = CreateService(scope, readFhirMock);
+
+        // Act – with triggerMessage = true, should throw after updating log
+        var ex = await Assert.ThrowsAsync<Exception>(
+            () => failService.RetrieveListData(logModel, triggerMessage: true, CancellationToken.None));
+        Assert.Contains("Failed to retrieve patient list", ex.Message);
+
+        // Assert — log updated to Failed in DB
+        var updatedLog = await logQueries.GetAsync(logEntity.Id);
+        Assert.Equal(RequestStatus.Failed, updatedLog!.Status);
+    }
+
+    [Fact]
+    public async Task RetrieveListData_FhirReadFails_NoTrigger_ReturnsEmptyAndMarksLogFailed()
+    {
+        using var scope = _fixture.ServiceProvider.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<DataAcquisitionDbContext>();
+        var logQueries = scope.ServiceProvider.GetRequiredService<IDataAcquisitionLogQueries>();
+        var tag = Guid.NewGuid().ToString("N")[..8];
+        var facilityId = $"CensusTest_FailNoMsg_{tag}";
+
+        await SeedFhirListAndQueryConfigAsync(dbContext, facilityId);
+
+        var service = CreateService(scope);
+        await service.CreateLog(facilityId, CancellationToken.None);
+
+        var logEntity = await dbContext.DataAcquisitionLogs
+            .Include(l => l.FhirQueries)
+                .ThenInclude(q => q.FhirQueryResourceTypes)
+            .Where(l => l.FacilityId == facilityId && l.IsCensus)
+            .SingleAsync();
+        var logModel = DataAcquisitionLogModel.FromDomain(logEntity);
+
+        var readFhirMock = new Mock<IReadFhirCommand>();
+        readFhirMock
+            .Setup(r => r.ExecuteAsync(It.IsAny<ReadFhirCommandRequest>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new Exception("Connection refused"));
+
+        var failService = CreateService(scope, readFhirMock);
+
+        // Act – with triggerMessage = false, should NOT throw
+        var results = await failService.RetrieveListData(logModel, triggerMessage: false, CancellationToken.None);
+
+        Assert.Empty(results);
+
+        var updatedLog = await logQueries.GetAsync(logEntity.Id);
+        Assert.Equal(RequestStatus.Failed, updatedLog!.Status);
+    }
+
+    // ─────────────────────────────────────────────────────────────────
+    //  End-to-end: CreateLog → DB → RetrieveListData → Kafka
+    //  This covers the full census pipeline a real report would exercise.
+    // ─────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task EndToEnd_CreateLog_ThenRetrieveListData_ProducesCorrectKafkaPayload()
+    {
+        using var scope = _fixture.ServiceProvider.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<DataAcquisitionDbContext>();
+        var logQueries = scope.ServiceProvider.GetRequiredService<IDataAcquisitionLogQueries>();
+        var tag = Guid.NewGuid().ToString("N")[..8];
+        var facilityId = $"CensusTest_E2E_{tag}";
+
+        await SeedFhirListAndQueryConfigAsync(dbContext, facilityId);
+
+        // ── Step 1: CreateLog writes a census DA log with 6 FHIR queries to the DB.
+        var createService = CreateService(scope);
+        await createService.CreateLog(facilityId, CancellationToken.None);
+
+        // ── Step 2: Read the log back from the DB (like AcquisitionProcessingJob would).
+        var logEntity = await dbContext.DataAcquisitionLogs
+            .Include(l => l.FhirQueries)
+                .ThenInclude(q => q.FhirQueryResourceTypes)
+            .Where(l => l.FacilityId == facilityId && l.IsCensus)
+            .SingleAsync();
+        var logModel = DataAcquisitionLogModel.FromDomain(logEntity);
+
+        // ── Step 3: Mock FHIR reads returning different patients per list.
+        var readFhirMock = new Mock<IReadFhirCommand>();
+        int callIndex = 0;
+        readFhirMock
+            .Setup(r => r.ExecuteAsync(It.IsAny<ReadFhirCommandRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((ReadFhirCommandRequest req, CancellationToken _) =>
+            {
+                var idx = Interlocked.Increment(ref callIndex);
+                return new List
+                {
+                    Id = req.resourceId,
+                    Entry =
+                    [
+                        new List.EntryComponent { Item = new ResourceReference($"Patient/E2E-{idx}-001") },
+                        new List.EntryComponent { Item = new ResourceReference($"Patient/E2E-{idx}-002") },
+                        new List.EntryComponent { Item = new ResourceReference($"Patient/E2E-{idx}-003") },
+                    ],
+                };
+            });
+
+        Message<string, PatientListMessage>? capturedMessage = null;
+        var kafkaProducerMock = new Mock<IProducer<string, PatientListMessage>>();
+        kafkaProducerMock
+            .Setup(p => p.ProduceAsync(
+                It.IsAny<string>(),
+                It.IsAny<Message<string, PatientListMessage>>(),
+                It.IsAny<CancellationToken>()))
+            .Callback<string, Message<string, PatientListMessage>, CancellationToken>((_, msg, _) => capturedMessage = msg)
+            .ReturnsAsync(new DeliveryResult<string, PatientListMessage>());
+
+        // ── Step 4: RetrieveListData processes log, calls FHIR, updates DB, produces Kafka.
+        var retrieveService = CreateService(scope, readFhirMock, kafkaProducerMock);
+        var results = await retrieveService.RetrieveListData(logModel, triggerMessage: true, CancellationToken.None);
+
+        // ── Assertions on returned results
+        Assert.Equal(6, results.Count);
+        Assert.All(results, r => Assert.Equal(3, r.PatientIds.Count));
+
+        // Verify we have both Admit and Discharge list types
+        var admitLists = results.Where(r => r.ListType == LantanaGroup.Link.Shared.Application.Models.DataAcq.ListType.Admit).ToList();
+        var dischargeLists = results.Where(r => r.ListType == LantanaGroup.Link.Shared.Application.Models.DataAcq.ListType.Discharge).ToList();
+        Assert.Equal(3, admitLists.Count);
+        Assert.Equal(3, dischargeLists.Count);
+
+        // Verify all three timeframes are covered for each type
+        var admitTimeFrames = admitLists.Select(r => r.TimeFrame).ToHashSet();
+        Assert.Contains(LantanaGroup.Link.Shared.Application.Models.DataAcq.TimeFrame.LessThan24Hours, admitTimeFrames);
+        Assert.Contains(LantanaGroup.Link.Shared.Application.Models.DataAcq.TimeFrame.Between24To48Hours, admitTimeFrames);
+        Assert.Contains(LantanaGroup.Link.Shared.Application.Models.DataAcq.TimeFrame.MoreThan48Hours, admitTimeFrames);
+
+        // ── Assertions on DB state
+        var updatedLog = await logQueries.GetAsync(logEntity.Id);
+        Assert.Equal(RequestStatus.Completed, updatedLog!.Status);
+        Assert.NotNull(updatedLog.CompletionDate);
+
+        // ── Assertions on Kafka message
+        Assert.NotNull(capturedMessage);
+        Assert.Equal(facilityId, capturedMessage!.Key);
+        Assert.Equal(6, capturedMessage.Value.PatientLists.Count);
+        var allPatientIds = capturedMessage.Value.PatientLists.SelectMany(pl => pl.PatientIds).ToList();
+        Assert.Equal(18, allPatientIds.Count); // 6 lists × 3 patients
+        Assert.All(allPatientIds, pid => Assert.StartsWith("E2E-", pid));
+    }
+}

--- a/DotNet/ServiceTests/IntegrationTests/DataAcquisition/Services/ReferenceResourceServiceTests.cs
+++ b/DotNet/ServiceTests/IntegrationTests/DataAcquisition/Services/ReferenceResourceServiceTests.cs
@@ -71,7 +71,7 @@ namespace IntegrationTests.DataAcquisition.Services
             var tag = Guid.NewGuid().ToString("N");
             var facilityId = $"TestFacility_{tag}";
             var correlationId = Guid.NewGuid().ToString();
-            var reportTrackingId = $"TestReport_{tag}";
+            var reportTrackingId = Guid.NewGuid().ToString();
 
             // Pre-seed a canonical reference resource
             await refMgr.CreateBatchAsync(new[]
@@ -90,7 +90,7 @@ namespace IntegrationTests.DataAcquisition.Services
             {
                 FacilityId = facilityId,
                 CorrelationId = correlationId,
-                ScheduledReport = new ScheduledReport { ReportTrackingId = reportTrackingId, StartDate = DateTime.UtcNow.AddDays(-1), EndDate = DateTime.UtcNow },
+                ReportTrackingId = reportTrackingId,
                 QueryPhase = QueryPhase.Initial,
                 QueryType = FhirQueryType.Search,
                 Status = RequestStatus.Pending,

--- a/DotNet/ServiceTests/IntegrationTests/DataAcquisition/Services/ReferenceResourceServiceTests.cs
+++ b/DotNet/ServiceTests/IntegrationTests/DataAcquisition/Services/ReferenceResourceServiceTests.cs
@@ -8,6 +8,7 @@ using LantanaGroup.Link.DataAcquisition.Domain.Application.Queries;
 using LantanaGroup.Link.DataAcquisition.Domain.Application.Services;
 using LantanaGroup.Link.DataAcquisition.Domain.Application.Services.FhirApi.Commands;
 using LantanaGroup.Link.DataAcquisition.Domain.Infrastructure.Context;
+using LantanaGroup.Link.DataAcquisition.Domain.Infrastructure.Entities;
 using LantanaGroup.Link.DataAcquisition.Domain.Infrastructure.Models.Enums;
 using LantanaGroup.Link.Shared.Application.Models;
 using LantanaGroup.Link.Shared.Application.Models.Kafka;
@@ -85,6 +86,15 @@ namespace IntegrationTests.DataAcquisition.Services
                     QueryPhase = QueryPhase.Referential
                 }
             });
+
+            dbContext.ScheduledReports.Add(new ScheduledReportEntity
+            {
+                ReportTrackingId = Guid.Parse(reportTrackingId),
+                Frequency = Frequency.Adhoc,
+                StartDate = DateTime.UtcNow.AddDays(-1),
+                EndDate = DateTime.UtcNow
+            });
+            await dbContext.SaveChangesAsync();
 
             var parentLog = await logManager.CreateAsync(new CreateDataAcquisitionLogModel
             {

--- a/DotNet/ServiceTests/IntegrationTests/DataAcquisition/Services/ReferenceResourceServiceTests.cs
+++ b/DotNet/ServiceTests/IntegrationTests/DataAcquisition/Services/ReferenceResourceServiceTests.cs
@@ -10,7 +10,6 @@ using LantanaGroup.Link.DataAcquisition.Domain.Application.Services.FhirApi.Comm
 using LantanaGroup.Link.DataAcquisition.Domain.Infrastructure.Context;
 using LantanaGroup.Link.DataAcquisition.Domain.Infrastructure.Entities;
 using LantanaGroup.Link.DataAcquisition.Domain.Infrastructure.Models.Enums;
-using LantanaGroup.Link.Shared.Application.Models;
 using LantanaGroup.Link.Shared.Application.Models.Kafka;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
@@ -19,6 +18,7 @@ using Moq;
 using FhirQueryType = LantanaGroup.Link.Shared.Application.Models.Integration.DataAcquisition.FhirQueryType;
 using QueryPhase = LantanaGroup.Link.Shared.Application.Models.Integration.DataAcquisition.QueryPhase;
 using RequestStatus = LantanaGroup.Link.Shared.Application.Models.Integration.DataAcquisition.RequestStatus;
+using ScheduledFrequency = LantanaGroup.Link.Shared.Application.Models.Frequency;
 using Task = System.Threading.Tasks.Task;
 
 namespace IntegrationTests.DataAcquisition.Services
@@ -90,7 +90,7 @@ namespace IntegrationTests.DataAcquisition.Services
             dbContext.ScheduledReports.Add(new ScheduledReportEntity
             {
                 ReportTrackingId = Guid.Parse(reportTrackingId),
-                Frequency = Frequency.Adhoc,
+                Frequency = ScheduledFrequency.Adhoc,
                 StartDate = DateTime.UtcNow.AddDays(-1),
                 EndDate = DateTime.UtcNow
             });

--- a/DotNet/ServiceTests/ServiceTests.csproj
+++ b/DotNet/ServiceTests/ServiceTests.csproj
@@ -50,6 +50,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Account\Account.csproj" />
     <ProjectReference Include="..\Admin.BFF\Admin.BFF.csproj" />
+    <ProjectReference Include="..\Automation.Link\Automation.Link.csproj" />
     <ProjectReference Include="..\Audit\Audit.csproj" />
     <ProjectReference Include="..\Census\Census.csproj" />
     <ProjectReference Include="..\DataAcquisition.AcquisitionWorker\DataAcquisition.AcquisitionWorker.csproj" />

--- a/DotNet/ServiceTests/UnitTests/Automation/ReportAbsManifestValidatorTests.cs
+++ b/DotNet/ServiceTests/UnitTests/Automation/ReportAbsManifestValidatorTests.cs
@@ -1,0 +1,219 @@
+﻿using System.Text.Json;
+using LantanaGroup.Automation.Helpers;
+using LantanaGroup.Automation.Generation;
+using LantanaGroup.Link.Automation.Link.Helpers;
+using LantanaGroup.Link.Automation.Link.Validation;
+using LantanaGroup.Link.Sdk.Clients;
+using Moq;
+using Task = System.Threading.Tasks.Task;
+
+namespace UnitTests.Automation;
+
+[Trait("Category", "UnitTests")]
+public class ReportAbsManifestValidatorTests
+{
+    private const string ExpectedStart = "2025-01-01T00:00:00Z";
+    private const string ExpectedEnd = "2025-01-31T23:59:59Z";
+
+    [Fact]
+    public async Task ValidateAllAsync_WithMockExternalAbsFromGeneratedData_Passes()
+    {
+        var output = new BufferingAutomationOutput();
+        var (patientIds, bundles) = FhirBundleGenerator.Generate(output, patientCount: 1, totalResourcesPerPatient: 120, patientIdPrefix: "AbsUnit");
+        var patientId = patientIds.Single();
+
+        var mockExternalAbsResources = BuildMockExternalAbsResources(patientId, bundles, "MEASURE-UT-1", ExpectedStart, ExpectedEnd);
+        var validator = new ReportAbsManifestValidator(output, CreatePipelineDataReader());
+
+        await validator.ValidateAllAsync(
+            mockExternalAbsResources,
+            new[] { patientId },
+            "MEASURE-UT-1",
+            ExpectedStart,
+            ExpectedEnd);
+    }
+
+    [Fact]
+    public async Task ValidateAllAsync_WithMissingPatientArtifact_Fails()
+    {
+        var output = new BufferingAutomationOutput();
+        var (patientIds, bundles) = FhirBundleGenerator.Generate(output, patientCount: 1, totalResourcesPerPatient: 120, patientIdPrefix: "AbsUnitFailA");
+        var patientId = patientIds.Single();
+
+        var mockExternalAbsResources = BuildMockExternalAbsResources(patientId, bundles, "MEASURE-UT-2", ExpectedStart, ExpectedEnd);
+        mockExternalAbsResources.Remove($"patient-{patientId}.ndjson");
+
+        var validator = new ReportAbsManifestValidator(output, CreatePipelineDataReader());
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            validator.ValidateAllAsync(
+                mockExternalAbsResources,
+                new[] { patientId },
+                "MEASURE-UT-2",
+                ExpectedStart,
+                ExpectedEnd));
+
+        Assert.Contains("VALIDATION failed", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task ValidateAllAsync_WithUnexpectedMeasureId_Fails()
+    {
+        var output = new BufferingAutomationOutput();
+        var (patientIds, bundles) = FhirBundleGenerator.Generate(output, patientCount: 1, totalResourcesPerPatient: 120, patientIdPrefix: "AbsUnitFailB");
+        var patientId = patientIds.Single();
+
+        var mockExternalAbsResources = BuildMockExternalAbsResources(patientId, bundles, "MEASURE-UT-3", ExpectedStart, ExpectedEnd);
+        var validator = new ReportAbsManifestValidator(output, CreatePipelineDataReader());
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            validator.ValidateAllAsync(
+                mockExternalAbsResources,
+                new[] { patientId },
+                "SOME-OTHER-MEASURE",
+                ExpectedStart,
+                ExpectedEnd));
+
+        Assert.Contains("VALIDATION failed", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static Dictionary<string, object> BuildMockExternalAbsResources(
+        string patientId,
+        IReadOnlyList<(string Name, string Json)> bundles,
+        string measureId,
+        string start,
+        string end)
+    {
+        var generatedPatientJson = ExtractGeneratedPatientJson(patientId, bundles);
+
+        var orgId = "Org-UT";
+        var deviceId = "Device-UT";
+        var manifestSubjectListMrId = "Manifest-SubjectList-UT";
+        var patientMrId = $"MeasureReport-{patientId}";
+
+        var manifestNdjson = string.Join("\n", new[]
+        {
+            JsonSerializer.Serialize(new
+            {
+                resourceType = "Organization",
+                id = orgId
+            }),
+            JsonSerializer.Serialize(new
+            {
+                resourceType = "Device",
+                id = deviceId
+            }),
+            JsonSerializer.Serialize(new
+            {
+                resourceType = "List",
+                id = "PatientList-UT",
+                status = "current",
+                mode = "snapshot",
+                extension = new object[]
+                {
+                    new
+                    {
+                        url = "http://www.cdc.gov/nhsn/fhirportal/dqm/ig/StructureDefinition/link-patient-list-applicable-period-extension",
+                        valuePeriod = new
+                        {
+                            start,
+                            end
+                        }
+                    }
+                },
+                entry = new object[]
+                {
+                    new { item = new { reference = $"Patient/{patientId}" } }
+                }
+            }),
+            JsonSerializer.Serialize(new
+            {
+                resourceType = "MeasureReport",
+                id = manifestSubjectListMrId,
+                type = "subject-list",
+                measure = $"Measure/{measureId}",
+                reporter = new { reference = $"Organization/{orgId}" },
+                period = new { start, end },
+                subject = new { reference = $"Patient/{patientId}" },
+                contained = new object[]
+                {
+                    new
+                    {
+                        resourceType = "List",
+                        id = "Contained-MeasureReport-List",
+                        entry = new object[]
+                        {
+                            new { item = new { reference = $"MeasureReport/{patientMrId}" } }
+                        }
+                    }
+                }
+            })
+        });
+
+        var patientNdjson = string.Join("\n", new[]
+        {
+            generatedPatientJson,
+            JsonSerializer.Serialize(new
+            {
+                resourceType = "MeasureReport",
+                id = patientMrId,
+                type = "individual",
+                measure = $"Measure/{measureId}",
+                subject = new { reference = $"Patient/{patientId}" },
+                period = new { start, end },
+                status = "complete"
+            })
+        });
+
+        return new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["manifest.ndjson"] = manifestNdjson,
+            [$"patient-{patientId}.ndjson"] = patientNdjson
+        };
+    }
+
+    private static string ExtractGeneratedPatientJson(string patientId, IReadOnlyList<(string Name, string Json)> bundles)
+    {
+        foreach (var (_, bundleJson) in bundles)
+        {
+            using var doc = JsonDocument.Parse(bundleJson);
+            if (!doc.RootElement.TryGetProperty("entry", out var entries) || entries.ValueKind != JsonValueKind.Array)
+                continue;
+
+            foreach (var entry in entries.EnumerateArray())
+            {
+                if (!entry.TryGetProperty("resource", out var resource) || resource.ValueKind != JsonValueKind.Object)
+                    continue;
+
+                var resourceType = resource.TryGetProperty("resourceType", out var rt) ? rt.GetString() : null;
+                var id = resource.TryGetProperty("id", out var rid) ? rid.GetString() : null;
+
+                if (string.Equals(resourceType, "Patient", StringComparison.OrdinalIgnoreCase)
+                    && string.Equals(id, patientId, StringComparison.Ordinal))
+                {
+                    return resource.GetRawText();
+                }
+            }
+        }
+
+        throw new InvalidOperationException($"Generated bundles did not include Patient/{patientId}.");
+    }
+
+    private static PipelineDataReader CreatePipelineDataReader()
+    {
+        return new PipelineDataReader(
+            new Mock<IReportServiceClient>().Object,
+            new Mock<IDataAcquisitionServiceClient>().Object,
+            new Mock<INormalizationServiceClient>().Object,
+            new Mock<IFacilityServiceClient>().Object);
+    }
+
+    private sealed class BufferingAutomationOutput : IAutomationOutput
+    {
+        public List<string> Lines { get; } = new();
+
+        public void WriteLine(string message) => Lines.Add(message);
+
+        public void WriteLine(string format, params object[] args) => Lines.Add(string.Format(format, args));
+    }
+}

--- a/DotNet/ServiceTests/UnitTests/DataAcquisition/PatientDataServiceTests.cs
+++ b/DotNet/ServiceTests/UnitTests/DataAcquisition/PatientDataServiceTests.cs
@@ -1,4 +1,4 @@
-using Confluent.Kafka;
+﻿using Confluent.Kafka;
 using DataAcquisition.Domain.Application.Models;
 using LantanaGroup.Link.DataAcquisition.Domain.Application.Managers;
 using LantanaGroup.Link.DataAcquisition.Domain.Application.Models;
@@ -15,10 +15,6 @@ using LantanaGroup.Link.DataAcquisition.Domain.Infrastructure;
 using LantanaGroup.Link.DataAcquisition.Domain.Infrastructure.Entities;
 using LantanaGroup.Link.DataAcquisition.Domain.Infrastructure.Interfaces;
 using LantanaGroup.Link.DataAcquisition.Domain.Infrastructure.Models.Enums;
-using LantanaGroup.Link.Shared.Application.Models.Integration.DataAcquisition;
-using RequestStatus = LantanaGroup.Link.Shared.Application.Models.Integration.DataAcquisition.RequestStatus;
-using QueryPhase = LantanaGroup.Link.Shared.Application.Models.Integration.DataAcquisition.QueryPhase;
-using FhirQueryType = LantanaGroup.Link.Shared.Application.Models.Integration.DataAcquisition.FhirQueryType;
 using LantanaGroup.Link.DataAcquisition.Domain.Infrastructure.Models.QueryConfig;
 using LantanaGroup.Link.DataAcquisition.Domain.Models;
 using LantanaGroup.Link.Shared.Application.Models;
@@ -27,6 +23,8 @@ using LantanaGroup.Link.Shared.Application.Models.Responses;
 using Medallion.Threading;
 using Microsoft.Extensions.Logging;
 using Moq;
+using FhirQueryType = LantanaGroup.Link.Shared.Application.Models.Integration.DataAcquisition.FhirQueryType;
+using RequestStatus = LantanaGroup.Link.Shared.Application.Models.Integration.DataAcquisition.RequestStatus;
 using ResourceType = Hl7.Fhir.Model.ResourceType;
 using Task = System.Threading.Tasks.Task;
 
@@ -53,6 +51,7 @@ public class PatientDataServiceTests
     private readonly Mock<IDistributedSemaphoreProvider> _mockDistributedSemaphoreProvider; // Added mock for the missing parameter
     private readonly Mock<IServiceProvider> _mockServiceProvider;
     private readonly Mock<IPatientCensusService> _mockPatientCensusService;
+    private readonly Mock<IScheduledReportManager> _mockScheduledReportManager;
 
     private readonly PatientDataService _service;
 
@@ -76,6 +75,7 @@ public class PatientDataServiceTests
         _mockDistributedSemaphoreProvider = new Mock<IDistributedSemaphoreProvider>(); // Added mock for the missing parameter
         _mockServiceProvider = new Mock<IServiceProvider>();
         _mockPatientCensusService = new Mock<IPatientCensusService>();
+        _mockScheduledReportManager = new Mock<IScheduledReportManager>();
 
         // Mock the semaphore and handle
         var mockSemaphore = new Mock<IDistributedSemaphore>();
@@ -103,7 +103,8 @@ public class PatientDataServiceTests
             _mockFhirApiService.Object,
             _mockDistributedSemaphoreProvider.Object,
             _mockServiceProvider.Object,
-            _mockPatientCensusService.Object
+            _mockPatientCensusService.Object,
+            _mockScheduledReportManager.Object
         );
     }
 
@@ -124,7 +125,7 @@ public class PatientDataServiceTests
                     Frequency = Frequency.Discharge,
                     StartDate = DateTime.UtcNow,
                     EndDate = DateTime.UtcNow.AddDays(1),
-                    ReportTrackingId = "tracking-1"
+                    ReportTrackingId = Guid.NewGuid().ToString()
                 }
             }
         };
@@ -223,7 +224,7 @@ public class PatientDataServiceTests
                     Frequency = Frequency.Discharge,
                     StartDate = DateTime.UtcNow,
                     EndDate = DateTime.UtcNow.AddDays(1),
-                    ReportTrackingId = "tracking-1"
+                    ReportTrackingId = Guid.NewGuid().ToString()
                 }
             }
         };


### PR DESCRIPTION
### 🛠️ Description of Changes

## Summary
This PR updates Data Acquisition log/report persistence to use `ReportTrackingId` as a GUID-backed natural key, improves scheduled report creation concurrency, and aligns log query/manager behavior and tests with the new schema.

## Why
- Remove `ScheduledReportId` indirection and key lookups by synthetic ID.
- Normalize around `ReportTrackingId` as the canonical key between `DataAcquisitionLog` and `ScheduledReports`.
- Prevent duplicate scheduled report inserts during concurrent processing.
- Improve reliability for log filtering and tailing operations using GUID-safe handling.

## What Changed
### Data model and EF mapping
- `DataAcquisitionLog.ReportTrackingId` changed from `string` to `Guid?`.
- Removed legacy `DataAcquisitionLog` fields:
  - `ScheduledReportId`
  - `ReportStartDate`
  - `ReportEndDate`
- `ScheduledReportEntity` now uses `ReportTrackingId` (`Guid`) as the primary key.
- Updated FK relationship:
  - `DataAcquisitionLog.ReportTrackingId -> ScheduledReports.ReportTrackingId` (`ON DELETE SET NULL`).
- Updated/added indexes for paging, facility/status access paths, report tracking lookups, and tailing optimization using the new key shape.

### Migration
- Added migration: `20260505000000_NaturalKeyScheduledReport`
  - Backfills orphan scheduled report rows from existing log data.
  - Validates `ReportTrackingId` values are GUID-convertible before schema conversion.
  - Drops old FK/indexes and removes `ScheduledReportId`.
  - Promotes `ScheduledReports.ReportTrackingId` to PK and converts both sides to `uniqueidentifier`.
  - Drops legacy `ReportStartDate`/`ReportEndDate` columns from `DataAcquisitionLog`.
  - Recreates indexes in final schema shape.
- Added designer file and updated model snapshot accordingly.

### Application logic
- Added `IScheduledReportManager` / `ScheduledReportManager`:
  - Ensures scheduled report rows exist by `ReportTrackingId`.
  - Handles concurrent insert races safely by catching unique constraint conflicts and re-reading.
- Registered `IScheduledReportManager` in DI (`GeneralStartupExtensions`).
- `PatientDataService` now ensures scheduled reports are created before log creation and continues stamping sibling counts after all logs are committed.
- `CreateDataAcquisitionLogModel` now carries `ReportTrackingId` directly instead of a nested scheduled report object.

### Query and manager updates
- `DataAcquisitionLogManager` and `DataAcquisitionLogQueries` now:
  - Parse and validate `ReportTrackingId` as GUID where filtering/updating is performed.
  - Return no results when invalid report tracking IDs are supplied to filters (instead of mismatched string comparisons).
  - Convert GUID values to string for API models where needed.
- Mapping updates ensure scheduled report `ReportTrackingId` is serialized back as string in response models.

### Tests
- Updated integration and unit tests across Data Acquisition to align with GUID `ReportTrackingId` semantics and constructor/DI changes.
- Updated `PatientDataServiceTests` to include `IScheduledReportManager` dependency and GUID-shaped tracking IDs.

## Validation
- Code changes include updated tests for manager/query/service paths impacted by the key migration.
- (Add local/CI run results here when available.)

### 🧪 Testing Performed

Please describe the testing that was performed on the changes included in this PR.

### 🧑‍🔬 Unit Testing

- [x] I have written or updated unit tests to cover my changes
- Coverage: 0.8%

### 📓 Documentation Updated

Please update any relevant sections in the project documentation that were impacted by the changes in the PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suite for report validation, including scenarios for missing artifacts and validation failures.

* **Chores**
  * Updated test infrastructure with additional project dependencies.
  * Refactored internal report handling to support optional scheduled reports while maintaining data validation for non-census logs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->





