### PR TITLE
LNK-5131: Add Cancelled state as a Terminal state when sending a Tail…

### DIFF
--- a/DotNet/DataAcquisition.Domain/Application/Managers/DataAcquisitionLogManager.cs
+++ b/DotNet/DataAcquisition.Domain/Application/Managers/DataAcquisitionLogManager.cs
@@ -749,7 +749,7 @@ public class DataAcquisitionLogManager : IDataAcquisitionLogManager
         using var activity = ServiceActivitySource.Instance.StartActivity("DataAcquisitionLogManager.TryCompleteTailAsync");
         activity?.SetTag(DiagnosticNames.ReportId, completedLogId);
 
-        var terminalStatuses = new[] { RequestStatus.Completed, RequestStatus.MaxRetriesReached, RequestStatus.Skipped, RequestStatus.ConfigurationMissing };
+        var terminalStatuses = new[] { RequestStatus.Completed, RequestStatus.MaxRetriesReached, RequestStatus.Skipped, RequestStatus.Cancelled, RequestStatus.ConfigurationMissing };
 
         // Load group identity for the completed log (PK lookup)
         var groupInfo = await _dbContext.DataAcquisitionLogs.AsNoTracking()

--- a/DotNet/DataAcquisition.Domain/Application/Queries/DataAcquisitionLogQueries.cs
+++ b/DotNet/DataAcquisition.Domain/Application/Queries/DataAcquisitionLogQueries.cs
@@ -927,7 +927,7 @@ public class DataAcquisitionLogQueries : IDataAcquisitionLogQueries
 
     public async Task<List<long>> GetOrphanedTailLogIds(TimeSpan minAge, int maxResults = 50, CancellationToken cancellationToken = default)
     {
-        var terminalStatuses = new[] { RequestStatus.Completed, RequestStatus.MaxRetriesReached, RequestStatus.Skipped };
+        var terminalStatuses = new[] { RequestStatus.Completed, RequestStatus.MaxRetriesReached, RequestStatus.Skipped, RequestStatus.Cancelled };
         var cutoff = DateTime.UtcNow.Subtract(minAge);
 
         // Find groups where:


### PR DESCRIPTION
… Message

### 🛠️ Description of Changes

Making Cancelled a Terminal state for a tail message, cause this was lost after the last code changes in DA.

### 🧪 Testing Performed

Tested locally

### 🧑‍🔬 Unit Testing

- [ ] I have written or updated unit tests to cover my changes
- Coverage: 0.0%

### 📓 Documentation Updated

Please update any relevant sections in the project documentation that were impacted by the changes in the PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved data acquisition log completion handling to correctly treat cancelled requests as terminal status. This ensures that cancelled items no longer prevent sibling logs from completing, and orphaned tail logs are properly identified for cleanup operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
