### PR TITLE
LEGLINK-391: Add SearchPost to acquisition log query type filter

### DIFF
--- a/Web/Admin.UI/src/app/components/tenant/acquisition-log/acquisition-log-view/acquisition-log-view.component.ts
+++ b/Web/Admin.UI/src/app/components/tenant/acquisition-log/acquisition-log-view/acquisition-log-view.component.ts
@@ -148,7 +148,7 @@ export class AcquisitionLogViewComponent implements OnInit {
   selectedPriorityFilter: string = 'Any';
   queryPhaseFilterOptions: string[] = [ "Initial", "Supplemental", "Referential", "Polling", "Monitoring" ];
   selectedQueryPhaseFilter: string = 'Any';
-  queryTypeFilterOptions: string[] = [ "Read", "Search", "BulkDataRequest", "BulkDataPoll" ];
+  queryTypeFilterOptions: string[] = [ "Read", "Search", "SearchPost", "BulkDataRequest", "BulkDataPoll" ];
   selectedQueryTypeFilter: string = 'Any';
   statusFilterOptions: string[] = [ "Pending", "Ready", "Processing", "Completed", "Failed", "Cancelled", "MaxRetriesReached", "ConfigurationMissing", "Skipped", "Queued"];
   selectedStatusFilter: string[] = [];


### PR DESCRIPTION
### 🛠️ Description of Changes

Adds `"SearchPost"` to the query type filter options on the acquisition log view (`AcquisitionLogViewComponent`), so POST-based searches (the SearchPost query type introduced for parameter queries) can be filtered in the UI alongside Read, Search, BulkDataRequest, and BulkDataPoll.

### 🧪 Testing Performed

- Verified the Admin UI builds (`npx ng build`).
- Manually confirmed the "SearchPost" option appears in the Query Type filter dropdown on the acquisition log view and filters acquisition log entries accordingly.

### 🧑‍🔬 Unit Testing

- Unit tests are not necessary
- Coverage: 0.0%

### 📓 Documentation Updated

No documentation or config keys impacted (UI-only filter option).



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced the acquisition log filter options with a new query type selection. Users can now filter acquisition logs using an expanded set of query types, providing more granular control over data retrieval, analysis, and reporting capabilities. This enables improved insight generation and more efficient log exploration within the acquisition log viewer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->