### PR TITLE
LEGLINK-20: Normalization Operation POST requests will now add a default sequence

### DIFF
--- a/DotNet/Automation.Link/Helpers/FacilitySetupHelper.cs
+++ b/DotNet/Automation.Link/Helpers/FacilitySetupHelper.cs
@@ -78,28 +78,44 @@ public static class FacilitySetupHelper
         IAutomationOutput output,
         string facilityId)
     {
-        var response = await normalizationClient.SearchFacilityOperationsAsync(facilityId);
-        if (response?.Records?.Count > 0)
+        try
         {
-            output.WriteLine($"Normalization config for facility '{facilityId}' already exists. Skipping create.");
-            return;
-        }
-
-        await normalizationClient.CreateOperationAsync(new CreateNormalizationOperationRequestApiModel
-        {
-            ResourceTypes = ["Location"],
-            FacilityId = facilityId,
-            Operation = new CreateNormalizationOperationDetailsApiModel
+            var response = await normalizationClient.SearchFacilityOperationsAsync(facilityId);
+            if (response?.Records?.Count > 0)
             {
-                OperationType = "CopyProperty",
-                Name = "Copy Location Identifier to Type",
-                Description = "A Test Operation",
-                SourceFhirPath = "identifier.value",
-                TargetFhirPath = "type[0].coding.code"
-            },
-            Description = "Copy Location Identifier to Code",
-            VendorIds = []
-        });
+                output.WriteLine($"Normalization config for facility '{facilityId}' already exists. Skipping create.");
+                return;
+            }
+
+            await normalizationClient.CreateOperationAsync(new CreateNormalizationOperationRequestApiModel
+            {
+                ResourceTypes = ["Location"],
+                FacilityId = facilityId,
+                Operation = new CreateNormalizationOperationDetailsApiModel
+                {
+                    OperationType = "CopyProperty",
+                    Name = "Copy Location Identifier to Type",
+                    Description = "A Test Operation",
+                    SourceFhirPath = "identifier.value",
+                    TargetFhirPath = "type[0].coding.code"
+                },
+                Description = "Copy Location Identifier to Code",
+                VendorIds = []
+            });
+        }
+        catch (Exception ex)
+        {
+            output.WriteLine($"CreateOperationAsync failed for facility '{facilityId}': {ex.StackTrace}");
+
+            var retryResponse = await normalizationClient.SearchFacilityOperationsAsync(facilityId);
+            if (retryResponse?.Records?.Count > 0)
+            {
+                output.WriteLine($"Normalization config for facility '{facilityId}' was created by a concurrent request. Continuing.");
+                return;
+            }
+
+            throw;
+        }
     }
 
     public static async Task EnsureQueryPlansAsync(

--- a/DotNet/Automation.Link/Helpers/PipelineDataReader.cs
+++ b/DotNet/Automation.Link/Helpers/PipelineDataReader.cs
@@ -15,7 +15,7 @@ public class PipelineDataReader
     private readonly IFacilityServiceClient _facilityClient;
 
     // ---------------------------------------------------------------
-    // Time-based cache — collapses duplicate HTTP calls from the
+    // Time-based cache collapses duplicate HTTP calls from the
     // many consumers (ProgressMonitor, PipelineProgressTracker,
     // MilestoneValidationOrchestrator, StoreBackedServicePoller,
     // PipelineSnapshot) into a single call per TTL window.
@@ -428,7 +428,7 @@ public class PipelineDataReader
             s.Id.ToString(),
             s.Sequence,
             s.OperationResourceType?.Operation?.OperationType,
-            s.OperationResourceType?.ResourceType?.ResourceName)).ToList();
+            s.OperationResourceType?.Resource?.ResourceName)).ToList();
     }
 
     public async Task<FacilityInfo?> GetFacilityAsync(string facilityId)

--- a/DotNet/LinkSdk/Clients/NormalizationServiceClient.cs
+++ b/DotNet/LinkSdk/Clients/NormalizationServiceClient.cs
@@ -28,7 +28,7 @@ public class NormalizationServiceClient : LinkApiClientBase, INormalizationServi
         int pageSize = 100,
         int pageNumber = 1,
         CancellationToken cancellationToken = default) =>
-        Request($"normalization/operations/facility/{facilityId}")
+        Request($"normalization/Operations/facility/{facilityId}")
             .SetQueryParam("includeDisabled", includeDisabled)
             .SetQueryParam("pageSize", pageSize)
             .SetQueryParam("pageNumber", pageNumber)
@@ -37,13 +37,13 @@ public class NormalizationServiceClient : LinkApiClientBase, INormalizationServi
     public Task CreateOperationAsync(
         CreateNormalizationOperationRequestApiModel requestBody,
         CancellationToken cancellationToken = default) =>
-        Request("normalization/operations")
+        Request("normalization/Operations")
             .PostJsonAsync(requestBody, cancellationToken: cancellationToken);
 
     public Task DeleteFacilityOperationsAsync(
         string facilityId,
         CancellationToken cancellationToken = default) =>
