### PR TITLE
LNK-5126: disable census configuration when we soft-delete a facility…

### DIFF
--- a/DotNet/Admin.BFF/Application/Clients/CensusService.cs
+++ b/DotNet/Admin.BFF/Application/Clients/CensusService.cs
@@ -56,6 +56,29 @@ namespace LantanaGroup.Link.LinkAdmin.BFF.Application.Clients
             }
         }
 
+        public async Task<HttpResponseMessage> DeleteCensusJobsAsync(ClaimsPrincipal user, string facilityId, CancellationToken cancellationToken)
+        {
+            var request = new HttpRequestMessage(HttpMethod.Delete, $"api/census/config/{Uri.EscapeDataString(facilityId)}/jobs");
+            await SetAuthHeaderAsync(user, request);
+            return await _client.SendAsync(request, cancellationToken);
+        }
+
+        public async Task<HttpResponseMessage> RestoreCensusJobsAsync(ClaimsPrincipal user, string facilityId, CancellationToken cancellationToken)
+        {
+            var request = new HttpRequestMessage(HttpMethod.Patch, $"api/census/config/{Uri.EscapeDataString(facilityId)}/jobs/restore");
+            await SetAuthHeaderAsync(user, request);
+            return await _client.SendAsync(request, cancellationToken);
+        }
+
+        private async Task SetAuthHeaderAsync(ClaimsPrincipal user, HttpRequestMessage request)
+        {
+            if (_authenticationSchemaConfig.Value.EnableAnonymousAccess) return;
+            using var scope = _scopeFactory.CreateScope();
+            var createLinkBearerToken = scope.ServiceProvider.GetRequiredService<ICreateLinkBearerToken>();
+            var token = await createLinkBearerToken.ExecuteAsync(user, 2);
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        }
+
         private void InitHttpClient()
         {
             //check if the service uri is set

--- a/DotNet/Admin.BFF/Application/Models/Facility/FacilityRestoreResult.cs
+++ b/DotNet/Admin.BFF/Application/Models/Facility/FacilityRestoreResult.cs
@@ -6,4 +6,5 @@ public class FacilityRestoreResult
     public bool TenantRestored { get; set; }
     public bool ReportSchedulesRestored { get; set; }
     public bool AcquisitionLogsRestored { get; set; }
+    public bool CensusJobsRestored { get; set; }
 }

--- a/DotNet/Admin.BFF/Application/Models/Facility/FacilitySoftDeleteResult.cs
+++ b/DotNet/Admin.BFF/Application/Models/Facility/FacilitySoftDeleteResult.cs
@@ -6,4 +6,5 @@ public class FacilitySoftDeleteResult
     public bool TenantDeleted { get; set; }
     public bool ReportSchedulesDeleted { get; set; }
     public bool AcquisitionLogsDeleted { get; set; }
+    public bool CensusJobsDeleted { get; set; }
 }

--- a/DotNet/Admin.BFF/Presentation/Endpoints/Aggregation/AggregationMapping.cs
+++ b/DotNet/Admin.BFF/Presentation/Endpoints/Aggregation/AggregationMapping.cs
@@ -27,7 +27,7 @@ public static class AggregationMapping
             .WithOpenApi(x => new OpenApiOperation(x)
             {
                 Summary = "Soft Delete Facility",
-                Description = "Soft deletes a facility and its associated report schedules and acquisition logs. " +
+                Description = "Soft deletes a facility and its associated report schedules, acquisition logs, and census cron jobs. " +
                               "Returns 409 if reports are currently running. " +
                               "Returns 404 if the facility does not exist. " +
                               "If a downstream step fails, all completed steps are rolled back and 500 is returned."
@@ -43,7 +43,7 @@ public static class AggregationMapping
             .WithOpenApi(x => new OpenApiOperation(x)
             {
                 Summary = "Restore Facility",
-                Description = "Restores a soft-deleted facility and its associated report schedules and acquisition logs. " +
+                Description = "Restores a soft-deleted facility and its associated report schedules, acquisition logs, and census cron jobs. " +
                               "Returns 404 if the facility does not exist. " +
                               "If a downstream step fails, all completed steps are rolled back and 500 is returned."
             });

--- a/DotNet/Admin.BFF/Presentation/Endpoints/Aggregation/Handlers/Facility/RestoreFacility.cs
+++ b/DotNet/Admin.BFF/Presentation/Endpoints/Aggregation/Handlers/Facility/RestoreFacility.cs
@@ -13,6 +13,7 @@ public static class RestoreFacility
         TenantService tenantService,
         ReportService reportService,
         DataAcquisitionService dataAcquisitionService,
+        CensusService censusService,
         string facilityId)
     {
         var logger = loggerFactory.CreateLogger("RestoreFacility");
@@ -78,12 +79,37 @@ public static class RestoreFacility
             return ProblemDetailsExtension.UserFacingProblem("Failed to restore acquisition logs. All previous steps have been rolled back.", StatusCodes.Status500InternalServerError);
         }
 
+        // Step 4: Restore Census cron jobs — roll back steps 1, 2 and 3 if this fails
+        HttpResponseMessage censusResponse;
+        try
+        {
+            censusResponse = await censusService.RestoreCensusJobsAsync(context.User, facilityId, context.RequestAborted);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Exception restoring census jobs for facility {FacilityId} — rolling back steps 1, 2 and 3", facilityId);
+            await RollbackAcquisitionLogsAsync(dataAcquisitionService, context, facilityId, logger);
+            await RollbackReportSchedulesAsync(reportService, context, facilityId, logger);
+            await RollbackTenantAsync(tenantService, context, facilityId, logger);
+            return ProblemDetailsExtension.UserFacingProblem("Failed to restore census jobs. All previous steps have been rolled back.", StatusCodes.Status500InternalServerError);
+        }
+
+        if (!censusResponse.IsSuccessStatusCode)
+        {
+            logger.LogWarning("Census job restore failed for facility {FacilityId} with status {StatusCode} — rolling back steps 1, 2 and 3", facilityId, censusResponse.StatusCode);
+            await RollbackAcquisitionLogsAsync(dataAcquisitionService, context, facilityId, logger);
+            await RollbackReportSchedulesAsync(reportService, context, facilityId, logger);
+            await RollbackTenantAsync(tenantService, context, facilityId, logger);
+            return ProblemDetailsExtension.UserFacingProblem("Failed to restore census jobs. All previous steps have been rolled back.", StatusCodes.Status500InternalServerError);
+        }
+
         return Results.Ok(new FacilityRestoreResult
         {
             FacilityId = facilityId,
             TenantRestored = true,
             ReportSchedulesRestored = true,
-            AcquisitionLogsRestored = true
+            AcquisitionLogsRestored = true,
+            CensusJobsRestored = true
         });
     }
 
