### PR TITLE
LEGLINK-365: Error on updating/deleting location configuration

### DIFF
--- a/DotNet/DataAcquisition.Domain/Application/Managers/OrganizationLocationConfigurationManager.cs
+++ b/DotNet/DataAcquisition.Domain/Application/Managers/OrganizationLocationConfigurationManager.cs
@@ -1,4 +1,5 @@
-﻿using LantanaGroup.Link.DataAcquisition.Domain.Application.Models;
+﻿using Hl7.FhirPath;
+using LantanaGroup.Link.DataAcquisition.Domain.Application.Models;
 using LantanaGroup.Link.DataAcquisition.Domain.Application.Models.Exceptions;
 using LantanaGroup.Link.DataAcquisition.Domain.Application.Queries;
 using LantanaGroup.Link.DataAcquisition.Domain.Infrastructure;
@@ -60,30 +61,27 @@ public class OrganizationLocationConfigurationManager : IOrganizationLocationCon
 
     public async Task<OrganizationLocationConfigurationModel> UpdateByIdAsync(int configId, UpdateOrganizationLocationConfigurationModel model)
     {
-        try
+        OrganizationLocationConfigurationModel result = null;
+
+        await _database.ExecuteInTransactionAsync(async () =>
         {
-            await _database.BeginTransactionAsync();
             var entity = await _database.LocationConfigurationRepository.GetAsync(configId);
 
             if (entity == null)
                 throw new NotFoundException($"OrganizationLocationConfiguration with ConfigId {configId} not found.");
 
-            entity.LocationConditions = await _database.LocationConditionRepository.FindAsync(c => c.ConfigId == configId);
+            entity.LocationConditions =
+                await _database.LocationConditionRepository.FindAsync(c => c.ConfigId == configId);
 
             await ApplyUpdateToEntity(entity, model);
             _database.LocationConfigurationRepository.Update(entity);
 
             await _database.SaveChangesAsync();
 
-            await _database.CommitTransactionAsync();
+            result = ProjectToModel(entity);
+        });
 
-            return ProjectToModel(entity);
-        }
-        catch
-        {
-            await _database.RollbackTransactionAsync();
-            throw;
-        }
+        return result;
     }
 
     public async Task<List<OrganizationLocationConfigurationModel>> UpdateByFacilityIdAsync(string facilityId, UpdateOrganizationLocationConfigurationModel model)
@@ -107,13 +105,12 @@ public class OrganizationLocationConfigurationManager : IOrganizationLocationCon
 
     public async Task DeleteByIdAsync(int configId)
     {
-        try
+        await _database.ExecuteInTransactionAsync(async () =>
         {
-            await _database.BeginTransactionAsync();
-
             var entity = await _database.LocationConfigurationRepository.GetAsync(configId);
 
-            entity.LocationConditions = await _database.LocationConditionRepository.FindAsync(c => c.ConfigId == configId);
+            entity.LocationConditions =
+                await _database.LocationConditionRepository.FindAsync(c => c.ConfigId == configId);
 
             foreach (var condition in entity.LocationConditions)
             {
@@ -122,13 +119,7 @@ public class OrganizationLocationConfigurationManager : IOrganizationLocationCon
 
             _database.LocationConfigurationRepository.Remove(entity);
             await _database.SaveChangesAsync();
-            
-            await _database.CommitTransactionAsync();
-        }
-        catch
-        {
-            await _database.RollbackTransactionAsync();
-        }
+        });
     }
 
     public async Task DeleteByFacilityIdAsync(string facilityId)
@@ -136,7 +127,7 @@ public class OrganizationLocationConfigurationManager : IOrganizationLocationCon
         var entities = await _database.LocationConfigurationRepository
             .FindAsync(c => c.FacilityId == facilityId);
 
-        foreach(var entity in entities)
+        foreach (var entity in entities)
         {
             await DeleteByIdAsync(entity.ConfigId);
         }

--- a/DotNet/DataAcquisition.Domain/Infrastructure/Database.cs
+++ b/DotNet/DataAcquisition.Domain/Infrastructure/Database.cs
@@ -1,6 +1,7 @@
 ﻿using LantanaGroup.Link.DataAcquisition.Domain.Infrastructure.Context;
 using LantanaGroup.Link.DataAcquisition.Domain.Infrastructure.Entities;
 using LantanaGroup.Link.Shared.Domain.Repositories.Interfaces;
