### PR TITLE
LNK-5111: Update Data Acquisition 'No Config' Disposition with New Status

### DIFF
--- a/DotNet/DataAcquisition.Domain/Application/Managers/DataAcquisitionLogManager.cs
+++ b/DotNet/DataAcquisition.Domain/Application/Managers/DataAcquisitionLogManager.cs
@@ -1,4 +1,4 @@
-﻿using DataAcquisition.Domain.Application.Models;
+using DataAcquisition.Domain.Application.Models;
 using LantanaGroup.Link.DataAcquisition.Domain.Application.Models.Api.QueryLog;
 using LantanaGroup.Link.DataAcquisition.Domain.Application.Models.Api.Requests;
 using LantanaGroup.Link.DataAcquisition.Domain.Application.Models.Domain;
@@ -45,6 +45,7 @@ public interface IDataAcquisitionLogManager
     Task<int> FailStalledQueuedLogsAsync(int stallMinutes, int maxBatches = 20, CancellationToken cancellationToken = default);
     Task<int> ResetStalledProcessingLogsAsync(int stallMinutes, int maxBatches = 20, CancellationToken cancellationToken = default);
     Task<int> SetMaxRetriesReachedWithNoteBatchAsync(IEnumerable<long> ids, string note, CancellationToken cancellationToken = default);