-        DeleteOrIgnoreAsync(() => Request($"normalization/operations/facility/{facilityId}")
+        DeleteOrIgnoreAsync(() => Request($"normalization/Operations/facility/{facilityId}")
             .DeleteAsync(cancellationToken: cancellationToken));
 
     public Task<List<NormalizationOperationSequenceApiModel>> GetOperationSequencesAsync(

--- a/DotNet/LinkSdk/Clients/NormalizationServiceClient.cs
+++ b/DotNet/LinkSdk/Clients/NormalizationServiceClient.cs
@@ -1,4 +1,4 @@
-﻿using Flurl.Http;
+﻿﻿using Flurl.Http;
 using LantanaGroup.Link.Sdk.ApiClient;
 using LantanaGroup.Link.Shared.Application.Extensions.Security;
 using LantanaGroup.Link.Shared.Application.Interfaces.Services.Security.Token;
@@ -34,16 +34,30 @@ public class NormalizationServiceClient : LinkApiClientBase, INormalizationServi
             .SetQueryParam("pageNumber", pageNumber)
             .GetJsonAsync<PagedConfigModel<NormalizationOperationApiModel>>(cancellationToken: cancellationToken);
 
-    public Task CreateOperationAsync(
+    public async Task CreateOperationAsync(
         CreateNormalizationOperationRequestApiModel requestBody,
-        CancellationToken cancellationToken = default) =>
-        Request("normalization/Operations")
-            .PostJsonAsync(requestBody, cancellationToken: cancellationToken);
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            await Request("normalization/Operations")
+                .PostJsonAsync(requestBody, cancellationToken: cancellationToken);
+        }
+        catch (FlurlHttpException ex)
+        {
+            string responseBody;
+            try { responseBody = await ex.GetResponseStringAsync(); }
+            catch { responseBody = "(unable to read response body)"; }
+
+            throw new InvalidOperationException(
+                $"POST normalization/Operations failed (HTTP {ex.StatusCode}): {responseBody}", ex);
+        }
+    }
 
     public Task DeleteFacilityOperationsAsync(
         string facilityId,
         CancellationToken cancellationToken = default) =>
-        DeleteOrIgnoreAsync(() => Request($"normalization/Operations/facility/{facilityId}")
+        DeleteOrIgnoreAsync(() => Request($"normalization/operations/facility/{facilityId}")
             .DeleteAsync(cancellationToken: cancellationToken));
 
     public Task<List<NormalizationOperationSequenceApiModel>> GetOperationSequencesAsync(

--- a/DotNet/LinkSdk/Clients/NormalizationServiceClient.cs
+++ b/DotNet/LinkSdk/Clients/NormalizationServiceClient.cs
@@ -28,7 +28,7 @@ public class NormalizationServiceClient : LinkApiClientBase, INormalizationServi
         int pageSize = 100,
         int pageNumber = 1,
         CancellationToken cancellationToken = default) =>
-        Request($"normalization/Operations/facility/{facilityId}")
+        Request($"normalization/operations/facility/{facilityId}")
             .SetQueryParam("includeDisabled", includeDisabled)
             .SetQueryParam("pageSize", pageSize)
             .SetQueryParam("pageNumber", pageNumber)
@@ -37,7 +37,7 @@ public class NormalizationServiceClient : LinkApiClientBase, INormalizationServi
     public Task CreateOperationAsync(
         CreateNormalizationOperationRequestApiModel requestBody,
         CancellationToken cancellationToken = default) =>
-        Request("normalization/Operations")
+        Request("normalization/operations")
             .PostJsonAsync(requestBody, cancellationToken: cancellationToken);
 
     public Task DeleteFacilityOperationsAsync(

--- a/DotNet/Normalization/Controllers/OperationsController.cs
+++ b/DotNet/Normalization/Controllers/OperationsController.cs
@@ -8,6 +8,7 @@ using LantanaGroup.Link.Normalization.Application.Operations;
 using LantanaGroup.Link.Normalization.Application.Services.Operations;
 using LantanaGroup.Link.Normalization.Domain.Managers;
 using LantanaGroup.Link.Normalization.Domain.Queries;
+using LantanaGroup.Link.Normalization.Listeners;
 using LantanaGroup.Link.Shared.Application.Enums;
 using LantanaGroup.Link.Shared.Application.Models.Responses;
 using LantanaGroup.Link.Shared.Application.Services;
@@ -33,8 +34,9 @@ namespace LantanaGroup.Link.Normalization.Controllers
         private readonly CodeMapOperationService _codeMapOperationService;
         private readonly ConditionalTransformOperationService _conditionalTransformOperationService;
         private readonly CopyLocationOperationService _copyLocationOperationService;
+        private readonly ILogger<OperationsController> _logger;
 
-        public OperationsController(IOperationManager operationManager, IOperationQueries operationQueries, IOperationSequenceQueries operationSequenceQueries, IVendorQueries vendorQueries, ITenantApiService tenantApiService, CopyPropertyOperationService copyPropertyService, CodeMapOperationService codeMapOperationService, ConditionalTransformOperationService conditionalTransformOperationService, CopyLocationOperationService copyLocationOperationService)
+        public OperationsController(IOperationManager operationManager, IOperationQueries operationQueries, IOperationSequenceQueries operationSequenceQueries, IVendorQueries vendorQueries, ITenantApiService tenantApiService, CopyPropertyOperationService copyPropertyService, CodeMapOperationService codeMapOperationService, ConditionalTransformOperationService conditionalTransformOperationService, CopyLocationOperationService copyLocationOperationService, ILogger<OperationsController> logger)
         {
             _operationManager = operationManager;
             _operationQueries = operationQueries;
@@ -45,6 +47,7 @@ namespace LantanaGroup.Link.Normalization.Controllers
             _codeMapOperationService = codeMapOperationService;
             _conditionalTransformOperationService = conditionalTransformOperationService;
             _copyLocationOperationService = copyLocationOperationService;
+            _logger = logger;
         }
 
         [HttpGet("")]
@@ -143,6 +146,7 @@ namespace LantanaGroup.Link.Normalization.Controllers
             }
             catch (Exception ex)
             {
+                _logger.LogError("Error: " + ex.Message, null);
                 return Problem(detail: ex.Message, statusCode: StatusCodes.Status500InternalServerError);
             }
         }

--- a/DotNet/Normalization/Controllers/OperationsController.cs
+++ b/DotNet/Normalization/Controllers/OperationsController.cs
@@ -260,42 +260,43 @@ namespace LantanaGroup.Link.Normalization.Controllers
                     return Problem(detail: taskResult.ErrorMessage, statusCode: StatusCodes.Status422UnprocessableEntity);
                 }
 
-                //OperationModel operationModel = (OperationModel)taskResult.ObjectResult;
+                OperationModel operationModel = (OperationModel)taskResult.ObjectResult;
 
