### PR TITLE
LNK-5155: Remove Dependency on ReportResource Table

### DIFF
--- a/DotNet/Automation.Link/Helpers/PipelineDataReader.cs
+++ b/DotNet/Automation.Link/Helpers/PipelineDataReader.cs
@@ -74,8 +74,7 @@ public class PipelineDataReader
         _cache.Clear();
     }
 
-    public record ResourceGroupSummary(string PatientId, string ResourceType, int Count);
-    public record ReportResourceIdentity(string PatientId, string ResourceType, string ResourceId);
+
     public record PatientResourceTypeCount(string PatientId, string ResourceType, int Count);
 
     public record ReportScheduleInfo(
@@ -204,16 +203,6 @@ public class PipelineDataReader
             .ToList();
     }
 
-    public async Task<List<ResourceGroupSummary>> GetReportResourceSummaryAsync(Guid scheduleId, string facilityId)
-    {
-        var identities = await GetReportResourceIdentitiesAsync(scheduleId, facilityId);
-        return identities
-            .GroupBy(r => new { r.PatientId, r.ResourceType })
-            .Select(g => new ResourceGroupSummary(g.Key.PatientId, g.Key.ResourceType, g.Count()))
-            .OrderBy(x => x.PatientId).ThenBy(x => x.ResourceType)
-            .ToList();
-    }
-
     public async Task<List<ReportPopulationInfo>> GetReportPopulationsAsync(Guid scheduleId, string facilityId)
     {
         var result = await GetOrFetchAsync($"populations:{scheduleId}:{facilityId}", async () =>
@@ -227,34 +216,6 @@ public class PipelineDataReader
                 p.GroupPopulations.Select(gp => new GroupPopulationInfo(
                     gp.PopulationCodeJson,
                     gp.MeasureReportPopulations.Select(mrp => new MeasureReportPopulationInfo(mrp.MeasureReportId)).ToList())).ToList())).ToList();
-        });
-
-        return result ?? [];
-    }
-
-    public async Task<List<ReportResourceIdentity>> GetReportResourceIdentitiesAsync(Guid scheduleId, string facilityId)
-    {
-        var result = await GetOrFetchAsync($"resourceIdentities:{scheduleId}:{facilityId}", async () =>
-        {
-            var pageNumber = 1;
-            const int pageSize = 100;
-            var results = new List<ReportResourceIdentity>();
-
-            while (true)
-            {
-                var page = await _reportClient.SearchResourcesAsync(facilityId, scheduleId.ToString(), pageSize: pageSize, pageNumber: pageNumber);
-                if (page?.Records == null || page.Records.Count == 0)
-                    break;
-
-                results.AddRange(page.Records.Select(r => new ReportResourceIdentity(r.PatientId, r.ResourceType, r.ResourceId)));
-
-                if (page.Records.Count < pageSize)
-                    break;
-
-                pageNumber++;
-            }
-
-            return results;
         });
 
         return result ?? [];
@@ -486,16 +447,6 @@ public class PipelineDataReader
                 facility.ScheduledReports?.Monthly ?? [],
                 facility.ScheduledReports?.Daily ?? [],
                 facility.ScheduledReports?.Weekly ?? []));
-    }
-
-    public async Task<List<PatientResourceTypeCount>> GetReportResourceCountsByPatientTypeAsync(Guid scheduleId, string facilityId)
-    {
-        var identities = await GetReportResourceIdentitiesAsync(scheduleId, facilityId);
-        return identities
-            .Where(r => !string.IsNullOrWhiteSpace(r.PatientId) && !string.IsNullOrWhiteSpace(r.ResourceType))
-            .GroupBy(r => new { r.PatientId, r.ResourceType })
-            .Select(g => new PatientResourceTypeCount(g.Key.PatientId, g.Key.ResourceType, g.Count()))
-            .ToList();
     }
 
     public async Task<List<PatientResourceTypeCount>> GetMeasureEvalResourceCountsByPatientTypeAsync(Guid scheduleId)

--- a/DotNet/Automation.Link/Helpers/PipelineSnapshot.cs
+++ b/DotNet/Automation.Link/Helpers/PipelineSnapshot.cs
@@ -89,11 +89,6 @@ public class PipelineSnapshot
                                  $"WithMeasureReportId: {withMrId}/{measureReports.Count}");
             }
 
-            var resources = await _reader.GetReportResourceSummaryAsync(scheduleId, facilityId);
-            var totalResources = resources.Sum(r => r.Count);
-            var patientCount = resources.Select(r => r.PatientId).Distinct().Count();
-            output.WriteLine($"[Snapshot][ReportResource]      {totalResources} resource(s) across {patientCount} patient(s)");
-
             var populations = await _reader.GetReportPopulationsAsync(scheduleId, facilityId);
             var groupCount = populations.SelectMany(p => p.GroupPopulations).Count();
             var mrpCount = populations.SelectMany(p => p.GroupPopulations).SelectMany(gp => gp.MeasureReportPopulations).Count();
@@ -238,12 +233,6 @@ public class PipelineSnapshot
                 .ToList();
 
             output.WriteLine($"[Snapshot][Validation]          ReportingStatus: {string.Join(", ", byReportingStatus)}");
