### PR TITLE
LEGLINK-65: Add PostSearch for Parameter queries

### DIFF
--- a/DotNet/DataAcquisition.Domain/Application/Factories/QueryFactories/ParameterQueryFactory.cs
+++ b/DotNet/DataAcquisition.Domain/Application/Factories/QueryFactories/ParameterQueryFactory.cs
@@ -6,6 +6,7 @@ using LantanaGroup.Link.DataAcquisition.Domain.Infrastructure.Models.QueryConfig
 using LantanaGroup.Link.DataAcquisition.Domain.Infrastructure.Models.QueryConfig.Parameter;
 using LantanaGroup.Link.Shared.Application.Models;
 using Microsoft.Extensions.Logging;
+using StackExchange.Redis;
 using OperationType = LantanaGroup.Link.DataAcquisition.Domain.Infrastructure.Models.QueryConfig.OperationType;
 
 namespace LantanaGroup.Link.DataAcquisition.Domain.Application.Factories.QueryFactories;
@@ -84,7 +85,13 @@ public class ParameterQueryFactory : IParameterQueryFactory
             }
         }
 
-        return isPaged ? new PagedParameterQueryFactoryResult(OperationType.Search, searchParamList)
-            : new SingularParameterQueryFactoryResult(OperationType.Search, searchParams);
+        // Read is not a valid operation type for a parameter query, 
+        // but if it is set to that, treat it as a search to avoid errors and still return results
+        var operationType = config.OperationType == OperationType.SearchPost
+         ? OperationType.SearchPost 
+         : OperationType.Search;
+
+        return isPaged ? new PagedParameterQueryFactoryResult(operationType, searchParamList)
+            : new SingularParameterQueryFactoryResult(operationType, searchParams);
     }
 }

--- a/DotNet/DataAcquisition.Domain/Application/Factories/QueryFactories/ParameterQueryFactory.cs
+++ b/DotNet/DataAcquisition.Domain/Application/Factories/QueryFactories/ParameterQueryFactory.cs
@@ -87,9 +87,22 @@ public class ParameterQueryFactory : IParameterQueryFactory
 
         // Read is not a valid operation type for a parameter query, 
         // but if it is set to that, treat it as a search to avoid errors and still return results
-        var operationType = config.OperationType == OperationType.SearchPost
-         ? OperationType.SearchPost 
-         : OperationType.Search;
+        OperationType operationType;
+        if (config.OperationType == OperationType.Read)
+        {
+            _logger.LogWarning(
+                "Read is not a valid operation type for ParameterQueryConfig. Treating as Search for" +
+                " ResourceType {ResourceType} on CorrelationId {CorrelationId}",
+                config.ResourceType,
+                request.CorrelationId);
+            operationType = OperationType.Search;
+        }
+        else
+        {
+            operationType = config.OperationType == OperationType.SearchPost
+                ? OperationType.SearchPost
+                : OperationType.Search;
+        }
 
         return isPaged ? new PagedParameterQueryFactoryResult(operationType, searchParamList)
             : new SingularParameterQueryFactoryResult(operationType, searchParams);

--- a/DotNet/DataAcquisition.Domain/Application/Validators/QueryPlanValidator.cs
+++ b/DotNet/DataAcquisition.Domain/Application/Validators/QueryPlanValidator.cs
@@ -226,6 +226,11 @@ public class QueryPlanValidator : IQueryPlanValidator
             result.IsValid = false;
             result.Errors.Add($"{prefix}: OperationType value '{config.OperationType}' is not a valid OperationType enum value.");
         }
+        else if (config.OperationType == OperationType.Read)
+        {
+            result.IsValid = false;
+            result.Errors.Add($"{prefix}: 'Read' is not a valid operation type for ParameterQueryConfig.");
+        }
 
         // Validate Parameters
         if (config.Parameters == null || !config.Parameters.Any())

--- a/DotNet/DataAcquisition.Domain/Application/Validators/QueryPlanValidator.cs
+++ b/DotNet/DataAcquisition.Domain/Application/Validators/QueryPlanValidator.cs
@@ -220,6 +220,13 @@ public class QueryPlanValidator : IQueryPlanValidator
             }
         }
 