@@ -126,6 +152,20 @@ public static class RestoreFacility
         catch (Exception ex)
         {
             logger.LogError(ex, "Rollback failed: exception soft-deleting report schedules for facility {FacilityId}", facilityId);
+        }
+    }
+
+    private static async Task RollbackAcquisitionLogsAsync(DataAcquisitionService dataAcquisitionService, HttpContext context, string facilityId, ILogger logger)
+    {
+        try
+        {
+            var response = await dataAcquisitionService.SoftDeleteLogsAsync(context.User, facilityId, context.RequestAborted);
+            if (!response.IsSuccessStatusCode)
+                logger.LogError("Rollback failed: could not soft-delete acquisition logs for facility {FacilityId} (status {StatusCode})", facilityId, response.StatusCode);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Rollback failed: exception soft-deleting acquisition logs for facility {FacilityId}", facilityId);
         }
     }
 }

--- a/DotNet/Admin.BFF/Presentation/Endpoints/Aggregation/Handlers/Facility/SoftDeleteFacility.cs
+++ b/DotNet/Admin.BFF/Presentation/Endpoints/Aggregation/Handlers/Facility/SoftDeleteFacility.cs
@@ -13,6 +13,7 @@ public static class SoftDeleteFacility
         TenantService tenantService,
         ReportService reportService,
         DataAcquisitionService dataAcquisitionService,
+        CensusService censusService,
         string facilityId)
     {
         var logger = loggerFactory.CreateLogger("SoftDeleteFacility");
@@ -101,12 +102,37 @@ public static class SoftDeleteFacility
             return ProblemDetailsExtension.UserFacingProblem("Failed to soft-delete acquisition logs. All previous steps have been rolled back.", StatusCodes.Status500InternalServerError);
         }
 
+        // Step 4: Delete Census cron jobs — roll back steps 1, 2 and 3 if this fails
+        HttpResponseMessage censusResponse;
+        try
+        {
+            censusResponse = await censusService.DeleteCensusJobsAsync(context.User, facilityId, context.RequestAborted);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Exception deleting census jobs for facility {FacilityId} — rolling back steps 1, 2 and 3", facilityId);
+            await RollbackAcquisitionLogsAsync(dataAcquisitionService, context, facilityId, logger);
+            await RollbackReportSchedulesAsync(reportService, context, facilityId, logger);
+            await RollbackTenantAsync(tenantService, context, facilityId, logger);
+            return ProblemDetailsExtension.UserFacingProblem("Failed to delete census jobs. All previous steps have been rolled back.", StatusCodes.Status500InternalServerError);
+        }
+
+        if (!censusResponse.IsSuccessStatusCode)
+        {
+            logger.LogWarning("Census job deletion failed for facility {FacilityId} with status {StatusCode} — rolling back steps 1, 2 and 3", facilityId, censusResponse.StatusCode);
+            await RollbackAcquisitionLogsAsync(dataAcquisitionService, context, facilityId, logger);
+            await RollbackReportSchedulesAsync(reportService, context, facilityId, logger);
+            await RollbackTenantAsync(tenantService, context, facilityId, logger);
+            return ProblemDetailsExtension.UserFacingProblem("Failed to delete census jobs. All previous steps have been rolled back.", StatusCodes.Status500InternalServerError);
+        }
+
         return Results.Ok(new FacilitySoftDeleteResult
         {
             FacilityId = facilityId,
             TenantDeleted = true,
             ReportSchedulesDeleted = true,
-            AcquisitionLogsDeleted = true
+            AcquisitionLogsDeleted = true,
+            CensusJobsDeleted = true
         });
     }
 
@@ -149,6 +175,20 @@ public static class SoftDeleteFacility
         catch (Exception ex)
         {
             logger.LogError(ex, "Rollback failed: exception restoring report schedules for facility {FacilityId}", facilityId);
+        }
+    }
+
+    private static async Task RollbackAcquisitionLogsAsync(DataAcquisitionService dataAcquisitionService, HttpContext context, string facilityId, ILogger logger)
+    {
+        try
+        {
+            var response = await dataAcquisitionService.RestoreLogsAsync(context.User, facilityId, context.RequestAborted);
+            if (!response.IsSuccessStatusCode)
+                logger.LogError("Rollback failed: could not restore acquisition logs for facility {FacilityId} (status {StatusCode})", facilityId, response.StatusCode);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Rollback failed: exception restoring acquisition logs for facility {FacilityId}", facilityId);
         }
     }
 }

--- a/DotNet/Census/Controllers/CensusConfigController.cs
+++ b/DotNet/Census/Controllers/CensusConfigController.cs
@@ -183,15 +183,21 @@ public class CensusConfigController : Controller
     /// Disables census scheduling for a facility and removes its cron jobs.
     /// </summary>
     /// <param name="facilityId"></param>
+    /// <param name="cancellationToken"></param>
     /// <returns>
     ///     No Content: 204
