### PR TITLE
LEGLINK-69: Normalization - Add extension removal support - Backend

### DIFF
--- a/DotNet/Normalization/Application/Operations/OperationConverter.cs
+++ b/DotNet/Normalization/Application/Operations/OperationConverter.cs
@@ -24,6 +24,7 @@ public class OperationConverter : JsonConverter<IOperation>
                 "CodeMap" => JsonSerializer.Deserialize<CodeMapOperation>(doc.RootElement.GetRawText(), options),
                 "ConditionalTransform" => JsonSerializer.Deserialize<ConditionalTransformOperation>(doc.RootElement.GetRawText(), options),
                 "CopyLocation" => JsonSerializer.Deserialize<CopyLocationOperation>(doc.RootElement.GetRawText(), options),
+                "RemoveExtensions" => JsonSerializer.Deserialize<RemoveExtensionsOperation>(doc.RootElement.GetRawText(), options),
                 _ => throw new JsonException($"Unknown operationType: {operationType}")
             };
         }

--- a/DotNet/Normalization/Application/Operations/OperationHelper.cs
+++ b/DotNet/Normalization/Application/Operations/OperationHelper.cs
@@ -19,6 +19,7 @@ namespace LantanaGroup.Link.Normalization.Application.Operations
                 OperationType.CodeMap => JsonSerializer.Deserialize<CodeMapOperation>(operationJson),
                 OperationType.ConditionalTransform => JsonSerializer.Deserialize<ConditionalTransformOperation>(operationJson),
                 OperationType.CopyLocation => JsonSerializer.Deserialize<CopyLocationOperation>(operationJson),
+                OperationType.RemoveExtensions => JsonSerializer.Deserialize<RemoveExtensionsOperation>(operationJson),
                 _ => null
             };
 

--- a/DotNet/Normalization/Application/Operations/OperationType.cs
+++ b/DotNet/Normalization/Application/Operations/OperationType.cs
@@ -6,6 +6,7 @@
         CopyProperty = 1,
         ConditionalTransform = 2,
         CodeMap = 3,
-        CopyLocation = 4
+        CopyLocation = 4,
+        RemoveExtensions = 5
     }
 }

--- a/DotNet/Normalization/Application/Operations/RemoveExtensionsOperation.cs
+++ b/DotNet/Normalization/Application/Operations/RemoveExtensionsOperation.cs
@@ -1,0 +1,13 @@
+namespace LantanaGroup.Link.Normalization.Application.Operations
+{
+    public class RemoveExtensionsOperation : IOperation
+    {
+        public OperationType OperationType => OperationType.RemoveExtensions;
+
+        public string Name { get; set; }
+        public string Description { get; set; }
+
+        // URLs of top-level extensions to remove; extensions with URLs not in this list are left intact.
+        public List<string> ExtensionUrls { get; set; } = new();
+    }
+}

--- a/DotNet/Normalization/Application/Services/Operations/OperationServiceHelper.cs
+++ b/DotNet/Normalization/Application/Services/Operations/OperationServiceHelper.cs
@@ -41,6 +41,7 @@ namespace LantanaGroup.Link.Normalization.Application.Services.Operations
                 OperationType.CodeMap => (object)(CodeMapOperation)operation,
                 OperationType.ConditionalTransform => (object)(ConditionalTransformOperation)operation,
                 OperationType.CopyLocation => (object)(CopyLocationOperation)operation,
+                OperationType.RemoveExtensions => (object)(RemoveExtensionsOperation)operation,
                 _ => null
             };
         }