-
-            var resourceCounts = await _reader.GetReportResourceCountsByPatientTypeAsync(scheduleId, facilityId);
-            var totalResources = resourceCounts.Sum(x => x.Count);
-            var patientCount = resourceCounts.Select(x => x.PatientId).Distinct(StringComparer.Ordinal).Count();
-
-            output.WriteLine($"[Snapshot][Validation]          Report resources: {totalResources} across {patientCount} patient(s)");
         }
         catch (Exception ex)
         {

--- a/DotNet/Automation.Link/Helpers/PipelineSummarySnapshotBuilder.cs
+++ b/DotNet/Automation.Link/Helpers/PipelineSummarySnapshotBuilder.cs
@@ -27,7 +27,6 @@ public class PipelineSummarySnapshotBuilder
         public IReadOnlyList<PipelineDataReader.ReportPopulationInfo> Populations { get; init; } = [];
         public PipelineDataReader.AcquisitionSummaryInfo? AcquisitionSummary { get; init; }
         public IReadOnlyList<PipelineDataReader.PatientResourceTypeCount> MeasureEvalResourceCounts { get; init; } = [];
-        public IReadOnlyList<PipelineDataReader.PatientResourceTypeCount> ReportResourceCounts { get; init; } = [];
 
         /// <summary>
         /// Structured test-validator results persisted by the run manager.
@@ -190,7 +189,6 @@ public class PipelineSummarySnapshotBuilder
         IReadOnlyList<PipelineDataReader.ReportPopulationInfo> populations;
         PipelineDataReader.AcquisitionSummaryInfo? acquisitionSummary;
         IReadOnlyList<PipelineDataReader.PatientResourceTypeCount> measureEvalResourceCounts;
-        IReadOnlyList<PipelineDataReader.PatientResourceTypeCount> reportResourceCounts;
 
         var data = await _domainDataProvider(scheduleId, facilityId);
         schedule = data.Schedule;
@@ -198,7 +196,6 @@ public class PipelineSummarySnapshotBuilder
         populations = data.Populations;
         acquisitionSummary = data.AcquisitionSummary;
         measureEvalResourceCounts = data.MeasureEvalResourceCounts;
-        reportResourceCounts = data.ReportResourceCounts;
 
         snapshot.Report.Schedule = schedule == null
             ? null
@@ -246,7 +243,6 @@ public class PipelineSummarySnapshotBuilder
             .ToList();
 
         var measureResources = measureEvalResourceCounts.Sum(x => x.Count);
-        var validationResources = reportResourceCounts.Sum(x => x.Count);
 
         // Normalization processes every resource acquired by DataAcquisition, so its
         // resource count mirrors DataAcquisition output. Resource type breakdown is the same.
@@ -256,19 +252,15 @@ public class PipelineSummarySnapshotBuilder
         snapshot.Normalization.ResourceTypeCounts = snapshot.DataAcquisition.ResourceTypeCounts.ToList();
 
         snapshot.MeasureEval.ResourceCount = measureResources;
-        snapshot.Validation.ResourceCount = validationResources;
-
         snapshot.MeasureEval.AverageResourcesPerSecond = ComputeResourcesPerSecond(measureResources, measureLines);
-        snapshot.Validation.AverageResourcesPerSecond = ComputeResourcesPerSecond(validationResources, validationLines);
+
+        // Validation operates in a per-patient context -- its 'resource count' is the
+        // number of patients whose validation reached a terminal status. The per-status
+        // breakdown is supplied below via FunnelCounts.
+        snapshot.Validation.ResourceCount = entries.Count;
+        snapshot.Validation.AverageResourcesPerSecond = ComputeResourcesPerSecond(entries.Count, validationLines);
 
         snapshot.MeasureEval.ResourceTypeCounts = measureEvalResourceCounts
-            .GroupBy(x => x.ResourceType)
-            .Select(g => new CategoryCountSnapshot { Status = g.Key, Count = g.Sum(x => x.Count) })
-            .OrderByDescending(x => x.Count)
-            .Take(15)
-            .ToList();
-
-        snapshot.Validation.ResourceTypeCounts = reportResourceCounts
             .GroupBy(x => x.ResourceType)
             .Select(g => new CategoryCountSnapshot { Status = g.Key, Count = g.Sum(x => x.Count) })
             .OrderByDescending(x => x.Count)

--- a/DotNet/Automation.Link/Validation/ReportAbsManifestValidator.cs
+++ b/DotNet/Automation.Link/Validation/ReportAbsManifestValidator.cs
@@ -20,11 +20,6 @@ public class ReportAbsManifestValidator
         "OperationOutcome"
     ];
 
-    private static readonly HashSet<string> AbsSupplementalResourceTypes =
-    [
-        "OperationOutcome"
-    ];
-
     private readonly IAutomationOutput _output;
     private readonly PipelineDataReader _reader;
 
@@ -130,16 +125,6 @@ public class ReportAbsManifestValidator
 
         if (!string.IsNullOrWhiteSpace(facilityId) && !string.IsNullOrWhiteSpace(reportId))
         {
-            await ValidateDatabaseReconciliationAsync(
-                facilityId,
-                reportId,
-                actualPatientFiles,
-                parsedPatientResources,
-                expectedMeasureIds,
-                manifest,
-                errors,
-                expectDataAcquisitionData);
-
             if (generatedBundles is { Count: > 0 })
             {
                 ValidateGeneratedBundleReconciliation(generatedBundles, parsedPatientResources, errors);
@@ -151,7 +136,7 @@ public class ReportAbsManifestValidator
         }
 
         // When a manifest is available, validate ABS resource counts against the concrete
-        // generated input â€” no DB interrogation or baseline needed.
+        // generated input — no DB interrogation or baseline needed.
         if (manifest != null)
         {
             // Populate the count-level expectation for OperationOutcome from the authoritative
@@ -199,7 +184,7 @@ public class ReportAbsManifestValidator
         }
         catch (Exception ex)
         {
-            // Do not fail the validator on a DB read hiccup â€” just log. The strict check
+            // Do not fail the validator on a DB read hiccup — just log. The strict check
             // will then flag any unpredicted OperationOutcomes, which is the safe default.
             _output.WriteLine($"[ABS][WARN] Could not read ReportEntry statuses to predict OperationOutcomes: {ex.Message}");
         }
@@ -408,114 +393,6 @@ public class ReportAbsManifestValidator
         }
     }
 