+    ///     Bad Request: 400
     ///     Server Error: 500
     /// </returns>
     [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     [HttpDelete("{facilityId}/jobs")]
     public async Task<IActionResult> DisableFacilityJobs(string facilityId, CancellationToken cancellationToken)
     {
+        if (string.IsNullOrWhiteSpace(facilityId))
+            return BadRequest("FacilityID is required.");
+
         try
         {
             await _censusConfigManager.DisableFacility(facilityId, cancellationToken);
@@ -211,15 +217,21 @@ public class CensusConfigController : Controller
     /// Enables census scheduling for a facility and recreates its cron jobs.
     /// </summary>
     /// <param name="facilityId"></param>
+    /// <param name="cancellationToken"></param>
     /// <returns>
     ///     No Content: 204
+    ///     Bad Request: 400
     ///     Server Error: 500
     /// </returns>
     [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     [HttpPatch("{facilityId}/jobs/restore")]
     public async Task<IActionResult> EnableFacilityJobs(string facilityId, CancellationToken cancellationToken)
     {
+        if (string.IsNullOrWhiteSpace(facilityId))
+            return BadRequest("FacilityID is required.");
+
         try
         {
             await _censusConfigManager.EnableFacility(facilityId, cancellationToken);

--- a/DotNet/Census/Controllers/CensusConfigController.cs
+++ b/DotNet/Census/Controllers/CensusConfigController.cs
@@ -180,6 +180,62 @@ public class CensusConfigController : Controller
     }
 
     /// <summary>
+    /// Disables census scheduling for a facility and removes its cron jobs.
+    /// </summary>
+    /// <param name="facilityId"></param>
+    /// <returns>
+    ///     No Content: 204
+    ///     Server Error: 500
+    /// </returns>
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+    [HttpDelete("{facilityId}/jobs")]
+    public async Task<IActionResult> DisableFacilityJobs(string facilityId, CancellationToken cancellationToken)
+    {
+        try
+        {
+            await _censusConfigManager.DisableFacility(facilityId, cancellationToken);
+            return NoContent();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Exception encountered in CensusConfigController.DisableFacilityJobs");
+            return Problem(
+                detail: "An error occurred while disabling census jobs.",
+                statusCode: StatusCodes.Status500InternalServerError
+            );
+        }
+    }
+
+    /// <summary>
+    /// Enables census scheduling for a facility and recreates its cron jobs.
+    /// </summary>
+    /// <param name="facilityId"></param>
+    /// <returns>
+    ///     No Content: 204
+    ///     Server Error: 500
+    /// </returns>
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+    [HttpPatch("{facilityId}/jobs/restore")]
+    public async Task<IActionResult> EnableFacilityJobs(string facilityId, CancellationToken cancellationToken)
+    {
+        try
+        {
+            await _censusConfigManager.EnableFacility(facilityId, cancellationToken);
+            return NoContent();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Exception encountered in CensusConfigController.EnableFacilityJobs");
+            return Problem(
+                detail: "An error occurred while restoring census jobs.",
+                statusCode: StatusCodes.Status500InternalServerError
+            );
+        }
+    }
+
+    /// <summary>
     /// Deletes the CensusConfig for a given facilityId
     /// </summary>
     /// <param name="facilityId"></param>

--- a/DotNet/Census/Domain/Managers/CensusConfigManager.cs
+++ b/DotNet/Census/Domain/Managers/CensusConfigManager.cs
@@ -151,8 +151,19 @@ public class CensusConfigManager : ICensusConfigManager
         existing.Enabled = false;
         existing.ModifyDate = DateTime.UtcNow;
 
-        await _censusConfigRepository.UpdateAsync(existing, cancellationToken);
-        await _censusSchedulingRepo.DeleteJobsForFacility(facilityId, await _schedulerFactory.GetScheduler(cancellationToken));
+        await using var transaction = await _patienteventQueries.StartTransaction(cancellationToken);
+        try
+        {
+            await _censusConfigRepository.UpdateAsync(existing, cancellationToken);
+            await _censusSchedulingRepo.DeleteJobsForFacility(facilityId, await _schedulerFactory.GetScheduler(cancellationToken));
+            await _patienteventQueries.CommitTransaction(transaction, cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Exception in CensusConfigManager.DisableFacility for facility {FacilityId}", facilityId);
+            await _patienteventQueries.RollbackTransaction(transaction, cancellationToken);
+            throw;
+        }
     }
 
     public async Task EnableFacility(string facilityId, CancellationToken cancellationToken = default)
@@ -164,7 +175,18 @@ public class CensusConfigManager : ICensusConfigManager
         existing.Enabled = true;
         existing.ModifyDate = DateTime.UtcNow;
 
-        await _censusConfigRepository.UpdateAsync(existing, cancellationToken);
-        await _censusSchedulingRepo.AddJobForFacility(existing, await _schedulerFactory.GetScheduler(cancellationToken));
+        await using var transaction = await _patienteventQueries.StartTransaction(cancellationToken);
+        try
+        {
+            await _censusConfigRepository.UpdateAsync(existing, cancellationToken);
+            await _censusSchedulingRepo.AddJobForFacility(existing, await _schedulerFactory.GetScheduler(cancellationToken));
+            await _patienteventQueries.CommitTransaction(transaction, cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Exception in CensusConfigManager.EnableFacility for facility {FacilityId}", facilityId);
+            await _patienteventQueries.RollbackTransaction(transaction, cancellationToken);
+            throw;
+        }
     }
 }

--- a/DotNet/Census/Domain/Managers/CensusConfigManager.cs
+++ b/DotNet/Census/Domain/Managers/CensusConfigManager.cs
@@ -4,6 +4,7 @@ using LantanaGroup.Link.Census.Application.Models;
 using LantanaGroup.Link.Census.Application.Models.Exceptions;
 using LantanaGroup.Link.Census.Domain.Queries;
 using LantanaGroup.Link.Shared.Application.Services;
+using LantanaGroup.Link.Shared.Application.Services.Security;
 using LantanaGroup.Link.Shared.Domain.Repositories.Interfaces;
 using Quartz;
 
@@ -160,7 +161,8 @@ public class CensusConfigManager : ICensusConfigManager
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Exception in CensusConfigManager.DisableFacility for facility {FacilityId}", facilityId);
+            var sanitizedFacilityId = facilityId.SanitizeAndRemove();
+            _logger.LogError(ex, "Exception in CensusConfigManager.DisableFacility for facility {FacilityId}", sanitizedFacilityId);
             await _patienteventQueries.RollbackTransaction(transaction, cancellationToken);
             throw;
         }
@@ -184,7 +186,8 @@ public class CensusConfigManager : ICensusConfigManager
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Exception in CensusConfigManager.EnableFacility for facility {FacilityId}", facilityId);
+            var sanitizedFacilityId = facilityId.SanitizeAndRemove();
+            _logger.LogError(ex, "Exception in CensusConfigManager.EnableFacility for facility {FacilityId}", sanitizedFacilityId);
             await _patienteventQueries.RollbackTransaction(transaction, cancellationToken);
             throw;
         }

--- a/DotNet/Census/Domain/Managers/CensusConfigManager.cs
+++ b/DotNet/Census/Domain/Managers/CensusConfigManager.cs
@@ -15,6 +15,8 @@ public interface ICensusConfigManager
     Task DeleteCensusConfigByFacilityId(string facilityId, CancellationToken cancellationToken = default);
     Task<CensusConfigEntity?> GetCensusConfigByFacilityId(string facilityId);
     Task<CensusConfigEntity> AddOrUpdateCensusConfig(CensusConfigModel entity, CancellationToken cancellationToken = default);
+    Task DisableFacility(string facilityId, CancellationToken cancellationToken = default);
+    Task EnableFacility(string facilityId, CancellationToken cancellationToken = default);
 }
 
 public class CensusConfigManager : ICensusConfigManager
@@ -138,5 +140,31 @@ public class CensusConfigManager : ICensusConfigManager
         }
 
         return existingEntity;
+    }
+
+    public async Task DisableFacility(string facilityId, CancellationToken cancellationToken = default)
+    {
+        var existing = await _censusConfigRepository.SingleOrDefaultAsync(c => c.FacilityID == facilityId, cancellationToken);
+        if (existing == null)
+            return;
+
+        existing.Enabled = false;
+        existing.ModifyDate = DateTime.UtcNow;
+
+        await _censusConfigRepository.UpdateAsync(existing, cancellationToken);
+        await _censusSchedulingRepo.DeleteJobsForFacility(facilityId, await _schedulerFactory.GetScheduler(cancellationToken));
+    }
+
+    public async Task EnableFacility(string facilityId, CancellationToken cancellationToken = default)
+    {
+        var existing = await _censusConfigRepository.SingleOrDefaultAsync(c => c.FacilityID == facilityId, cancellationToken);
+        if (existing == null)
+            return;
+
+        existing.Enabled = true;
+        existing.ModifyDate = DateTime.UtcNow;
+
+        await _censusConfigRepository.UpdateAsync(existing, cancellationToken);
+        await _censusSchedulingRepo.AddJobForFacility(existing, await _schedulerFactory.GetScheduler(cancellationToken));
     }
 }

