### PR TITLE
LNK-4227: Store facility credentials in Azure Key Vault

### DIFF
--- a/DotNet/Account/Program.cs
+++ b/DotNet/Account/Program.cs
@@ -131,13 +131,10 @@ static void RegisterServices(WebApplicationBuilder builder)
 
 
     // Add Secret Manager
-    if (builder.Configuration.GetValue<bool>("SecretManagement:Enabled"))
+    builder.Services.AddSecretManager(options =>
     {
-        builder.Services.AddSecretManager(options =>
-        {
-            options.Manager = builder.Configuration.GetValue<string>("SecretManagement:Manager")!;
-        });
-    }
+        options.Manager = builder.Configuration.GetValue<string>("SecretManagement:Manager") ?? "Local";
+    });
 
     // Add Link Security
     bool allowAnonymousAccess = builder.Configuration.GetValue<bool>("Authentication:EnableAnonymousAccess");

--- a/DotNet/Account/appsettings.Development.json
+++ b/DotNet/Account/appsettings.Development.json
@@ -21,7 +21,6 @@
     }
   },
   "SecretManagement": {
-    "Enabled": false,
     "Manager": "AzureKeyVault",
     "ManagerUri": ""
   },

--- a/DotNet/Account/appsettings.Docker.json
+++ b/DotNet/Account/appsettings.Docker.json
@@ -38,7 +38,7 @@
     "EnableAnonymousAccess": true
   },
   "SecretManagement": {
-    "Manager": "",
+    "Manager": "Local",
     "ManagerUri": ""
   },
   "Kestrel": {

--- a/DotNet/Account/appsettings.Docker.json
+++ b/DotNet/Account/appsettings.Docker.json
@@ -38,7 +38,6 @@
     "EnableAnonymousAccess": true
   },
   "SecretManagement": {
-    "Enabled": false,
     "Manager": "",
     "ManagerUri": ""
   },

--- a/DotNet/Account/appsettings.json
+++ b/DotNet/Account/appsettings.json
@@ -24,7 +24,6 @@
     }
   },
   "SecretManagement": {
-    "Enabled": false,
     "Manager": "",
     "ManagerUri": ""
   },

--- a/DotNet/Account/appsettings.json
+++ b/DotNet/Account/appsettings.json
@@ -24,7 +24,7 @@
     }
   },
   "SecretManagement": {
-    "Manager": "",
+    "Manager": "Local",
     "ManagerUri": ""
   },
   "Cache": {

--- a/DotNet/Admin.BFF/Program.cs
+++ b/DotNet/Admin.BFF/Program.cs
@@ -162,15 +162,12 @@ static void RegisterServices(WebApplicationBuilder builder)
     }
 
     // Add Secret Manager
-    if (builder.Configuration.GetValue<bool>("SecretManagement:Enabled"))
+    var secretManagerProvider = builder.Configuration.GetValue<string>("SecretManagement:Manager") ?? "Local";
+    Log.Logger.Information("Registering Secret Manager with provider {provider} for the Link Admin API.", secretManagerProvider);
+    builder.Services.AddSecretManager(options =>
     {
-        var manager = builder.Configuration.GetValue<string>("SecretManagement:Manager")!;
-        Log.Logger.Information("Registering Secret Manager with provider {provider} for the Link Admin API.", manager);
-        builder.Services.AddSecretManager(options =>
-        {
-            options.Manager = manager;
-        });
-    }
+        options.Manager = secretManagerProvider;
+    });
 
     // Add Link Security    
     if (!allowAnonymousAccess)

--- a/DotNet/Admin.BFF/appsettings.Development.json
+++ b/DotNet/Admin.BFF/appsettings.Development.json
@@ -6,7 +6,6 @@
   "MonitorBackendHealthChecks": false,
   "ExternalConfigurationSource": "",
   "SecretManagement": {
-    "Enabled": false,
     "Manager": "AzureKeyVault"
   },
   "DataProtection": {

--- a/DotNet/Admin.BFF/appsettings.json
+++ b/DotNet/Admin.BFF/appsettings.json
@@ -6,7 +6,6 @@
   "MonitorBackendHealthChecks": false,
   "ExternalConfigurationSource": "",
   "SecretManagement": {
-    "Enabled": false,
     "Manager": "",
     "ManagerUri": ""
   },

--- a/DotNet/Admin.BFF/appsettings.json
+++ b/DotNet/Admin.BFF/appsettings.json
@@ -6,7 +6,7 @@
   "MonitorBackendHealthChecks": false,
   "ExternalConfigurationSource": "",
   "SecretManagement": {
-    "Manager": "",
+    "Manager": "Local",
     "ManagerUri": ""
   },
   "DataProtection": {

--- a/DotNet/DataAcquisition.AcquisitionWorker/appsettings.Development.json
+++ b/DotNet/DataAcquisition.AcquisitionWorker/appsettings.Development.json
@@ -13,7 +13,6 @@
     "Redis": "localhost:6379"
   },
   "SecretManagement": {
-    "Enabled": true,
     "Manager": "",
     "ManagerUri": ""
   },

--- a/DotNet/DataAcquisition.AcquisitionWorker/appsettings.Development.json
+++ b/DotNet/DataAcquisition.AcquisitionWorker/appsettings.Development.json
@@ -13,7 +13,7 @@
     "Redis": "localhost:6379"
   },
   "SecretManagement": {
-    "Manager": "",
+    "Manager": "Local",
     "ManagerUri": ""
   },
   "DistributedLockSettings": {

--- a/DotNet/DataAcquisition.AcquisitionWorker/appsettings.json
+++ b/DotNet/DataAcquisition.AcquisitionWorker/appsettings.json
@@ -22,7 +22,6 @@
     "Redis": ""
   },
   "SecretManagement": {
-    "Enabled": false,
     "Manager": "",
     "ManagerUri": ""
   },