+        // Validate OperationType
+        if (!Enum.IsDefined(typeof(OperationType), config.OperationType))
+        {
+            result.IsValid = false;
+            result.Errors.Add($"{prefix}: OperationType value '{config.OperationType}' is not a valid OperationType enum value.");
+        }
+
         // Validate Parameters
         if (config.Parameters == null || !config.Parameters.Any())
         {

--- a/DotNet/DataAcquisition.Domain/Infrastructure/Attributes/ValidateQueryPlanConfigDictionaryAttribute.cs
+++ b/DotNet/DataAcquisition.Domain/Infrastructure/Attributes/ValidateQueryPlanConfigDictionaryAttribute.cs
@@ -90,6 +90,15 @@ public class ValidateQueryPlanConfigDictionaryAttribute : ValidationAttribute
             return;
         }
 
+        if (!Enum.IsDefined(typeof(OperationType), config.OperationType))
+        {
+            errors.Add($"Key '{key}': Invalid OperationType value for ParameterQueryConfig.");
+        }
+        else if (config.OperationType == OperationType.Read)
+        {
+            errors.Add($"Key '{key}': 'Read' is not a valid operation type for ParameterQueryConfig.");
+        }
+
         // Validate each parameter
         for (int i = 0; i < config.Parameters.Count; i++)
         {

--- a/DotNet/DataAcquisition.Domain/Infrastructure/Models/QueryConfig/ParameterQueryConfig.cs
+++ b/DotNet/DataAcquisition.Domain/Infrastructure/Models/QueryConfig/ParameterQueryConfig.cs
@@ -5,6 +5,9 @@ public class ParameterQueryConfig : IQueryConfig
 {
     public QueryConfigType QueryConfigType { get; set; } = QueryConfigType.Parameter;
     public string ResourceType { get; set; }
+
+    public OperationType OperationType { get; set; } = OperationType.Search;
+
     public List<IParameter> Parameters { get; set; }
 
     public ParameterQueryConfig()

--- a/DotNet/ServiceTests/UnitTests/DataAcquisition/Factories/ParameterQueryFactoryTests.cs
+++ b/DotNet/ServiceTests/UnitTests/DataAcquisition/Factories/ParameterQueryFactoryTests.cs
@@ -144,5 +144,61 @@ namespace UnitTests.DataAcquisition.Factories
             Assert.Single(singularResult.SearchParams);
             Assert.Equal("lit2", singularResult.SearchParams[0].Key);
         }
+
+        [Theory]
+        [InlineData(OperationType.Search, OperationType.Search)]
+        [InlineData(OperationType.SearchPost, OperationType.SearchPost)]
+        [InlineData(OperationType.Read, OperationType.Search)] // Read is invalid for parameter queries; must fall back to Search
+        public async Task Build_SingularResult_UsesExpectedOperationType(OperationType configured, OperationType expected)
+        {
+            // Arrange
+            var config = new ParameterQueryConfig
+            {
+                ResourceType = "Patient",
+                OperationType = configured,
+                Parameters = new List<IParameter>
+                {
+                    new LiteralParameter { Name = "lit1", Literal = "val1" }
+                }
+            };
+            var request = new GetPatientDataRequest { CorrelationId = "corr1", FacilityId = "fac1" };
+
+            // Act
+            var result = await _parameterQueryFactory.Build(config, request, null, null, _dataAcquisitionLogQueriesMock.Object);
+
+            // Assert
+            var singularResult = Assert.IsType<SingularParameterQueryFactoryResult>(result);
+            Assert.Equal(expected, singularResult.opType);
+        }
+
+        [Theory]
+        [InlineData(OperationType.Search, OperationType.Search)]
+        [InlineData(OperationType.SearchPost, OperationType.SearchPost)]
+        [InlineData(OperationType.Read, OperationType.Search)] // Read is invalid for parameter queries; must fall back to Search
+        public async Task Build_PagedResult_UsesExpectedOperationType(OperationType configured, OperationType expected)
+        {
+            // Arrange
+            var config = new ParameterQueryConfig
+            {
+                ResourceType = "Patient",
+                OperationType = configured,
+                Parameters = new List<IParameter>
+                {
+                    new ResourceIdsParameter { Name = "_id", Resource = "Patient", Paged = "2" }
+                }
+            };
+            var request = new GetPatientDataRequest { CorrelationId = "corr1", FacilityId = "fac1" };
+
+            _dataAcquisitionLogQueriesMock
+                .Setup(q => q.GetResourceIdsForReportPatient(request.CorrelationId, request.FacilityId, "Patient", It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new List<string> { "id1", "id2", "id3" });
+
+            // Act
+            var result = await _parameterQueryFactory.Build(config, request, null, null, _dataAcquisitionLogQueriesMock.Object);
+
+            // Assert
+            var pagedResult = Assert.IsType<PagedParameterQueryFactoryResult>(result);
+            Assert.Equal(expected, pagedResult.opType);
+        }
     }
 }