--- a/DotNet/ServiceTests/UnitTests/Admin.BFF/Aggregation/RestoreFacilityTests.cs
+++ b/DotNet/ServiceTests/UnitTests/Admin.BFF/Aggregation/RestoreFacilityTests.cs
@@ -34,7 +34,8 @@ public class RestoreFacilityTests
                 TenantServiceUrl = "http://tenant/"
             },
             ReportServiceUrl = "http://report/",
-            DataAcquisitionServiceUrl = "http://da/"
+            DataAcquisitionServiceUrl = "http://da/",
+            CensusServiceUrl = "http://census/"
         });
 
         _authConfig = Options.Create(new AuthenticationSchemaConfig
@@ -49,22 +50,25 @@ public class RestoreFacilityTests
     // Helpers
     // ---------------------------------------------------------------------------
 
-    private (TenantService tenant, ReportService report, DataAcquisitionService da)
+    private (TenantService tenant, ReportService report, DataAcquisitionService da, CensusService census)
         BuildServices(MockHttpMessageHandler handler)
     {
         var tenantLogger = new Mock<ILogger<TenantService>>().Object;
         var reportLogger = new Mock<ILogger<ReportService>>().Object;
         var daLogger = new Mock<ILogger<DataAcquisitionService>>().Object;
+        var censusLogger = new Mock<ILogger<CensusService>>().Object;
 
         var tenantClient = new HttpClient(handler) { BaseAddress = new Uri("http://tenant/") };
         var reportClient = new HttpClient(handler) { BaseAddress = new Uri("http://report/") };
         var daClient = new HttpClient(handler) { BaseAddress = new Uri("http://da/") };
+        var censusClient = new HttpClient(handler) { BaseAddress = new Uri("http://census/") };
 
         var tenant = new TenantService(tenantLogger, tenantClient, _serviceRegistry, _authConfig, _mockScopeFactory.Object);
         var report = new ReportService(reportLogger, reportClient, _serviceRegistry, _authConfig, _mockScopeFactory.Object);
         var da = new DataAcquisitionService(daLogger, daClient, _serviceRegistry, _authConfig, _mockScopeFactory.Object);
+        var census = new CensusService(censusLogger, censusClient, _serviceRegistry, _authConfig, _mockScopeFactory.Object);
 
-        return (tenant, report, da);
+        return (tenant, report, da, census);
     }
 
     private static DefaultHttpContext BuildHttpContext() => new();
@@ -131,14 +135,20 @@ public class RestoreFacilityTests
                 request.RequestUri!.PathAndQuery.Contains("/restore"))
                 return NoContentResponse();
 
+            // Census jobs restore
+            if (request.Method == HttpMethod.Patch &&
+                request.RequestUri!.PathAndQuery.Contains("api/census/config/") &&
+                request.RequestUri!.PathAndQuery.Contains("/jobs/restore"))
+                return NoContentResponse();
+
             throw new InvalidOperationException($"Unexpected request: {request.Method} {request.RequestUri}");
         });
 
-        var (tenant, report, da) = BuildServices(handler);
+        var (tenant, report, da, census) = BuildServices(handler);
         var context = BuildHttpContext();
 
         // Act
-        var result = await RestoreFacility.Handle(_loggerFactory, context, tenant, report, da, FacilityId);
+        var result = await RestoreFacility.Handle(_loggerFactory, context, tenant, report, da, census, FacilityId);
 
         // Assert
         var statusCode = await ExecuteResultAsync(result);
@@ -162,11 +172,11 @@ public class RestoreFacilityTests
             throw new InvalidOperationException($"Unexpected request: {request.Method} {request.RequestUri}");
         });
 
-        var (tenant, report, da) = BuildServices(handler);
+        var (tenant, report, da, census) = BuildServices(handler);
         var context = BuildHttpContext();
 
         // Act
-        var result = await RestoreFacility.Handle(_loggerFactory, context, tenant, report, da, FacilityId);
+        var result = await RestoreFacility.Handle(_loggerFactory, context, tenant, report, da, census, FacilityId);
 
         // Assert
         var statusCode = await ExecuteResultAsync(result);
@@ -190,11 +200,11 @@ public class RestoreFacilityTests
             throw new InvalidOperationException($"Unexpected request: {request.Method} {request.RequestUri}");
         });
 
-        var (tenant, report, da) = BuildServices(handler);
+        var (tenant, report, da, census) = BuildServices(handler);
         var context = BuildHttpContext();
 
         // Act
-        var result = await RestoreFacility.Handle(_loggerFactory, context, tenant, report, da, FacilityId);
+        var result = await RestoreFacility.Handle(_loggerFactory, context, tenant, report, da, census, FacilityId);
 
         // Assert
         var statusCode = await ExecuteResultAsync(result);
@@ -234,11 +244,11 @@ public class RestoreFacilityTests
             throw new InvalidOperationException($"Unexpected request: {request.Method} {request.RequestUri}");
         });
 
-        var (tenant, report, da) = BuildServices(handler);
+        var (tenant, report, da, census) = BuildServices(handler);
         var context = BuildHttpContext();
 
         // Act
-        var result = await RestoreFacility.Handle(_loggerFactory, context, tenant, report, da, FacilityId);
+        var result = await RestoreFacility.Handle(_loggerFactory, context, tenant, report, da, census, FacilityId);
 
         // Assert
         var statusCode = await ExecuteResultAsync(result);
@@ -276,11 +286,11 @@ public class RestoreFacilityTests
             throw new InvalidOperationException($"Unexpected request: {request.Method} {request.RequestUri}");
         });
 
-        var (tenant, report, da) = BuildServices(handler);
+        var (tenant, report, da, census) = BuildServices(handler);
         var context = BuildHttpContext();
 
         // Act
-        var result = await RestoreFacility.Handle(_loggerFactory, context, tenant, report, da, FacilityId);
+        var result = await RestoreFacility.Handle(_loggerFactory, context, tenant, report, da, census, FacilityId);
 
         // Assert
         var statusCode = await ExecuteResultAsync(result);
@@ -335,11 +345,11 @@ public class RestoreFacilityTests
             throw new InvalidOperationException($"Unexpected request: {request.Method} {request.RequestUri}");
         });
 
-        var (tenant, report, da) = BuildServices(handler);
+        var (tenant, report, da, census) = BuildServices(handler);
         var context = BuildHttpContext();
 
         // Act
-        var result = await RestoreFacility.Handle(_loggerFactory, context, tenant, report, da, FacilityId);
+        var result = await RestoreFacility.Handle(_loggerFactory, context, tenant, report, da, census, FacilityId);
 
         // Assert
         var statusCode = await ExecuteResultAsync(result);
@@ -392,11 +402,11 @@ public class RestoreFacilityTests
             throw new InvalidOperationException($"Unexpected request: {request.Method} {request.RequestUri}");
         });
 
-        var (tenant, report, da) = BuildServices(handler);
+        var (tenant, report, da, census) = BuildServices(handler);
         var context = BuildHttpContext();
 
         // Act