--- a/DotNet/DataAcquisition.AcquisitionWorker/appsettings.json
+++ b/DotNet/DataAcquisition.AcquisitionWorker/appsettings.json
@@ -22,7 +22,7 @@
     "Redis": ""
   },
   "SecretManagement": {
-    "Manager": "",
+    "Manager": "Local",
     "ManagerUri": ""
   },
   "DataAcquisitionVariablePaths": {

--- a/DotNet/DataAcquisition.Domain/Application/Services/Auth/BasicAuth.cs
+++ b/DotNet/DataAcquisition.Domain/Application/Services/Auth/BasicAuth.cs
@@ -1,5 +1,7 @@
 ﻿using DataAcquisition.Domain.Application.Models;
+using Hl7.Fhir.Model.CdsHooks;
 using LantanaGroup.Link.DataAcquisition.Domain.Application.Services.Interfaces;
+using LantanaGroup.Link.Shared.Application.Interfaces.Services;
 using System.Net.Http.Headers;
 using System.Text;
 
@@ -7,13 +9,38 @@ namespace LantanaGroup.Link.DataAcquisition.Domain.Application.Services.Auth;
 
 public class BasicAuth : IAuth
 {
+    private readonly ISecretManager _secretManager;
+
+    public BasicAuth(ISecretManager secretManager)
+    {
+        _secretManager = secretManager;
+    }
+
     public async Task<(bool isQueryParam, object authHeaderValue)> SetAuthentication(string facilityId, AuthenticationConfigurationModel authSettings)
     {
         char[]? credentialsArray = null;
 
         try
         {
-            credentialsArray = $"{authSettings.UserName}:{authSettings.Password}".ToCharArray();
+            if (string.IsNullOrWhiteSpace(authSettings.UserName))
+                throw new ArgumentException("A secret name for UserName must be provided for Basic authentication.");
+            if (string.IsNullOrWhiteSpace(authSettings.Password))
+                throw new ArgumentException("A secret name for Password must be provided for Basic authentication.");
+
+            var userName = await _secretManager.GetSecretAsync(authSettings.UserName, CancellationToken.None);
+            var password = await _secretManager.GetSecretAsync(authSettings.Password, CancellationToken.None);
+
+            if (string.IsNullOrWhiteSpace(userName))
+            {
+                throw new InvalidOperationException($"No value found in secret manager for UserName");
+            }
+            if (string.IsNullOrWhiteSpace(password))
+            {
+                throw new InvalidOperationException($"No value found in secret manager for Password");
+            }
+
+
+            credentialsArray = $"{userName}:{password}".ToCharArray();
 
             var pw = Convert.ToBase64String(Encoding.UTF8.GetBytes(credentialsArray));
 

--- a/DotNet/DataAcquisition.Domain/Application/Services/Auth/BasicAuth.cs
+++ b/DotNet/DataAcquisition.Domain/Application/Services/Auth/BasicAuth.cs
@@ -1,5 +1,4 @@
 ﻿using DataAcquisition.Domain.Application.Models;
-using Hl7.Fhir.Model.CdsHooks;
 using LantanaGroup.Link.DataAcquisition.Domain.Application.Services.Interfaces;
 using LantanaGroup.Link.Shared.Application.Interfaces.Services;
 using System.Net.Http.Headers;

--- a/DotNet/DataAcquisition.Domain/Application/Services/Auth/CustomHeaderAuth.cs
+++ b/DotNet/DataAcquisition.Domain/Application/Services/Auth/CustomHeaderAuth.cs
@@ -25,7 +25,12 @@ public class CustomHeaderAuth : IAuth
         {
             var secretName = header.Value;
             var secretValue = await _secretManager.GetSecretAsync(secretName, CancellationToken.None);
-            headers.Add(header.Key, secretValue ?? "");
+            if (string.IsNullOrEmpty(secretValue))
+            {
+                throw new InvalidOperationException(
+                    $"Secret for custom auth header '{header.Key}' (secret name: '{secretName}') could not be resolved or is empty.");
+            }
+            headers.Add(header.Key, secretValue);
         }
 
         return (false, headers);

--- a/DotNet/DataAcquisition.Domain/Application/Services/Auth/CustomHeaderAuth.cs
+++ b/DotNet/DataAcquisition.Domain/Application/Services/Auth/CustomHeaderAuth.cs
@@ -1,17 +1,33 @@
 using DataAcquisition.Domain.Application.Models;
 using LantanaGroup.Link.DataAcquisition.Domain.Application.Services.Interfaces;
+using LantanaGroup.Link.Shared.Application.Interfaces.Services;
 
 namespace LantanaGroup.Link.DataAcquisition.Domain.Application.Services.Auth;
 
 public class CustomHeaderAuth : IAuth
 {
-    public Task<(bool isQueryParam, object authHeaderValue)> SetAuthentication(string facilityId, AuthenticationConfigurationModel authSettings)
+    private readonly ISecretManager _secretManager;
+
+    public CustomHeaderAuth(ISecretManager secretManager)
+    {
+        _secretManager = secretManager;
+    }
+
+    public async Task<(bool isQueryParam, object authHeaderValue)> SetAuthentication(string facilityId, AuthenticationConfigurationModel authSettings)
     {
         if (authSettings.CustomHeaders == null || !authSettings.CustomHeaders.Any())
         {
-            return Task.FromResult<(bool, object)>((false, null));
+            return (false, new Dictionary<string, string>());
         }
 
-        return Task.FromResult<(bool, object)>((false, authSettings.CustomHeaders));
+        var headers = new Dictionary<string, string>();
+        foreach (var header in authSettings.CustomHeaders)
+        {
+            var secretName = header.Value;
+            var secretValue = await _secretManager.GetSecretAsync(secretName, CancellationToken.None);
+            headers.Add(header.Key, secretValue ?? "");
+        }
+
+        return (false, headers);
     }
 }

--- a/DotNet/DataAcquisition.Domain/Application/Services/Auth/EpicAuth.cs
+++ b/DotNet/DataAcquisition.Domain/Application/Services/Auth/EpicAuth.cs
@@ -13,6 +13,7 @@ using LantanaGroup.Link.DataAcquisition.Domain.Application.Services.Interfaces;
 using Org.BouncyCastle.Crypto;
 using Org.BouncyCastle.Crypto.Parameters;
 using Org.BouncyCastle.Security;
+using LantanaGroup.Link.Shared.Application.Interfaces.Services;
 
 namespace LantanaGroup.Link.DataAcquisition.Domain.Application.Services.Auth;
 
@@ -21,16 +22,18 @@ public class EpicAuth : IAuth
     private readonly HttpClient _httpClient;
     private readonly ILogger<EpicAuth> _logger;
     private readonly ICacheService _cacheService;
-
+    private readonly ISecretManager _secretManager;
     public EpicAuth(
         HttpClient httpClient,
         ILogger<EpicAuth> logger,
-        ICacheService cacheService
+        ICacheService cacheService,
+        ISecretManager secretManager
         )
     {
         _httpClient = httpClient;
         _logger = logger;
         _cacheService = cacheService;
+        _secretManager = secretManager;
     }
 
     /// <summary>
@@ -46,7 +49,7 @@ public class EpicAuth : IAuth
         if (!string.IsNullOrWhiteSpace(cachedToken))
             return (false, new AuthenticationHeaderValue("Bearer", cachedToken));
 
-        string jwt = GetJwt(authSettings);
+        string jwt = await GetJwt(authSettings);
 
         try
         {
@@ -84,7 +87,7 @@ public class EpicAuth : IAuth
         return sanitizedInput;
     }
 
-    private string GetJwt(AuthenticationConfigurationModel authSettings)
+    private async Task<string> GetJwt(AuthenticationConfigurationModel authSettings)
     {
         var key = authSettings.Key.Replace("\\r\\n\\t", "\r\n\t");
 
@@ -106,16 +109,24 @@ public class EpicAuth : IAuth
 
         var signingCredentials = new SigningCredentials(rsaKey, SecurityAlgorithms.RsaSha256);
 
+        if (string.IsNullOrWhiteSpace(authSettings.ClientId))
+                throw new ArgumentException("A secret name for ClientId must be provided for Epic authentication.");
+
+        var clientId = await _secretManager.GetSecretAsync(authSettings.ClientId, CancellationToken.None);
+
+        if (string.IsNullOrWhiteSpace(clientId))
+            throw new InvalidOperationException($"No value found in secret manager for ClientId");
+
         var descriptor = new SecurityTokenDescriptor
         {
-            Issuer = authSettings.ClientId,
+            Issuer = clientId,
             Audience = authSettings.TokenUrl,
             IssuedAt = now,
             NotBefore = now,
             Expires = now.AddMinutes(4),
             AdditionalHeaderClaims = headers,
             Claims = new Dictionary<string, object> { { "jti", Guid.NewGuid().ToString() } },
-            Subject = new ClaimsIdentity(new List<Claim> { new Claim("sub", authSettings.ClientId) }),
+            Subject = new ClaimsIdentity(new List<Claim> { new Claim("sub", clientId) }),
             SigningCredentials = signingCredentials
         };
 

--- a/DotNet/DataAcquisition.Domain/Application/Services/Auth/EpicAuth.cs
+++ b/DotNet/DataAcquisition.Domain/Application/Services/Auth/EpicAuth.cs
@@ -73,7 +73,7 @@ public class EpicAuth : IAuth
                 }
             }
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not ArgumentException && ex is not InvalidOperationException)
         {
             _logger.LogError(ex, "Error Acquiring Access Token Encountered");
         }

--- a/DotNet/DataAcquisition.Domain/Application/Services/Auth/OAuth.cs
+++ b/DotNet/DataAcquisition.Domain/Application/Services/Auth/OAuth.cs
@@ -2,6 +2,7 @@ using DataAcquisition.Domain.Application.Models;
 using LantanaGroup.Link.DataAcquisition.Domain.Application.Services.Interfaces;
 using LantanaGroup.Link.DataAcquisition.Domain.Settings;
 using LantanaGroup.Link.Shared.Application.Interfaces;
+using LantanaGroup.Link.Shared.Application.Interfaces.Services;
 using LantanaGroup.Link.Shared.Application.Models.Configs;
 using LantanaGroup.Link.Shared.Application.Services.Security;
 using Microsoft.Extensions.Logging;
@@ -14,15 +15,18 @@ public class OAuth : IAuth
     private readonly HttpClient _httpClient;
     private readonly ILogger<OAuth> _logger;
     private readonly ICacheService _cacheService;
+    private readonly ISecretManager _secretManager;
 
     public OAuth(
         HttpClient httpClient,
         ILogger<OAuth> logger,
-        ICacheService cacheService)
+        ICacheService cacheService,
+        ISecretManager secretManager)
     {
         _httpClient = httpClient;
         _logger = logger;
         _cacheService = cacheService;
+        _secretManager = secretManager;
     }
 
     public async Task<(bool isQueryParam, object authHeaderValue)> SetAuthentication(string facilityId, AuthenticationConfigurationModel authSettings)
@@ -34,8 +38,21 @@ public class OAuth : IAuth
 
         try
         {
+            if (string.IsNullOrWhiteSpace(authSettings.ClientId))
+                throw new ArgumentException("A secret name for ClientId must be provided for OAuth authentication.");
+            if (string.IsNullOrWhiteSpace(authSettings.ClientSecret))
+                throw new ArgumentException("A secret name for ClientSecret must be provided for OAuth authentication.");
+
+            var clientId = await _secretManager.GetSecretAsync(authSettings.ClientId, CancellationToken.None);
+            var clientSecret = await _secretManager.GetSecretAsync(authSettings.ClientSecret, CancellationToken.None);
+
+            if (string.IsNullOrWhiteSpace(clientId))
+                throw new InvalidOperationException($"No value found in secret manager for ClientId");
+            if (string.IsNullOrWhiteSpace(clientSecret))
+                throw new InvalidOperationException($"No value found in secret manager for ClientSecret");
+
             var credentials = Convert.ToBase64String(
-                System.Text.Encoding.UTF8.GetBytes($"{authSettings.ClientId}:{authSettings.ClientSecret}"));
+                System.Text.Encoding.UTF8.GetBytes($"{clientId}:{clientSecret}"));
 
             var request = new HttpRequestMessage(HttpMethod.Post, authSettings.TokenUrl);
             request.Headers.Authorization = new AuthenticationHeaderValue("Basic", credentials);

--- a/DotNet/DataAcquisition.Domain/Application/Services/Auth/OAuth.cs
+++ b/DotNet/DataAcquisition.Domain/Application/Services/Auth/OAuth.cs
@@ -84,7 +84,7 @@ public class OAuth : IAuth
                 }
             }
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not ArgumentException && ex is not InvalidOperationException)
         {
             _logger.LogError(ex, "Error acquiring OAuth access token for facility {FacilityId}", facilityId.SanitizeUntrustedString());
         }