@@ -826,6 +827,21 @@ namespace LantanaGroup.Link.Normalization.Application.Services.Operations
                 else if (operation is CopyLocationOperation)
                 {
                     //No validation needed for CopyLocationOperation
+                }
+                else if (operation is RemoveExtensionsOperation)
+                {
+                    var op = (RemoveExtensionsOperation)operation;
+
+                    if (op.ExtensionUrls == null || !op.ExtensionUrls.Any())
+                    {
+                        return (false, "RemoveExtensionsOperation.ExtensionUrls must contain at least one URL.");
+                    }
+
+                    var emptyUrls = op.ExtensionUrls.Where(string.IsNullOrWhiteSpace).ToList();
+                    if (emptyUrls.Any())
+                    {
+                        return (false, "RemoveExtensionsOperation.ExtensionUrls must not contain null or empty entries.");
+                    }
                 }
                 else
                 {

--- a/DotNet/Normalization/Application/Services/Operations/RemoveExtensionsOperationService.cs
+++ b/DotNet/Normalization/Application/Services/Operations/RemoveExtensionsOperationService.cs
@@ -1,0 +1,43 @@
+using Hl7.Fhir.Model;
+using LantanaGroup.Link.Normalization.Application.Models.Operations;
+using LantanaGroup.Link.Normalization.Application.Operations;
+using LantanaGroup.Link.Shared.Application.Services.Security;
+using Task = System.Threading.Tasks.Task;
+
+namespace LantanaGroup.Link.Normalization.Application.Services.Operations
+{
+    public class RemoveExtensionsOperationService : BaseOperationService<RemoveExtensionsOperation>
+    {
+        private readonly ILogger<RemoveExtensionsOperationService> _logger;
+
+        public RemoveExtensionsOperationService(ILogger<RemoveExtensionsOperationService> logger, TimeSpan? operationTimeout = null)
+            : base(logger, operationTimeout)
+        {
+            _logger = logger;
+        }
+
+        protected override Task<OperationResult> ExecuteOperation(RemoveExtensionsOperation operation, DomainResource resource)
+        {
+            if (resource.Extension == null || resource.Extension.Count == 0)
+            {
+                return Task.FromResult(OperationResult.NoAction("Resource has no extensions.", resource));
+            }
+
+            var urlSet = new HashSet<string>(operation.ExtensionUrls, StringComparer.Ordinal);
+            int removedCount = resource.Extension.RemoveAll(e => e.Url != null && urlSet.Contains(e.Url));
+
+            if (removedCount == 0)
+            {
+                return Task.FromResult(OperationResult.NoAction("No extensions matched the configured URLs.", resource));
+            }
+
+            _logger.LogDebug(
+                "Removed {Count} extension(s) from {ResourceType}/{ResourceId}",
+                removedCount,
+                resource.TypeName.SanitizeForLog(),
+                resource.Id.SanitizeForLog());
+
+            return Task.FromResult(OperationResult.Success(resource));
+        }
+    }
+}

--- a/DotNet/Normalization/Controllers/OperationsController.cs
+++ b/DotNet/Normalization/Controllers/OperationsController.cs
@@ -33,8 +33,9 @@ namespace LantanaGroup.Link.Normalization.Controllers
         private readonly CodeMapOperationService _codeMapOperationService;
         private readonly ConditionalTransformOperationService _conditionalTransformOperationService;
         private readonly CopyLocationOperationService _copyLocationOperationService;
+        private readonly RemoveExtensionsOperationService _removeExtensionsOperationService;
 
-        public OperationsController(IOperationManager operationManager, IOperationQueries operationQueries, IOperationSequenceQueries operationSequenceQueries, IVendorQueries vendorQueries, ITenantApiService tenantApiService, CopyPropertyOperationService copyPropertyService, CodeMapOperationService codeMapOperationService, ConditionalTransformOperationService conditionalTransformOperationService, CopyLocationOperationService copyLocationOperationService)
+        public OperationsController(IOperationManager operationManager, IOperationQueries operationQueries, IOperationSequenceQueries operationSequenceQueries, IVendorQueries vendorQueries, ITenantApiService tenantApiService, CopyPropertyOperationService copyPropertyService, CodeMapOperationService codeMapOperationService, ConditionalTransformOperationService conditionalTransformOperationService, CopyLocationOperationService copyLocationOperationService, RemoveExtensionsOperationService removeExtensionsOperationService)
         {
             _operationManager = operationManager;
             _operationQueries = operationQueries;
@@ -45,6 +46,7 @@ namespace LantanaGroup.Link.Normalization.Controllers
             _codeMapOperationService = codeMapOperationService;
             _conditionalTransformOperationService = conditionalTransformOperationService;
             _copyLocationOperationService = copyLocationOperationService;
+            _removeExtensionsOperationService = removeExtensionsOperationService;
         }
 
         [HttpGet("")]
@@ -405,6 +407,7 @@ namespace LantanaGroup.Link.Normalization.Controllers
                     OperationType.CodeMap => await _codeMapOperationService.ProcessOperationAsync((CodeMapOperation)operationImplementation, domainResource),
                     OperationType.ConditionalTransform => await _conditionalTransformOperationService.ProcessOperationAsync((ConditionalTransformOperation)operationImplementation, domainResource),
                     OperationType.CopyLocation => await _copyLocationOperationService.ProcessOperationAsync((CopyLocationOperation)operationImplementation, domainResource),
+                    OperationType.RemoveExtensions => await _removeExtensionsOperationService.ProcessOperationAsync((RemoveExtensionsOperation)operationImplementation, domainResource),
                     _ => null
                 };
 