-                //foreach (var resourceType in model.ResourceTypes)
-                //{
-                //    var results = await _operationSequenceQueries.Search(new OperationSequenceSearchModel()
-                //    {
-                //        ResourceType = resourceType,
-                //        FacilityId = model.FacilityId ?? string.Empty
-                //    }, false);
+                foreach (var resourceType in model.ResourceTypes)
+                {
+                    var results = await _operationSequenceQueries.Search(new OperationSequenceSearchModel()
+                    {
+                        ResourceType = resourceType,
+                        FacilityId = model.FacilityId ?? string.Empty
+                    }, false);
 
-                //    int maxSequence = results == null || results.Count == 0 ? 1 : results.Select(x => x.Sequence).Max() + 1;
+                    int maxSequence = results == null || results.Count == 0 ? 1 : results.Select(x => x.Sequence).Max() + 1;
 
-                //    List<CreateOperationSequenceModel> createSequences = new List<CreateOperationSequenceModel>();
+                    List<CreateOperationSequenceModel> createSequences = new List<CreateOperationSequenceModel>();
 
-                //    foreach (var result in results) 
-                //    {
-                //        createSequences.Add(new CreateOperationSequenceModel() { OperationId = result.OperationResourceType.OperationId, Sequence = result.Sequence });
-                //    }
+                    //foreach (var result in results)
+                    //{
+                    //    createSequences.Add(new CreateOperationSequenceModel() { OperationId = result.OperationResourceType.OperationId, Sequence = result.Sequence });
+                    //}
 
-                //    createSequences.Add(new CreateOperationSequenceModel()
-                //    {
-                //        OperationId = operationModel.Id,
-                //        Sequence = maxSequence
-                //    });
+                    //createSequences.Add(new CreateOperationSequenceModel()
+                    //{
+                    //    OperationId = operationModel.Id,
+                    //    Sequence = maxSequence
+                    //});
 
-                //    var sequences = await _operationManager.CreateOperationSequences(new CreateOperationSequencesModel()
-                //    {
-                //        FacilityId = model.FacilityId,
-                //        ResourceType = resourceType,
-                //        OperationSequences = createSequences
-                //    });
-                //}
+                    //var sequences = await _operationManager.CreateOperationSequences(new CreateOperationSequencesModel()
+                    //{
+                    //    FacilityId = model.FacilityId,
+                    //    ResourceType = resourceType,
+                    //    OperationSequences = createSequences
+                    //});
+                }
                 return Created("", taskResult.ObjectResult);
             }
             catch (Exception ex)
             {
+                Console.WriteLine("Error: " +  ex.Message );
                 return Problem(detail: ex.Message, statusCode: StatusCodes.Status500InternalServerError);
             }
         }

--- a/DotNet/Normalization/Controllers/OperationsController.cs
+++ b/DotNet/Normalization/Controllers/OperationsController.cs
@@ -260,38 +260,38 @@ namespace LantanaGroup.Link.Normalization.Controllers
                     return Problem(detail: taskResult.ErrorMessage, statusCode: StatusCodes.Status422UnprocessableEntity);
                 }
 
-                OperationModel operationModel = (OperationModel)taskResult.ObjectResult;
+                //OperationModel operationModel = (OperationModel)taskResult.ObjectResult;
 
-                foreach (var resourceType in model.ResourceTypes)
-                {
-                    var results = await _operationSequenceQueries.Search(new OperationSequenceSearchModel()
-                    {
-                        ResourceType = resourceType,
-                        FacilityId = model.FacilityId ?? string.Empty
-                    }, false);
+                //foreach (var resourceType in model.ResourceTypes)
+                //{
+                //    var results = await _operationSequenceQueries.Search(new OperationSequenceSearchModel()
+                //    {
+                //        ResourceType = resourceType,
+                //        FacilityId = model.FacilityId ?? string.Empty
+                //    }, false);
 
-                    int maxSequence = results == null || results.Count == 0 ? 1 : results.Select(x => x.Sequence).Max() + 1;
+                //    int maxSequence = results == null || results.Count == 0 ? 1 : results.Select(x => x.Sequence).Max() + 1;
 
-                    List<CreateOperationSequenceModel> createSequences = new List<CreateOperationSequenceModel>();
+                //    List<CreateOperationSequenceModel> createSequences = new List<CreateOperationSequenceModel>();
 
-                    foreach (var result in results) 
-                    {
-                        createSequences.Add(new CreateOperationSequenceModel() { OperationId = result.OperationResourceType.OperationId, Sequence = result.Sequence });
-                    }
+                //    foreach (var result in results) 
+                //    {
+                //        createSequences.Add(new CreateOperationSequenceModel() { OperationId = result.OperationResourceType.OperationId, Sequence = result.Sequence });
+                //    }
 
-                    createSequences.Add(new CreateOperationSequenceModel()
-                    {
-                        OperationId = operationModel.Id,
-                        Sequence = maxSequence
-                    });
+                //    createSequences.Add(new CreateOperationSequenceModel()
+                //    {
+                //        OperationId = operationModel.Id,
+                //        Sequence = maxSequence
+                //    });
 
-                    var sequences = await _operationManager.CreateOperationSequences(new CreateOperationSequencesModel()
-                    {
-                        FacilityId = model.FacilityId,
-                        ResourceType = resourceType,
-                        OperationSequences = createSequences
-                    });
-                }
+                //    var sequences = await _operationManager.CreateOperationSequences(new CreateOperationSequencesModel()
+                //    {
+                //        FacilityId = model.FacilityId,
+                //        ResourceType = resourceType,
+                //        OperationSequences = createSequences
+                //    });
+                //}
                 return Created("", taskResult.ObjectResult);
             }
             catch (Exception ex)

--- a/DotNet/Normalization/Controllers/OperationsController.cs
+++ b/DotNet/Normalization/Controllers/OperationsController.cs
@@ -288,12 +288,12 @@ namespace LantanaGroup.Link.Normalization.Controllers
                         Sequence = maxSequence
                     });
 
-                    var sequences = await _operationManager.CreateOperationSequences(new CreateOperationSequencesModel()
-                    {
-                        FacilityId = model.FacilityId,
-                        ResourceType = resourceType,
-                        OperationSequences = createSequences
-                    });
+                    //var sequences = await _operationManager.CreateOperationSequences(new CreateOperationSequencesModel()
+                    //{
+                    //    FacilityId = model.FacilityId,
+                    //    ResourceType = resourceType,
+                    //    OperationSequences = createSequences
+                    //});
                 }
                 return Created("", taskResult.ObjectResult);
             }

--- a/DotNet/Normalization/Controllers/OperationsController.cs
+++ b/DotNet/Normalization/Controllers/OperationsController.cs
@@ -304,6 +304,7 @@ namespace LantanaGroup.Link.Normalization.Controllers
             }
             catch (Exception ex)
             {
+                _logger.LogError("Unexpected Operations Post error: {Message}", ex.Message);
                 return Problem(detail: ex.Message, statusCode: StatusCodes.Status500InternalServerError);
             }
         }

--- a/DotNet/Normalization/Controllers/OperationsController.cs
+++ b/DotNet/Normalization/Controllers/OperationsController.cs
@@ -268,7 +268,7 @@ namespace LantanaGroup.Link.Normalization.Controllers
                     {
                         ResourceType = resourceType,
                         FacilityId = model.FacilityId ?? string.Empty
-                    });
+                    }, false);
 
                     int maxSequence = results == null || results.Count == 0 ? 1 : results.Select(x => x.Sequence).Max() + 1;
 