-    private async Task ValidateDatabaseReconciliationAsync(
-        string facilityId,
-        string reportId,
-        IReadOnlySet<string> actualPatientFiles,
-        List<AbsResourceRecord> patientResources,
-        IReadOnlyList<string> expectedMeasureIds,
-        GenerationManifest? manifest,
-        List<string> errors,
-        bool expectDataAcquisitionData)
-    {
-        if (!Guid.TryParse(reportId, out var scheduleId))
-        {
-            AddError(errors, $"Invalid reportId format for reconciliation: {reportId}");
-            return;
-        }
-
-        var reportResources = await _reader.GetReportResourceIdentitiesAsync(scheduleId, facilityId);
-        if (reportResources.Count == 0)
-        {
-            AddError(errors, "Report DB has no ReportResource rows for this schedule/facility.");
-            return;
-        }
-
-        var allEntries = await _reader.GetReportEntriesAsync(scheduleId);
-        var entryByPatient = allEntries
-            .GroupBy(e => e.PatientId)
-            .ToDictionary(g => g.Key, g => g.First(), StringComparer.Ordinal);
-
-        var submittedEntries = await _reader.GetSubmittedReportEntriesAsync(scheduleId);
-        var submittedPatients = submittedEntries.Select(e => e.PatientId).ToHashSet(StringComparer.Ordinal);
-        if (submittedPatients.Count > 0)
-        {
-            var artifactPatients = actualPatientFiles
-                .Select(f => f.Substring("patient-".Length, f.Length - "patient-".Length - ".ndjson".Length))
-                .ToHashSet(StringComparer.Ordinal);
-
-            foreach (var patientId in submittedPatients)
-            {
-                if (!artifactPatients.Contains(patientId))
-                    AddError(errors, $"Submitted ReportEntry patient {patientId} is missing a patient artifact file.");
-            }
-        }
-
-        var patientsWithOperationOutcome = patientResources
-            .Where(r => string.Equals(r.ResourceType, "OperationOutcome", StringComparison.OrdinalIgnoreCase))
-            .Select(r => r.PatientId)
-            .Distinct(StringComparer.Ordinal)
-            .ToList();
-
-        foreach (var patientId in patientsWithOperationOutcome)
-        {
-            if (!entryByPatient.TryGetValue(patientId, out var entry))
-            {
-                AddError(errors, $"Patient artifact for {patientId} contains OperationOutcome but no matching ReportEntry was found.");
-                continue;
-            }
-
-            if (!string.Equals(entry.ReportingStatus, "FailedValidation", StringComparison.OrdinalIgnoreCase))
-            {
-                AddError(errors,
-                    $"Patient artifact for {patientId} contains OperationOutcome but ReportEntry.ReportingStatus is {entry.ReportingStatus} (expected FailedValidation).");
-            }
-        }
-
-        var expectedKeys = reportResources
-            .Select(r => ToResourceKey(r.ResourceType, r.ResourceId))
-            .ToHashSet(StringComparer.OrdinalIgnoreCase);
-
-        var absKeys = patientResources
-            .Where(r => !string.IsNullOrWhiteSpace(r.ResourceType) && !string.IsNullOrWhiteSpace(r.ResourceId))
-            .Select(r => ToResourceKey(r.ResourceType, r.ResourceId))
-            .ToHashSet(StringComparer.OrdinalIgnoreCase);
-
-        var absComparableKeys = absKeys
-            .Where(k => !IsAbsSupplementalType(GetResourceTypeFromKey(k)))
-            .ToHashSet(StringComparer.OrdinalIgnoreCase);
-
-        var missingInAbs = expectedKeys.Except(absKeys, StringComparer.OrdinalIgnoreCase).Take(50).ToList();
-        foreach (var missing in missingInAbs)
-            AddError(errors, $"ABS patient artifacts are missing ReportResource {missing}.");
-
-        var unexpectedInAbs = absComparableKeys.Except(expectedKeys, StringComparer.OrdinalIgnoreCase).Take(50).ToList();
-        foreach (var extra in unexpectedInAbs)
-            AddError(errors, $"ABS patient artifacts contain unexpected resource not present in ReportResource table: {extra}.");
-
-        var reportCountMap = ToCountMap(
-            (await _reader.GetReportResourceCountsByPatientTypeAsync(scheduleId, facilityId))
-            .Select(x => (x.PatientId, x.ResourceType, x.Count)));
-
-        var absCountMap = ToCountMap(
-            patientResources
-                .Where(r => !string.IsNullOrWhiteSpace(r.ResourceType) && !string.IsNullOrWhiteSpace(r.ResourceId) && !IsAbsSupplementalType(r.ResourceType))
-                .GroupBy(r => new { r.PatientId, r.ResourceType })
-                .Select(g => (g.Key.PatientId, g.Key.ResourceType, g.Count())));
-
-        CompareCountMapsExact("ReportResource->ABS", reportCountMap, absCountMap, errors);
-
-        var measureEvalCountMap = ToCountMap(
-            (await _reader.GetMeasureEvalResourceCountsByPatientTypeAsync(scheduleId))
-            .Select(x => (x.PatientId, x.ResourceType, x.Count)));
-
-        CompareCountMapsExact("MeasureEval->ReportResource", measureEvalCountMap, reportCountMap, errors);
-        CompareCountMapsExact("MeasureEval->ABS", measureEvalCountMap, absCountMap, errors);
-
-        // NOTE: DataAcquisition database integrity checks belong in DA-focused validators.
-        // ABS validator intentionally reconciles deterministic expected sets against Report/ABS artifacts only.
-    }
-
     private void ValidateGeneratedBundleReconciliation(
         IReadOnlyList<(string Name, string Json)> generatedBundles,
         List<AbsResourceRecord> patientResources,
@@ -620,7 +497,7 @@ public class ReportAbsManifestValidator
     /// </list>
     ///
     /// A resource type is expected in ABS when: we generated it AND the query plan acquires
-    /// it AND the CQL references it. The system is deterministic â€” no tolerance is needed.
+    /// it AND the CQL references it. The system is deterministic — no tolerance is needed.
     ///
     /// Shared infrastructure resources are stored under the empty patient key in the manifest.
     /// They are excluded from per-patient key validation because their IDs are rewritten by
@@ -669,7 +546,7 @@ public class ReportAbsManifestValidator
                 {
                     AddError(errors,
                         $"ABS patient={patientId}, type={resourceType}: " +
-                        $"expected={expectedCount} (sim-acquired âˆ© reachable-CQL + derived), actual={actualCount}.");
+                        $"expected={expectedCount} (sim-acquired ? reachable-CQL + derived), actual={actualCount}.");
                 }
                 else
                 {
@@ -681,7 +558,7 @@ public class ReportAbsManifestValidator
         }
 
         // Validate that every expected patient-scoped resource key is present in ABS.
