### PR TITLE
TECH_DEBT: Surface 'download bundle' button on report page 

### DIFF
--- a/Web/Admin.UI/src/app/components/tenant/facility-view/view-report/view-report.component.html
+++ b/Web/Admin.UI/src/app/components/tenant/facility-view/view-report/view-report.component.html
@@ -22,7 +22,7 @@
         <fa-icon [icon]="faFileInvoice"></fa-icon>
         Acquisition Log
       </button>
-      <button type="button" class="link-button primary" aria-label="Download Report" (click)="onDownload()" *ngIf="reportSummary.submitted">
+      <button type="button" class="link-button primary" aria-label="Download Report" (click)="onDownload()" *ngIf="reportSummary.payloadRootUri">
         <fa-icon [icon]="faFileArrowDown"></fa-icon>
         Download
       </button>


### PR DESCRIPTION
### 🛠️ Description of Changes

Summary
- Updated the Admin UI to ensure the report download button is visible whenever report files are available, regardless of the report's submission or validation status.

Changes
- Modified `Web\Admin.UI\src\app\components\tenant\facility-view\view-report\view-report.component.html` to change the visibility condition of the "Download" button from `reportSummary.submitted` to `reportSummary.payloadRootUri`.
- This change allows users to download the full ZIP archive (including manifest and patient measure reports) as soon as the system has generated the manifest and stored it in blob storage.

### 🧪 Testing Performed

Local:
<img width="1871" height="330" alt="image" src="https://github.com/user-attachments/assets/919343ff-9df6-4693-8386-98a23a87e617" />


### 🧑‍🔬 Unit Testing

- [ ] I have written or updated unit tests to cover my changes
- Coverage: 0.0%

### 📓 Documentation Updated

n/a



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Updated the "Download Report" button visibility to display based on report payload availability, ensuring the button appears only when the report can be downloaded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->