-        var result = await RestoreFacility.Handle(_loggerFactory, context, tenant, report, da, FacilityId);
+        var result = await RestoreFacility.Handle(_loggerFactory, context, tenant, report, da, census, FacilityId);
 
         // Assert
         var statusCode = await ExecuteResultAsync(result);
@@ -422,11 +432,11 @@ public class RestoreFacilityTests
             throw new InvalidOperationException($"Unexpected request: {request.Method} {request.RequestUri}");
         });
 
-        var (tenant, report, da) = BuildServices(handler);
+        var (tenant, report, da, census) = BuildServices(handler);
         var context = BuildHttpContext();
 
         // Act
-        var result = await RestoreFacility.Handle(_loggerFactory, context, tenant, report, da, FacilityId);
+        var result = await RestoreFacility.Handle(_loggerFactory, context, tenant, report, da, census, FacilityId);
 
         // Assert
         var statusCode = await ExecuteResultAsync(result);
@@ -464,14 +474,167 @@ public class RestoreFacilityTests
             throw new InvalidOperationException($"Unexpected request: {request.Method} {request.RequestUri}");
         });
 
-        var (tenant, report, da) = BuildServices(handler);
+        var (tenant, report, da, census) = BuildServices(handler);
         var context = BuildHttpContext();
 
         // Act
-        await RestoreFacility.Handle(_loggerFactory, context, tenant, report, da, FacilityId);
+        await RestoreFacility.Handle(_loggerFactory, context, tenant, report, da, census, FacilityId);
 
         // Assert
         Assert.False(reportCalled, "Report service should not be called when tenant restore fails.");
         Assert.False(daCalled, "DA service should not be called when tenant restore fails.");
+    }
+
+    // ---------------------------------------------------------------------------
+    // Scenario 8: Census restore fails — returns 500 + rolls back all three
+    // ---------------------------------------------------------------------------
+
+    [Fact]
+    public async Task Handle_CensusRestoreFails_Returns500AndRollsBackAll()
+    {
+        // Arrange
+        var tenantSoftDeleteCalled = false;
+        var reportSoftDeleteCalled = false;
+        var daSoftDeleteCalled = false;
+        var handler = new MockHttpMessageHandler(request =>
+        {
+            // Tenant restore succeeds
+            if (request.Method == HttpMethod.Patch &&
+                request.RequestUri!.PathAndQuery.Contains("api/facility/restore/"))
+                return NoContentResponse();
+
+            // Report restore succeeds
+            if (request.Method == HttpMethod.Patch &&
+                request.RequestUri!.PathAndQuery.Contains("api/schedules/facility/") &&
+                request.RequestUri!.Query.Contains("deleted=false"))
+                return NoContentResponse();
+
+            // DA restore succeeds
+            if (request.Method == HttpMethod.Patch &&
+                request.RequestUri!.PathAndQuery.Contains("api/data/acquisition-logs/facility/") &&
+                request.RequestUri!.PathAndQuery.Contains("/restore"))
+                return NoContentResponse();
+
+            // Census restore fails
+            if (request.Method == HttpMethod.Patch &&
+                request.RequestUri!.PathAndQuery.Contains("api/census/config/") &&
+                request.RequestUri!.PathAndQuery.Contains("/jobs/restore"))
+                return StatusResponse(HttpStatusCode.ServiceUnavailable);
+
+            // DA rollback (soft-delete)
+            if (request.Method == HttpMethod.Delete &&
+                request.RequestUri!.PathAndQuery.Contains("api/data/acquisition-logs/facility/"))
+            {
+                daSoftDeleteCalled = true;
+                return NoContentResponse();
+            }
+
+            // Report rollback (soft-delete)
+            if (request.Method == HttpMethod.Patch &&
+                request.RequestUri!.PathAndQuery.Contains("api/schedules/facility/") &&
+                request.RequestUri!.Query.Contains("deleted=true"))
+            {
+                reportSoftDeleteCalled = true;
+                return NoContentResponse();
+            }
+
+            // Tenant rollback (soft-delete)
+            if (request.Method == HttpMethod.Delete &&
+                request.RequestUri!.PathAndQuery.Contains("api/facility/softDelete/"))
+            {
+                tenantSoftDeleteCalled = true;
+                return NoContentResponse();
+            }
+
+            throw new InvalidOperationException($"Unexpected request: {request.Method} {request.RequestUri}");
+        });
+
+        var (tenant, report, da, census) = BuildServices(handler);
+        var context = BuildHttpContext();
+
+        // Act
+        var result = await RestoreFacility.Handle(_loggerFactory, context, tenant, report, da, census, FacilityId);
+
+        // Assert
+        var statusCode = await ExecuteResultAsync(result);
+        Assert.Equal(StatusCodes.Status500InternalServerError, statusCode);
+        Assert.True(daSoftDeleteCalled, "Expected DA rollback (soft-delete) to be called when census restore fails.");
+        Assert.True(reportSoftDeleteCalled, "Expected report schedule rollback (soft-delete) to be called when census restore fails.");
+        Assert.True(tenantSoftDeleteCalled, "Expected tenant rollback (soft-delete) to be called when census restore fails.");
+    }
+
+    // ---------------------------------------------------------------------------
+    // Scenario 9: Census restore throws — returns 500 + rolls back all three
+    // ---------------------------------------------------------------------------
+
+    [Fact]
+    public async Task Handle_CensusRestoreThrows_Returns500AndRollsBackAll()
+    {
+        // Arrange
+        var tenantSoftDeleteCalled = false;
+        var reportSoftDeleteCalled = false;
+        var daSoftDeleteCalled = false;
+        var handler = new MockHttpMessageHandler(request =>
+        {
+            if (request.Method == HttpMethod.Patch &&
+                request.RequestUri!.PathAndQuery.Contains("api/facility/restore/"))
+                return NoContentResponse();
+
+            if (request.Method == HttpMethod.Patch &&
+                request.RequestUri!.PathAndQuery.Contains("api/schedules/facility/") &&
+                request.RequestUri!.Query.Contains("deleted=false"))
+                return NoContentResponse();
+
+            if (request.Method == HttpMethod.Patch &&
+                request.RequestUri!.PathAndQuery.Contains("api/data/acquisition-logs/facility/") &&
+                request.RequestUri!.PathAndQuery.Contains("/restore"))
+                return NoContentResponse();
+
+            // Census restore throws
+            if (request.Method == HttpMethod.Patch &&
+                request.RequestUri!.PathAndQuery.Contains("api/census/config/") &&
+                request.RequestUri!.PathAndQuery.Contains("/jobs/restore"))
+                throw new HttpRequestException("Census service unavailable");
+
+            // DA rollback (soft-delete)
+            if (request.Method == HttpMethod.Delete &&
+                request.RequestUri!.PathAndQuery.Contains("api/data/acquisition-logs/facility/"))
+            {
+                daSoftDeleteCalled = true;
+                return NoContentResponse();
+            }
+
+            // Report rollback (soft-delete)
+            if (request.Method == HttpMethod.Patch &&
+                request.RequestUri!.PathAndQuery.Contains("api/schedules/facility/") &&
+                request.RequestUri!.Query.Contains("deleted=true"))
+            {
+                reportSoftDeleteCalled = true;
+                return NoContentResponse();
+            }
+
+            // Tenant rollback (soft-delete)
+            if (request.Method == HttpMethod.Delete &&
+                request.RequestUri!.PathAndQuery.Contains("api/facility/softDelete/"))
+            {
+                tenantSoftDeleteCalled = true;
+                return NoContentResponse();
+            }
+
+            throw new InvalidOperationException($"Unexpected request: {request.Method} {request.RequestUri}");
+        });
+
+        var (tenant, report, da, census) = BuildServices(handler);
+        var context = BuildHttpContext();
+
+        // Act
+        var result = await RestoreFacility.Handle(_loggerFactory, context, tenant, report, da, census, FacilityId);
+
+        // Assert
+        var statusCode = await ExecuteResultAsync(result);
+        Assert.Equal(StatusCodes.Status500InternalServerError, statusCode);
+        Assert.True(daSoftDeleteCalled, "Expected DA rollback (soft-delete) to be called when census restore throws.");
+        Assert.True(reportSoftDeleteCalled, "Expected report schedule rollback (soft-delete) to be called when census restore throws.");
+        Assert.True(tenantSoftDeleteCalled, "Expected tenant rollback (soft-delete) to be called when census restore throws.");
     }
 }