--- a/DotNet/DataAcquisition.Domain/Extensions/GeneralStartupExtensions.cs
+++ b/DotNet/DataAcquisition.Domain/Extensions/GeneralStartupExtensions.cs
@@ -81,12 +81,7 @@ public static class GeneralStartupExtensions
             builder.RegisterRedis();
         }
 
-        // Determine if secret manager should be enabled based on configuration
-        var configureSecretManager = builder.Configuration.GetValue<bool>("SecretManagement:Enabled");
-        if (configureSecretManager)
-        {
-            builder.Services.RegisterSecretManager(builder.Configuration);
-        }
+        builder.Services.RegisterSecretManager(builder.Configuration);
 
         builder.Services.RegisterInMemoryCache();
         builder.Services.RegisterHittpClient();

--- a/DotNet/DataAcquisition/appsettings.Development.json
+++ b/DotNet/DataAcquisition/appsettings.Development.json
@@ -17,7 +17,7 @@
     "SaslUsername": ""
   },
   "SecretManagement": {
-    "Manager": "",
+    "Manager": "Local",
     "ManagerUri": ""
   },
   "Authentication": {

--- a/DotNet/DataAcquisition/appsettings.Development.json
+++ b/DotNet/DataAcquisition/appsettings.Development.json
@@ -17,7 +17,6 @@
     "SaslUsername": ""
   },
   "SecretManagement": {
-    "Enabled": true,
     "Manager": "",
     "ManagerUri": ""
   },