@@ -276,7 +276,7 @@ namespace LantanaGroup.Link.Normalization.Controllers
 
                     foreach (var result in results) 
                     {
-                        createSequences.Add(new CreateOperationSequenceModel() { OperationId = operationModel.Id, Sequence = result.Sequence });
+                        createSequences.Add(new CreateOperationSequenceModel() { OperationId = result.OperationResourceType.OperationId, Sequence = result.Sequence });
                     }
 
                     createSequences.Add(new CreateOperationSequenceModel()

--- a/DotNet/Normalization/Controllers/OperationsController.cs
+++ b/DotNet/Normalization/Controllers/OperationsController.cs
@@ -147,7 +147,6 @@ namespace LantanaGroup.Link.Normalization.Controllers
             }
             catch (Exception ex)
             {
-                _logger.LogError("Unexpected Operations Post error: {Message}", ex.Message);
                 return Problem(detail: ex.Message, statusCode: StatusCodes.Status500InternalServerError);
             }
         }
@@ -293,12 +292,12 @@ namespace LantanaGroup.Link.Normalization.Controllers
                         Sequence = maxSequence
                     });
 
-                    //var sequences = await _operationManager.CreateOperationSequences(new CreateOperationSequencesModel()
-                    //{
-                    //    FacilityId = model.FacilityId ?? string.Empty,
-                    //    ResourceType = resourceType,
-                    //    OperationSequences = createSequences
-                    //});
+                    var sequences = await _operationManager.CreateOperationSequences(new CreateOperationSequencesModel()
+                    {
+                        FacilityId = model.FacilityId ?? string.Empty,
+                        ResourceType = resourceType,
+                        OperationSequences = createSequences
+                    });
                 }
                 return Created("", taskResult.ObjectResult);
             }

--- a/DotNet/Normalization/Controllers/OperationsController.cs
+++ b/DotNet/Normalization/Controllers/OperationsController.cs
@@ -293,12 +293,12 @@ namespace LantanaGroup.Link.Normalization.Controllers
                         Sequence = maxSequence
                     });
 
-                    var sequences = await _operationManager.CreateOperationSequences(new CreateOperationSequencesModel()
-                    {
-                        FacilityId = model.FacilityId ?? string.Empty,
-                        ResourceType = resourceType,
-                        OperationSequences = createSequences
-                    });
+                    //var sequences = await _operationManager.CreateOperationSequences(new CreateOperationSequencesModel()
+                    //{
+                    //    FacilityId = model.FacilityId ?? string.Empty,
+                    //    ResourceType = resourceType,
+                    //    OperationSequences = createSequences
+                    //});
                 }
                 return Created("", taskResult.ObjectResult);
             }

--- a/DotNet/Normalization/Controllers/OperationsController.cs
+++ b/DotNet/Normalization/Controllers/OperationsController.cs
@@ -299,7 +299,6 @@ namespace LantanaGroup.Link.Normalization.Controllers
             }
             catch (Exception ex)
             {
-                Console.WriteLine("Error: " +  ex.Message );
                 return Problem(detail: ex.Message, statusCode: StatusCodes.Status500InternalServerError);
             }
         }

--- a/DotNet/Normalization/Controllers/OperationsController.cs
+++ b/DotNet/Normalization/Controllers/OperationsController.cs
@@ -17,6 +17,7 @@ using Link.Authorization.Policies;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using System.Text.Json;
+using System.Text.RegularExpressions;
 
 namespace LantanaGroup.Link.Normalization.Controllers
 {
@@ -146,7 +147,7 @@ namespace LantanaGroup.Link.Normalization.Controllers
             }
             catch (Exception ex)
             {
-                _logger.LogError("Error: " + ex.Message, null);
+                _logger.LogError("Unexpected Operations Post error: {Message}", ex.Message);
                 return Problem(detail: ex.Message, statusCode: StatusCodes.Status500InternalServerError);
             }
         }

--- a/DotNet/Normalization/Controllers/OperationsController.cs
+++ b/DotNet/Normalization/Controllers/OperationsController.cs
@@ -1,4 +1,4 @@
-﻿using Hl7.Fhir.Model;
+﻿﻿﻿using Hl7.Fhir.Model;
 using LantanaGroup.Link.Normalization.Application.Models.Operations;
 using LantanaGroup.Link.Normalization.Application.Models.Operations.Business;
 using LantanaGroup.Link.Normalization.Application.Models.Operations.Business.Manager;
@@ -8,7 +8,6 @@ using LantanaGroup.Link.Normalization.Application.Operations;
 using LantanaGroup.Link.Normalization.Application.Services.Operations;
 using LantanaGroup.Link.Normalization.Domain.Managers;
 using LantanaGroup.Link.Normalization.Domain.Queries;
-using LantanaGroup.Link.Normalization.Listeners;
 using LantanaGroup.Link.Shared.Application.Enums;
 using LantanaGroup.Link.Shared.Application.Models.Responses;
 using LantanaGroup.Link.Shared.Application.Services;
@@ -17,7 +16,6 @@ using Link.Authorization.Policies;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using System.Text.Json;
-using System.Text.RegularExpressions;
 
 namespace LantanaGroup.Link.Normalization.Controllers
 {
@@ -35,9 +33,8 @@ namespace LantanaGroup.Link.Normalization.Controllers
         private readonly CodeMapOperationService _codeMapOperationService;
         private readonly ConditionalTransformOperationService _conditionalTransformOperationService;
         private readonly CopyLocationOperationService _copyLocationOperationService;
-        private readonly ILogger<OperationsController> _logger;
 
-        public OperationsController(IOperationManager operationManager, IOperationQueries operationQueries, IOperationSequenceQueries operationSequenceQueries, IVendorQueries vendorQueries, ITenantApiService tenantApiService, CopyPropertyOperationService copyPropertyService, CodeMapOperationService codeMapOperationService, ConditionalTransformOperationService conditionalTransformOperationService, CopyLocationOperationService copyLocationOperationService, ILogger<OperationsController> logger)
+        public OperationsController(IOperationManager operationManager, IOperationQueries operationQueries, IOperationSequenceQueries operationSequenceQueries, IVendorQueries vendorQueries, ITenantApiService tenantApiService, CopyPropertyOperationService copyPropertyService, CodeMapOperationService codeMapOperationService, ConditionalTransformOperationService conditionalTransformOperationService, CopyLocationOperationService copyLocationOperationService)
         {
             _operationManager = operationManager;
             _operationQueries = operationQueries;
@@ -48,7 +45,6 @@ namespace LantanaGroup.Link.Normalization.Controllers
             _codeMapOperationService = codeMapOperationService;
             _conditionalTransformOperationService = conditionalTransformOperationService;
             _copyLocationOperationService = copyLocationOperationService;
-            _logger = logger;
         }
 
         [HttpGet("")]
@@ -264,46 +260,49 @@ namespace LantanaGroup.Link.Normalization.Controllers
                     return Problem(detail: taskResult.ErrorMessage, statusCode: StatusCodes.Status422UnprocessableEntity);
                 }
 