@@ -452,6 +455,7 @@ namespace LantanaGroup.Link.Normalization.Controllers
                     OperationType.CodeMap => await _codeMapOperationService.ProcessOperationAsync((CodeMapOperation)operation, domainResource),
                     OperationType.ConditionalTransform => await _conditionalTransformOperationService.ProcessOperationAsync((ConditionalTransformOperation)operation, domainResource),
                     OperationType.CopyLocation => await _copyLocationOperationService.ProcessOperationAsync((CopyLocationOperation)operation, domainResource),
+                    OperationType.RemoveExtensions => await _removeExtensionsOperationService.ProcessOperationAsync((RemoveExtensionsOperation)operation, domainResource),
                     _ => null
                 };
 

--- a/DotNet/Normalization/Listeners/ResourceAcquiredListener.cs
+++ b/DotNet/Normalization/Listeners/ResourceAcquiredListener.cs
@@ -42,6 +42,7 @@ public class ResourceAcquiredListener : BackgroundService
     private readonly CodeMapOperationService _codeMapOperationService;
     private readonly ConditionalTransformOperationService _conditionalTransformOperationService;
     private readonly CopyLocationOperationService _copyLocationOperationService;
+    private readonly RemoveExtensionsOperationService _removeExtensionsOperationService;
 
     public ResourceAcquiredListener(
         ILogger<ResourceAcquiredListener> logger,
@@ -56,7 +57,8 @@ public class ResourceAcquiredListener : BackgroundService
         CopyPropertyOperationService copyPropertyOperationService,
         CodeMapOperationService codeMapOperationService,
         ConditionalTransformOperationService conditionalTransformOperationService,
-        CopyLocationOperationService copyLocationOperationService)
+        CopyLocationOperationService copyLocationOperationService,
+        RemoveExtensionsOperationService removeExtensionsOperationService)
     {
         this._logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _consumerFactory = consumerFactory ?? throw new ArgumentNullException(nameof(consumerFactory));
@@ -80,6 +82,7 @@ public class ResourceAcquiredListener : BackgroundService
         _codeMapOperationService = codeMapOperationService ?? throw new ArgumentNullException(nameof(codeMapOperationService));
         _conditionalTransformOperationService = conditionalTransformOperationService ?? throw new ArgumentNullException(nameof(conditionalTransformOperationService));
         _copyLocationOperationService = copyLocationOperationService ?? throw new ArgumentNullException(nameof(copyLocationOperationService));
+        _removeExtensionsOperationService = removeExtensionsOperationService ?? throw new ArgumentNullException(nameof(removeExtensionsOperationService));
     }
 
     protected override async Task ExecuteAsync(CancellationToken cancellationToken)
@@ -195,6 +198,7 @@ public class ResourceAcquiredListener : BackgroundService
                                         OperationType.CodeMap => await _codeMapOperationService.ProcessOperationAsync((CodeMapOperation)operation, resource),
                                         OperationType.ConditionalTransform => await _conditionalTransformOperationService.ProcessOperationAsync((ConditionalTransformOperation)operation, resource),
                                         OperationType.CopyLocation => await _copyLocationOperationService.ProcessOperationAsync((CopyLocationOperation)operation, resource),
+                                        OperationType.RemoveExtensions => await _removeExtensionsOperationService.ProcessOperationAsync((RemoveExtensionsOperation)operation, resource),
                                         _ => null
                                     };
 

--- a/DotNet/Normalization/Program.cs
+++ b/DotNet/Normalization/Program.cs
@@ -197,6 +197,7 @@ static void RegisterServices(WebApplicationBuilder builder)
     builder.Services.AddSingleton<CodeMapOperationService>();
     builder.Services.AddSingleton<ConditionalTransformOperationService>();
     builder.Services.AddSingleton<CopyLocationOperationService>();