+using Microsoft.EntityFrameworkCore;
 
 namespace LantanaGroup.Link.DataAcquisition.Domain.Infrastructure
 {
@@ -23,9 +24,14 @@ namespace LantanaGroup.Link.DataAcquisition.Domain.Infrastructure
         IEntityRepository<EncounterLocation> EncounterLocationRepository { get; set; }
 
 
-        Task BeginTransactionAsync(CancellationToken cancellationToken = default);
-        Task CommitTransactionAsync(CancellationToken cancellationToken = default);
-        Task RollbackTransactionAsync(CancellationToken cancellationToken = default);
+        /// <summary>
+        /// Runs <paramref name="operation"/> inside a database transaction using the context's
+        /// configured execution strategy, so it is safe to use with connection-resiliency
+        /// (EnableRetryOnFailure). The whole unit is retried atomically on transient failure;
+        /// any exception rolls the transaction back and is rethrown.
+        /// </summary>
+        Task ExecuteInTransactionAsync(Func<Task> operation, CancellationToken cancellationToken = default);
+
         Task SaveChangesAsync();
     }
     public class Database : IDatabase
@@ -46,7 +52,7 @@ namespace LantanaGroup.Link.DataAcquisition.Domain.Infrastructure
         public IEntityRepository<OrganizationLocationMapping> LocationMappingRepository { get; set; }
         public IEntityRepository<EncounterMapping> EncounterMappingRepository { get; set; }
         public IEntityRepository<EncounterLocation> EncounterLocationRepository { get; set; }
-
+        
         public Database(
             DataAcquisitionDbContext context,
             IEntityRepository<FhirQueryConfiguration> queryConfigurationRepository,
@@ -88,19 +94,27 @@ namespace LantanaGroup.Link.DataAcquisition.Domain.Infrastructure
             await _context.SaveChangesAsync();
         }
 
-        public async Task BeginTransactionAsync(CancellationToken cancellationToken = default)
+        public async Task ExecuteInTransactionAsync(Func<Task> operation, CancellationToken cancellationToken = default)
         {
-            await _context.Database.BeginTransactionAsync(cancellationToken);
-        }
+            var strategy = _context.Database.CreateExecutionStrategy();
+            await strategy.ExecuteAsync(async () =>
+            {
+                // Each attempt starts from a clean slate so a retry re-reads state instead of
+                // reusing entities mutated by a prior failed attempt.
+                _context.ChangeTracker.Clear();
 
-        public async Task CommitTransactionAsync(CancellationToken cancellationToken = default)
-        {
-            await _context.Database.CommitTransactionAsync(cancellationToken);
-        }
-
-        public async Task RollbackTransactionAsync(CancellationToken cancellationToken = default)
-        {
-            await _context.Database.RollbackTransactionAsync(cancellationToken);
+                await using var transaction = await _context.Database.BeginTransactionAsync(cancellationToken);
+                try
+                {
+                    await operation();
+                    await transaction.CommitAsync(cancellationToken);
+                }
+                catch
+                {
+                    await transaction.RollbackAsync(cancellationToken);
+                    throw;
+                }
+            });
         }
     }
 }


### PR DESCRIPTION
### 🛠️ Description of Changes

 Fixed the 500 on PUT/Delete location mapping config.

  Fix: Switched UpdateByIdAsync to the existing ExecuteInTransactionAsync helper, which opens the transaction inside CreateExecutionStrategy().ExecuteAsync(...) — same fix for  DeleteByIdAsync. Retry-on-failure is preserved. Also removed the now-unused manual BeginTransactionAsync/CommitTransactionAsync/RollbackTransactionAsync wrappers.

### 🧪 Testing Performed

Tested locally

### 🧑‍🔬 Unit Testing

- [ ] I have written or updated unit tests to cover my changes
- Coverage: 

### 📓 Documentation Updated

Please update any relevant sections in the project documentation that were impacted by the changes in the PR.