-                OperationModel operationModel = (OperationModel)taskResult.ObjectResult;
-
-                foreach (var resourceType in model.ResourceTypes)
+                if (!string.IsNullOrEmpty(model.FacilityId))
                 {
-                    var results = await _operationSequenceQueries.Search(new OperationSequenceSearchModel()
+                    OperationModel operationModel = (OperationModel)taskResult.ObjectResult;
+
+                    foreach (var resourceType in model.ResourceTypes)
                     {
-                        ResourceType = resourceType,
-                        FacilityId = model.FacilityId ?? string.Empty
-                    }, false);
-
-                    int maxSequence = results == null || results.Count == 0 ? 1 : results.Select(x => x.Sequence).Max() + 1;
-
-                    List<CreateOperationSequenceModel> createSequences = new List<CreateOperationSequenceModel>();
-
-                    if (results != null && results.Count() > 0)
-                    {
-                        foreach (var result in results)
+                        var results = await _operationSequenceQueries.Search(new OperationSequenceSearchModel()
                         {
-                            createSequences.Add(new CreateOperationSequenceModel() { OperationId = result.OperationResourceType.OperationId, Sequence = result.Sequence });
+                            ResourceType = resourceType,
+                            FacilityId = model.FacilityId
+                        }, false);
+
+                        int maxSequence = results == null || results.Count == 0 ? 1 : results.Select(x => x.Sequence).Max() + 1;
+
+                        List<CreateOperationSequenceModel> createSequences = new List<CreateOperationSequenceModel>();
+
+                        if (results != null && results.Count() > 0)
+                        {
+                            foreach (var result in results)
+                            {
+                                createSequences.Add(new CreateOperationSequenceModel() { OperationId = result.OperationResourceType.OperationId, Sequence = result.Sequence });
+                            }
                         }
+
+                        createSequences.Add(new CreateOperationSequenceModel()
+                        {
+                            OperationId = operationModel.Id,
+                            Sequence = maxSequence
+                        });
+
+                        await _operationManager.CreateOperationSequences(new CreateOperationSequencesModel()
+                        {
+                            FacilityId = model.FacilityId,
+                            ResourceType = resourceType,
+                            OperationSequences = createSequences,
+                        });
                     }
-
-                    createSequences.Add(new CreateOperationSequenceModel()
-                    {
-                        OperationId = operationModel.Id,
-                        Sequence = maxSequence
-                    });
-
-                    var sequences = await _operationManager.CreateOperationSequences(new CreateOperationSequencesModel()
-                    {
-                        FacilityId = model.FacilityId ?? string.Empty,
-                        ResourceType = resourceType,
-                        OperationSequences = createSequences
-                    });
                 }
+
                 return Created("", taskResult.ObjectResult);
             }
             catch (Exception ex)
             {
-                _logger.LogError("Unexpected Operations Post error: {Message}", ex.Message);
                 return Problem(detail: ex.Message, statusCode: StatusCodes.Status500InternalServerError);
             }
         }

--- a/DotNet/Normalization/Controllers/OperationsController.cs
+++ b/DotNet/Normalization/Controllers/OperationsController.cs
@@ -274,23 +274,26 @@ namespace LantanaGroup.Link.Normalization.Controllers
 
                     List<CreateOperationSequenceModel> createSequences = new List<CreateOperationSequenceModel>();
 
-                    //foreach (var result in results)
-                    //{
-                    //    createSequences.Add(new CreateOperationSequenceModel() { OperationId = result.OperationResourceType.OperationId, Sequence = result.Sequence });
-                    //}
+                    if (results != null && results.Count() > 0)
+                    {
+                        foreach (var result in results)
+                        {
+                            createSequences.Add(new CreateOperationSequenceModel() { OperationId = result.OperationResourceType.OperationId, Sequence = result.Sequence });
+                        }
+                    }
 
-                    //createSequences.Add(new CreateOperationSequenceModel()
-                    //{
-                    //    OperationId = operationModel.Id,
-                    //    Sequence = maxSequence
-                    //});
+                    createSequences.Add(new CreateOperationSequenceModel()
+                    {
+                        OperationId = operationModel.Id,
+                        Sequence = maxSequence
+                    });
 
-                    //var sequences = await _operationManager.CreateOperationSequences(new CreateOperationSequencesModel()
-                    //{
-                    //    FacilityId = model.FacilityId,
-                    //    ResourceType = resourceType,
-                    //    OperationSequences = createSequences
-                    //});
+                    var sequences = await _operationManager.CreateOperationSequences(new CreateOperationSequencesModel()
+                    {
+                        FacilityId = model.FacilityId,
+                        ResourceType = resourceType,
+                        OperationSequences = createSequences
+                    });
                 }
                 return Created("", taskResult.ObjectResult);
             }

--- a/DotNet/Normalization/Controllers/OperationsController.cs
+++ b/DotNet/Normalization/Controllers/OperationsController.cs
@@ -288,12 +288,12 @@ namespace LantanaGroup.Link.Normalization.Controllers
                         Sequence = maxSequence
                     });
 
-                    //var sequences = await _operationManager.CreateOperationSequences(new CreateOperationSequencesModel()
-                    //{
-                    //    FacilityId = model.FacilityId,
-                    //    ResourceType = resourceType,
-                    //    OperationSequences = createSequences
-                    //});
+                    var sequences = await _operationManager.CreateOperationSequences(new CreateOperationSequencesModel()
+                    {
+                        FacilityId = model.FacilityId ?? string.Empty,
+                        ResourceType = resourceType,
+                        OperationSequences = createSequences
+                    });
                 }
                 return Created("", taskResult.ObjectResult);
             }