+    builder.Services.AddSingleton<RemoveExtensionsOperationService>();
     
     if (consumerSettings != null && !consumerSettings.DisableConsumer)
     {

--- a/DotNet/ServiceTests/IntegrationTests/Normalization/NormalizationIntegrationTestFixture.cs
+++ b/DotNet/ServiceTests/IntegrationTests/Normalization/NormalizationIntegrationTestFixture.cs
@@ -37,6 +37,7 @@ namespace IntegrationTests.Normalization
                     services.AddSingleton<CopyLocationOperationService>();
                     services.AddSingleton<CodeMapOperationService>();
                     services.AddSingleton<ConditionalTransformOperationService>();
+                    services.AddSingleton<RemoveExtensionsOperationService>();
 
                     // Register other services
                     services.AddScoped<IEntityRepository<Operation>, OperationRepository>();

--- a/DotNet/ServiceTests/IntegrationTests/Normalization/OperationServiceTests.cs
+++ b/DotNet/ServiceTests/IntegrationTests/Normalization/OperationServiceTests.cs
@@ -28,6 +28,7 @@ namespace IntegrationTests.Normalization
         private readonly CodeMapOperationService _codeMapOperationService;
         private readonly ConditionalTransformOperationService _conditionalTransformService;
         private readonly CopyLocationOperationService _copyLocationOperationService;
+        private readonly RemoveExtensionsOperationService _removeExtensionsOperationService;
 
         public OperationServiceTests(NormalizationIntegrationTestFixture fixture, ITestOutputHelper output)
         {
@@ -41,6 +42,7 @@ namespace IntegrationTests.Normalization
             _codeMapOperationService = _fixture.ServiceProvider.GetRequiredService<CodeMapOperationService>();
             _conditionalTransformService = _fixture.ServiceProvider.GetRequiredService<ConditionalTransformOperationService>();
             _copyLocationOperationService = _fixture.ServiceProvider.GetRequiredService<CopyLocationOperationService>();
+            _removeExtensionsOperationService = _fixture.ServiceProvider.GetRequiredService<RemoveExtensionsOperationService>();
         }
 
         [Fact]
@@ -2466,6 +2468,100 @@ namespace IntegrationTests.Normalization
             _output.WriteLine(await serializer.SerializeToStringAsync(modifiedLocation));
 
             Assert.Equal(location.Identifier[0].Value, modifiedLocation.Type[0].Coding[0].Code);
+        }
+
+        [Fact]
+        public async Task Integration_RemoveExtensionsOperation_Patient_RemovesListedExtensions_LeavesOthersIntact()
+        {
+            var urlToRemove1 = "http://example.com/fhir/extension/vendor-tag";
+            var urlToRemove2 = "http://example.com/fhir/extension/internal-flag";
+            var urlToKeep = "http://hl7.org/fhir/StructureDefinition/patient-mothersMaidenName";
+
+            var operation = new RemoveExtensionsOperation
+            {
+                Name = "Remove Vendor Extensions",
+                Description = "Integration Test Remove Extensions Operation",
+                ExtensionUrls = [urlToRemove1, urlToRemove2]
+            };
+
+            var taskResult = await _operationManager.CreateOperation(new CreateOperationModel()
+            {
+                OperationJson = JsonSerializer.Serialize(operation),
+                OperationType = OperationType.RemoveExtensions.ToString(),
+                FacilityId = "TestFacilityId",
+                Description = "Integration Test Remove Extensions Operation",
+                IsDisabled = false,
+                ResourceTypes = ["Patient"]
+            });
+
+            Assert.True(taskResult.IsSuccess, taskResult.ErrorMessage);
+            Assert.NotNull(taskResult.ObjectResult);
+
+            var result = (OperationModel)taskResult.ObjectResult;
+
+            Assert.NotNull(result);
+            Assert.True(result.Id != default);
+
+            var fetched = await _operationQueries.Get(result.Id, result.FacilityId);
+
+            Assert.NotNull(fetched);
+            Assert.True(fetched.Id != default);
+
+            var parser = LinkFhirSerializerOptions.FhirJsonParserPermissive;
+            string assemblyLocation = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+            string resourcePath = Path.Combine(assemblyLocation, "Resources", "PatientWithExtensions.txt");
+            string text = File.ReadAllText(resourcePath);
+            var patient = parser.Parse<Patient>(text);
+
+            Assert.Equal(3, patient.Extension.Count);
+
+            Assert.NotNull(fetched.OperationJson);
+            var removeOperation = JsonSerializer.Deserialize<RemoveExtensionsOperation>(fetched.OperationJson);
+
+            Assert.NotNull(removeOperation);
+            Assert.NotEmpty(removeOperation.ExtensionUrls);
+
+            var operationResult = await _removeExtensionsOperationService.ProcessOperationAsync(removeOperation, patient);
+            Assert.Equal(OperationStatus.Success, operationResult.SuccessCode);
+
+            var modifiedPatient = (Patient)operationResult.Resource;
+
+            _output.WriteLine("Original: ");
+            _output.WriteLine(text);
+
+            _output.WriteLine("Modified: ");
+            FhirJsonSerializer serializer = new FhirJsonSerializer();
+            _output.WriteLine(await serializer.SerializeToStringAsync(modifiedPatient));
+
+            Assert.Single(modifiedPatient.Extension);
+            Assert.Equal(urlToKeep, modifiedPatient.Extension[0].Url);
+            Assert.DoesNotContain(modifiedPatient.Extension, e => e.Url == urlToRemove1);
+            Assert.DoesNotContain(modifiedPatient.Extension, e => e.Url == urlToRemove2);
+        }
+
+        [Fact]
+        public async Task Integration_RemoveExtensionsOperation_Validation_RejectsEmptyUrlList()
+        {
+            var operation = new RemoveExtensionsOperation
+            {
+                Name = "Remove Extensions - Empty List",
+                Description = "Should fail validation",
+                ExtensionUrls = []
+            };
+
+            var taskResult = await _operationManager.CreateOperation(new CreateOperationModel()
+            {
+                OperationJson = JsonSerializer.Serialize(operation),
+                OperationType = OperationType.RemoveExtensions.ToString(),
+                FacilityId = "TestFacilityId",
+                Description = "Integration Test Remove Extensions Validation",
+                IsDisabled = false,
+                ResourceTypes = ["Patient"]
+            });
+
+            Assert.False(taskResult.IsSuccess);
+            Assert.NotNull(taskResult.ErrorMessage);
+            Assert.Contains("ExtensionUrls", taskResult.ErrorMessage);
         }
     }
 }

