### PR TITLE
LEGLINK-284: Auto-sequencing of normalization operations sometimes fails

### DIFF
--- a/DotNet/Normalization/Application/Models/Operations/HttpModels/PostOperationModel.cs
+++ b/DotNet/Normalization/Application/Models/Operations/HttpModels/PostOperationModel.cs
@@ -12,7 +12,7 @@ namespace LantanaGroup.Link.Normalization.Application.Models.Operations.HttpMode
         [Required, DataMember]
         public List<string> ResourceTypes { get; set; } = new List<string>();
         [Required, DataMember]
-        public required IOperation Operation { get; set; }
+        public IOperation Operation { get; set; }
         [DataMember]
         public string? FacilityId { get; set; } = null;
         [DataMember(IsRequired = false)]

--- a/DotNet/Normalization/Application/Models/Operations/HttpModels/PostOperationModel.cs
+++ b/DotNet/Normalization/Application/Models/Operations/HttpModels/PostOperationModel.cs
@@ -25,7 +25,7 @@ namespace LantanaGroup.Link.Normalization.Application.Models.Operations.HttpMode
             FacilityId = facilityId;
             VendorIds = vendorIds;
 
-            if (this.Operation.OperationType == OperationType.CopyLocation)
+            if (this.Operation.OperationType == OperationType.CopyLocation && !this.ResourceTypes.Contains(ResourceType.Location.ToString()))
             {
                 this.ResourceTypes.Add(ResourceType.Location.ToString());
             }

--- a/DotNet/Normalization/Application/Models/Operations/HttpModels/PutOperationModel.cs
+++ b/DotNet/Normalization/Application/Models/Operations/HttpModels/PutOperationModel.cs
@@ -28,7 +28,7 @@ namespace LantanaGroup.Link.Normalization.Application.Models.Operations.HttpMode
             FacilityId = facilityId;
             VendorIds = vendorIds;
 
-            if (this.Operation.OperationType == OperationType.CopyLocation)
+            if (this.Operation.OperationType == OperationType.CopyLocation && !this.ResourceTypes.Contains("Location"))
             {
                 this.ResourceTypes.Add("Location");
             }

--- a/DotNet/Normalization/Application/Models/Operations/HttpModels/PutOperationModel.cs
+++ b/DotNet/Normalization/Application/Models/Operations/HttpModels/PutOperationModel.cs
@@ -9,7 +9,7 @@ namespace LantanaGroup.Link.Normalization.Application.Models.Operations.HttpMode
     public class PutOperationModel
     {
         [Required, DataMember]
-        public required Guid? Id { get; set; }
+        public Guid? Id { get; set; }
         [Required, DataMember]
         public List<string> ResourceTypes { get; set; } = new List<string>();
         [Required, DataMember]

--- a/DotNet/ServiceTests/UnitTests/Normalization/OperationModelTests.cs
+++ b/DotNet/ServiceTests/UnitTests/Normalization/OperationModelTests.cs
@@ -1,0 +1,64 @@
+using LantanaGroup.Link.Normalization.Application.Models.Operations.HttpModels;
+using LantanaGroup.Link.Normalization.Application.Operations;
+
+namespace UnitTests.Normalization;
+
+[Trait("Category", "UnitTests")]
+public class OperationModelTests
+{
+    [Fact]
+    public void PostOperationModel_CopyLocation_AddsLocationWhenNotPresent()
+    {
+        var model = new PostOperationModel(
+            resourceTypes: [],
+            operation: new CopyLocationOperation(),
+            facilityId: null,
+            vendorIds: null);
+
+        Assert.Single(model.ResourceTypes);
+        Assert.Contains("Location", model.ResourceTypes);
+    }
+
+    [Fact]
+    public void PostOperationModel_CopyLocation_DoesNotDuplicateLocationWhenAlreadyPresent()
+    {
+        var model = new PostOperationModel(
+            resourceTypes: ["Location"],
+            operation: new CopyLocationOperation(),
+            facilityId: null,
+            vendorIds: null);
+
+        Assert.Single(model.ResourceTypes);
+        Assert.Equal("Location", model.ResourceTypes[0]);
+    }
+
+    [Fact]
+    public void PutOperationModel_CopyLocation_AddsLocationWhenNotPresent()
+    {
+        var model = new PutOperationModel(
+            id: Guid.NewGuid(),
+            resourceTypes: [],
+            operation: new CopyLocationOperation(),
+            isDisabled: false,
+            facilityId: null,
+            vendorIds: null);
+
+        Assert.Single(model.ResourceTypes);
+        Assert.Contains("Location", model.ResourceTypes);
+    }
+
+    [Fact]
+    public void PutOperationModel_CopyLocation_DoesNotDuplicateLocationWhenAlreadyPresent()
+    {
+        var model = new PutOperationModel(
+            id: Guid.NewGuid(),
+            resourceTypes: ["Location"],
+            operation: new CopyLocationOperation(),
+            isDisabled: false,
+            facilityId: null,
+            vendorIds: null);
+
+        Assert.Single(model.ResourceTypes);
+        Assert.Equal("Location", model.ResourceTypes[0]);
+    }
+}


### PR DESCRIPTION
### 🛠️ Description of Changes

Don't add `Location` to a `CopyLocation` operation's resource types if it's already present.

### 🧪 Testing Performed

Tested locally with `CopyLocation` and other operations.

### 🧑‍🔬 Unit Testing

- [X] I have written or updated unit tests to cover my changes
- Coverage: 0.0%

### 📓 Documentation Updated

N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed potential duplicate Location entries when processing copy location operations by implementing validation checks.
  * Improved flexibility of operation models by updating property requirements.

* **Tests**
  * Added unit tests validating correct location handling and duplicate prevention in copy location operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lantanagroup/link-cloud/pull/1632)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