--- a/DotNet/Normalization/Controllers/OperationsController.cs
+++ b/DotNet/Normalization/Controllers/OperationsController.cs
@@ -26,6 +26,7 @@ namespace LantanaGroup.Link.Normalization.Controllers
     {
         private readonly IOperationManager _operationManager;
         private readonly IOperationQueries _operationQueries;
+        private readonly IOperationSequenceQueries _operationSequenceQueries;
         private readonly IVendorQueries _vendorQueries;
         private readonly ITenantApiService _tenantApiService;
         private readonly CopyPropertyOperationService _copyPropertyOperationService;
@@ -33,10 +34,11 @@ namespace LantanaGroup.Link.Normalization.Controllers
         private readonly ConditionalTransformOperationService _conditionalTransformOperationService;
         private readonly CopyLocationOperationService _copyLocationOperationService;
 
-        public OperationsController(IOperationManager operationManager, IOperationQueries operationQueries, IVendorQueries vendorQueries, ITenantApiService tenantApiService, CopyPropertyOperationService copyPropertyService, CodeMapOperationService codeMapOperationService, ConditionalTransformOperationService conditionalTransformOperationService, CopyLocationOperationService copyLocationOperationService)
+        public OperationsController(IOperationManager operationManager, IOperationQueries operationQueries, IOperationSequenceQueries operationSequenceQueries, IVendorQueries vendorQueries, ITenantApiService tenantApiService, CopyPropertyOperationService copyPropertyService, CodeMapOperationService codeMapOperationService, ConditionalTransformOperationService conditionalTransformOperationService, CopyLocationOperationService copyLocationOperationService)
         {
             _operationManager = operationManager;
             _operationQueries = operationQueries;
+            _operationSequenceQueries = operationSequenceQueries;
             _vendorQueries = vendorQueries;
             _tenantApiService = tenantApiService;
             _copyPropertyOperationService = copyPropertyService;
@@ -247,7 +249,7 @@ namespace LantanaGroup.Link.Normalization.Controllers
                     OperationType = operationType.ToString(),
                     OperationJson = JsonSerializer.Serialize(operationImplementation),
                     ResourceTypes = model.ResourceTypes,
-                    FacilityId = model.FacilityId == string.Empty ? null : model.FacilityId,
+                    FacilityId = model.FacilityId ?? string.Empty,
                     Name = model.Operation.Name,
                     Description = model.Operation.Description,
                     VendorIds = model.VendorIds
@@ -258,6 +260,38 @@ namespace LantanaGroup.Link.Normalization.Controllers
                     return Problem(detail: taskResult.ErrorMessage, statusCode: StatusCodes.Status422UnprocessableEntity);
                 }
 
+                OperationModel operationModel = (OperationModel)taskResult.ObjectResult;
+
+                foreach (var resourceType in model.ResourceTypes)
+                {
+                    var results = await _operationSequenceQueries.Search(new OperationSequenceSearchModel()
+                    {
+                        ResourceType = resourceType,
+                        FacilityId = model.FacilityId ?? string.Empty
+                    });
+
+                    int maxSequence = results == null || results.Count == 0 ? 1 : results.Select(x => x.Sequence).Max() + 1;
+
+                    List<CreateOperationSequenceModel> createSequences = new List<CreateOperationSequenceModel>();
+
+                    foreach (var result in results) 
+                    {
+                        createSequences.Add(new CreateOperationSequenceModel() { OperationId = operationModel.Id, Sequence = result.Sequence });
+                    }
+
+                    createSequences.Add(new CreateOperationSequenceModel()
+                    {
+                        OperationId = operationModel.Id,
+                        Sequence = maxSequence
+                    });
+
+                    var sequences = await _operationManager.CreateOperationSequences(new CreateOperationSequencesModel()
+                    {
+                        FacilityId = model.FacilityId,
+                        ResourceType = resourceType,
+                        OperationSequences = createSequences
+                    });
+                }
                 return Created("", taskResult.ObjectResult);
             }
             catch (Exception ex)