-        // Shared infrastructure (empty patient key) is excluded â€” those resources reach ABS
+        // Shared infrastructure (empty patient key) is excluded — those resources reach ABS
         // through MeasureReport contained resources with MeasureEval-rewritten IDs.
         var allAbsKeys = parsedPatientResources
             .Where(r => !string.IsNullOrWhiteSpace(r.ResourceType) && !string.IsNullOrWhiteSpace(r.ResourceId))
@@ -864,55 +741,8 @@ public class ReportAbsManifestValidator
 
     private static string ToResourceKey(string type, string id) => $"{type}/{id}";
 
-    private static string GetResourceTypeFromKey(string key)
-    {
-        var idx = key.IndexOf('/');
-        return idx > 0 ? key[..idx] : key;
-    }
-
     private static bool IsDerivedType(string resourceType) =>
         DerivedResourceTypes.Contains(resourceType, StringComparer.OrdinalIgnoreCase);
-
-    private static bool IsAbsSupplementalType(string resourceType) =>
-        AbsSupplementalResourceTypes.Contains(resourceType, StringComparer.OrdinalIgnoreCase);
-
-    private static Dictionary<(string PatientId, string ResourceType), int> ToCountMap(
-        IEnumerable<(string PatientId, string ResourceType, int Count)> source)
-    {
-        var map = new Dictionary<(string PatientId, string ResourceType), int>();
-
-        foreach (var row in source)
-        {
-            if (string.IsNullOrWhiteSpace(row.PatientId) || string.IsNullOrWhiteSpace(row.ResourceType))
-                continue;
-
-            var key = (row.PatientId, row.ResourceType);
-            map[key] = map.TryGetValue(key, out var existing) ? existing + row.Count : row.Count;
-        }
-
-        return map;
-    }
-
-    private static void CompareCountMapsExact(
-        string sourceName,
-        Dictionary<(string PatientId, string ResourceType), int> expected,
-        Dictionary<(string PatientId, string ResourceType), int> actual,
-        List<string> errors)
-    {
-        var keys = expected.Keys.Union(actual.Keys).ToList();
-
-        foreach (var key in keys)
-        {
-            expected.TryGetValue(key, out var expectedCount);
-            actual.TryGetValue(key, out var actualCount);
-
-            if (expectedCount != actualCount)
-            {
-                AddError(errors,
-                    $"{sourceName} count mismatch for patient={key.PatientId}, type={key.ResourceType}: expected={expectedCount}, actual={actualCount}.");
-            }
-        }
-    }
 
     private sealed record AbsResourceRecord(string SourceFile, string PatientId, string ResourceType, string ResourceId, JsonElement Resource);
 }

--- a/DotNet/Automation.Link/Validation/ReportDatabaseValidator.cs
+++ b/DotNet/Automation.Link/Validation/ReportDatabaseValidator.cs
@@ -66,7 +66,6 @@ public class ReportDatabaseValidator
             await ValidateScheduleReportTypes(scheduleId, expectedMeasureIds, errors);
             await ValidateReportEntries(scheduleId, facilityId, expectedPatientIds, expectedSubmitted, errors);
             await ValidateEntryMeasureReports(scheduleId, expectedMeasureIds, expectedPatientIds.Count, errors);
-            await ValidateReportResources(scheduleId, facilityId, expectedSubmitted, manifest, errors);
             await ValidateReportPopulations(scheduleId, facilityId, expectedMeasureIds, qualifyingCountPerMeasure, errors);
         }
         catch (Exception ex)
@@ -188,7 +187,7 @@ public class ReportDatabaseValidator
         var expectedTotal = expectedPatientCount * expectedMeasureIds.Count;
 
         if (reports.Count != expectedTotal)
-            AddError(errors, $"EntryMeasureReport count mismatch: expected {expectedTotal} ({expectedPatientCount} patients Ã— {expectedMeasureIds.Count} measures), actual {reports.Count}");
+            AddError(errors, $"EntryMeasureReport count mismatch: expected {expectedTotal} ({expectedPatientCount} patients × {expectedMeasureIds.Count} measures), actual {reports.Count}");
 
         var expectedSet = expectedMeasureIds.ToHashSet(StringComparer.OrdinalIgnoreCase);
         foreach (var report in reports)
@@ -198,70 +197,6 @@ public class ReportDatabaseValidator
 
             if (string.IsNullOrWhiteSpace(report.MeasureReportId))
                 AddError(errors, $"EntryMeasureReport {report.Id} MeasureReportId should be populated.");