--- a/DotNet/DataAcquisition/appsettings.Docker.json
+++ b/DotNet/DataAcquisition/appsettings.Docker.json
@@ -16,7 +16,7 @@
     "Redis": "redis_cache:6379"
   },
   "SecretManagement": {
-    "Manager": "",
+    "Manager": "Local",
     "ManagerUri": ""
   },
   "DistributedLockSettings": {

--- a/DotNet/DataAcquisition/appsettings.Docker.json
+++ b/DotNet/DataAcquisition/appsettings.Docker.json
@@ -16,7 +16,6 @@
     "Redis": "redis_cache:6379"
   },
   "SecretManagement": {
-    "Enabled": true,
     "Manager": "",
     "ManagerUri": ""
   },

--- a/DotNet/DataAcquisition/appsettings.json
+++ b/DotNet/DataAcquisition/appsettings.json
@@ -37,7 +37,6 @@
     "Redis": ""
   },
   "SecretManagement": {
-    "Enabled": false,
     "Manager": "",
     "ManagerUri": ""
   },

--- a/DotNet/ServiceTests/UnitTests/DataAcquisition/Services/Auth/BasicAuthTests.cs
+++ b/DotNet/ServiceTests/UnitTests/DataAcquisition/Services/Auth/BasicAuthTests.cs
@@ -1,0 +1,124 @@
+using DataAcquisition.Domain.Application.Models;
+using LantanaGroup.Link.DataAcquisition.Domain.Application.Services.Auth;
+using LantanaGroup.Link.Shared.Application.Interfaces.Services;
+using Moq;
+using System.Net.Http.Headers;
+using System.Text;
+using Task = System.Threading.Tasks.Task;
+
+namespace UnitTests.DataAcquisition.Auth;
+
+[Trait("Category", "UnitTests")]
+public class BasicAuthTests
+{
+    private const string FacilityId = "test-facility";
+    private const string UserNameSecretKey = "secret/username";
+    private const string PasswordSecretKey = "secret/password";
+    private const string ResolvedUserName = "testuser";
+    private const string ResolvedPassword = "testpass";
+
+    private readonly Mock<ISecretManager> _mockSecretManager;
+
+    public BasicAuthTests()
+    {
+        _mockSecretManager = new Mock<ISecretManager>();
+        _mockSecretManager
+            .Setup(x => x.GetSecretAsync(UserNameSecretKey, CancellationToken.None))
+            .ReturnsAsync(ResolvedUserName);
+        _mockSecretManager
+            .Setup(x => x.GetSecretAsync(PasswordSecretKey, CancellationToken.None))
+            .ReturnsAsync(ResolvedPassword);
+    }
+
+    private BasicAuth BuildSut() => new(_mockSecretManager.Object);
+
+    private static AuthenticationConfigurationModel BuildAuthSettings(
+        string? userName = UserNameSecretKey,
+        string? password = PasswordSecretKey) => new()
+        {
+            AuthType = "Basic",
+            UserName = userName,
+            Password = password
+        };
+
+    [Fact]
+    public async Task SetAuthentication_ReturnsIsQueryParamFalse_WhenCredentialsAreValid()
+    {
+        var sut = BuildSut();
+
+        var (isQueryParam, _) = await sut.SetAuthentication(FacilityId, BuildAuthSettings());
+
+        Assert.False(isQueryParam);
+    }
+
+    [Fact]
+    public async Task SetAuthentication_ReturnsBasicScheme_WhenCredentialsAreValid()
+    {
+        var sut = BuildSut();
+
+        var (_, authHeaderValue) = await sut.SetAuthentication(FacilityId, BuildAuthSettings());
+
+        var header = Assert.IsType<AuthenticationHeaderValue>(authHeaderValue);
+        Assert.Equal("basic", header.Scheme);
+    }
+
+    [Fact]
+    public async Task SetAuthentication_ReturnsBase64EncodedCredentials_WhenCredentialsAreValid()
+    {
+        var sut = BuildSut();
+        var expectedParameter = Convert.ToBase64String(
+            Encoding.UTF8.GetBytes($"{ResolvedUserName}:{ResolvedPassword}".ToCharArray()));
+
+        var (_, authHeaderValue) = await sut.SetAuthentication(FacilityId, BuildAuthSettings());
+
+        var header = Assert.IsType<AuthenticationHeaderValue>(authHeaderValue);
+        Assert.Equal(expectedParameter, header.Parameter);
+    }
+
+    [Fact]
+    public async Task SetAuthentication_ResolvesCredentials_FromSecretManager()
+    {
+        var sut = BuildSut();
+
+        await sut.SetAuthentication(FacilityId, BuildAuthSettings());
+
+        _mockSecretManager.Verify(x => x.GetSecretAsync(UserNameSecretKey, CancellationToken.None), Times.Once);
+        _mockSecretManager.Verify(x => x.GetSecretAsync(PasswordSecretKey, CancellationToken.None), Times.Once);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task SetAuthentication_ThrowsArgumentException_WhenUserNameIsNullOrWhitespace(string? userName)
+    {
+        var sut = BuildSut();
+
+        await Assert.ThrowsAsync<ArgumentException>(() =>
+            sut.SetAuthentication(FacilityId, BuildAuthSettings(userName: userName)));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task SetAuthentication_ThrowsArgumentException_WhenPasswordIsNullOrWhitespace(string? password)
+    {
+        var sut = BuildSut();
+
+        await Assert.ThrowsAsync<ArgumentException>(() =>
+            sut.SetAuthentication(FacilityId, BuildAuthSettings(password: password)));
+    }
+
+    [Fact]
+    public async Task SetAuthentication_PropagatesException_WhenSecretManagerThrows()
+    {
+        _mockSecretManager
+            .Setup(x => x.GetSecretAsync(UserNameSecretKey, CancellationToken.None))
+            .ThrowsAsync(new InvalidOperationException("Secret store unavailable."));
+        var sut = BuildSut();
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            sut.SetAuthentication(FacilityId, BuildAuthSettings()));
+    }
+}

--- a/DotNet/ServiceTests/UnitTests/DataAcquisition/Services/Auth/BasicAuthTests.cs
+++ b/DotNet/ServiceTests/UnitTests/DataAcquisition/Services/Auth/BasicAuthTests.cs
@@ -121,4 +121,34 @@ public class BasicAuthTests
         await Assert.ThrowsAsync<InvalidOperationException>(() =>
             sut.SetAuthentication(FacilityId, BuildAuthSettings()));
     }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task SetAuthentication_ThrowsInvalidOperationException_WhenSecretManagerReturnsNullOrWhitespaceForUserName(string? resolvedUserName)