--- a/DotNet/ServiceTests/UnitTests/Admin.BFF/Aggregation/SoftDeleteFacilityTests.cs
+++ b/DotNet/ServiceTests/UnitTests/Admin.BFF/Aggregation/SoftDeleteFacilityTests.cs
@@ -34,7 +34,8 @@ public class SoftDeleteFacilityTests
                 TenantServiceUrl = "http://tenant/"
             },
             ReportServiceUrl = "http://report/",
-            DataAcquisitionServiceUrl = "http://da/"
+            DataAcquisitionServiceUrl = "http://da/",
+            CensusServiceUrl = "http://census/"
         });
 
         _authConfig = Options.Create(new AuthenticationSchemaConfig
@@ -53,22 +54,25 @@ public class SoftDeleteFacilityTests
     /// Builds a <see cref="MockHttpMessageHandler"/> that dispatches responses by examining
     /// the request URI path and HTTP method, then wires up real service instances around it.
     /// </summary>
-    private (TenantService tenant, ReportService report, DataAcquisitionService da, MockHttpMessageHandler handler)
+    private (TenantService tenant, ReportService report, DataAcquisitionService da, CensusService census, MockHttpMessageHandler handler)
         BuildServices(MockHttpMessageHandler handler)
     {
         var tenantLogger = new Mock<ILogger<TenantService>>().Object;
         var reportLogger = new Mock<ILogger<ReportService>>().Object;
         var daLogger = new Mock<ILogger<DataAcquisitionService>>().Object;
+        var censusLogger = new Mock<ILogger<CensusService>>().Object;
 
         var tenantClient = new HttpClient(handler) { BaseAddress = new Uri("http://tenant/") };
         var reportClient = new HttpClient(handler) { BaseAddress = new Uri("http://report/") };
         var daClient = new HttpClient(handler) { BaseAddress = new Uri("http://da/") };
+        var censusClient = new HttpClient(handler) { BaseAddress = new Uri("http://census/") };
 
         var tenant = new TenantService(tenantLogger, tenantClient, _serviceRegistry, _authConfig, _mockScopeFactory.Object);
         var report = new ReportService(reportLogger, reportClient, _serviceRegistry, _authConfig, _mockScopeFactory.Object);
         var da = new DataAcquisitionService(daLogger, daClient, _serviceRegistry, _authConfig, _mockScopeFactory.Object);
+        var census = new CensusService(censusLogger, censusClient, _serviceRegistry, _authConfig, _mockScopeFactory.Object);
 
-        return (tenant, report, da, handler);
+        return (tenant, report, da, census, handler);
     }
 
     private static DefaultHttpContext BuildHttpContext() => new();
@@ -124,14 +128,20 @@ public class SoftDeleteFacilityTests
                 request.RequestUri!.PathAndQuery.Contains("api/data/acquisition-logs/facility/"))
                 return NoContentResponse();
 
+            // Census jobs delete
+            if (request.Method == HttpMethod.Delete &&
+                request.RequestUri!.PathAndQuery.Contains("api/census/config/") &&
+                request.RequestUri!.PathAndQuery.Contains("/jobs"))
+                return NoContentResponse();
+
             throw new InvalidOperationException($"Unexpected request: {request.Method} {request.RequestUri}");
         });
 
-        var (tenant, report, da, _) = BuildServices(handler);
+        var (tenant, report, da, census, _) = BuildServices(handler);
         var context = BuildHttpContext();
 
         // Act
-        var result = await SoftDeleteFacility.Handle(_loggerFactory, context, tenant, report, da, FacilityId);
+        var result = await SoftDeleteFacility.Handle(_loggerFactory, context, tenant, report, da, census, FacilityId);
 
         // Assert
         var statusCode = await ExecuteResultAsync(result);
@@ -155,11 +165,11 @@ public class SoftDeleteFacilityTests
             throw new InvalidOperationException($"Unexpected request: {request.Method} {request.RequestUri}");
         });
 
-        var (tenant, report, da, _) = BuildServices(handler);
+        var (tenant, report, da, census, _) = BuildServices(handler);
         var context = BuildHttpContext();
 
         // Act
-        var result = await SoftDeleteFacility.Handle(_loggerFactory, context, tenant, report, da, FacilityId);
+        var result = await SoftDeleteFacility.Handle(_loggerFactory, context, tenant, report, da, census, FacilityId);
 
         // Assert
         var statusCode = await ExecuteResultAsync(result);
@@ -196,14 +206,20 @@ public class SoftDeleteFacilityTests
                 request.RequestUri!.PathAndQuery.Contains("api/data/acquisition-logs/facility/"))
                 return NoContentResponse();
 
+            // Census jobs delete
+            if (request.Method == HttpMethod.Delete &&
+                request.RequestUri!.PathAndQuery.Contains("api/census/config/") &&
+                request.RequestUri!.PathAndQuery.Contains("/jobs"))
+                return NoContentResponse();
+
             throw new InvalidOperationException($"Unexpected request: {request.Method} {request.RequestUri}");
         });
 
-        var (tenant, report, da, _) = BuildServices(handler);
+        var (tenant, report, da, census, _) = BuildServices(handler);
         var context = BuildHttpContext();
 
         // Act
-        var result = await SoftDeleteFacility.Handle(_loggerFactory, context, tenant, report, da, FacilityId);
+        var result = await SoftDeleteFacility.Handle(_loggerFactory, context, tenant, report, da, census, FacilityId);
 
         // Assert
         var statusCode = await ExecuteResultAsync(result);
