### PR TITLE
LEGLINK-317: Fix Redis connection failures over docker bridge networks

### DIFF
--- a/DotNet/Shared/Application/Extensions/ExternalServices/RedisCacheExtension.cs
+++ b/DotNet/Shared/Application/Extensions/ExternalServices/RedisCacheExtension.cs
@@ -17,6 +17,10 @@ namespace LantanaGroup.Link.Shared.Application.Extensions.ExternalServices
                 options.ConfigurationOptions = new ConfigurationOptions
                 {
                     EndPoints = { redisCacheOptions.ConnectionString },
+                    // See DistributedLockSettings: SE.Redis with a hostname endpoint and
+                    // AddressFamily.Unspecified fails to connect over docker bridge networks
+                    // (Standalone DidNotRespond, ConnectTimeout). ResolveDns forces an IPEndPoint.
+                    ResolveDns = true,
                 };
 
                 if (!string.IsNullOrEmpty(redisCacheOptions.InstanceName))

--- a/DotNet/Shared/Application/Models/Configs/DistributedLockSettings.cs
+++ b/DotNet/Shared/Application/Models/Configs/DistributedLockSettings.cs
@@ -82,6 +82,11 @@ public static class DistributedLockSettingsExtensions
         {
             EndPoints = { distributedLockSettings.ConnectionString },
             AbortOnConnectFail = false,
+            // Forces SE.Redis to resolve the hostname to a specific IP (preferring IPv4) and
+            // bind to an IPEndPoint instead of a DnsEndPoint with AddressFamily.Unspecified.
+            // Without this, on docker bridge networks the socket can pick an unreachable
+            // address family and silently never establish the connection (PING just times out).
+            ResolveDns = true,
         };
 
         if (distributedLockSettings?.Password != null)


### PR DESCRIPTION
### 🛠️ Description of Changes

Sets `ResolveDns = true` on the StackExchange.Redis `ConfigurationOptions` in two shared
places where services build a Redis connection:

- `DotNet/Shared/Application/Extensions/ExternalServices/RedisCacheExtension.cs` — the
  `IDistributedCache` (Redis) registration used by services that cache via `AddRedisCache`.
- `DotNet/Shared/Application/Models/Configs/DistributedLockSettings.cs` — the
  `ConnectionMultiplexer` used by the distributed-lock infrastructure.

**Root cause:** When SE.Redis is given a hostname endpoint and the default
`AddressFamily.Unspecified`, it constructs a `DnsEndPoint` and lets the socket layer
pick a family at connect time.  Docker wasn't resolving to the correct IP

`ResolveDns = true` forces SE.Redis to resolve the hostname up front (preferring
IPv4) and bind to a concrete `IPEndPoint`, which makes the connection succeed
reliably inside the compose stack.

### 🧪 Testing Performed

- Brought up the local stack via `docker compose up -d` and confirmed services
  that previously failed to acquire Redis-backed distributed locks now connect
  successfully on first attempt.
- Verified `IDistributedCache` reads/writes succeed for services using the
  shared `AddRedisCache` registration.
- Existing unit tests in `DotNet/ServiceTests` continue to pass
  (`dotnet test DotNet/ServiceTests/ServiceTests.csproj`).

### 🧑‍🔬 Unit Testing

- [ ] I have written or updated unit tests to cover my changes
- Coverage: 0.0%
  clien

### 📓 Documentation Updated

No documentation changes required. No new config keys were introduced
(`app-config.yaml` unchanged); the behavior change is internal to the shared
Redis client construction.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced Redis connection configuration for cache and distributed lock services to improve reliability and stability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lantanagroup/link-cloud/pull/1638?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