--- a/DotNet/ServiceTests/Resources/PatientWithExtensions.txt
+++ b/DotNet/ServiceTests/Resources/PatientWithExtensions.txt
@@ -1,0 +1,22 @@
+{
+  "resourceType": "Patient",
+  "id": "patient-with-extensions",
+  "extension": [
+    {
+      "url": "http://example.com/fhir/extension/vendor-tag",
+      "valueString": "should be removed"
+    },
+    {
+      "url": "http://example.com/fhir/extension/internal-flag",
+      "valueBoolean": true
+    },
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/patient-mothersMaidenName",
+      "valueString": "should be kept"
+    }
+  ],
+  "identifier": [{"use": "official", "system": "http://example.com/ids", "value": "12345"}],
+  "name": [{"family": "Test", "given": ["Patient"]}],
+  "gender": "male",
+  "birthDate": "1980-01-01"
+}

--- a/DotNet/ServiceTests/ServiceTests.csproj
+++ b/DotNet/ServiceTests/ServiceTests.csproj
@@ -126,6 +126,9 @@
     <None Update="Resources\PatientJohnDoe.txt">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+    <None Update="Resources\PatientWithExtensions.txt">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
     <None Update="Resources\RawEncounter.txt">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>

--- a/DotNet/ServiceTests/UnitTests/Normalization/RemoveExtensionsOperationServiceTests.cs
+++ b/DotNet/ServiceTests/UnitTests/Normalization/RemoveExtensionsOperationServiceTests.cs
@@ -1,0 +1,162 @@
+using LantanaGroup.Link.Normalization.Application.Models.Operations;
+using LantanaGroup.Link.Normalization.Application.Operations;
+using LantanaGroup.Link.Normalization.Application.Services.Operations;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Task = System.Threading.Tasks.Task;
+
+namespace UnitTests.Normalization;
+
+[Trait("Category", "UnitTests")]
+public class RemoveExtensionsOperationServiceTests
+{
+    private const string UrlA = "http://example.com/fhir/extension/vendor-tag";
+    private const string UrlB = "http://example.com/fhir/extension/internal-flag";
+    private const string UrlC = "http://hl7.org/fhir/StructureDefinition/patient-mothersMaidenName";
+
+    private readonly RemoveExtensionsOperationService _service;
+
+    public RemoveExtensionsOperationServiceTests()
+    {
+        var logger = new Mock<ILogger<RemoveExtensionsOperationService>>().Object;
+        _service = new RemoveExtensionsOperationService(logger);
+    }
+
+    private static Patient PatientWithExtensions(params string[] urls)
+    {
+        var patient = new Patient { Id = "test-patient" };
+        foreach (var url in urls)
+            patient.Extension.Add(new Extension(url, new FhirString("value")));
+        return patient;
+    }
+
+    [Fact]
+    public async Task RemoveExtensions_SingleMatchingUrl_RemovesExtension_ReturnsSuccess()
+    {
+        var patient = PatientWithExtensions(UrlA, UrlC);
+        var operation = new RemoveExtensionsOperation
+        {
+            Name = "Remove vendor tag",
+            ExtensionUrls = [UrlA]
+        };
+
+        var result = await _service.ProcessOperationAsync(operation, patient);
+
+        Assert.Equal(OperationStatus.Success, result.SuccessCode);
+        var modified = (Patient)result.Resource;
+        Assert.Single(modified.Extension);
+        Assert.Equal(UrlC, modified.Extension[0].Url);
+    }
+
+    [Fact]
+    public async Task RemoveExtensions_MultipleMatchingUrls_AllRemoved_ReturnsSuccess()
+    {
+        var patient = PatientWithExtensions(UrlA, UrlB, UrlC);
+        var operation = new RemoveExtensionsOperation
+        {
+            Name = "Remove vendor extensions",
+            ExtensionUrls = [UrlA, UrlB]
+        };
+
+        var result = await _service.ProcessOperationAsync(operation, patient);
+
+        Assert.Equal(OperationStatus.Success, result.SuccessCode);
+        var modified = (Patient)result.Resource;
+        Assert.Single(modified.Extension);
+        Assert.Equal(UrlC, modified.Extension[0].Url);
+    }
+
+    [Fact]
+    public async Task RemoveExtensions_AllExtensionsListed_AllRemoved_ReturnsSuccess()
+    {
+        var patient = PatientWithExtensions(UrlA, UrlB);
+        var operation = new RemoveExtensionsOperation
+        {
+            Name = "Remove all",
+            ExtensionUrls = [UrlA, UrlB]
+        };
+
+        var result = await _service.ProcessOperationAsync(operation, patient);
+
+        Assert.Equal(OperationStatus.Success, result.SuccessCode);
+        var modified = (Patient)result.Resource;
+        Assert.Empty(modified.Extension);
+    }
+
+    [Fact]
+    public async Task RemoveExtensions_NoMatchingUrls_ReturnsNoAction()
+    {
+        var patient = PatientWithExtensions(UrlC);
+        var operation = new RemoveExtensionsOperation
+        {
+            Name = "Remove vendor tag",
+            ExtensionUrls = [UrlA]
+        };
+
+        var result = await _service.ProcessOperationAsync(operation, patient);
+
+        Assert.Equal(OperationStatus.NoAction, result.SuccessCode);
+        var modified = (Patient)result.Resource;
+        Assert.Single(modified.Extension);
+        Assert.Equal(UrlC, modified.Extension[0].Url);
+    }
+
+    [Fact]
+    public async Task RemoveExtensions_ResourceHasNoExtensions_ReturnsNoAction()
+    {
+        var patient = new Patient { Id = "test-patient" };
+        var operation = new RemoveExtensionsOperation
+        {
+            Name = "Remove vendor tag",
+            ExtensionUrls = [UrlA]
+        };
+
+        var result = await _service.ProcessOperationAsync(operation, patient);
+
+        Assert.Equal(OperationStatus.NoAction, result.SuccessCode);
+    }
+
+    [Fact]
+    public async Task RemoveExtensions_NullResource_ReturnsFailure()
+    {
+        var operation = new RemoveExtensionsOperation
+        {
+            Name = "Remove vendor tag",
+            ExtensionUrls = [UrlA]
+        };
+
+        var result = await _service.ProcessOperationAsync(operation, null);
+
+        Assert.Equal(OperationStatus.Failure, result.SuccessCode);
+    }
+
+    [Fact]
+    public async Task RemoveExtensions_NullOperation_ReturnsFailure()
+    {
+        var patient = PatientWithExtensions(UrlA);
+
+        var result = await _service.ProcessOperationAsync(null, patient);
+
+        Assert.Equal(OperationStatus.Failure, result.SuccessCode);
+    }
+
+    [Fact]
+    public async Task RemoveExtensions_UrlNotInList_ExtensionLeftIntact()
+    {
+        var patient = PatientWithExtensions(UrlA, UrlB, UrlC);
+        var operation = new RemoveExtensionsOperation
+        {
+            Name = "Remove only A",
+            ExtensionUrls = [UrlA]
+        };
+
+        var result = await _service.ProcessOperationAsync(operation, patient);
+
+        Assert.Equal(OperationStatus.Success, result.SuccessCode);
+        var modified = (Patient)result.Resource;
+        Assert.Equal(2, modified.Extension.Count);
+        Assert.DoesNotContain(modified.Extension, e => e.Url == UrlA);
+        Assert.Contains(modified.Extension, e => e.Url == UrlB);
+        Assert.Contains(modified.Extension, e => e.Url == UrlC);
+    }
+}

