### PR TITLE
LNK-4951: Data Acquisition checks Secret Management before Azure App Configuration is populated

### DIFF
--- a/DotNet/DataAcquisition.AcquisitionWorker/Program.cs
+++ b/DotNet/DataAcquisition.AcquisitionWorker/Program.cs
@@ -21,9 +21,9 @@ using System.Reflection;
 var builder = WebApplication.CreateBuilder(args);
 builder.Configuration.AddStandardEnvironmentConfiguration();
 
-var consumerSettings = builder.Configuration.GetRequiredSection(nameof(ConsumerSettings)).Get<ConsumerSettings>();
-
 builder.RegisterAll(DataAcquisitionWorkerConstants.ServiceName, configureRedis: true);
+
+var consumerSettings = builder.Configuration.GetRequiredSection(nameof(ConsumerSettings)).Get<ConsumerSettings>();
 
 builder.Services.AddTransient<SftpAcquisitionHandler>();
 

--- a/DotNet/DataAcquisition.AcquisitionWorker/Program.cs
+++ b/DotNet/DataAcquisition.AcquisitionWorker/Program.cs
@@ -1,4 +1,4 @@
-﻿using HealthChecks.UI.Client;
+using HealthChecks.UI.Client;
 using LantanaGroup.Link.DataAcquisition.AcquisitionWorker;
 using LantanaGroup.Link.DataAcquisition.AcquisitionWorker.Listeners;
 using LantanaGroup.Link.DataAcquisition.AcquisitionWorker.Services;
@@ -23,10 +23,7 @@ builder.Configuration.AddStandardEnvironmentConfiguration();
 
 var consumerSettings = builder.Configuration.GetRequiredSection(nameof(ConsumerSettings)).Get<ConsumerSettings>();
 
-// Determine if secret manager should be enabled based on configuration
-var secretManagerEnabled = builder.Configuration.GetValue<bool>("SecretManagement:Enabled");
-
-builder.RegisterAll(DataAcquisitionWorkerConstants.ServiceName, configureRedis: true, configureSecretManager: secretManagerEnabled);
+builder.RegisterAll(DataAcquisitionWorkerConstants.ServiceName, configureRedis: true);
 
 builder.Services.AddTransient<SftpAcquisitionHandler>();
 

--- a/DotNet/DataAcquisition.Domain/Extensions/GeneralStartupExtensions.cs
+++ b/DotNet/DataAcquisition.Domain/Extensions/GeneralStartupExtensions.cs
@@ -1,4 +1,4 @@
-﻿using System.Diagnostics;
+using System.Diagnostics;
 using System.Net;
 using System.Reflection;
 using Confluent.Kafka;
@@ -59,8 +59,7 @@ public static class GeneralStartupExtensions
     public static void RegisterAll(
         this WebApplicationBuilder builder,
         string serviceName,
-        bool? configureRedis = false,
-        bool? configureSecretManager = false)
+        bool? configureRedis = false)
     {
         var assemblyVersion = Assembly.GetExecutingAssembly().GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion ?? string.Empty;
 
@@ -82,7 +81,9 @@ public static class GeneralStartupExtensions
             builder.RegisterRedis();
         }
 
-        if (configureSecretManager.GetValueOrDefault())
+        // Determine if secret manager should be enabled based on configuration
+        var configureSecretManager = builder.Configuration.GetValue<bool>("SecretManagement:Enabled");
+        if (configureSecretManager)
         {
             builder.Services.RegisterSecretManager(builder.Configuration);
         }

--- a/DotNet/DataAcquisition/Program.cs
+++ b/DotNet/DataAcquisition/Program.cs
@@ -43,9 +43,9 @@ app.Run();
 
 static void RegisterServices(WebApplicationBuilder builder)
 {
-    var consumerSettings = builder.Configuration.GetRequiredSection(nameof(ConsumerSettings)).Get<ConsumerSettings>();
-
     builder.RegisterAll(DataAcquisitionConstants.ServiceName, configureRedis: true);
+
+    var consumerSettings = builder.Configuration.GetRequiredSection(nameof(ConsumerSettings)).Get<ConsumerSettings>();
 
     // Add Data Protection
     builder.Services.AddDataProtection()

--- a/DotNet/DataAcquisition/Program.cs
+++ b/DotNet/DataAcquisition/Program.cs
@@ -1,4 +1,4 @@
-﻿using HealthChecks.UI.Client;
+using HealthChecks.UI.Client;
 using Hl7.Fhir.Model;
 using Hl7.Fhir.Serialization;
 using LantanaGroup.Link.DataAcquisition.Domain.Application.Interfaces;
@@ -45,10 +45,7 @@ static void RegisterServices(WebApplicationBuilder builder)
 {
     var consumerSettings = builder.Configuration.GetRequiredSection(nameof(ConsumerSettings)).Get<ConsumerSettings>();
 
-    // Determine if secret manager should be enabled based on configuration
-    var secretManagerEnabled = builder.Configuration.GetValue<bool>("SecretManagement:Enabled");
-
-    builder.RegisterAll(DataAcquisitionConstants.ServiceName, configureRedis: true, configureSecretManager: secretManagerEnabled);
+    builder.RegisterAll(DataAcquisitionConstants.ServiceName, configureRedis: true);
 
     // Add Data Protection
     builder.Services.AddDataProtection()


### PR DESCRIPTION
### 🛠️ Description of Changes

Moved secret manager config check after AddExternalConfiguration. This ensures that configureSecretManager is using the value from external configuration when it is enabled.

### 🧪 Testing Performed

Observed the reported error when manually setting configureSecretManager to false. I was unable to do any further testing without promoting to a higher environment that is using Azure App Configuration.

### 🧑‍🔬 Unit Testing

- [ ] I have written or updated unit tests to cover my changes
- Coverage: 0.0%

### 📓 Documentation Updated

Please update any relevant sections in the project documentation that were impacted by the changes in the PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified internal service registration configuration by consolidating secret manager setup to rely on configuration settings rather than optional parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