--- a/DotNet/ServiceTests/UnitTests/DataAcquisition/QueryPlanConverterTests.cs
+++ b/DotNet/ServiceTests/UnitTests/DataAcquisition/QueryPlanConverterTests.cs
@@ -175,13 +175,14 @@ public class QueryPlanConverterTests
         var config = new ParameterQueryConfig
         {
             ResourceType = "Encounter",
-            Parameters = new List<IParameter>()
+            Parameters = new List<IParameter>(),
+            OperationType = OperationType.Search
         };
 
         string json = JsonSerializer.Serialize<IQueryConfig>(config, _options);
 
         var expected = """
-        {"QueryConfigType":"Parameter","ResourceType":"Encounter","Parameters":[]}
+        {"QueryConfigType":"Parameter","ResourceType":"Encounter","OperationType":"Search","Parameters":[]}
         """.Replace("\r\n", "").Replace("\n", "");
 
         Assert.Equal(expected, json);

--- a/DotNet/ServiceTests/UnitTests/DataAcquisition/QueryPlanValidatorTests.cs
+++ b/DotNet/ServiceTests/UnitTests/DataAcquisition/QueryPlanValidatorTests.cs
@@ -749,4 +749,120 @@ public class QueryPlanValidatorTests
         Assert.True(result.IsValid);
         Assert.Contains(result.Warnings, w => w.Contains("Duplicate ResourceType"));
     }