--- a/DotNet/ServiceTests/UnitTests/Normalization/ResourceAcquiredListenerTests.cs
+++ b/DotNet/ServiceTests/UnitTests/Normalization/ResourceAcquiredListenerTests.cs
@@ -31,6 +31,7 @@ public class ResourceAcquiredListenerTests
     private readonly Mock<CodeMapOperationService> _codeMapOperationServiceMock;
     private readonly Mock<ConditionalTransformOperationService> _conditionalTransformOperationServiceMock;
     private readonly Mock<CopyLocationOperationService> _copyLocationOperationServiceMock;
+    private readonly Mock<RemoveExtensionsOperationService> _removeExtensionsOperationServiceMock;
 
     public ResourceAcquiredListenerTests()
     {
@@ -49,6 +50,7 @@ public class ResourceAcquiredListenerTests
         _codeMapOperationServiceMock = new Mock<CodeMapOperationService>(new Mock<ILogger<CodeMapOperationService>>().Object, null);
         _conditionalTransformOperationServiceMock = new Mock<ConditionalTransformOperationService>(new Mock<ILogger<ConditionalTransformOperationService>>().Object, null);
         _copyLocationOperationServiceMock = new Mock<CopyLocationOperationService>(new Mock<ILogger<CopyLocationOperationService>>().Object, null);
+        _removeExtensionsOperationServiceMock = new Mock<RemoveExtensionsOperationService>(new Mock<ILogger<RemoveExtensionsOperationService>>().Object, null);
     }
 
     [Fact]