@@ -228,11 +244,11 @@ public class SoftDeleteFacilityTests
             throw new InvalidOperationException($"Unexpected request: {request.Method} {request.RequestUri}");
         });
 
-        var (tenant, report, da, _) = BuildServices(handler);
+        var (tenant, report, da, census, _) = BuildServices(handler);
         var context = BuildHttpContext();
 
         // Act
-        var result = await SoftDeleteFacility.Handle(_loggerFactory, context, tenant, report, da, FacilityId);
+        var result = await SoftDeleteFacility.Handle(_loggerFactory, context, tenant, report, da, census, FacilityId);
 
         // Assert
         var statusCode = await ExecuteResultAsync(result);
@@ -262,11 +278,11 @@ public class SoftDeleteFacilityTests
             throw new InvalidOperationException($"Unexpected request: {request.Method} {request.RequestUri}");
         });
 
-        var (tenant, report, da, _) = BuildServices(handler);
+        var (tenant, report, da, census, _) = BuildServices(handler);
         var context = BuildHttpContext();
 
         // Act
-        var result = await SoftDeleteFacility.Handle(_loggerFactory, context, tenant, report, da, FacilityId);
+        var result = await SoftDeleteFacility.Handle(_loggerFactory, context, tenant, report, da, census, FacilityId);
 
         // Assert
         var statusCode = await ExecuteResultAsync(result);
@@ -294,11 +310,11 @@ public class SoftDeleteFacilityTests
             throw new InvalidOperationException($"Unexpected request: {request.Method} {request.RequestUri}");
         });
 
-        var (tenant, report, da, _) = BuildServices(handler);
+        var (tenant, report, da, census, _) = BuildServices(handler);
         var context = BuildHttpContext();
 
         // Act
-        var result = await SoftDeleteFacility.Handle(_loggerFactory, context, tenant, report, da, FacilityId);
+        var result = await SoftDeleteFacility.Handle(_loggerFactory, context, tenant, report, da, census, FacilityId);
 
         // Assert
         var statusCode = await ExecuteResultAsync(result);
@@ -342,11 +358,11 @@ public class SoftDeleteFacilityTests
             throw new InvalidOperationException($"Unexpected request: {request.Method} {request.RequestUri}");
         });
 
-        var (tenant, report, da, _) = BuildServices(handler);
+        var (tenant, report, da, census, _) = BuildServices(handler);
         var context = BuildHttpContext();
 
         // Act
-        var result = await SoftDeleteFacility.Handle(_loggerFactory, context, tenant, report, da, FacilityId);
+        var result = await SoftDeleteFacility.Handle(_loggerFactory, context, tenant, report, da, census, FacilityId);
 
         // Assert
         var statusCode = await ExecuteResultAsync(result);
@@ -388,11 +404,11 @@ public class SoftDeleteFacilityTests
             throw new InvalidOperationException($"Unexpected request: {request.Method} {request.RequestUri}");
         });
 
-        var (tenant, report, da, _) = BuildServices(handler);
+        var (tenant, report, da, census, _) = BuildServices(handler);
         var context = BuildHttpContext();
 
         // Act
-        var result = await SoftDeleteFacility.Handle(_loggerFactory, context, tenant, report, da, FacilityId);
+        var result = await SoftDeleteFacility.Handle(_loggerFactory, context, tenant, report, da, census, FacilityId);
 
         // Assert
         var statusCode = await ExecuteResultAsync(result);
@@ -450,11 +466,11 @@ public class SoftDeleteFacilityTests
             throw new InvalidOperationException($"Unexpected request: {request.Method} {request.RequestUri}");
         });
 
-        var (tenant, report, da, _) = BuildServices(handler);
+        var (tenant, report, da, census, _) = BuildServices(handler);
         var context = BuildHttpContext();
 
         // Act
-        var result = await SoftDeleteFacility.Handle(_loggerFactory, context, tenant, report, da, FacilityId);
+        var result = await SoftDeleteFacility.Handle(_loggerFactory, context, tenant, report, da, census, FacilityId);
 
         // Assert
         var statusCode = await ExecuteResultAsync(result);
@@ -510,11 +526,11 @@ public class SoftDeleteFacilityTests
             throw new InvalidOperationException($"Unexpected request: {request.Method} {request.RequestUri}");
         });
 
-        var (tenant, report, da, _) = BuildServices(handler);
+        var (tenant, report, da, census, _) = BuildServices(handler);
         var context = BuildHttpContext();
 
         // Act
-        var result = await SoftDeleteFacility.Handle(_loggerFactory, context, tenant, report, da, FacilityId);
+        var result = await SoftDeleteFacility.Handle(_loggerFactory, context, tenant, report, da, census, FacilityId);
 
         // Assert
         var statusCode = await ExecuteResultAsync(result);
@@ -555,14 +571,20 @@ public class SoftDeleteFacilityTests
                 request.RequestUri!.PathAndQuery.Contains("api/data/acquisition-logs/facility/"))
                 return NoContentResponse();
 
+            // Census jobs delete
+            if (request.Method == HttpMethod.Delete &&
+                request.RequestUri!.PathAndQuery.Contains("api/census/config/") &&
+                request.RequestUri!.PathAndQuery.Contains("/jobs"))
+                return NoContentResponse();
+
             throw new InvalidOperationException($"Unexpected request: {request.Method} {request.RequestUri}");
         });
 
-        var (tenant, report, da, _) = BuildServices(handler);
+        var (tenant, report, da, census, _) = BuildServices(handler);
         var context = BuildHttpContext();
 
         // Act
-        var result = await SoftDeleteFacility.Handle(_loggerFactory, context, tenant, report, da, FacilityId);
+        var result = await SoftDeleteFacility.Handle(_loggerFactory, context, tenant, report, da, census, FacilityId);
 
         // Assert
         var statusCode = await ExecuteResultAsync(result);
@@ -591,11 +613,11 @@ public class SoftDeleteFacilityTests
             throw new InvalidOperationException($"Unexpected request: {request.Method} {request.RequestUri}");
         });
 
-        var (tenant, report, da, _) = BuildServices(handler);
+        var (tenant, report, da, census, _) = BuildServices(handler);
         var context = BuildHttpContext();
 
         // Act
-        var result = await SoftDeleteFacility.Handle(_loggerFactory, context, tenant, report, da, FacilityId);
+        var result = await SoftDeleteFacility.Handle(_loggerFactory, context, tenant, report, da, census, FacilityId);
 
         // Assert
         var statusCode = await ExecuteResultAsync(result);
@@ -620,6 +642,164 @@ public class SoftDeleteFacilityTests
         {
             Content = new StringContent(string.Empty)
         };