+
+    [Theory]
+    [InlineData(OperationType.Search)]
+    [InlineData(OperationType.SearchPost)]
+    public void ValidateQueryPlan_ParameterQueryWithSearchOperationType_ReturnsSuccess(OperationType operationType)
+    {
+        // Arrange
+        var initialQueries = new Dictionary<string, IQueryConfig>
+        {
+            ["0"] = new ParameterQueryConfig
+            {
+                ResourceType = "Patient",
+                OperationType = operationType,
+                Parameters = new List<IParameter>
+                {
+                    new LiteralParameter { Name = "_id", Literal = "123" }
+                }
+            }
+        };
+
+        var supplementalQueries = new Dictionary<string, IQueryConfig>
+        {
+            ["0"] = new ParameterQueryConfig
+            {
+                ResourceType = "Encounter",
+                OperationType = operationType,
+                Parameters = new List<IParameter>
+                {
+                    new LiteralParameter { Name = "patient", Literal = "456" }
+                }
+            }
+        };
+
+        // Act
+        var result = _validator.ValidateQueryPlan(initialQueries, supplementalQueries);
+
+        // Assert
+        Assert.True(result.IsValid);
+        Assert.Empty(result.Errors);
+    }
+
+    [Fact]
+    public void ValidateQueryPlan_ParameterQueryWithReadOperationType_ReturnsError()
+    {
+        // Arrange
+        var initialQueries = new Dictionary<string, IQueryConfig>
+        {
+            ["0"] = new ParameterQueryConfig
+            {
+                ResourceType = "Patient",
+                OperationType = OperationType.Read,
+                Parameters = new List<IParameter>
+                {
+                    new LiteralParameter { Name = "_id", Literal = "123" }
+                }
+            }
+        };
+
+        var supplementalQueries = new Dictionary<string, IQueryConfig>
+        {
+            ["0"] = new ParameterQueryConfig
+            {
+                ResourceType = "Encounter",
+                OperationType = OperationType.Search,
+                Parameters = new List<IParameter>
+                {
+                    new LiteralParameter { Name = "patient", Literal = "456" }
+                }
+            }
+        };
+
+        // Act
+        var result = _validator.ValidateQueryPlan(initialQueries, supplementalQueries);
+
+        // Assert
+        Assert.False(result.IsValid);
+        Assert.Contains(result.Errors, e => e.Contains("'Read' is not a valid operation type for ParameterQueryConfig"));
+    }
+
+    [Fact]
+    public void ValidateQueryPlan_ParameterQueryWithUndefinedOperationType_ReturnsError()
+    {
+        // Arrange
+        var initialQueries = new Dictionary<string, IQueryConfig>
+        {
+            ["0"] = new ParameterQueryConfig
+            {
+                ResourceType = "Patient",
+                OperationType = (OperationType)999, // Undefined enum value
+                Parameters = new List<IParameter>
+                {
+                    new LiteralParameter { Name = "_id", Literal = "123" }
+                }
+            }
+        };
+
+        var supplementalQueries = new Dictionary<string, IQueryConfig>
+        {
+            ["0"] = new ParameterQueryConfig
+            {
+                ResourceType = "Encounter",
+                OperationType = OperationType.Search,
+                Parameters = new List<IParameter>
+                {
+                    new LiteralParameter { Name = "patient", Literal = "456" }
+                }
+            }
+        };
+
+        // Act
+        var result = _validator.ValidateQueryPlan(initialQueries, supplementalQueries);
+
+        // Assert
+        Assert.False(result.IsValid);
+        Assert.Contains(result.Errors, e => e.Contains("is not a valid OperationType enum value"));
+    }
 }

