### PR TITLE
LEGLINK-376: Configurable report donut chart colors + Admin.UI test suite fixes

### DIFF
--- a/Web/Admin.UI/angular.json
+++ b/Web/Admin.UI/angular.json
@@ -106,8 +106,14 @@
             ],
             "styles": [
               "@angular/material/prebuilt-themes/indigo-pink.css",
-              "src/styles.css"
+              "src/styles.scss"
             ],
+            "stylePreprocessorOptions": {
+              "includePaths": [
+                "src",
+                "src/styles"
+              ]
+            },
             "scripts": []
           }
         }

--- a/Web/Admin.UI/angular.json
+++ b/Web/Admin.UI/angular.json
@@ -95,7 +95,9 @@
           "builder": "@angular/build:karma",
           "options": {
             "main": "src/test.ts",
-            "polyfills": "src/polyfills.ts",
+            "polyfills": [
+              "src/polyfills.ts"
+            ],
             "tsConfig": "tsconfig.spec.json",
             "karmaConfig": "karma.conf.js",
             "assets": [

--- a/Web/Admin.UI/src/app/components/core/donut-chart/donut-chart.component.ts
+++ b/Web/Admin.UI/src/app/components/core/donut-chart/donut-chart.component.ts
@@ -22,6 +22,8 @@ export class DonutChartComponent implements AfterViewInit, OnChanges, OnDestroy 
 
   @Input() data: Record<string, number> = {};
   @Input() enableSelection: boolean = false;
+  /** Optional label → color (hex/CSS) map. Labels not present fall back to the default palette. */
+  @Input() colorMap?: Record<string, string>;
   @Output() sliceSelected = new EventEmitter<string>();
   @ViewChild('container', { static: true }) container!: ElementRef;
   @ViewChild('chart', { static: true }) chart!: ElementRef<SVGSVGElement>;
@@ -61,7 +63,8 @@ export class DonutChartComponent implements AfterViewInit, OnChanges, OnDestroy 
       .attr('transform', `translate(${width / 2}, ${height / 2})`);
 
     const dataEntries = Object.entries(this.data);
-    const color = d3.scaleOrdinal(d3.schemeTableau10);
+    const fallbackColor = d3.scaleOrdinal(d3.schemeTableau10);
+    const color = (label: string): string => this.colorMap?.[label] ?? fallbackColor(label);
 
     const pie = d3.pie<any>().value(d => d[1]);
     const arc = d3.arc<d3.PieArcDatum<[string, number]>>()

--- a/Web/Admin.UI/src/app/components/data-acquisition/query-plan-config/query-plan-config.component.spec.ts
+++ b/Web/Admin.UI/src/app/components/data-acquisition/query-plan-config/query-plan-config.component.spec.ts
@@ -1,18 +1,18 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
-import { QueryPlanConfigComponent } from './query-plan-config.component';
+import { QueryPlanConfigFormComponent } from './query-plan-config.component';
 
-describe('QueryPlanConfigComponent', () => {
-  let component: QueryPlanConfigComponent;
-  let fixture: ComponentFixture<QueryPlanConfigComponent>;
+describe('QueryPlanConfigFormComponent', () => {
+  let component: QueryPlanConfigFormComponent;
+  let fixture: ComponentFixture<QueryPlanConfigFormComponent>;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [QueryPlanConfigComponent]
+      imports: [QueryPlanConfigFormComponent]
     })
     .compileComponents();
 
-    fixture = TestBed.createComponent(QueryPlanConfigComponent);
+    fixture = TestBed.createComponent(QueryPlanConfigFormComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
   });

--- a/Web/Admin.UI/src/app/components/query-dispatch/query-dispatch-config-dialog/query-dispatch-config-dialog.component.spec.ts
+++ b/Web/Admin.UI/src/app/components/query-dispatch/query-dispatch-config-dialog/query-dispatch-config-dialog.component.spec.ts
@@ -1,18 +1,18 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
-import { QueryConfigDialogComponent } from './query-dispatch-config-dialog.component';
+import { QueryDispatchConfigDialogComponent } from './query-dispatch-config-dialog.component';
 
 describe('CensusConfigDialogComponent', () => {
-  let component: QueryConfigDialogComponent;
-  let fixture: ComponentFixture<QueryConfigDialogComponent>;
+  let component: QueryDispatchConfigDialogComponent;
+  let fixture: ComponentFixture<QueryDispatchConfigDialogComponent>;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [ QueryConfigDialogComponent ]
+      imports: [ QueryDispatchConfigDialogComponent ]
     })
     .compileComponents();
 
-    fixture = TestBed.createComponent(QueryConfigDialogComponent);
+    fixture = TestBed.createComponent(QueryDispatchConfigDialogComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
   });

--- a/Web/Admin.UI/src/app/components/query-dispatch/query-dispatch-config-form/query-dispatch-config-form.component.spec.ts
+++ b/Web/Admin.UI/src/app/components/query-dispatch/query-dispatch-config-form/query-dispatch-config-form.component.spec.ts
@@ -1,18 +1,18 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
-import { QueryConfigFormComponent } from './query-dispatch-config-form.component';
+import { QueryDispatchConfigFormComponent } from './query-dispatch-config-form.component';
 
 describe('CensusConfigFormComponent', () => {
-  let component: QueryConfigFormComponent;
-  let fixture: ComponentFixture<QueryConfigFormComponent>;
+  let component: QueryDispatchConfigFormComponent;
+  let fixture: ComponentFixture<QueryDispatchConfigFormComponent>;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [ QueryConfigFormComponent ]
+      imports: [ QueryDispatchConfigFormComponent ]
     })
     .compileComponents();
 
-    fixture = TestBed.createComponent(QueryConfigFormComponent);
+    fixture = TestBed.createComponent(QueryDispatchConfigFormComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
   });

--- a/Web/Admin.UI/src/app/components/tenant/facility-view/view-report/view-report.component.html
+++ b/Web/Admin.UI/src/app/components/tenant/facility-view/view-report/view-report.component.html
@@ -112,7 +112,7 @@
     </div>
     <div class="report-chart-row">
       <div class="report-chart-cell">
-        <app-donut-chart [data]="measureIpCountsData"></app-donut-chart>
+        <app-donut-chart [data]="measureIpCountsData" [colorMap]="measureIpColors"></app-donut-chart>
       </div>
       <div class="report-chart-cell">
         <app-donut-chart

--- a/Web/Admin.UI/src/app/components/tenant/facility-view/view-report/view-report.component.html
+++ b/Web/Admin.UI/src/app/components/tenant/facility-view/view-report/view-report.component.html
@@ -117,12 +117,14 @@
       <div class="report-chart-cell">
         <app-donut-chart
           [data]="reportStatusData"
+          [colorMap]="reportStatusColors"
           [enableSelection]="true"
           (sliceSelected)="onReportStatusSliceSelected($event)"></app-donut-chart>
       </div>
       <div class="report-chart-cell">
         <app-donut-chart
           [data]="submissionStatusData"
+          [colorMap]="submissionStatusColors"
           [enableSelection]="true"
           (sliceSelected)="onSubmissionStatusSliceSelected($event)"></app-donut-chart>
       </div>

--- a/Web/Admin.UI/src/app/components/tenant/facility-view/view-report/view-report.component.ts
+++ b/Web/Admin.UI/src/app/components/tenant/facility-view/view-report/view-report.component.ts
@@ -102,6 +102,25 @@ export class ViewReportComponent implements OnInit {
   reportStatusData: Record<string, number> = {};
   submissionStatusData: Record<string, number> = {};
 
+  // Fixed donut-chart colors keyed by the labels produced by
+  // getReportingStatusText / getSubmissionStatusText. Labels not listed
+  // fall back to the chart's default palette.
+  reportStatusColors: Record<string, string> = {
+    'Patient Identified': '#1f77b4', // blue - in pipeline
+    'Pending Validation': '#ff9800', // amber - in progress
+    'Passed Validation': '#2ca02c',  // green - good
+    'Failed Validation': '#d62728',  // red - bad
+    'Not Reportable': '#9e9e9e',     // grey - neutral
+  };
+  submissionStatusColors: Record<string, string> = {
+    'Pending Validation': '#ff9800', // amber - in progress
+    'Submitting': '#1f77b4',         // blue - in progress
+    'Submitted': '#2ca02c',          // green - good
+    'Failed Submission': '#d62728',  // red - bad
+    'Not Eligible': '#9e9e9e',       // grey - neutral
+    'Pending': '#bdbdbd',            // light grey - neutral
+  };
+
   defaultPageNumber: number = 0
   defaultPageSize: number = 10;
   sortBy: string | null = null;

--- a/Web/Admin.UI/src/app/components/tenant/facility-view/view-report/view-report.component.ts
+++ b/Web/Admin.UI/src/app/components/tenant/facility-view/view-report/view-report.component.ts
@@ -34,6 +34,7 @@ import {
   faXmark
 } from '@fortawesome/free-solid-svg-icons';
 import {LoadingService} from 'src/app/services/loading.service';
+import {ChartColorService} from 'src/app/services/chart-color.service';
 import {DonutChartComponent} from 'src/app/components/core/donut-chart/donut-chart.component';
 import {ViewReportTableCommandComponent} from './table-command/view-report-table-command.component';
 import {AcquisitionLogService} from '../../acquisition-log/acquisition-log.service';
@@ -99,6 +100,8 @@ export class ViewReportComponent implements OnInit {
   // Add summary data for donut charts
   reportEntrySummary: IReportEntrySummary | undefined;
   measureIpCountsData: Record<string, number> = {};
+  // Stable colors per report type, persisted across refreshes via ChartColorService.
+  measureIpColors: Record<string, string> = {};
   reportStatusData: Record<string, number> = {};
   submissionStatusData: Record<string, number> = {};
 
@@ -161,7 +164,8 @@ export class ViewReportComponent implements OnInit {
     private facilityViewService: FacilityViewService,
     private acquisitionLogService: AcquisitionLogService,
     private loadingService: LoadingService,
-    private reportService: ReportService) { }
+    private reportService: ReportService,
+    private chartColorService: ChartColorService) { }
 
   ngOnInit(): void {
     const savedPageSize = localStorage.getItem(this.PAGE_SIZE_KEY);
@@ -254,6 +258,10 @@ export class ViewReportComponent implements OnInit {
         next: (data) => {
           this.reportEntrySummary = data;
           this.measureIpCountsData = data.reportTypeCounts;
+          this.measureIpColors = this.chartColorService.getColorMap(
+            'measure-report-type',
+            Object.keys(data.reportTypeCounts)
+          );
           this.reportStatusData = Object.entries(data.reportingStatusCounts).reduce((acc, [statusKey, count]) => {
             const statusValue = this.toReportingStatus(statusKey);
             const label = statusValue !== null ? this.getReportingStatusText(statusValue) : statusKey;

--- a/Web/Admin.UI/src/app/components/testing/patient-listacquired-form/patient-listacquired-form.component.spec.ts
+++ b/Web/Admin.UI/src/app/components/testing/patient-listacquired-form/patient-listacquired-form.component.spec.ts
@@ -1,18 +1,18 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
-import { PatientListacquiredFormComponent } from './patient-listacquired-form.component';
+import { PatientListAcquiredComponent } from './patient-listacquired-form.component';
 
-describe('PatientListacquiredFormComponent', () => {
-  let component: PatientListacquiredFormComponent;
-  let fixture: ComponentFixture<PatientListacquiredFormComponent>;
+describe('PatientListAcquiredComponent', () => {
+  let component: PatientListAcquiredComponent;
+  let fixture: ComponentFixture<PatientListAcquiredComponent>;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [PatientListacquiredFormComponent]
+      imports: [PatientListAcquiredComponent]
     })
     .compileComponents();
 
-    fixture = TestBed.createComponent(PatientListacquiredFormComponent);
+    fixture = TestBed.createComponent(PatientListAcquiredComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
   });

--- a/Web/Admin.UI/src/app/interfaces/data-acquisition/data-acquisition-auth-config-model.interface.ts
+++ b/Web/Admin.UI/src/app/interfaces/data-acquisition/data-acquisition-auth-config-model.interface.ts
@@ -4,8 +4,8 @@ export interface IDataAcquisitionAuthenticationConfigModel {
     tokenUrl: string;
     audience: string;
     clientId: string;
-    clientSecret: string;
-    scope: string;
+    clientSecret?: string;
+    scope?: string;
     userName: string;
     password: string;
     customHeaders?: { [key: string]: string };

--- a/Web/Admin.UI/src/app/services/chart-color.service.spec.ts
+++ b/Web/Admin.UI/src/app/services/chart-color.service.spec.ts
@@ -1,0 +1,110 @@
+import { TestBed } from '@angular/core/testing';
+import * as d3 from 'd3';
+
+import { ChartColorService } from './chart-color.service';
+
+describe('ChartColorService', () => {
+  let service: ChartColorService;
+  const category = 'test-category';
+  const paletteSize = d3.schemeTableau10.length;
+
+  beforeEach(() => {
+    localStorage.clear();
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(ChartColorService);
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  it('assigns a color to every requested label', () => {
+    const map = service.getColorMap(category, ['a', 'b', 'c']);
+
+    expect(Object.keys(map)).toEqual(['a', 'b', 'c']);
+    expect(map['a']).toBeTruthy();
+    expect(map['b']).toBeTruthy();
+    expect(map['c']).toBeTruthy();
+  });
+
+  it('returns the same color for a label across calls', () => {
+    const first = service.getColorMap(category, ['a', 'b']);
+    const second = service.getColorMap(category, ['b', 'a']);
+
+    expect(second['a']).toBe(first['a']);
+    expect(second['b']).toBe(first['b']);
+  });
+
+  it('gives distinct labels distinct colors within the palette', () => {
+    const labels = Array.from({ length: paletteSize }, (_, i) => `label-${i}`);
+    const map = service.getColorMap(category, labels);
+
+    const colors = labels.map(l => map[l]);
+    expect(new Set(colors).size).toBe(paletteSize);
+  });
+
+  it('assigns palette colors in first-seen order', () => {
+    const map = service.getColorMap(category, ['x', 'y']);
+
+    expect(map['x']).toBe(d3.schemeTableau10[0]);
+    expect(map['y']).toBe(d3.schemeTableau10[1]);
+  });
+
+  it('wraps around to the start of the palette past its size', () => {
+    const labels = Array.from({ length: paletteSize + 1 }, (_, i) => `label-${i}`);
+    const map = service.getColorMap(category, labels);
+
+    expect(map[`label-${paletteSize}`]).toBe(map['label-0']);
+  });
+
+  it('keeps assignments isolated per category', () => {
+    const a = service.getColorMap('cat-a', ['shared']);
+    // A second category whose first label differs would otherwise collide on index 0.
+    const b = service.getColorMap('cat-b', ['other', 'shared']);
+
+    expect(a['shared']).toBe(d3.schemeTableau10[0]);
+    expect(b['shared']).toBe(d3.schemeTableau10[1]);
+  });
+
+  it('persists assignments across a fresh service instance', () => {
+    const first = service.getColorMap(category, ['a', 'b']);
+
+    const fresh = new ChartColorService();
+    const reloaded = fresh.getColorMap(category, ['b', 'a']);
+
+    expect(reloaded['a']).toBe(first['a']);
+    expect(reloaded['b']).toBe(first['b']);
+  });
+
+  it('clear() forgets a category so colors are reassigned', () => {
+    const before = service.getColorMap(category, ['a', 'b']);
+    service.clear(category);
+    // Reassign in a different order; 'b' should now take the first palette slot.
+    const after = service.getColorMap(category, ['b', 'a']);
+
+    expect(after['b']).toBe(d3.schemeTableau10[0]);
+    expect(after['a']).toBe(d3.schemeTableau10[1]);
+    expect(after['b']).not.toBe(before['b']);
+  });
+
+  it('still returns colors when localStorage writes throw', () => {
+    spyOn(window.localStorage, 'setItem').and.throwError('quota exceeded');
+
+    let map: Record<string, string> | undefined;
+    expect(() => { map = service.getColorMap(category, ['a', 'b']); }).not.toThrow();
+    expect(map!['a']).toBe(d3.schemeTableau10[0]);
+    expect(map!['b']).toBe(d3.schemeTableau10[1]);
+  });
+
+  it('falls back to fresh assignment when localStorage reads throw', () => {
+    spyOn(window.localStorage, 'getItem').and.throwError('read failure');
+
+    let map: Record<string, string> | undefined;
+    expect(() => { map = service.getColorMap(category, ['a']); }).not.toThrow();
+    expect(map!['a']).toBe(d3.schemeTableau10[0]);
+  });
+});

--- a/Web/Admin.UI/src/app/services/chart-color.service.ts
+++ b/Web/Admin.UI/src/app/services/chart-color.service.ts
@@ -1,0 +1,73 @@
+import { Injectable } from '@angular/core';
+import * as d3 from 'd3';
+
+/**
+ * Assigns and persists a stable color per label within a named category, so
+ * charts whose categories are dynamic (e.g. measure report types) keep the
+ * same color across page refreshes and across different reports.
+ *
+ * Colors are drawn from d3.schemeTableau10 (the donut chart's default palette)
+ * in first-seen order and stored in localStorage keyed by category. Labels
+ * beyond the palette size wrap around.
+ */
+@Injectable({ providedIn: 'root' })
+export class ChartColorService {
+  private static readonly STORAGE_PREFIX = 'chart-colors:';
+  private readonly palette: readonly string[] = d3.schemeTableau10;
+
+  /**
+   * Returns a label -> color map covering every label provided. Any label not
+   * already assigned gets the next palette color and the category is persisted.
+   */
+  getColorMap(category: string, labels: string[]): Record<string, string> {
+    const stored = this.load(category);
+    let changed = false;
+
+    for (const label of labels) {
+      if (!stored[label]) {
+        stored[label] = this.nextColor(stored);
+        changed = true;
+      }
+    }
+
+    if (changed) {
+      this.save(category, stored);
+    }
+
+    return labels.reduce((acc, label) => {
+      acc[label] = stored[label];
+      return acc;
+    }, {} as Record<string, string>);
+  }
+
+  /** Forget all color assignments for a category. */
+  clear(category: string): void {
+    try {
+      window.localStorage.removeItem(this.storageKey(category));
+    } catch { /* ignore storage failures */ }
+  }
+
+  private nextColor(stored: Record<string, string>): string {
+    const index = Object.keys(stored).length;
+    return this.palette[index % this.palette.length];
+  }
+
+  private load(category: string): Record<string, string> {
+    try {
+      const raw = window.localStorage.getItem(this.storageKey(category));
+      return raw ? JSON.parse(raw) as Record<string, string> : {};
+    } catch {
+      return {};
+    }
+  }
+
+  private save(category: string, map: Record<string, string>): void {
+    try {
+      window.localStorage.setItem(this.storageKey(category), JSON.stringify(map));
+    } catch { /* ignore storage failures */ }
+  }
+
+  private storageKey(category: string): string {
+    return `${ChartColorService.STORAGE_PREFIX}${category}`;
+  }
+}

--- a/Web/Admin.UI/tsconfig.json
+++ b/Web/Admin.UI/tsconfig.json
@@ -29,5 +29,10 @@
     "strictInjectionParameters": true,
     "strictInputAccessModifiers": true,
     "strictTemplates": false
-  }
+  },
+  "files": [],
+  "references": [
+    { "path": "./tsconfig.app.json" },
+    { "path": "./tsconfig.spec.json" }
+  ]
 }

--- a/Web/Admin.UI/tsconfig.spec.json
+++ b/Web/Admin.UI/tsconfig.spec.json
@@ -5,7 +5,10 @@
     "outDir": "./out-tsc/spec",
     "types": [
       "jasmine"
-    ]
+    ],
+    "paths": {
+      "chart.js/dist/types/utils": ["node_modules/chart.js/dist/types/utils.d.ts"]
+    }
   },
   "files": [
     "src/test.ts",


### PR DESCRIPTION
### 🛠️ Description of Changes

Adds configurable colors to the report donut charts and fixes the Admin.UI unit-test suite so it compiles again.

**Feature — donut chart colors**
- `DonutChartComponent` gains an optional `colorMap` input (label → CSS color); labels not in the map fall back to the default `schemeTableau10` palette. Applies to both slices and legend swatches.
- `ViewReportComponent` defines fixed semantic colors for the Report Status and Submission Status charts (green = success, red = failure, amber = in progress, grey = neutral).
  - Report status colors:
    - **Patient Identified** - Blue
    - **Pending Validation** - Amber 
    - **Passed Validation** - Green
    - **Failed Validation** - Red
    - **Not Reportable** - Grey
  - Submission status colors:
    - **Pending Validation** - Amber
    - **Submitting** - Blue
    - **Submitted** - Green
    - **Failed Submission** - Red
    - **Not Eligible** - Grey
    - **Pending** - light grey
- New `ChartColorService` assigns and persists a stable color per label within a named category to `localStorage`, so the Measure IP-count chart keeps the same color per report type across page refreshes and across reports.

**Test-infrastructure fixes (test-only; production build unaffected)**
- `angular.json` test target: `polyfills` → array form, `styles` → `styles.scss`, added `stylePreprocessorOptions.includePaths` so global SCSS `@use` resolves.
- `tsconfig.spec.json`: map `chart.js/dist/types/utils` to its `.d.ts` (mirrors `tsconfig.app.json`) so ng2-charts type defs resolve under bundler resolution.
- Root `tsconfig.json`: add solution-style `files: []` + `references` so the editor routes `*.spec.ts` to the jasmine-typed spec config (clears `ts(2593)` editor errors).
- Re-point 4 stale CLI-stub specs to their renamed component classes.
- Make `clientSecret`/`scope` optional in `IDataAcquisitionAuthenticationConfigModel` (only required for OAuth; reads already use optional chaining).

### 🧪 Testing Performed

- `npx ng build` (development): succeeds — production app build unaffected by any change.
- `npx ng test --include="src/app/services/chart-color.service.spec.ts" --watch=false --browsers=ChromeHeadless`: **11/11 pass**.
- Full `ng test` now compiles and runs (previously the bundle failed to compile). Note: the wider suite still has pre-existing per-spec runtime failures (auto-generated stubs missing DI providers) tracked separately — not introduced by this PR.
- Ran a report locally and observed the colors stayed with each refresh in the browser.

### 🧑‍🔬 Unit Testing

- Coverage: 0.0%

- [x] I have written or updated unit tests to cover my changes
- Unit tests were run as indicated above.

### 📓 Documentation Updated

No external/config docs impacted (no new config keys; UI-only change plus test tooling).