--- a/DotNet/Normalization/Domain/Managers/OperationManager.cs
+++ b/DotNet/Normalization/Domain/Managers/OperationManager.cs
@@ -399,7 +399,7 @@ namespace LantanaGroup.Link.Normalization.Domain.Managers
 
             foreach (var sequence in sequences)
             {
-                var operation = await _database.Operations.SingleAsync(o => o.Id == sequence.OperationId);
+                var operation = await _database.Operations.FirstAsync(o => o.Id == sequence.OperationId);
                 var operationResourceTypeMap = await _database.OperationResourceTypes.SingleAsync(ort => ort.OperationId == operation.Id && ort.ResourceTypeId == resource.Id);
                 await _database.OperationSequences.AddAsync(new OperationSequence()
                 {

--- a/DotNet/Normalization/Domain/Managers/OperationManager.cs
+++ b/DotNet/Normalization/Domain/Managers/OperationManager.cs
@@ -400,7 +400,7 @@ namespace LantanaGroup.Link.Normalization.Domain.Managers
             foreach (var sequence in sequences)
             {
                 var operation = await _database.Operations.FirstAsync(o => o.Id == sequence.OperationId);
-                var operationResourceTypeMap = await _database.OperationResourceTypes.SingleAsync(ort => ort.OperationId == operation.Id && ort.ResourceTypeId == resource.Id);
+                var operationResourceTypeMap = await _database.OperationResourceTypes.FirstAsync(ort => ort.OperationId == operation.Id && ort.ResourceTypeId == resource.Id);
                 await _database.OperationSequences.AddAsync(new OperationSequence()
                 {
                     FacilityId = model.FacilityId,

--- a/DotNet/Normalization/Domain/Managers/OperationManager.cs
+++ b/DotNet/Normalization/Domain/Managers/OperationManager.cs
@@ -415,7 +415,7 @@ namespace LantanaGroup.Link.Normalization.Domain.Managers
             {
                 FacilityId = model.FacilityId,
                 ResourceType = model.ResourceType
-            });
+            }, false);
         }
 
         public async Task<bool> DeleteOperationSequence(DeleteOperationSequencesModel model)

--- a/DotNet/Normalization/Domain/Managers/OperationManager.cs
+++ b/DotNet/Normalization/Domain/Managers/OperationManager.cs
@@ -390,7 +390,7 @@ namespace LantanaGroup.Link.Normalization.Domain.Managers
 
             var sequences = model.OperationSequences.OrderBy(s => s.Sequence).ToList();
 
-            var resource = await _database.ResourceTypes.SingleOrDefaultAsync(r => r.Name == model.ResourceType);
+            var resource = await _database.ResourceTypes.FirstOrDefaultAsync(r => r.Name == model.ResourceType);
 
             if (resource == null)
             {

--- a/DotNet/Normalization/Domain/Managers/OperationManager.cs
+++ b/DotNet/Normalization/Domain/Managers/OperationManager.cs
@@ -1,4 +1,4 @@
-﻿using LantanaGroup.Link.Normalization.Application.Models.Operations.Business;
+﻿﻿using LantanaGroup.Link.Normalization.Application.Models.Operations.Business;
 using LantanaGroup.Link.Normalization.Application.Models.Operations.Business.Manager;
 using LantanaGroup.Link.Normalization.Application.Models.Operations.Business.Query;
 using LantanaGroup.Link.Normalization.Application.Services.Operations;
@@ -390,9 +390,9 @@ namespace LantanaGroup.Link.Normalization.Domain.Managers
 
             var sequences = model.OperationSequences.OrderBy(s => s.Sequence).ToList();
 
-            var resource = await _database.ResourceTypes.FirstOrDefaultAsync(r => r.Name == model.ResourceType);
+            var resourceExists = await _database.ResourceTypes.AnyAsync(r => r.Name == model.ResourceType);
 
-            if (resource == null)
+            if (!resourceExists)
             {
                 throw new InvalidOperationException("No Resource Found.");
             }
@@ -400,7 +400,7 @@ namespace LantanaGroup.Link.Normalization.Domain.Managers
             foreach (var sequence in sequences)
             {
                 var operation = await _database.Operations.FirstAsync(o => o.Id == sequence.OperationId);
-                var operationResourceTypeMap = await _database.OperationResourceTypes.FirstAsync(ort => ort.OperationId == operation.Id && ort.ResourceTypeId == resource.Id);
+                var operationResourceTypeMap = await _database.OperationResourceTypes.FirstAsync(ort => ort.OperationId == operation.Id && ort.ResourceType.Name == model.ResourceType);
                 await _database.OperationSequences.AddAsync(new OperationSequence()
                 {
                     FacilityId = model.FacilityId,
@@ -415,7 +415,7 @@ namespace LantanaGroup.Link.Normalization.Domain.Managers
             {
                 FacilityId = model.FacilityId,
                 ResourceType = model.ResourceType
-            }, false);
+            },false);
         }
 
         public async Task<bool> DeleteOperationSequence(DeleteOperationSequencesModel model)

--- a/DotNet/Normalization/Domain/Queries/OperationQueries.cs
+++ b/DotNet/Normalization/Domain/Queries/OperationQueries.cs
@@ -31,7 +31,7 @@ namespace LantanaGroup.Link.Normalization.Domain.Queries
                 OperationId = id,
                 FacilityId = facilityId,
                 IncludeDisabled = true
-            })).Records.Single();
+            })).Records.FirstOrDefault();
         }
 
         public async Task<PagedConfigModel<OperationModel>> Search(OperationSearchModel model)

--- a/DotNet/Normalization/Domain/Queries/OperationSequenceQueries.cs
+++ b/DotNet/Normalization/Domain/Queries/OperationSequenceQueries.cs
@@ -1,4 +1,4 @@
-﻿using AngleSharp;
+﻿﻿﻿using AngleSharp;
 using LantanaGroup.Link.Normalization.Application.Models.Operations.Business;
 using LantanaGroup.Link.Normalization.Application.Models.Operations.Business.Query;
 using LantanaGroup.Link.Normalization.Domain.Entities;
@@ -51,7 +51,7 @@ namespace LantanaGroup.Link.Normalization.Domain.Queries
 
         public async Task<List<OperationSequenceModel>> Search(OperationSequenceSearchModel model, bool useCache = true)
         {
-            if (!useCache)
+            if (!useCache) 
             {
                 return Query(model);
             }

--- a/DotNet/Normalization/Domain/Queries/OperationSequenceQueries.cs
+++ b/DotNet/Normalization/Domain/Queries/OperationSequenceQueries.cs
@@ -51,21 +51,21 @@ namespace LantanaGroup.Link.Normalization.Domain.Queries
 
         public async Task<List<OperationSequenceModel>> Search(OperationSequenceSearchModel model, bool useCache = true)
         {
-            if (!useCache) 
-            {
+            //if (!useCache) 
+            //{
                 return Query(model);
-            }
+            //}
 
-            //Daniel - 4/2026: Temporarily adding queried configs into memory cache to reduce the amount of queries made to the database.
-            var cacheKey = BuildCacheKey(model);
-            var cacheResult = _cache.GetOrCreate(cacheKey, entry =>
-            {
-                entry.AbsoluteExpirationRelativeToNow = _cacheTtl;
+            ////Daniel - 4/2026: Temporarily adding queried configs into memory cache to reduce the amount of queries made to the database.
+            //var cacheKey = BuildCacheKey(model);
+            //var cacheResult = _cache.GetOrCreate(cacheKey, entry =>
+            //{
+            //    entry.AbsoluteExpirationRelativeToNow = _cacheTtl;
 
-                return Query(model);
-            });
+            //    return Query(model);
+            //});
 
-            return cacheResult;
+            //return cacheResult;
         }
 
         public void ClearCache(OperationSequenceSearchModel model) {

--- a/DotNet/Normalization/Domain/Queries/OperationSequenceQueries.cs
+++ b/DotNet/Normalization/Domain/Queries/OperationSequenceQueries.cs
@@ -10,7 +10,7 @@ namespace LantanaGroup.Link.Normalization.Domain.Queries
     public interface IOperationSequenceQueries
     {
         Task<OperationSequenceModel> Get(string resourceType, string? facilityId);
-        Task<List<OperationSequenceModel>> Search(OperationSequenceSearchModel model);
+        Task<List<OperationSequenceModel>> Search(OperationSequenceSearchModel model, bool useCache = true);
         void ClearCache(OperationSequenceSearchModel model);
     }
 
@@ -48,15 +48,33 @@ namespace LantanaGroup.Link.Normalization.Domain.Queries
 
         private static (string? FacilityId, string? ResourceType, Guid? ResourceTypeId) BuildCacheKey(OperationSequenceSearchModel model) => (model.FacilityId, model.ResourceType, model.ResourceTypeId);
 
-        public async Task<List<OperationSequenceModel>> Search(OperationSequenceSearchModel model)
+
+        public async Task<List<OperationSequenceModel>> Search(OperationSequenceSearchModel model, bool useCache = true)
         {
+            if (!useCache) 
+            {
+                return Query(model);
+            }
+
             //Daniel - 4/2026: Temporarily adding queried configs into memory cache to reduce the amount of queries made to the database.
             var cacheKey = BuildCacheKey(model);
             var cacheResult = _cache.GetOrCreate(cacheKey, entry =>
             {
                 entry.AbsoluteExpirationRelativeToNow = _cacheTtl;
 
-                IQueryable<OperationSequenceModel> query = 
+                return Query(model);
+            });
+
+            return cacheResult;
+        }
+
+        public void ClearCache(OperationSequenceSearchModel model) {
+            _cache.Remove(model.FacilityId + model.ResourceType);
+        }
+
+        private List<OperationSequenceModel> Query(OperationSequenceSearchModel model) 
+        {
+            IQueryable<OperationSequenceModel> query =
                     from o in _dbContext.OperationSequences
                     where o.FacilityId == model.FacilityId
                     select new OperationSequenceModel()
@@ -126,24 +144,17 @@ namespace LantanaGroup.Link.Normalization.Domain.Queries
                         }).ToList()
                     };
 