+    {
+        _mockSecretManager
+            .Setup(x => x.GetSecretAsync(UserNameSecretKey, CancellationToken.None))
+            .ReturnsAsync(resolvedUserName);
+        var sut = BuildSut();
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            sut.SetAuthentication(FacilityId, BuildAuthSettings()));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task SetAuthentication_ThrowsInvalidOperationException_WhenSecretManagerReturnsNullOrWhitespaceForPassword(string? resolvedPassword)
+    {
+        _mockSecretManager
+            .Setup(x => x.GetSecretAsync(PasswordSecretKey, CancellationToken.None))
+            .ReturnsAsync(resolvedPassword);
+        var sut = BuildSut();
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            sut.SetAuthentication(FacilityId, BuildAuthSettings()));
+    }
 }

--- a/DotNet/ServiceTests/UnitTests/DataAcquisition/Services/Auth/CustomHeaderAuthTests.cs
+++ b/DotNet/ServiceTests/UnitTests/DataAcquisition/Services/Auth/CustomHeaderAuthTests.cs
@@ -1,5 +1,7 @@
 using DataAcquisition.Domain.Application.Models;
 using LantanaGroup.Link.DataAcquisition.Domain.Application.Services.Auth;
+using LantanaGroup.Link.Shared.Application.Interfaces.Services;
+using Moq;
 using Task = System.Threading.Tasks.Task;
 
 namespace UnitTests.DataAcquisition.Auth;