+
+    // ---------------------------------------------------------------------------
+    // Scenario 10: Census job delete fails — returns 500 + rolls back all three
+    // ---------------------------------------------------------------------------
+
+    [Fact]
+    public async Task Handle_CensusJobDeleteFails_Returns500AndRollsBackAll()
+    {
+        // Arrange
+        var tenantRestoreCalled = false;
+        var reportRestoreCalled = false;
+        var daRestoreCalled = false;
+        var handler = new MockHttpMessageHandler(request =>
+        {
+            if (request.Method == HttpMethod.Get &&
+                request.RequestUri!.PathAndQuery.Contains("api/schedules/facilities/"))
+                return OkResponse("[]");
+
+            if (request.Method == HttpMethod.Delete &&
+                request.RequestUri!.PathAndQuery.Contains("api/facility/softDelete/"))
+                return NoContentResponse();
+
+            if (request.Method == HttpMethod.Patch &&
+                request.RequestUri!.PathAndQuery.Contains("api/schedules/facility/") &&
+                request.RequestUri!.Query.Contains("deleted=true"))
+                return NoContentResponse();
+
+            if (request.Method == HttpMethod.Delete &&
+                request.RequestUri!.PathAndQuery.Contains("api/data/acquisition-logs/facility/"))
+                return NoContentResponse();
+
+            // Census job delete fails
+            if (request.Method == HttpMethod.Delete &&
+                request.RequestUri!.PathAndQuery.Contains("api/census/config/") &&
+                request.RequestUri!.PathAndQuery.Contains("/jobs"))
+                return StatusResponse(HttpStatusCode.ServiceUnavailable);
+
+            // DA rollback (restore)
+            if (request.Method == HttpMethod.Patch &&
+                request.RequestUri!.PathAndQuery.Contains("api/data/acquisition-logs/facility/") &&
+                request.RequestUri!.PathAndQuery.Contains("/restore"))
+            {
+                daRestoreCalled = true;
+                return NoContentResponse();
+            }
+
+            // Report rollback (restore)
+            if (request.Method == HttpMethod.Patch &&
+                request.RequestUri!.PathAndQuery.Contains("api/schedules/facility/") &&
+                request.RequestUri!.Query.Contains("deleted=false"))
+            {
+                reportRestoreCalled = true;
+                return NoContentResponse();
+            }
+
+            // Tenant rollback (restore)
+            if (request.Method == HttpMethod.Patch &&
+                request.RequestUri!.PathAndQuery.Contains("api/facility/restore/"))
+            {
+                tenantRestoreCalled = true;
+                return NoContentResponse();
+            }
+
+            throw new InvalidOperationException($"Unexpected request: {request.Method} {request.RequestUri}");
+        });
+
+        var (tenant, report, da, census, _) = BuildServices(handler);
+        var context = BuildHttpContext();
+
+        // Act
+        var result = await SoftDeleteFacility.Handle(_loggerFactory, context, tenant, report, da, census, FacilityId);
+
+        // Assert
+        var statusCode = await ExecuteResultAsync(result);
+        Assert.Equal(StatusCodes.Status500InternalServerError, statusCode);
+        Assert.True(daRestoreCalled, "Expected DA rollback (restore) to be called when census job delete fails.");
+        Assert.True(reportRestoreCalled, "Expected report schedule rollback (restore) to be called when census job delete fails.");
+        Assert.True(tenantRestoreCalled, "Expected tenant rollback (restore) to be called when census job delete fails.");
+    }
+
+    // ---------------------------------------------------------------------------
+    // Scenario 11: Census job delete throws — returns 500 + rolls back all three
+    // ---------------------------------------------------------------------------
+
+    [Fact]
+    public async Task Handle_CensusJobDeleteThrows_Returns500AndRollsBackAll()
+    {
+        // Arrange
+        var tenantRestoreCalled = false;
+        var reportRestoreCalled = false;
+        var daRestoreCalled = false;
+        var handler = new MockHttpMessageHandler(request =>
+        {
+            if (request.Method == HttpMethod.Get &&
+                request.RequestUri!.PathAndQuery.Contains("api/schedules/facilities/"))
+                return OkResponse("[]");
+
+            if (request.Method == HttpMethod.Delete &&
+                request.RequestUri!.PathAndQuery.Contains("api/facility/softDelete/"))
+                return NoContentResponse();
+
+            if (request.Method == HttpMethod.Patch &&
+                request.RequestUri!.PathAndQuery.Contains("api/schedules/facility/") &&
+                request.RequestUri!.Query.Contains("deleted=true"))
+                return NoContentResponse();
+
+            if (request.Method == HttpMethod.Delete &&
+                request.RequestUri!.PathAndQuery.Contains("api/data/acquisition-logs/facility/"))
+                return NoContentResponse();
+
+            // Census job delete throws
+            if (request.Method == HttpMethod.Delete &&
+                request.RequestUri!.PathAndQuery.Contains("api/census/config/") &&
+                request.RequestUri!.PathAndQuery.Contains("/jobs"))
+                throw new HttpRequestException("Census service unavailable");
+
+            // DA rollback (restore)
+            if (request.Method == HttpMethod.Patch &&
+                request.RequestUri!.PathAndQuery.Contains("api/data/acquisition-logs/facility/") &&
+                request.RequestUri!.PathAndQuery.Contains("/restore"))
+            {
+                daRestoreCalled = true;
+                return NoContentResponse();
+            }
+
+            // Report rollback (restore)
+            if (request.Method == HttpMethod.Patch &&
+                request.RequestUri!.PathAndQuery.Contains("api/schedules/facility/") &&
+                request.RequestUri!.Query.Contains("deleted=false"))
+            {
+                reportRestoreCalled = true;
+                return NoContentResponse();
+            }
+
+            // Tenant rollback (restore)
+            if (request.Method == HttpMethod.Patch &&
+                request.RequestUri!.PathAndQuery.Contains("api/facility/restore/"))
+            {
+                tenantRestoreCalled = true;
+                return NoContentResponse();
+            }
+
+            throw new InvalidOperationException($"Unexpected request: {request.Method} {request.RequestUri}");
+        });
+
+        var (tenant, report, da, census, _) = BuildServices(handler);
+        var context = BuildHttpContext();
+
+        // Act
+        var result = await SoftDeleteFacility.Handle(_loggerFactory, context, tenant, report, da, census, FacilityId);
+
+        // Assert
+        var statusCode = await ExecuteResultAsync(result);
+        Assert.Equal(StatusCodes.Status500InternalServerError, statusCode);
+        Assert.True(daRestoreCalled, "Expected DA rollback (restore) to be called when census job delete throws.");
+        Assert.True(reportRestoreCalled, "Expected report schedule rollback (restore) to be called when census job delete throws.");
+        Assert.True(tenantRestoreCalled, "Expected tenant rollback (restore) to be called when census job delete throws.");
+    }
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION


### 🛠️ Description of Changes

 Disabled census configuration when we soft-delete a facility and also delete the census cron jobs

### 🧪 Testing Performed

Tested locally

### 🧑‍🔬 Unit Testing

- [ ] I have written or updated unit tests to cover my changes
- Coverage: 43.3%

### 📓 Documentation Updated

Please update any relevant sections in the project documentation that were impacted by the changes in the PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Census jobs can now be deleted during facility soft-delete operations and restored during facility restore operations.
  * System tracks census job deletion and restoration status as part of facility management workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