+    Task<int> SetConfigurationMissingWithNoteBatchAsync(IEnumerable<long> ids, string note, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Stamps the SiblingCount on all logs in a (FacilityId, CorrelationId, QueryPhase) group.
@@ -689,14 +690,24 @@ public class DataAcquisitionLogManager : IDataAcquisitionLogManager
 
     public async Task<int> SetMaxRetriesReachedWithNoteBatchAsync(IEnumerable<long> ids, string note, CancellationToken cancellationToken = default)
     {
-        using var activity = ServiceActivitySource.Instance.StartActivity("DataAcquisitionLogManager.SetMaxRetriesReachedWithNoteBatchAsync");
+        return await SetTerminalStatusWithNoteBatchAsync(ids, RequestStatus.MaxRetriesReached, note, cancellationToken);
+    }
+
+    public async Task<int> SetConfigurationMissingWithNoteBatchAsync(IEnumerable<long> ids, string note, CancellationToken cancellationToken = default)
+    {
+        return await SetTerminalStatusWithNoteBatchAsync(ids, RequestStatus.ConfigurationMissing, note, cancellationToken);
+    }
+
+    private async Task<int> SetTerminalStatusWithNoteBatchAsync(IEnumerable<long> ids, RequestStatus status, string note, CancellationToken cancellationToken = default)
+    {
+        using var activity = ServiceActivitySource.Instance.StartActivity("DataAcquisitionLogManager.SetTerminalStatusWithNoteBatchAsync");
 
         var idList = ids as ICollection<long> ?? ids.ToList();
 
         int updated = await _dbContext.DataAcquisitionLogs
             .Where(l => idList.Contains(l.Id))
             .ExecuteUpdateAsync(setters => setters
-                .SetProperty(l => l.Status, RequestStatus.MaxRetriesReached)
+                .SetProperty(l => l.Status, status)
                 .SetProperty(l => l.ModifyDate, DateTime.UtcNow),
                 cancellationToken);
 
@@ -738,7 +749,7 @@ public class DataAcquisitionLogManager : IDataAcquisitionLogManager
         using var activity = ServiceActivitySource.Instance.StartActivity("DataAcquisitionLogManager.TryCompleteTailAsync");
         activity?.SetTag(DiagnosticNames.ReportId, completedLogId);
 
-        var terminalStatuses = new[] { RequestStatus.Completed, RequestStatus.MaxRetriesReached, RequestStatus.Skipped };
+        var terminalStatuses = new[] { RequestStatus.Completed, RequestStatus.MaxRetriesReached, RequestStatus.Skipped, RequestStatus.ConfigurationMissing };
 
         // Load group identity for the completed log (PK lookup)
         var groupInfo = await _dbContext.DataAcquisitionLogs.AsNoTracking()

--- a/DotNet/DataAcquisition/Jobs/AcquisitionProcessingJob.cs
+++ b/DotNet/DataAcquisition/Jobs/AcquisitionProcessingJob.cs
@@ -1,4 +1,4 @@
-﻿using Confluent.Kafka;
+using Confluent.Kafka;
 using LantanaGroup.Link.DataAcquisition.Domain.Application.Managers;
 using LantanaGroup.Link.DataAcquisition.Domain.Application.Models.Kafka;
 using LantanaGroup.Link.DataAcquisition.Domain.Application.Queries;
@@ -172,10 +172,10 @@ public class AcquisitionProcessingJob : IJob
                     if (!requests.Any()) break;
 
                     // Missing config is a configuration error, not a transient failure.
-                    // Move all affected logs directly to the terminal MaxRetriesReached status
+                    // Move all affected logs directly to the terminal ConfigurationMissing status
                     // so they are never re-queued, and record the reason as a note.
                     var allIds = requests.Select(r => r.Id).ToList();
-                    await dataAcquisitionLogManager.SetMaxRetriesReachedWithNoteBatchAsync(
+                    await dataAcquisitionLogManager.SetConfigurationMissingWithNoteBatchAsync(
                         allIds,
                         "FhirQueryConfiguration not found for this facility.",
                         cancellationToken);

--- a/DotNet/ServiceTests/IntegrationTests/DataAcquisition/AcquisitionProcessingJobTests.cs
+++ b/DotNet/ServiceTests/IntegrationTests/DataAcquisition/AcquisitionProcessingJobTests.cs
@@ -1,4 +1,4 @@
-﻿using Confluent.Kafka;
+using Confluent.Kafka;
 using DataAcquisition.Domain.Application.Models;
 using LantanaGroup.Link.DataAcquisition.Domain.Application.Managers;
 using LantanaGroup.Link.DataAcquisition.Domain.Application.Models.Kafka;
@@ -103,7 +103,7 @@ public class AcquisitionProcessingJobTests
     }
 
     [Fact]
-    public async Task ProcessPendingLogs_NoConfig_SetsMaxRetriesReachedWithNoteImmediately()
+    public async Task ProcessPendingLogs_NoConfig_SetsConfigurationMissingWithNoteImmediately()
     {
         _fixture.ReadyToAcquireProducerMock.Reset();
         _fixture.ResourceAcquiredProducerMock.Reset();
@@ -155,7 +155,7 @@ public class AcquisitionProcessingJobTests
         var assertDbContext = assertScope.ServiceProvider.GetRequiredService<DataAcquisitionDbContext>();
 
         var updatedLog = await assertDbContext.DataAcquisitionLogs.FindAsync(log.Id);
-        Assert.Equal(RequestStatus.MaxRetriesReached, updatedLog.Status);
+        Assert.Equal(RequestStatus.ConfigurationMissing, updatedLog.Status);
 
         var note = await assertDbContext.DataAcquisitionLogNotes
             .FirstOrDefaultAsync(n => n.DataAcquisitionLogId == log.Id);
@@ -164,7 +164,7 @@ public class AcquisitionProcessingJobTests
     }
 
     [Fact]
-    public async Task ProcessPendingLogs_NoConfig_AlreadyFailedLog_AlsoSetsMaxRetriesReachedWithNote()
+    public async Task ProcessPendingLogs_NoConfig_AlreadyFailedLog_AlsoSetsConfigurationMissingWithNote()
     {
         _fixture.ReadyToAcquireProducerMock.Reset();
         _fixture.ResourceAcquiredProducerMock.Reset();
@@ -210,7 +210,7 @@ public class AcquisitionProcessingJobTests
         var assertDbContext = assertScope.ServiceProvider.GetRequiredService<DataAcquisitionDbContext>();
 
         var updatedLog = await assertDbContext.DataAcquisitionLogs.FindAsync(failedLog.Id);
-        Assert.Equal(RequestStatus.MaxRetriesReached, updatedLog.Status);
+        Assert.Equal(RequestStatus.ConfigurationMissing, updatedLog.Status);
 
         var note = await assertDbContext.DataAcquisitionLogNotes
             .FirstOrDefaultAsync(n => n.DataAcquisitionLogId == failedLog.Id);

--- a/DotNet/Shared/Application/Models/Integration/DataAcquisition/DataAcquisitionApiModels.cs
+++ b/DotNet/Shared/Application/Models/Integration/DataAcquisition/DataAcquisitionApiModels.cs
@@ -1,4 +1,4 @@
-﻿using LantanaGroup.Link.Shared.Application.Utilities;
+using LantanaGroup.Link.Shared.Application.Utilities;
 
 namespace LantanaGroup.Link.Shared.Application.Models.Integration.DataAcquisition;
 
@@ -134,7 +134,9 @@ public enum RequestStatus
     [StringValue("Configuration Required")]
     ConfigurationRequired,
     [StringValue("Cancelled")]
-    Cancelled
+    Cancelled,
+    [StringValue("Configuration Missing")]
+    ConfigurationMissing
 }
 
 public enum QueryPhase

--- a/Web/Admin.UI/src/app/components/tenant/acquisition-log/acquisition-log-view/acquisition-log-view.component.html
+++ b/Web/Admin.UI/src/app/components/tenant/acquisition-log/acquisition-log-view/acquisition-log-view.component.html
@@ -428,6 +428,7 @@
                     'status-completed': log.status === 'Completed',
                     'status-failed': log.status === 'Failed',
                     'status-maxRetryReached': log.status === 'MaxRetriesReached',
+                    'status-configurationMissing': log.status === 'ConfigurationMissing',
                     'status-skipped': log.status === 'Skipped',
                     'status-cancelled': log.status === 'Cancelled'
                   }">{{log.status}}</span>

--- a/Web/Admin.UI/src/app/components/tenant/acquisition-log/acquisition-log-view/acquisition-log-view.component.scss
+++ b/Web/Admin.UI/src/app/components/tenant/acquisition-log/acquisition-log-view/acquisition-log-view.component.scss
@@ -28,6 +28,7 @@ $failed-status: #a1030eb3;
 $failed-maxRetry-status: #a10303ff;
 $skipped-status: #ffbf00;
 $cancelled-status: #6b7280;
+$configuration-missing-status: #b45309;
 
 .status-pending {
     @extend .log-status;
@@ -79,6 +80,15 @@ $cancelled-status: #6b7280;
   background-color: color.adjust($failed-maxRetry-status, $lightness: 60%);
   color: $failed-maxRetry-status;
   box-shadow: 0 0 0 1px color.adjust($failed-maxRetry-status, $lightness: -10%);
+  padding: 6px 6px;
+  border-radius: 0.375rem;
+}
+
+.status-configurationMissing {
+  @extend .log-status;
+  background-color: color.adjust($configuration-missing-status, $lightness: 55%);
+  color: $configuration-missing-status;
+  box-shadow: 0 0 0 1px color.adjust($configuration-missing-status, $lightness: -10%);
   padding: 6px 6px;
   border-radius: 0.375rem;
 }

--- a/Web/Admin.UI/src/app/components/tenant/acquisition-log/acquisition-log-view/acquisition-log-view.component.ts
+++ b/Web/Admin.UI/src/app/components/tenant/acquisition-log/acquisition-log-view/acquisition-log-view.component.ts
@@ -150,7 +150,7 @@ export class AcquisitionLogViewComponent implements OnInit {
   selectedQueryPhaseFilter: string = 'Any';
   queryTypeFilterOptions: string[] = [ "Read", "Search", "BulkDataRequest", "BulkDataPoll" ];
   selectedQueryTypeFilter: string = 'Any';
-  statusFilterOptions: string[] = [ "Pending", "Ready", "Processing", "Completed", "Failed", "Cancelled", "MaxRetriesReached", "Skipped", "Queued"];
+  statusFilterOptions: string[] = [ "Pending", "Ready", "Processing", "Completed", "Failed", "Cancelled", "MaxRetriesReached", "ConfigurationMissing", "Skipped", "Queued"];
   selectedStatusFilter: string[] = [];
   targetPageNumber: number | null = null;
   selectedLogIds: Set<string> = new Set<string>();
@@ -173,7 +173,7 @@ export class AcquisitionLogViewComponent implements OnInit {
     private acquisitionLogService: AcquisitionLogService,
     private snackBar: MatSnackBar) { }
 
-  private readonly TERMINAL_STATUSES = ['Completed', 'MaxRetriesReached', 'Skipped', 'Cancelled'];
+  private readonly TERMINAL_STATUSES = ['Completed', 'MaxRetriesReached', 'ConfigurationMissing', 'Skipped', 'Cancelled'];
   cancelMinAgeHours: number = 0;
 
   private get cancelMinAgeMs(): number {

--- a/Web/Admin.UI/src/app/components/tenant/acquisition-log/acquisition-log-view/table-command/table-command.component.ts
+++ b/Web/Admin.UI/src/app/components/tenant/acquisition-log/acquisition-log-view/table-command/table-command.component.ts
@@ -51,7 +51,7 @@ export class TableCommandComponent implements OnInit, OnDestroy {
   isOpen = false;
 
   get isCancelEligible(): boolean {
-    if (['MaxRetriesReached', 'Completed', 'Cancelled', 'Skipped'].includes(this.status)) return false;
+    if (['MaxRetriesReached', 'ConfigurationMissing', 'Completed', 'Cancelled', 'Skipped'].includes(this.status)) return false;
     if (this.cancelMinAgeHours === 0) return true;
     if (!this.createDate) return false;
     // Match backend: CreateDate <= UtcNow.AddHours(-minAgeHours)


### PR DESCRIPTION
### 🛠️ Description of Changes

# LNK-5111: Assign "Configuration Missing" status for facilities without configuration during DA log processing

## Summary

During Data Acquisition log processing, when a facility has no `FhirQueryConfiguration`, the system now assigns a dedicated **`ConfigurationMissing`** status instead of reusing `MaxRetriesReached`. This provides accurate classification that clearly distinguishes configuration issues from retry exhaustion.

## Problem

Previously, when a facility's configuration was missing, all affected DA logs were moved to `MaxRetriesReached` — the same terminal status used when transient failures (connectivity, timeouts, etc.) exhaust the retry limit. This made it impossible for users to tell whether a log failed due to a missing configuration or an actual retry-related failure.

## Changes

### Backend

- **`RequestStatus` enum** (`DataAcquisitionApiModels.cs`): Added new `ConfigurationMissing` enum value with display string `"Configuration Missing"`.
- **`DataAcquisitionLogManager`** (`DataAcquisitionLogManager.cs`):
  - Added `SetConfigurationMissingWithNoteBatchAsync` to the `IDataAcquisitionLogManager` interface and implementation.
  - Extracted a shared `SetTerminalStatusWithNoteBatchAsync` private method to eliminate duplication between `SetMaxRetriesReachedWithNoteBatchAsync` and the new method.
  - Added `ConfigurationMissing` to the terminal statuses array in `TryCompleteTailAsync` so tail-completion logic correctly recognizes it.
- **`AcquisitionProcessingJob`** (`AcquisitionProcessingJob.cs`): The missing-configuration branch in `ProcessFacilityPendingLogs` now calls `SetConfigurationMissingWithNoteBatchAsync` instead of `SetMaxRetriesReachedWithNoteBatchAsync`.

### Admin UI

- **Status filter** (`acquisition-log-view.component.ts`): Added `"ConfigurationMissing"` to `statusFilterOptions` so users can filter by this status.
- **Terminal status handling** (`acquisition-log-view.component.ts`, `table-command.component.ts`): Added `"ConfigurationMissing"` to all terminal status arrays so cancel eligibility and bulk actions behave correctly.
- **Status badge display** (`acquisition-log-view.component.html`): Added `ngClass` binding for `'status-configurationMissing'`.
- **Status badge styling** (`acquisition-log-view.component.scss`): Added `$configuration-missing-status` color variable (`#b45309`, amber) and `.status-configurationMissing` CSS class, visually distinct from failure/retry statuses.

### Tests

- **`AcquisitionProcessingJobTests`**: Updated the two missing-config integration tests to expect `RequestStatus.ConfigurationMissing` instead of `RequestStatus.MaxRetriesReached` and renamed the test methods accordingly.

## Behavior

| Scenario | Before | After |
|---|---|---|
| Facility has no `FhirQueryConfiguration` | `MaxRetriesReached` | `ConfigurationMissing` |
| Retry limit exhausted (connectivity, timeout, etc.) | `MaxRetriesReached` | `MaxRetriesReached` (unchanged) |

## How to Test

1. Create DA log entries for a facility that has **no** `FhirQueryConfiguration`.
2. Let the `AcquisitionProcessingJob` run.
3. Verify the logs are assigned `ConfigurationMissing` status with a note indicating the missing configuration.
4. In the Admin UI, confirm the status badge displays with the amber styling and is available in the status filter dropdown.
5. Verify that `ConfigurationMissing` logs are treated as terminal (not cancellable, not re-queued).

## Related

- **Jira**: [LNK-5111](https://lantana.atlassian.net/browse/LNK-5111)


### 🧪 Testing Performed

<img width="2493" height="1121" alt="image" src="https://github.com/user-attachments/assets/c3ee4f6e-2950-4a7f-b946-6c1bd832588e" />

### 🧑‍🔬 Unit Testing

- [x] I have written or updated unit tests to cover my changes
- Coverage: 0.0%

### 📓 Documentation Updated

Please update any relevant sections in the project documentation that were impacted by the changes in the PR.


[LNK-5111]: https://lantana.atlassian.net/browse/LNK-5111?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a new "Configuration Missing" status for data acquisition logs, with dedicated styling and filtering capability in the admin interface.

* **Changes**
  * Updated behavior: data acquisition logs now transition to "Configuration Missing" status when FHIR query configuration is unavailable, replacing the previous "Max Retries Reached" designation for this scenario.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