@@ -7,11 +9,23 @@ namespace UnitTests.DataAcquisition.Auth;
 [Trait("Category", "UnitTests")]
 public class CustomHeaderAuthTests
 {
+    private readonly Mock<ISecretManager> _mockSecretManager;
+
+    public CustomHeaderAuthTests()
+    {
+        _mockSecretManager = new Mock<ISecretManager>();
+        _mockSecretManager
+            .Setup(x => x.GetSecretAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((string name, CancellationToken _) => name);
+    }
+
+    private CustomHeaderAuth BuildSut() => new(_mockSecretManager.Object);
+
     [Fact]
-    public async Task SetAuthentication_WithNullCustomHeaders_ReturnsNullValue()
+    public async Task SetAuthentication_WithNullCustomHeaders_ReturnsEmptyDictionary()
     {
         // Arrange
-        var customHeaderAuth = new CustomHeaderAuth();
+        var customHeaderAuth = BuildSut();
         var facilityId = "test-facility-id";
         var authSettings = new AuthenticationConfigurationModel
         {
@@ -24,14 +38,15 @@ public class CustomHeaderAuthTests
 
         // Assert
         Assert.False(result.isQueryParam);
-        Assert.Null(result.authHeaderValue);
+        var returnedHeaders = Assert.IsType<Dictionary<string, string>>(result.authHeaderValue);
+        Assert.Empty(returnedHeaders);
     }
 
     [Fact]
-    public async System.Threading.Tasks.Task SetAuthentication_WithEmptyCustomHeaders_ReturnsNullValue()
+    public async System.Threading.Tasks.Task SetAuthentication_WithEmptyCustomHeaders_ReturnsEmptyDictionary()
     {
         // Arrange
-        var customHeaderAuth = new CustomHeaderAuth();
+        var customHeaderAuth = BuildSut();
         var facilityId = "test-facility-id";
         var authSettings = new AuthenticationConfigurationModel
         {
@@ -44,14 +59,15 @@ public class CustomHeaderAuthTests
 
         // Assert
         Assert.False(result.isQueryParam);
-        Assert.Null(result.authHeaderValue);
+        var returnedHeaders = Assert.IsType<Dictionary<string, string>>(result.authHeaderValue);
+        Assert.Empty(returnedHeaders);
     }
 
     [Fact]
     public async Task SetAuthentication_WithSingleCustomHeader_ReturnsHeaderDictionary()
     {
         // Arrange
-        var customHeaderAuth = new CustomHeaderAuth();
+        var customHeaderAuth = BuildSut();
         var facilityId = "test-facility-id";
         var expectedHeaders = new Dictionary<string, string>
         {
@@ -79,7 +95,7 @@ public class CustomHeaderAuthTests
     public async Task SetAuthentication_WithMultipleCustomHeaders_ReturnsAllHeaders()
     {
         // Arrange
-        var customHeaderAuth = new CustomHeaderAuth();
+        var customHeaderAuth = BuildSut();
         var facilityId = "test-facility-id";
         var expectedHeaders = new Dictionary<string, string>
         {
@@ -111,7 +127,7 @@ public class CustomHeaderAuthTests
     public async Task SetAuthentication_IsQueryParamAlwaysFalse()
     {
         // Arrange
-        var customHeaderAuth = new CustomHeaderAuth();
+        var customHeaderAuth = BuildSut();
         var facilityId = "test-facility-id";
         var authSettings = new AuthenticationConfigurationModel
         {
@@ -130,10 +146,10 @@ public class CustomHeaderAuthTests
     }
 
     [Fact]
-    public async Task SetAuthentication_ReturnsSameHeadersObject()
+    public async Task SetAuthentication_ReturnsEqualHeadersObject()
     {
         // Arrange
-        var customHeaderAuth = new CustomHeaderAuth();
+        var customHeaderAuth = BuildSut();
         var facilityId = "test-facility-id";
         var expectedHeaders = new Dictionary<string, string>
         {
@@ -149,14 +165,14 @@ public class CustomHeaderAuthTests
         var result = await customHeaderAuth.SetAuthentication(facilityId, authSettings);
 
         // Assert
-        Assert.Same(expectedHeaders, result.authHeaderValue);
+        Assert.Equal(expectedHeaders, result.authHeaderValue);
     }
 
     [Fact]
     public async Task SetAuthentication_WithDifferentFacilityIds_ReturnsExpectedHeaders()
     {
         // Arrange
-        var customHeaderAuth = new CustomHeaderAuth();
+        var customHeaderAuth = BuildSut();
         var headers1 = new Dictionary<string, string> { { "X-Header-1", "Value-1" } };
         var headers2 = new Dictionary<string, string> { { "X-Header-2", "Value-2" } };
         
@@ -177,7 +193,7 @@ public class CustomHeaderAuthTests
         var result2 = await customHeaderAuth.SetAuthentication("facility-2", authSettings2);
 
         // Assert
-        Assert.Same(headers1, result1.authHeaderValue);
-        Assert.Same(headers2, result2.authHeaderValue);
+        Assert.Equal(headers1, result1.authHeaderValue);
+        Assert.Equal(headers2, result2.authHeaderValue);
     }
 }

--- a/DotNet/ServiceTests/UnitTests/DataAcquisition/Services/Auth/OAuthTests.cs
+++ b/DotNet/ServiceTests/UnitTests/DataAcquisition/Services/Auth/OAuthTests.cs
@@ -2,6 +2,7 @@ using DataAcquisition.Domain.Application.Models;
 using LantanaGroup.Link.DataAcquisition.Domain.Application.Services.Auth;
 using LantanaGroup.Link.DataAcquisition.Domain.Settings;
 using LantanaGroup.Link.Shared.Application.Interfaces;
+using LantanaGroup.Link.Shared.Application.Interfaces.Services;
 using LantanaGroup.Link.Shared.Application.Models.Configs;
 using Microsoft.Extensions.Logging;
 using Moq;
@@ -24,15 +25,20 @@ public class OAuthTests
 
     private readonly Mock<ILogger<OAuth>> _mockLogger;
     private readonly Mock<ICacheService> _mockCacheService;
+    private readonly Mock<ISecretManager> _mockSecretManager;
 
     public OAuthTests()
     {
         _mockLogger = new Mock<ILogger<OAuth>>();
         _mockCacheService = new Mock<ICacheService>();
+        _mockSecretManager = new Mock<ISecretManager>();
+        _mockSecretManager
+            .Setup(x => x.GetSecretAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((string name, CancellationToken _) => name);
     }
 
     private OAuth BuildSut(HttpMessageHandler handler) =>
-        new(new HttpClient(handler), _mockLogger.Object, _mockCacheService.Object);
+        new(new HttpClient(handler), _mockLogger.Object, _mockCacheService.Object, _mockSecretManager.Object);
 
     private static AuthenticationConfigurationModel BuildAuthSettings(string? scope = null) => new()
     {

--- a/DotNet/Shared/Application/Extensions/Security/SecretManagerExtension.cs
+++ b/DotNet/Shared/Application/Extensions/Security/SecretManagerExtension.cs
@@ -21,8 +21,7 @@ namespace LantanaGroup.Link.Shared.Application.Extensions.Security
                     break;
 
                 default:
-                    services.AddSingleton<ISecretManager, LocalSecretManager>();
-                    break;
+                    throw new ArgumentException("Invalid secret manager");
             }
 
             return services;

--- a/DotNet/Shared/Application/Extensions/Security/SecretManagerExtension.cs
+++ b/DotNet/Shared/Application/Extensions/Security/SecretManagerExtension.cs
@@ -21,7 +21,8 @@ namespace LantanaGroup.Link.Shared.Application.Extensions.Security
                     break;
 
                 default:
-                    throw new ArgumentException("Invalid secret manager");
+                    services.AddSingleton<ISecretManager, LocalSecretManager>();
+                    break;
             }
 
             return services;
@@ -29,7 +30,7 @@ namespace LantanaGroup.Link.Shared.Application.Extensions.Security
 
         public class SecretManagerOptions
         {
-            public string Manager { get; set; } = default!;
+            public string Manager { get; set; } = "Local";
         }
     }
 }

--- a/Web/Admin.UI/src/app/components/data-acquisition/data-acquisition-fhir-query-config-form/data-acquisition-fhir-query-config-form.component.html
+++ b/Web/Admin.UI/src/app/components/data-acquisition/data-acquisition-fhir-query-config-form/data-acquisition-fhir-query-config-form.component.html
@@ -334,7 +334,7 @@
             <thead>
               <tr>
                 <th style="text-align: left; padding: 8px; border-bottom: 1px solid #ddd;">Key</th>
-                <th style="text-align: left; padding: 8px; border-bottom: 1px solid #ddd;">Value</th>
+                <th style="text-align: left; padding: 8px; border-bottom: 1px solid #ddd;">Secret Name</th>
                 @if (!viewOnly) {
                 <th style="width: 60px; padding: 8px; border-bottom: 1px solid #ddd;"></th>
                 }
@@ -353,9 +353,9 @@
                 </td>
                 <td style="padding: 8px;">
                   <mat-form-field appearance="outline" style="width: 100%;">
-                    <input matInput formControlName="value" placeholder="Header Value" [readonly]="viewOnly">
+                    <input matInput formControlName="value" placeholder="Secret Name" [readonly]="viewOnly">
                     @if (header.get('value')?.hasError('required') && header.get('value')?.touched) {
-                    <mat-error>Value is required</mat-error>
+                    <mat-error>Secret Name is required</mat-error>
                     }
                   </mat-form-field>
                 </td>

--- a/Web/Admin.UI/src/app/components/data-acquisition/data-acquisition-fhir-query-config-form/data-acquisition-fhir-query-config-form.component.html
+++ b/Web/Admin.UI/src/app/components/data-acquisition/data-acquisition-fhir-query-config-form/data-acquisition-fhir-query-config-form.component.html
@@ -235,7 +235,7 @@
         @if (authTypeControl.value === 'OAuth' || authTypeControl.value === 'Epic') {
         <div class="form-input">
           <mat-form-field appearance="outline" class="subject-input form-input ">
-            <mat-label>Client ID</mat-label>
+            <mat-label>Client ID - Secret Name</mat-label>
             <input matInput formControlName="clientId" [readonly]="viewOnly" placeholder="Client ID">
             @if (clientIdControl.value && !viewOnly) {
             <button matSuffix mat-icon-button aria-label="Clear" (click)="clearClientId()">
@@ -244,7 +244,7 @@
             }
             @if (clientIdControl.hasError('required')) {
             <mat-error>
-              Client Id is <strong>required</strong>.
+              Client ID - Secret Name is <strong>required</strong>.
             </mat-error>
             }
           </mat-form-field>
@@ -254,8 +254,8 @@
         @if (authTypeControl.value === 'OAuth') {
         <div class="form-input">
           <mat-form-field appearance="outline" class="subject-input form-input ">
-            <mat-label>Client Secret</mat-label>
-            <input matInput formControlName="clientSecret" [readonly]="viewOnly" type="password" placeholder="Client Secret">
+            <mat-label>Client Secret - Secret Name</mat-label>
+            <input matInput formControlName="clientSecret" [readonly]="viewOnly" placeholder="Client Secret">
             @if (clientSecretControl.value && !viewOnly) {
             <button matSuffix mat-icon-button aria-label="Clear" (click)="clearClientSecret()">
               <mat-icon>close</mat-icon>
@@ -263,7 +263,7 @@
             }
             @if (clientSecretControl.hasError('required')) {
             <mat-error>
-              Client Secret is <strong>required</strong>.
+              Client Secret - Secret Name is <strong>required</strong>.
             </mat-error>
             }
           </mat-form-field>

--- a/Web/Admin.UI/src/app/components/data-acquisition/data-acquisition-fhir-query-config-form/data-acquisition-fhir-query-config-form.component.html
+++ b/Web/Admin.UI/src/app/components/data-acquisition/data-acquisition-fhir-query-config-form/data-acquisition-fhir-query-config-form.component.html
@@ -290,8 +290,8 @@
         @if (authTypeControl.value === 'Basic') {
         <div class="form-input">
           <mat-form-field appearance="outline" class="subject-input form-input ">
-            <mat-label>User Name</mat-label>
-            <input matInput formControlName="userName" [readonly]="viewOnly" placeholder="User Name">
+            <mat-label>User Name Secret Name</mat-label>
+            <input matInput formControlName="userName" [readonly]="viewOnly" placeholder="User Name Secret Name">
             @if (userNameControl.value && !viewOnly) {
             <button matSuffix mat-icon-button aria-label="Clear" (click)="clearUserName()">
               <mat-icon>close</mat-icon>
@@ -299,7 +299,7 @@
             }
             @if (authTypeControl.value == 'Basic') {
             <mat-error>
-              User Name is <strong>required</strong>.
+              User Name Secret Name is <strong>required</strong>.
             </mat-error>
             }
           </mat-form-field>
@@ -309,8 +309,8 @@
         @if (authTypeControl.value === 'Basic') {
         <div class="form-input">
           <mat-form-field appearance="outline" class="subject-input form-input ">
-            <mat-label>Password</mat-label>
-            <input matInput formControlName="password" type="password" [readonly]="viewOnly" placeholder="Password">
+            <mat-label>Password Secret Name</mat-label>
+            <input matInput formControlName="password" [readonly]="viewOnly" placeholder="Password Secret Name">
             @if (passwordControl.value && !viewOnly) {
             <button matSuffix mat-icon-button aria-label="Clear" (click)="clearPassword()">
               <mat-icon>close</mat-icon>
@@ -318,7 +318,7 @@
             }
             @if (authTypeControl.value == 'Basic') {
             <mat-error>
-              Password is <strong>required</strong>.
+              Password Secret Name is <strong>required</strong>.
             </mat-error>
             }
           </mat-form-field>

--- a/docs/docs/services/DataAcquisitionService/0.2.0.md
+++ b/docs/docs/services/DataAcquisitionService/0.2.0.md
@@ -357,7 +357,6 @@ SFTP credentials and other sensitive data are stored using a configurable secret
 
 | Property | Description | Required | Default Value | Secret? |
 |----------|-------------|----------|---------------|---------|
-| SecretManagement__Enabled | Enable/disable secret management | No | true | No |
 | SecretManagement__Manager | Secret manager type: "AzureKeyVault" or "Local" | No | Local | No |
 | SecretManagement__ManagerUri | Azure Key Vault URI (required for AzureKeyVault) | Conditional | - | No |
 | DataProtection__KeyRing | Key ring name for data protection | No | Link | No |
@@ -366,7 +365,6 @@ SFTP credentials and other sensitive data are stored using a configurable secret
 ```json
 {
   "SecretManagement": {
-    "Enabled": true,
     "Manager": "AzureKeyVault",
     "ManagerUri": "https://your-keyvault.vault.azure.net/"
   },
@@ -380,7 +378,6 @@ SFTP credentials and other sensitive data are stored using a configurable secret
 ```json
 {
   "SecretManagement": {
-    "Enabled": true,
     "Manager": "Local"
   },
   "DataProtection": {

--- a/docs/docs/services/DataAcquisitionService/0.2.0.md
+++ b/docs/docs/services/DataAcquisitionService/0.2.0.md
@@ -264,7 +264,111 @@ Below is an example of a monthly query plan that's configured to acquire the fol
 
 Data sources (where the FHIR server is located and how to authenticate) are configured via "Query Configs". There is currently no association between a query _plan_ and data source. Whenever data acquisition attempts to execute a query plan against a data source, it uses the FHIR server and authentication method specified by the "Query Config", for the specified facility/tenant.
 
-TODO: Add details about how to authenticate against Epic, Cerner, Basic, and/or OAuth data sources.
+Authentication is configured per facility via the `authentication` field on the FHIR Query Configuration, or independently through the Authentication Configuration API endpoints:
+
+| Method | Route | Description |
+|--------|-------|-------------|
+| GET | `/api/data/{facilityId}/{configType}/authentication` | Get auth config for a facility |
+| POST | `/api/data/{facilityId}/{configType}/authentication` | Create auth config |
+| PUT | `/api/data/{facilityId}/{configType}/authentication` | Update auth config |
+| DELETE | `/api/data/{facilityId}/{configType}/authentication` | Delete auth config |
+
+The `{configType}` path segment is either `fhirQueryConfiguration` or `fhirQueryListConfiguration`.
+
+> **Security note:** Fields that reference credentials (`clientId`, `clientSecret`, `userName`, `password`, and `customHeaders` values) are **secret names/keys** resolved at runtime via the configured secret manager (e.g., Azure Key Vault). These are never stored as literal credential values.
+
+#### Supported Auth Types
+
+The `authType` field determines which authentication method is used. The following values are supported:
+
+---
+
+##### Basic
+
+Standard HTTP Basic Authentication. Credentials are resolved from the secret manager at runtime and sent as a base64-encoded `Authorization: Basic` header.
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `authType` | Yes | Must be `"Basic"` |
+| `userName` | Yes | Secret manager key for the username |
+| `password` | Yes | Secret manager key for the password |
+
+```json
+{
+  "authType": "Basic",
+  "userName": "my-facility-username-secret",
+  "password": "my-facility-password-secret"
+}
+```
+
+---
+
+##### Epic
+
+Backend services authentication for Epic systems. Uses a signed JWT (RS256) client assertion posted to Epic's token endpoint in exchange for a bearer token. The token is cached until expiry.
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `authType` | Yes | Must be `"Epic"` |
+| `key` | Yes | PEM-encoded RSA private key used to sign the JWT client assertion |
+| `clientId` | Yes | Secret manager key for the Epic-registered client/app ID |
+| `tokenUrl` | Yes | Epic OAuth2 token endpoint URL |
+
+```json
+{
+  "authType": "Epic",
+  "key": "-----BEGIN RSA PRIVATE KEY-----\n...\n-----END RSA PRIVATE KEY-----",
+  "tokenUrl": "https://epic.example.org/oauth2/token",
+  "clientId": "my-epic-client-id-secret"
+}
+```
+
+The JWT is constructed with `iss`, `sub`, `aud`, and `jti` claims and a 4-minute expiry, then posted with `grant_type=client_credentials` and `client_assertion_type=urn:ietf:params:oauth:client-assertion-type:jwt-bearer`.
+
+---
+
+##### OAuth
+
+Standard OAuth2 client credentials flow. Resolves `clientId` and `clientSecret` from the secret manager, then POSTs to the token endpoint with `Authorization: Basic` and `grant_type=client_credentials`. The resulting bearer token is cached until expiry.
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `authType` | Yes | Must be `"OAuth"` |
+| `tokenUrl` | Yes | OAuth2 token endpoint URL |
+| `clientId` | Yes | Secret manager key for the client ID |
+| `clientSecret` | Yes | Secret manager key for the client secret |
+| `scope` | Yes | OAuth scopes to request (e.g., `system/*.read`) |
+
+```json
+{
+  "authType": "OAuth",
+  "tokenUrl": "https://auth.example.org/oauth2/token",
+  "clientId": "my-oauth-client-id-secret",
+  "clientSecret": "my-oauth-client-secret-secret",
+  "scope": "system/*.read"
+}
+```
+
+---
+
+##### CustomHeaders
+
+Injects one or more arbitrary HTTP headers into every request. Each entry in the `customHeaders` map specifies a header name and the secret manager key whose resolved value will be sent as that header's value. This supports vendor-specific API key schemes and other non-standard authentication mechanisms.
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `authType` | Yes | Must be `"CustomHeaders"` |
+| `customHeaders` | Yes | Object where each key is an HTTP header name and each value is a secret manager key |
+
+```json
+{
+  "authType": "CustomHeaders",
+  "customHeaders": {
+    "X-API-Key": "my-facility-api-key-secret",
+    "X-Tenant-Id": "my-facility-tenant-secret"
+  }
+}
+```
 
 ### SFTP Configuration
 


### PR DESCRIPTION
### 🛠️ Description of Changes

This PR repurposes the sensitive fields (client id, client secret, etc.) in `AuthenticationConfiguration` to be secret name/key lookups. The values are now retrieved from Azure Key Vault rather than stored as text in the database.

ISecretManager is now always enabled. `LocalSecretManager` is used in the development environment and `AzureKeyVaultSecretManager` in shared environments. 

The Admin UI was updated to indicate the fields are now secret names.

### 🧪 Testing Performed

Added secrets to Key Vault and tested that OAuth and CustomHeader Auth can still authenticate with real sandbox EHR systems.

### 🧑‍🔬 Unit Testing

- [x] I have written or updated unit tests to cover my changes
- Coverage: 56.2%

### 📓 Documentation Updated

Added documentation to DataAcquisition explaining the different authentication methods.
Removed `SecretManagement__Enabled` from the documentation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Authentication credentials now resolved from secret manager instead of plain configuration, enhancing security.
  * UI updated to clarify that credential fields require secret names, not actual values.

* **Bug Fixes**
  * Secret management now defaults to "Local" when not explicitly configured.

* **Documentation**
  * Added complete authentication configuration guide with supported types and examples.
  * Updated secret management documentation to reflect streamlined configuration approach.

* **Tests**
  * Added comprehensive test coverage for secret-based authentication workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

