### PR TITLE
LNK-5132: Restored removed debug log level statements and various comments

### DIFF
--- a/DotNet/Report/Business/Managers/ReportPopulationManager.cs
+++ b/DotNet/Report/Business/Managers/ReportPopulationManager.cs
@@ -167,6 +167,16 @@ namespace LantanaGroup.Link.Report.Domain.Managers
             }
         }
 
+        /// <summary>
+        /// Daniel - 3/2026: This function exists to build the population list when a reportScheduled event is consumed. This helps in a few ways:
+        ///     1. In the case where all evaluated measure reports for a facility do not meet the criteria of the measure, a population record already exists with a count set to 0.
+        ///     2. The admin UI doesn't have to add logic to render 0 count populations.
+        ///     3. When generating a manifest, logic doesn't need to be added to figure out if there was a 0 count for any of the reported measures. 
+        /// It's assumed that each developed measure will at least have 'initial-population' as a Population Id. This logic would need to change if that assumption is no longer true.
+        /// </summary>
+        /// <param name="reportSchedule"></param>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
         public async Task<List<ReportPopulationModel>> AddWithReportScheduleAsync(ReportScheduleModel reportSchedule, CancellationToken cancellationToken)
         {
             List<ReportPopulation> models = new();

--- a/DotNet/Report/Listeners/MeasureReportGeneratedListener.cs
+++ b/DotNet/Report/Listeners/MeasureReportGeneratedListener.cs
@@ -10,6 +10,7 @@ using LantanaGroup.Link.Shared.Application.Error.Interfaces;
 using LantanaGroup.Link.Shared.Application.Extensions;
 using LantanaGroup.Link.Shared.Application.Interfaces;
 using LantanaGroup.Link.Shared.Application.Models;
+using System.Diagnostics;
 using System.Text;
 using Task = System.Threading.Tasks.Task;
 
@@ -147,6 +148,8 @@ namespace LantanaGroup.Link.Report.Listeners
             var messageValue = result.Message.Value;
             var correlationId = Encoding.UTF8.GetString(headerValue);
 
+            _logger.LogDebug("Consuming MeasureReportGenerated (Facility = {FacilityId}, PatientId = {PatientId}, ReportScheduleId = {ReportScheduleId}, ReportType = {ReportType})", messageValue.FacilityId, messageValue.PatientId, messageValue.ReportTrackingId, messageValue.ReportType);
+
             using var scope = _serviceScopeFactory.CreateScope();
             var reportScheduledManager = scope.ServiceProvider.GetRequiredService<IReportScheduledManager>();
             var reportEntryManager = scope.ServiceProvider.GetRequiredService<IReportEntryManager>();
@@ -167,18 +170,27 @@ namespace LantanaGroup.Link.Report.Listeners
 
             if (isAllNonReportable)
             {
+                _logger.LogDebug("Entry not reportable (Facility = {FacilityId}, PatientId = {PatientId}, ReportScheduleId = {ReportScheduleId})", messageValue.FacilityId, messageValue.PatientId, messageValue.ReportTrackingId);
+
                 await reportEntryManager.UpdateAsyncNotReportableEntry(reportEntry, cancellationToken);
                 await reportManifestProducer.Produce(schedule, correlationId);
                 return;
             }
 
+            //The aggregation step for a patient will only be performed once the Report service has consumed 'MeasureReportGenerated' events for all entries in reportEntry.MeasureReportList.
             var readyForAggregation = reportEntry.MeasureReports.All(x => x.Status == Domain.Enums.MeasureReportStatus.NotReportable || x.Status == Domain.Enums.MeasureReportStatus.ReadyForValidation);
 
             if (!readyForAggregation)
             {
+                _logger.LogDebug("Patient not ready for aggregation (Facility = {FacilityId}, PatientId = {PatientId}, ReportScheduleId = {ReportScheduleId})", messageValue.FacilityId, messageValue.PatientId, messageValue.ReportTrackingId);
+                //Daniel - 02/2026 - The 'isAllNonReportable' logic above was added and may replace the need for executing reportManifestProducer below. It won't hurt to run, but may not be needed. If we find that we don't need to execute the manifest producer, we will only need to return in this block.
+
                 await reportManifestProducer.Produce(schedule, correlationId);
                 return;
             }
+
+            _logger.LogDebug("Patient ready for aggregation (Facility = {FacilityId}, PatientId = {PatientId}, ReportScheduleId = {ReportScheduleId})", messageValue.FacilityId, messageValue.PatientId, messageValue.ReportTrackingId);
+            var startTime = Stopwatch.GetTimestamp();
 
             AggregateResult aggregateResult;
             try
@@ -189,6 +201,10 @@ namespace LantanaGroup.Link.Report.Listeners
             {
                 throw new DeadLetterException(ex.Message, ex);
             }
+
+            var elapsed = Stopwatch.GetElapsedTime(startTime);
+            _logger.LogDebug("Patient aggregation complete. Elapsed time: {Elapsed} (Facility = {FacilityId}, PatientId = {PatientId}, ReportScheduleId = {ReportScheduleId})", elapsed.ToString(), messageValue.FacilityId, messageValue.PatientId, messageValue.ReportTrackingId);
+            startTime = Stopwatch.GetTimestamp();
 
             await reportEntryManager.UpdateAsyncWithAggregateResult(reportEntry, aggregateResult);
             await reportResourceManager.AddAsyncWithAggregateResult(facilityId, reportTrackingId, messageValue.PatientId, aggregateResult, cancellationToken);
@@ -216,6 +232,10 @@ namespace LantanaGroup.Link.Report.Listeners
                 return;
             }
 