-                if (!string.IsNullOrEmpty(model.ResourceType))
-                {
-                    query = query.Where(q => q.OperationResourceType.Resource.ResourceName == model.ResourceType);
-                }
+            if (!string.IsNullOrEmpty(model.ResourceType))
+            {
+                query = query.Where(q => q.OperationResourceType.Resource.ResourceName == model.ResourceType);
+            }
 
-                if (model.ResourceTypeId.HasValue)
-                {
-                    query = query.Where(q => q.OperationResourceType.Resource.ResourceTypeId == model.ResourceTypeId);
-                }
+            if (model.ResourceTypeId.HasValue)
+            {
+                query = query.Where(q => q.OperationResourceType.Resource.ResourceTypeId == model.ResourceTypeId);
+            }
 
-                return query.ToList();
-            });
-
-            return cacheResult;
-        }
-
-        public void ClearCache(OperationSequenceSearchModel model) {
-            _cache.Remove(model.FacilityId + model.ResourceType);
+            return query.ToList();
         }
     }
 }

--- a/DotNet/Normalization/Domain/Queries/OperationSequenceQueries.cs
+++ b/DotNet/Normalization/Domain/Queries/OperationSequenceQueries.cs
@@ -51,21 +51,21 @@ namespace LantanaGroup.Link.Normalization.Domain.Queries
 
         public async Task<List<OperationSequenceModel>> Search(OperationSequenceSearchModel model, bool useCache = true)
         {
-            //if (!useCache) 
-            //{
+            if (!useCache)
+            {
                 return Query(model);
-            //}
+            }
 
-            ////Daniel - 4/2026: Temporarily adding queried configs into memory cache to reduce the amount of queries made to the database.
-            //var cacheKey = BuildCacheKey(model);
-            //var cacheResult = _cache.GetOrCreate(cacheKey, entry =>
-            //{
-            //    entry.AbsoluteExpirationRelativeToNow = _cacheTtl;
+            //Daniel - 4/2026: Temporarily adding queried configs into memory cache to reduce the amount of queries made to the database.
+            var cacheKey = BuildCacheKey(model);
+            var cacheResult = _cache.GetOrCreate(cacheKey, entry =>
+            {
+                entry.AbsoluteExpirationRelativeToNow = _cacheTtl;
 
-            //    return Query(model);
-            //});
+                return Query(model);
+            });
 
-            //return cacheResult;
+            return cacheResult;
         }
 
         public void ClearCache(OperationSequenceSearchModel model) {

--- a/DotNet/Normalization/Domain/Queries/ResourceQueries.cs
+++ b/DotNet/Normalization/Domain/Queries/ResourceQueries.cs
@@ -1,4 +1,4 @@
-﻿using LantanaGroup.Link.Normalization.Application.Models.Operations.Business;
+﻿﻿using LantanaGroup.Link.Normalization.Application.Models.Operations.Business;
 using LantanaGroup.Link.Normalization.Domain.Entities;
 using Microsoft.EntityFrameworkCore;
 
@@ -33,7 +33,7 @@ namespace LantanaGroup.Link.Normalization.Domain.Queries
             return (await Search(new ResourceSearchModel()
             {
                 Name = resourceName
-            })).SingleOrDefault();
+            })).FirstOrDefault();
         }
 
         public async Task<List<ResourceModel>> GetAll()

--- a/DotNet/Shared/Application/Models/Integration/Normalization/NormalizationApiModels.cs
+++ b/DotNet/Shared/Application/Models/Integration/Normalization/NormalizationApiModels.cs
@@ -54,5 +54,5 @@ public class NormalizationOperationSequenceApiModel
 public class NormalizationOperationResourceTypeSequenceApiModel
 {
     public NormalizationOperationApiModel? Operation { get; set; }
-    public NormalizationResourceApiModel? ResourceType { get; set; }
+    public NormalizationResourceApiModel? Resource { get; set; }
 }


### PR DESCRIPTION
### 🛠️ Description of Changes

When making a POST request to the Operation Rest API endpoint, a sequence record will also be assigned to new operation.

### 🧪 Testing Performed

Tested locally to ensure that sequence records were being created:
<img width="1508" height="651" alt="image" src="https://github.com/user-attachments/assets/65563ba8-5da9-4e95-a61b-0ca70a466e62" />

### 🧑‍🔬 Unit Testing

- Coverage: 24.4%

N/A

### 📓 Documentation Updated

N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic per-resource-type operation sequencing after creation for clearer numbering
  * Facility operation search now supports paging (page size & number)
  * Optional caching for operation sequence queries to improve responsiveness

* **Bug Fixes**
  * Consistent facility ID handling to avoid null/empty inconsistencies in operations
  * Corrected service endpoints and minor data-mapping fixes to stabilize operation lookups
<!-- end of auto-generated comment: release notes by coderabbit.ai -->