-        }
-    }
-
-    private async Task ValidateReportResources(Guid scheduleId, string facilityId, List<string> expectedPatientIds, GenerationManifest? manifest, List<string> errors)
-    {
-        var resources = await _reader.GetReportResourceSummaryAsync(scheduleId, facilityId);
-        var patientsWithResources = resources.Select(r => r.PatientId).Distinct().ToHashSet();
-
-        foreach (var patientId in expectedPatientIds)
-        {
-            if (!patientsWithResources.Contains(patientId))
-                AddError(errors, $"No ReportResource rows found for expected patient {patientId}.");
-        }
-
-        // When the manifest is available, validate per-patient resource type counts.
-        // ReportResource is populated by PatientAggregator from the MeasureReport contained
-        // resources captured in the per-measure .mr file. Unlike the ABS patient NDJSON, the
-        // ReportResource table never receives OperationOutcome rows â€” ValidationCompleteListener
-        // appends those directly to the blob, bypassing the aggregation flow.
-        if (manifest != null)
-        {
-            var dbCountsByPatient = resources
-                .GroupBy(r => r.PatientId)
-                .ToDictionary(g => g.Key,
-                    g => g.GroupBy(r => r.ResourceType)
-                          .ToDictionary(rg => rg.Key, rg => rg.Sum(r => r.Count), StringComparer.OrdinalIgnoreCase),
-                    StringComparer.Ordinal);
-
-            foreach (var patientId in expectedPatientIds)
-            {
-                var expectedCounts = manifest.GetExpectedReportResourceCountsForPatient(patientId);
-                if (expectedCounts == null)
-                    continue;
-
-                dbCountsByPatient.TryGetValue(patientId, out var actualCounts);
-                actualCounts ??= new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
-
-                // Strict prediction-vs-actual: every expected type must match exactly, and any
-                // type actually present must have been predicted.
-                var allTypes = new HashSet<string>(expectedCounts.Keys, StringComparer.OrdinalIgnoreCase);
-                foreach (var t in actualCounts.Keys) allTypes.Add(t);
-
-                foreach (var resourceType in allTypes)
-                {
-                    expectedCounts.TryGetValue(resourceType, out var expectedCount);
-                    actualCounts.TryGetValue(resourceType, out var actualCount);
-
-                    if (actualCount == expectedCount)
-                        continue;
-
-                    if (actualCount < expectedCount)
-                    {
-                        AddError(errors,
-                            $"ReportResource count for patient={patientId}, type={resourceType}: " +
-                            $"expected={expectedCount} (sim-acquired âˆ© reachable-CQL + derived), actual={actualCount}.");
-                    }
-                    else
-                    {
-                        AddError(errors,
-                            $"ReportResource count for patient={patientId}, type={resourceType}: " +
-                            $"expected={expectedCount}, actual={actualCount} (DB has {actualCount - expectedCount} more than predicted).");
-                    }
-                }
-            }
         }
     }
 
@@ -298,7 +233,7 @@ public class ReportDatabaseValidator
             {
                 if (!measureHasQualifyingPatients)
                 {
-                    _output.WriteLine($"  ReportPopulation '{pop.ReportType}' has no GroupPopulations (expected â€” 0 qualifying patients per cohort config).");
+                    _output.WriteLine($"  ReportPopulation '{pop.ReportType}' has no GroupPopulations (expected — 0 qualifying patients per cohort config).");
                     continue;
                 }
 
@@ -316,7 +251,7 @@ public class ReportDatabaseValidator
             {
                 if (!measureHasQualifyingPatients)
                 {
-                    _output.WriteLine($"  ReportPopulation '{pop.ReportType}' has GroupPopulations but none are valid (expected â€” 0 qualifying patients per cohort config).");
+                    _output.WriteLine($"  ReportPopulation '{pop.ReportType}' has GroupPopulations but none are valid (expected — 0 qualifying patients per cohort config).");
                     continue;
                 }
 

--- a/DotNet/Automation.UI/Services/AutomationRunManager.cs
+++ b/DotNet/Automation.UI/Services/AutomationRunManager.cs
@@ -251,19 +251,17 @@ public class AutomationRunManager : IAutomationRunManager
                 var populations = await SafeGetDomainAsync<List<PipelineDataReader.ReportPopulationInfo>>(runId, "populations", cancellationToken) ?? [];
                 var acquisitionSummary = await SafeGetDomainAsync<PipelineDataReader.AcquisitionSummaryInfo>(runId, "acquisitionSummary", cancellationToken);
                 var measureResources = await SafeGetDomainAsync<List<PipelineDataReader.PatientResourceTypeCount>>(runId, "measureResources", cancellationToken) ?? [];
-                var validationResources = await SafeGetDomainAsync<List<PipelineDataReader.PatientResourceTypeCount>>(runId, "validationResources", cancellationToken) ?? [];
                 var validatorResults = await SafeGetDomainAsync<List<PipelineSummarySnapshotBuilder.ValidatorResultSnapshot>>(runId, "validatorResults", cancellationToken);
 
                 _logger.LogDebug(
-                    "[Snapshot][{RunId}] Domain data: schedule={HasSchedule}, entries={EntryCount}, populations={PopCount}, acqSummary={HasAcqSummary} (logs={AcqLogs}), measureRes={MeasureCount}, valRes={ValCount}",
+                    "[Snapshot][{RunId}] Domain data: schedule={HasSchedule}, entries={EntryCount}, populations={PopCount}, acqSummary={HasAcqSummary} (logs={AcqLogs}), measureRes={MeasureCount}",
                     runId,
                     schedule != null,
                     entries.Count,
                     populations.Count,
                     acquisitionSummary != null,
                     acquisitionSummary?.TotalLogs ?? 0,
-                    measureResources.Count,
-                    validationResources.Count);
+                    measureResources.Count);
 
                 return new PipelineSummarySnapshotBuilder.ResolvedDomainData
                 {
@@ -272,7 +270,6 @@ public class AutomationRunManager : IAutomationRunManager
                     Populations = populations,
                     AcquisitionSummary = acquisitionSummary,
                     MeasureEvalResourceCounts = measureResources,
-                    ReportResourceCounts = validationResources,
                     ValidatorResults = validatorResults
                 };
             });