--- a/DotNet/ServiceTests/UnitTests/DataAcquisition/SearchFhirCommandTests.cs
+++ b/DotNet/ServiceTests/UnitTests/DataAcquisition/SearchFhirCommandTests.cs
@@ -48,12 +48,16 @@ public class SearchFhirCommandTests
     private sealed class StubHttpMessageHandler : HttpMessageHandler
     {
         private readonly Queue<HttpResponseMessage> _queue = new();
+        private readonly List<HttpRequestMessage> _captured = new();
+
+        public IReadOnlyList<HttpRequestMessage> CapturedRequests => _captured;
 
         public void Enqueue(HttpResponseMessage response) => _queue.Enqueue(response);
 
         protected override Task<HttpResponseMessage> SendAsync(
             HttpRequestMessage request, CancellationToken cancellationToken)
         {
+            _captured.Add(request);
             if (_queue.TryDequeue(out var response))
                 return Task.FromResult(response);
             throw new InvalidOperationException("StubHttpMessageHandler: no more queued responses.");
@@ -324,5 +328,28 @@ public class SearchFhirCommandTests
 
         Assert.Equal(2, results.Count);
         Assert.Equal(new[] { "acquired", "released", "acquired", "released" }, trace);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_QueryTypeSearchPost_SendsHttpPostRequest()
+    {
+        // SearchFhirCommand picks SearchUsingPostAsync vs SearchAsync purely on
+        // request.queryType. SearchUsingPostAsync issues POST [base]/[type]/_search;
+        // SearchAsync issues GET. Asserting the outgoing HTTP method proves the
+        // SearchPost branch ran. IsReference is a FhirApiService concern and
+        // never reaches this command, so it is not part of this assertion.
+        var stub = new StubHttpMessageHandler();
+        stub.Enqueue(OkBundleResponse(BundleWithNoNext("b1")));
+
+        var (semProvider, _, _) = SetupSemaphoreMocks();
+        var sut = BuildSut(stub, semProvider, SetupMetricsMock(), SetupNoAuthMock());
+
+        var request = CreateRequest() with { queryType = FhirQueryType.SearchPost };
+
+        await foreach (var _ in sut.ExecuteAsync(request)) { }
+
+        var captured = Assert.Single(stub.CapturedRequests);
+        Assert.Equal(HttpMethod.Post, captured.Method);
+        Assert.EndsWith("_search", captured.RequestUri!.AbsolutePath);
     }
 }

--- a/DotNet/ServiceTests/UnitTests/DataAcquisition/ValidateQueryPlanConfigDictionaryAttributeTests.cs
+++ b/DotNet/ServiceTests/UnitTests/DataAcquisition/ValidateQueryPlanConfigDictionaryAttributeTests.cs
@@ -1,0 +1,97 @@
+using LantanaGroup.Link.DataAcquisition.Domain.Application.Attributes;
+using LantanaGroup.Link.DataAcquisition.Domain.Infrastructure.Interfaces;
+using LantanaGroup.Link.DataAcquisition.Domain.Infrastructure.Models.QueryConfig;
+using LantanaGroup.Link.DataAcquisition.Domain.Infrastructure.Models.QueryConfig.Parameter;
+using System.ComponentModel.DataAnnotations;
+
+namespace UnitTests.DataAcquisition;
+
+[Trait("Category", "UnitTests")]
+public class ValidateQueryPlanConfigDictionaryAttributeTests
+{
+    private const string InvalidOperationTypeError = "Invalid OperationType value for ParameterQueryConfig.";
+    private const string ReadNotValidError = "'Read' is not a valid operation type for ParameterQueryConfig.";
+
+    private readonly ValidateQueryPlanConfigDictionaryAttribute _attribute = new();
+
+    private static Dictionary<string, IQueryConfig> BuildDictionary(OperationType operationType)
+    {
+        return new Dictionary<string, IQueryConfig>
+        {
+            ["0"] = new ParameterQueryConfig
+            {
+                ResourceType = "Patient",
+                OperationType = operationType,
+                Parameters = new List<IParameter>
+                {
+                    new LiteralParameter { Name = "_id", Literal = "abc" }
+                }
+            }
+        };
+    }
+
+    private ValidationResult? Validate(Dictionary<string, IQueryConfig> dictionary)
+    {
+        var context = new ValidationContext(dictionary) { DisplayName = "TestQueries" };
+        return _attribute.GetValidationResult(dictionary, context);
+    }
+
+    [Theory]
+    [InlineData(OperationType.Search)]
+    [InlineData(OperationType.SearchPost)]
+    public void Validate_ParameterQueryConfig_WithValidOperationType_DoesNotAddOperationTypeError(OperationType operationType)
+    {
+        // Arrange
+        var dictionary = BuildDictionary(operationType);
+
+        // Act
+        var result = Validate(dictionary);
+
+        // Assert
+        Assert.True(result == ValidationResult.Success || !result!.ErrorMessage!.Contains(InvalidOperationTypeError));
+        Assert.True(result == ValidationResult.Success || !result!.ErrorMessage!.Contains(ReadNotValidError));
+    }
+
+    [Fact]
+    public void Validate_ParameterQueryConfig_WithReadOperationType_AddsReadNotValidError()
+    {
+        // Arrange
+        var dictionary = BuildDictionary(OperationType.Read);
+
+        // Act
+        var result = Validate(dictionary);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Contains(ReadNotValidError, result!.ErrorMessage);
+        Assert.DoesNotContain(InvalidOperationTypeError, result.ErrorMessage);
+    }
+
+    [Fact]
+    public void Validate_ParameterQueryConfig_WithUndefinedOperationType_AddsInvalidOperationTypeError()
+    {
+        // Arrange — Read=0, Search=1, SearchPost=2; 999 is not a defined member
+        var dictionary = BuildDictionary((OperationType)999);
+
+        // Act
+        var result = Validate(dictionary);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Contains(InvalidOperationTypeError, result!.ErrorMessage);
+    }
+
+    [Fact]
+    public void Validate_ParameterQueryConfig_WithUndefinedOperationType_DoesNotAlsoAddReadError()
+    {
+        // Arrange — verifies the `else if` gate: undefined value must not also trip the Read-specific message
+        var dictionary = BuildDictionary((OperationType)999);
+
+        // Act
+        var result = Validate(dictionary);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.DoesNotContain(ReadNotValidError, result!.ErrorMessage);
+    }
+}

--- a/DotNet/ServiceTests/UnitTests/DataAcquisition/ValidateQueryPlanConfigDictionaryAttributeTests.cs
+++ b/DotNet/ServiceTests/UnitTests/DataAcquisition/ValidateQueryPlanConfigDictionaryAttributeTests.cs
@@ -48,8 +48,7 @@ public class ValidateQueryPlanConfigDictionaryAttributeTests
         var result = Validate(dictionary);
 
         // Assert
-        Assert.True(result == ValidationResult.Success || !result!.ErrorMessage!.Contains(InvalidOperationTypeError));
-        Assert.True(result == ValidationResult.Success || !result!.ErrorMessage!.Contains(ReadNotValidError));
+        Assert.Equal(ValidationResult.Success, result);
     }
 
     [Fact]