@@ -68,7 +70,8 @@ public class ResourceAcquiredListenerTests
             _copyPropertyOperationServiceMock.Object,
             _codeMapOperationServiceMock.Object,
             _conditionalTransformOperationServiceMock.Object,
-            _copyLocationOperationServiceMock.Object);
+            _copyLocationOperationServiceMock.Object,
+            _removeExtensionsOperationServiceMock.Object);
 
         var facilityId = "TestFacility";
         var correlationId = "TestCorrelationId";
@@ -136,7 +139,8 @@ public class ResourceAcquiredListenerTests
             _copyPropertyOperationServiceMock.Object,
             _codeMapOperationServiceMock.Object,
             _conditionalTransformOperationServiceMock.Object,
-            _copyLocationOperationServiceMock.Object);
+            _copyLocationOperationServiceMock.Object,
+            _removeExtensionsOperationServiceMock.Object);
 
         var facilityId = "TestFacility";
         var correlationId = "TestCorrelationId";


### PR DESCRIPTION
### 🛠️ Description of Changes

Added a new normalization operation for removing top-level extensions identified by a configurable list of URLs.

### 🧪 Testing Performed

Tested locally via the `POST /api/normalization/Operations/test` endpoint.

### 🧑‍🔬 Unit Testing

- [X] I have written or updated unit tests to cover my changes
- Coverage: 76.3%

### 📓 Documentation Updated

Updated the Normalization service documentation to include the new operation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added new operation type that enables selective removal of resource extensions by specifying target extension URLs to be removed, providing granular control over which extensions are retained

## Tests
* Added comprehensive unit and integration tests to validate extension removal operation behavior, including edge cases, validation error scenarios, and partial removal workflows

<!-- end of auto-generated comment: release notes by coderabbit.ai -->