--- a/DotNet/Automation.UI/Services/StoreBackedServicePoller.cs
+++ b/DotNet/Automation.UI/Services/StoreBackedServicePoller.cs
@@ -1,4 +1,4 @@
-ï»¿using Automation.UI.Services.Persistence;
+using Automation.UI.Services.Persistence;
 using LantanaGroup.Link.Automation.Link.Helpers;
 
 namespace Automation.UI.Services;
@@ -52,7 +52,7 @@ public sealed class StoreBackedServicePoller
                 await PollAllDomainsAsync(scheduleId, ct);
                 if (firstSuccess)
                 {
-                    _logger.LogInformation("[Run {RunId}] First poll success â€” all domains now persisted", _meta.RunId);
+                    _logger.LogInformation("[Run {RunId}] First poll success — all domains now persisted", _meta.RunId);
                     firstSuccess = false;
                 }
             }
@@ -83,8 +83,7 @@ public sealed class StoreBackedServicePoller
             PollDomainAsync("entries", () => PollEntriesAsync(scheduleId, ct)),
             PollDomainAsync("populations", () => PollPopulationsAsync(scheduleId, ct)),
             PollDomainAsync("acquisitionSummary", () => PollAcquisitionAsync(ct)),
-            PollDomainAsync("measureResources", () => PollMeasureEvalResourcesAsync(scheduleId, ct)),
-            PollDomainAsync("validationResources", () => PollValidationResourcesAsync(scheduleId, ct)));
+            PollDomainAsync("measureResources", () => PollMeasureEvalResourcesAsync(scheduleId, ct)));
     }
 
     private async Task PollDomainAsync(string domain, Func<Task> action)
@@ -95,7 +94,7 @@ public sealed class StoreBackedServicePoller
         }
         catch (OperationCanceledException)
         {
-            // Expected during shutdown â€” not an error.
+            // Expected during shutdown — not an error.
         }
         catch (Exception ex)
         {
@@ -162,7 +161,7 @@ public sealed class StoreBackedServicePoller
     {
         var summary = await _reader.GetDataAcquisitionReportSummaryAsync(_meta.ReportId);
 
-        // Always write â€” even when null â€” so stale data from a prior report
+        // Always write — even when null — so stale data from a prior report
         // (e.g., before regeneration cleared snapshots) is overwritten.
         await _store.SetDomainAsync(_meta.RunId, "acquisitionSummary", summary, ct);
     }
@@ -171,11 +170,5 @@ public sealed class StoreBackedServicePoller
     {
         var result = await _reader.GetMeasureEvalResourceCountsByPatientTypeAsync(scheduleId);
         await _store.SetDomainAsync(_meta.RunId, "measureResources", result, ct);
-    }
-
-    private async Task PollValidationResourcesAsync(Guid scheduleId, CancellationToken ct)
-    {
-        var result = await _reader.GetReportResourceCountsByPatientTypeAsync(scheduleId, _meta.FacilityId);
-        await _store.SetDomainAsync(_meta.RunId, "validationResources", result, ct);
     }
 }

--- a/DotNet/Automation.UI/Views/Runs/Details.cshtml
+++ b/DotNet/Automation.UI/Views/Runs/Details.cshtml
@@ -263,27 +263,23 @@
                 <div class="card-header"><i class="bi bi-shield-check me-2"></i>Validation</div>
                 <div class="card-body">
                     <div class="row g-3 mb-3">
-                        <div class="col-md-3"><div class="border rounded p-2"><div class="small text-muted">Resource Count</div><div class="fs-4 fw-semibold" id="validationResourceCount">0</div></div></div>
-                        <div class="col-md-3"><div class="border rounded p-2"><div class="small text-muted">Avg Resources/sec</div><div class="fs-4 fw-semibold" id="validationResPerSec">0.00</div></div></div>
-                        <div class="col-md-3"><div class="border rounded p-2"><div class="small text-muted">Events/sec</div><div class="fs-4 fw-semibold" id="validationRate">0.00</div></div></div>
+                        <div class="col-md-3"><div class="border rounded p-2"><div class="small text-muted">Patients</div><div class="fs-4 fw-semibold" id="validationPatientCount">0</div></div></div>
+                        <div class="col-md-3"><div class="border rounded p-2"><div class="small text-muted">Passed</div><div class="fs-4 fw-semibold text-success" id="validationPassedCount">0</div></div></div>
+                        <div class="col-md-3"><div class="border rounded p-2"><div class="small text-muted">Failed</div><div class="fs-4 fw-semibold text-danger" id="validationFailedCount">0</div></div></div>
                         <div class="col-md-3 d-flex align-items-end justify-content-end">
                             <button type="button" id="validationErrorsBtn" class="btn btn-sm btn-outline-danger" style="display:none;">Errors Encountered</button>
                         </div>
                     </div>
 
                     <div class="row g-3">
-                        <div class="col-md-4">
+                        <div class="col-md-6">
                             <div class="small text-muted mb-1">Validation Patient States</div>
                             <canvas id="validationStageChart" height="170" style="height:170px;max-height:170px;"></canvas>
                             <div id="validationStageLegend" class="small mt-2"></div>
                         </div>
-                        <div class="col-md-4">
+                        <div class="col-md-6">
                             <div class="small text-muted mb-1">Throughput Timeline (10s buckets)</div>
                             <canvas id="validationTimeline" height="90" style="height:90px;max-height:90px;"></canvas>
-                        </div>
-                        <div class="col-md-4">
-                            <div class="small text-muted mb-1">Top Resource Types</div>
-                            <canvas id="validationResourceMixChart" height="170" style="height:170px;max-height:170px;"></canvas>
                         </div>
                     </div>
                 </div>