--- a/Web/Admin.UI/src/app/components/data-acquisition/query-config-edit/query-config-edit.component.html
+++ b/Web/Admin.UI/src/app/components/data-acquisition/query-config-edit/query-config-edit.component.html
@@ -19,23 +19,26 @@
     </mat-form-field>
   </div>
 
-  @if (queryForm.get('queryConfigType')?.value === 'Reference') {
-    <div class="form-row">
-      <mat-form-field appearance="outline">
-        <mat-label>Operation Type</mat-label>
-        <mat-select formControlName="operationType">
-          @for (op of operationTypes; track op.value) {
+  <div class="form-row">
+    <mat-form-field appearance="outline">
+      <mat-label>Operation Type</mat-label>
+      <mat-select formControlName="operationType">
+        @for (op of operationTypes; track op.value) {
+          <!-- Parameter query types do not allow read operations, so hide that option unless query config type is Reference -->
+          @if (op.label !== 'Read' || queryForm.get('queryConfigType')?.value === 'Reference') {
             <mat-option [value]="op.value">{{op.label}}</mat-option>
           }
-        </mat-select>
-      </mat-form-field>
+        }
+      </mat-select>
+    </mat-form-field>
 
-      <mat-form-field appearance="outline">
-        <mat-label>Paged</mat-label>
-        <input matInput type="number" formControlName="paged">
-      </mat-form-field>
-    </div>
+  @if (queryForm.get('queryConfigType')?.value === 'Reference') {
+    <mat-form-field appearance="outline">
+      <mat-label>Paged</mat-label>
+      <input matInput type="number" formControlName="paged">
+    </mat-form-field>
   }
+  </div>
 
   @if (queryForm.get('queryConfigType')?.value === 'Parameter') {
     <div class="parameters-section">

--- a/Web/Admin.UI/src/app/components/data-acquisition/query-config-edit/query-config-edit.component.ts
+++ b/Web/Admin.UI/src/app/components/data-acquisition/query-config-edit/query-config-edit.component.ts
@@ -141,6 +141,12 @@ export class QueryConfigEditComponent implements OnInit {
       pagedCtrl?.setValidators([Validators.required, Validators.min(1)]);
     } else {
       pagedCtrl?.clearValidators();
+
+      // Since parameter doesn't use read, reset read to search
+      // which is the default for parameter
+      if (operationTypeCtrl?.value === ReferenceQueryOperationType.read) {
+        operationTypeCtrl.setValue(ReferenceQueryOperationType.search);
+      }      
     }
     operationTypeCtrl?.updateValueAndValidity();
     pagedCtrl?.updateValueAndValidity();

--- a/Web/Admin.UI/src/app/components/data-acquisition/query-config-edit/query-config-edit.component.ts
+++ b/Web/Admin.UI/src/app/components/data-acquisition/query-config-edit/query-config-edit.component.ts
@@ -107,7 +107,7 @@ export class QueryConfigEditComponent implements OnInit {
       resourceType: [this.config?.resourceType || '', Validators.required],
       queryConfigType: [this.config?.queryConfigType || 'Parameter', Validators.required],
       // Reference specific
-      operationType: [this.config?.queryConfigType === 'Reference' ? this.normalizeOperationType((this.config as IReferenceQueryConfigModel).operationType as unknown) : ReferenceQueryOperationType.search],
+      operationType: [this.normalizeOperationType((this.config as any)?.operationType)],
       paged: [this.config?.queryConfigType === 'Reference' ? (this.config as IReferenceQueryConfigModel).paged : 100],
       // Parameter specific
       parameters: this.fb.array([])
@@ -133,12 +133,11 @@ export class QueryConfigEditComponent implements OnInit {
   updateValidators(type: string): void {
     const operationTypeCtrl = this.queryForm.get('operationType');
     const pagedCtrl = this.queryForm.get('paged');
+    operationTypeCtrl?.setValidators(Validators.required);
 
     if (type === 'Reference') {
-      operationTypeCtrl?.setValidators(Validators.required);
       pagedCtrl?.setValidators([Validators.required, Validators.min(1)]);
     } else {
-      operationTypeCtrl?.clearValidators();
       pagedCtrl?.clearValidators();
     }
     operationTypeCtrl?.updateValueAndValidity();
@@ -251,6 +250,7 @@ export class QueryConfigEditComponent implements OnInit {
       result = {
         resourceType: formValue.resourceType,
         queryConfigType: 'Parameter',
+        operationType: formValue.operationType,
         parameters: params
       } as IParameterQueryConfigModel;
     }

--- a/Web/Admin.UI/src/app/components/data-acquisition/query-plan-config/query-plan-config.component.ts
+++ b/Web/Admin.UI/src/app/components/data-acquisition/query-plan-config/query-plan-config.component.ts
@@ -358,9 +358,7 @@ export class QueryPlanConfigFormComponent {
     if (!cfg) return cfg;
     const c: any = cfg as any;
 
-    if (c.queryConfigType === 'Reference') {
-      c.operationType = this.normalizeOperationType(c.operationType);
-    }
+    c.operationType = this.normalizeOperationType(c.operationType);
 
     if (c.parameters && Array.isArray(c.parameters)) {
       c.parameters = c.parameters.map((p: any) => {

--- a/Web/Admin.UI/src/app/interfaces/data-acquisition/query-plan-model.interface.ts
+++ b/Web/Admin.UI/src/app/interfaces/data-acquisition/query-plan-model.interface.ts
@@ -13,6 +13,7 @@ export type QueryConfigModel = IParameterQueryConfigModel | IReferenceQueryConfi
 
 export interface IQueryConfigModel {
     resourceType: string;
+    operationType?: ReferenceQueryOperationType;
     queryConfigType: string;
 }
 
@@ -23,7 +24,6 @@ export interface IParameterQueryConfigModel extends IQueryConfigModel {
 
 export interface IReferenceQueryConfigModel extends IQueryConfigModel {
     queryConfigType: 'Reference';
-    operationType: ReferenceQueryOperationType;
     paged: number;
 }
 


### PR DESCRIPTION
### 🛠️ Description of Changes

Added the ability to select a query type when entering a Parameter query.  Available options are Search and PostSearch

### 🧪 Testing Performed

Changed the Encounter parameter to a PostSearch.  Ran a report.  Observed PostSearch and Search was used in the Acquisition Logs when the appropriate query type is used.

### 🧑‍🔬 Unit Testing

- [X] I have written or updated unit tests to cover my changes
- Coverage: 100.0%

### 📓 Documentation Updated

Please update any relevant sections in the project documentation that were impacted by the changes in the PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Operation Type can be set for parameter queries; UI exposes the field and conditionally hides "Read" except for reference queries. Paged field visibility updated.

* **Improvements**
  * Validation now rejects invalid or forbidden operation types for parameter queries.
  * SearchPost (POST-based) search path supported.

* **Tests**
  * New unit tests covering operation-type handling, validation, and POST search behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