+            elapsed = Stopwatch.GetElapsedTime(startTime);
+
+            _logger.LogDebug("Database updates complete. Elapsed time: {Elapsed} (Facility = {FacilityId}, PatientId = {PatientId}, ReportScheduleId = {ReportScheduleId})", elapsed.ToString(), messageValue.FacilityId, messageValue.PatientId, messageValue.ReportTrackingId);
+            
             try
             {
                 await _readyForValidationProducer.Produce(schedule.Id, schedule.ReportTypes, schedule.FacilityId, messageValue.PatientId, aggregateResult.Uri.AbsoluteUri, correlationId);

--- a/DotNet/Report/Listeners/PatientEventListener.cs
+++ b/DotNet/Report/Listeners/PatientEventListener.cs
@@ -145,11 +145,11 @@ namespace LantanaGroup.Link.Report.Listeners
 
                 if (value.EventType != PatientEvents.Admit.ToString())
                 {
-                    _logger.LogInformation("Patient {PatientId} has event type of {EventType}. Ignoring.", HtmlInputSanitizer.Sanitize(value.PatientId), HtmlInputSanitizer.Sanitize(value.EventType));
+                    _logger.LogDebug("Patient {PatientId} has event type of {EventType}. Ignoring.", HtmlInputSanitizer.Sanitize(value.PatientId), HtmlInputSanitizer.Sanitize(value.EventType));
                     return;
                 }
 
-                _logger.LogInformation("Consuming Admit PatientEvent (FacilityId: {facilityId}, PatientId: {PatientId})", HtmlInputSanitizer.Sanitize(facilityId), HtmlInputSanitizer.Sanitize(value.PatientId));
+                _logger.LogDebug("Consuming Admit PatientEvent (FacilityId: {facilityId}, PatientId: {PatientId})", HtmlInputSanitizer.Sanitize(facilityId), HtmlInputSanitizer.Sanitize(value.PatientId));
 
                 var scheduledReports = await reportScheduledManager.FindAsync(x => x.FacilityId == facilityId && x.EndOfReportPeriodJobHasRun == false, cancellationToken);
 

--- a/DotNet/Report/Listeners/ValidationCompleteListener.cs
+++ b/DotNet/Report/Listeners/ValidationCompleteListener.cs
@@ -171,6 +171,8 @@ namespace LantanaGroup.Link.Report.Listeners
                 throw new DeadLetterException($"Received message without correlation ID (ReportId = {reportId}, FacilityId = {facilityId}).");
             }
 
+            _logger.LogDebug("Consuming ValidationComplete (Facility = {FacilityId}, PatientId = {PatientId}, ReportScheduleId = {ReportScheduleId})", facilityId, value.PatientId, reportId);
+
             var correlationIdStr = Encoding.UTF8.GetString(headerValue);
             var reportEntry = await reportEntryManager.GetEntry(schedule.Id, value.PatientId, cancellationToken);
 


### PR DESCRIPTION
### 🛠️ Description of Changes

Updates to the 0.6 Report service removed debug prints from the Report service that are valuable to have to track the patient reporting workflow along with timing information when writing to the db and running the patient aggregator. This pull request is to restore those logs.

### 🧪 Testing Performed

Example console print when log level is set to Debug:
<img width="1567" height="134" alt="image" src="https://github.com/user-attachments/assets/0975b6ac-2c8d-425b-ae63-d726f97259a2" />

### 🧑‍🔬 Unit Testing

- Coverage: 0.0%

N/A

### 📓 Documentation Updated

N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced debug logging and diagnostic information across event processing for improved system observability and troubleshooting
  * Added comprehensive code documentation for internal processes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