@@ -1257,15 +1253,19 @@
                 measureErrors = snapshot.measureEval?.errors || [];
                 document.getElementById('measureErrorsBtn').style.display = measureErrors.length > 0 ? '' : 'none';
 
-                document.getElementById('validationRate').textContent = formatNumber(snapshot.validation?.completionRatePerSecond);
-                document.getElementById('validationResourceCount').textContent = snapshot.validation?.resourceCount || 0;
-                document.getElementById('validationResPerSec').textContent = formatNumber(snapshot.validation?.averageResourcesPerSecond);
-                renderStageChart('validationStageChart', 'validationStageLegend', snapshot.validation?.funnelCounts || [], {
+                const validationFunnel = snapshot.validation?.funnelCounts || [];
+                const validationTotal = validationFunnel.reduce((acc, item) => acc + (item.count || 0), 0);
+                const validationPassed = (validationFunnel.find(f => (f.status || '').toLowerCase() === 'passedvalidation') || {}).count || 0;
+                const validationFailed = (validationFunnel.find(f => (f.status || '').toLowerCase() === 'failedvalidation') || {}).count || 0;
+
+                document.getElementById('validationPatientCount').textContent = validationTotal;
+                document.getElementById('validationPassedCount').textContent = validationPassed;
+                document.getElementById('validationFailedCount').textContent = validationFailed;
+                renderStageChart('validationStageChart', 'validationStageLegend', validationFunnel, {
                     notvalidated: '#94a3b8',
                     failedvalidation: '#ef4444',
                     passedvalidation: '#198754'
                 });
-                renderResourceMix('validationResourceMixChart', snapshot.validation?.resourceTypeCounts || []);
                 renderTimeline('validationTimeline', snapshot.validation?.throughputBuckets || [], '#198754');
 
                 validationErrors = snapshot.validation?.errors || [];

--- a/DotNet/Automation/Generation/GenerationManifest.cs
+++ b/DotNet/Automation/Generation/GenerationManifest.cs
@@ -15,8 +15,8 @@ public sealed class GenerationManifest
     /// Resource types that are pipeline-derived (not produced by our FHIR generator).
     /// They appear in ABS as a deterministic function of the pipeline, not of generated input:
     /// <list type="bullet">
-    ///   <item><c>MeasureReport</c> — MeasureEval writes one per submitted patient per measure.</item>
-    ///   <item><c>OperationOutcome</c> — one per patient that fails validation. Normally 0;
+    ///   <item><c>MeasureReport</c> � MeasureEval writes one per submitted patient per measure.</item>
+    ///   <item><c>OperationOutcome</c> � one per patient that fails validation. Normally 0;
     ///         callers set <see cref="ExpectedOperationOutcomeCountByPatient"/> when failures are expected.</item>
     /// </list>
     /// These types are never compared key-for-key; instead a count-level prediction is added
@@ -169,7 +169,7 @@ public sealed class GenerationManifest
     ///         to <c>patient-{id}.ndjson</c> in ABS and to the ReportResource DB.</item>
     /// </list>
     ///
-    /// Therefore: Generated ∩ QP-Acquired ∩ CQL-Referenced = Expected in ABS.
+    /// Therefore: Generated ? QP-Acquired ? CQL-Referenced = Expected in ABS.
     /// </summary>
     public bool IsExpectedInAbs(string resourceType)
     {
@@ -184,56 +184,29 @@ public sealed class GenerationManifest
         if (CqlReferencedResourceTypes.Count > 0)
             return CqlReferencedResourceTypes.Contains(resourceType);
 
-        // Fallback when CQL analysis is unavailable — assume all acquired types pass
+        // Fallback when CQL analysis is unavailable � assume all acquired types pass
         return true;
     }
 
     /// <summary>
     /// Returns the per-patient resource type -> count map filtered to only types
-    /// expected in the ABS patient NDJSON artifact (generated ∩ query-plan-acquired ∩
+    /// expected in the ABS patient NDJSON artifact (generated ? query-plan-acquired ?
     /// CQL-referenced), plus deterministic pipeline-derived additions:
     /// <list type="bullet">
-    ///   <item><c>Patient</c> — always 1 for patients that qualify for any selected measure
+    ///   <item><c>Patient</c> � always 1 for patients that qualify for any selected measure
     ///         (MeasureEval's CQL engine loads Patient implicitly, so it always lands in ABS).</item>
-    ///   <item><c>MeasureReport</c> — one per measure the patient qualifies for
+    ///   <item><c>MeasureReport</c> � one per measure the patient qualifies for
     ///         (MeasureEval writes exactly one MeasureReport per submitted patient per measure).</item>
-    ///   <item><c>OperationOutcome</c> — the caller-supplied expectation from
-    ///         <see cref="ExpectedOperationOutcomeCountByPatient"/> (default 0). Only present
-    ///         in the ABS blob; not persisted to ReportResource DB.</item>
+    ///   <item><c>OperationOutcome</c> � the caller-supplied expectation from
+    ///         <see cref="ExpectedOperationOutcomeCountByPatient"/> (default 0). Appended
+    ///         directly to the patient aggregate blob by <c>ValidationCompleteListener</c>
+    ///         for any patient whose <c>ValidationComplete.IsValid == false</c>.</item>
     /// </list>
     /// </summary>
     public Dictionary<string, int>? GetExpectedAbsCountsForPatient(string patientId)
-        => BuildExpectedCountsForPatient(patientId, AbsDestination.PatientNdjson);
+        => BuildExpectedCountsForPatient(patientId);
 
-    /// <summary>
-    /// Returns the per-patient resource type -> count map expected in the <c>ReportResource</c>
-    /// database table. Same as <see cref="GetExpectedAbsCountsForPatient"/> except it excludes
-    /// resource types that are appended directly to the ABS blob by the Report service (bypassing
-    /// <c>PatientAggregator</c> and <c>ReportResourceManager</c>):
-    /// <list type="bullet">
-    ///   <item><c>OperationOutcome</c> — <c>ValidationCompleteListener</c> calls
-    ///         <c>AppendResourceToBlob</c> directly when <c>ValidationComplete.IsValid == false</c>,
-    ///         so the OO lands in <c>patient-{id}.ndjson</c> but is never inserted into
-    ///         <c>ReportResource</c>.</item>
-    /// </list>
-    /// </summary>
-    public Dictionary<string, int>? GetExpectedReportResourceCountsForPatient(string patientId)
-        => BuildExpectedCountsForPatient(patientId, AbsDestination.ReportResourceDb);
-
-    /// <summary>
-    /// Downstream persistence destinations for generated resources. The two destinations
-    /// differ only for types that are appended directly to the ABS blob by the Report
-    /// service (see <see cref="GetExpectedReportResourceCountsForPatient"/>).
-    /// </summary>
-    public enum AbsDestination
-    {
-        /// <summary>The patient NDJSON file in ABS (<c>patient-{id}.ndjson</c>).</summary>
-        PatientNdjson,
-        /// <summary>The <c>ReportResource</c> table in the Report database.</summary>
-        ReportResourceDb
-    }
-
-    private Dictionary<string, int>? BuildExpectedCountsForPatient(string patientId, AbsDestination destination)
+    private Dictionary<string, int>? BuildExpectedCountsForPatient(string patientId)
     {
         var expectedKeys = GetExpectedAbsKeysForPatient(patientId);
         var counts = expectedKeys
@@ -242,8 +215,8 @@ public sealed class GenerationManifest
             .GroupBy(t => t, StringComparer.OrdinalIgnoreCase)
             .ToDictionary(g => g.Key, g => g.Count(), StringComparer.OrdinalIgnoreCase);
 
-        // Pipeline-derived additions — count-level only because IDs are assigned downstream.
-        AddPipelineDerivedExpectedCounts(patientId, counts, destination);
+        // Pipeline-derived additions � count-level only because IDs are assigned downstream.
+        AddPipelineDerivedExpectedCounts(patientId, counts);
 
         return counts;
     }
@@ -251,11 +224,11 @@ public sealed class GenerationManifest
     /// <summary>
     /// Returns expected ABS resource keys for a patient using deterministic key-level logic:
     /// simulated-acquired keys (when available) filtered to types that pass all three gates
-    /// (generated ∩ acquired ∩ CQL-referenced). Falls back to generated keys when
+    /// (generated ? acquired ? CQL-referenced). Falls back to generated keys when
     /// acquisition simulation is unavailable.
     ///
     /// For patients qualifying for any selected measure, <c>Patient/{patientId}</c> is always
-    /// included — MeasureEval's CQL engine loads the Patient resource as an implicit anchor
+    /// included � MeasureEval's CQL engine loads the Patient resource as an implicit anchor
     /// even if the query plan has no explicit Patient query.
     ///
     /// Pipeline-derived resources (<c>MeasureReport</c>, <c>OperationOutcome</c>) are
@@ -301,10 +274,10 @@ public sealed class GenerationManifest
     /// <summary>
     /// Adds count-level predictions for pipeline-derived resource types that have no
     /// deterministic key-level prediction (IDs assigned downstream).
-    /// OperationOutcome is only added for the ABS blob destination — <c>ValidationCompleteListener</c>
-    /// appends it directly to the patient aggregate blob and it never reaches <c>ReportResource</c>.
+    /// <c>OperationOutcome</c> is appended directly to the patient aggregate blob by
+    /// <c>ValidationCompleteListener</c> when <c>ValidationComplete.IsValid == false</c>.
     /// </summary>
-    private void AddPipelineDerivedExpectedCounts(string patientId, Dictionary<string, int> counts, AbsDestination destination)
+    private void AddPipelineDerivedExpectedCounts(string patientId, Dictionary<string, int> counts)
     {
         var qualifyingMeasureCount = CountQualifyingMeasuresForPatient(patientId);
         if (qualifyingMeasureCount > 0)
@@ -313,8 +286,7 @@ public sealed class GenerationManifest
             counts["MeasureReport"] = qualifyingMeasureCount;
         }
 
-        if (destination == AbsDestination.PatientNdjson
-            && ExpectedOperationOutcomeCountByPatient != null
+        if (ExpectedOperationOutcomeCountByPatient != null
             && ExpectedOperationOutcomeCountByPatient.TryGetValue(patientId, out var ooCount)
             && ooCount > 0)
         {
@@ -438,7 +410,7 @@ public sealed class GenerationManifest
             eligibility[PatientIds[i]] = qualifying;
         }
 
-        // Build predicted ABS counts per patient (generated ∩ acquired ∩ CQL-referenced)
+        // Build predicted ABS counts per patient (generated ? acquired ? CQL-referenced)
         var expectedAbsByPatient = new Dictionary<string, Dictionary<string, int>>(StringComparer.Ordinal);
         var expectedAbsTotals = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
         foreach (var patientId in PatientIds)


### PR DESCRIPTION
### 🛠️ Description of Changes

Report ABS Validator no longer uses Report Resource as a second set of eyes, now relies entirely on Generation Manifest predictions.

Report Database Validator now excludes Report Resource from its validations.

### 🧪 Testing Performed

Please describe the testing that was performed on the changes included in this PR.

### 🧑‍🔬 Unit Testing

- [ ] I have written or updated unit tests to cover my changes
- Coverage: 0.0%

### 📓 Documentation Updated

Please update any relevant sections in the project documentation that were impacted by the changes in the PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated Validation metrics dashboard to display Patient count, Passed count, and Failed count instead of resource-based metrics.

* **Refactor**
  * Removed resource-based validation checks from the database reconciliation process.
  * Removed "Top Resource Types" chart from the Validation view.
  * Simplified expected count computation logic for validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
