### PR TITLE
LEGLINK-15: MeasureEval - Add Meta MeasureReport profile for each eva…

### DIFF
--- a/Java/measureeval/src/main/java/com/lantanagroup/link/measureeval/services/MeasureEvaluator.java
+++ b/Java/measureeval/src/main/java/com/lantanagroup/link/measureeval/services/MeasureEvaluator.java
@@ -29,6 +29,10 @@ import java.util.TimeZone;
 public class MeasureEvaluator {
     private static final Logger logger = LoggerFactory.getLogger(MeasureEvaluator.class);
 
+
+    public static final String INDIVIDUAL_MEASURE_REPORT_PROFILE =
+            "http://hl7.org/fhir/us/davinci-deqm/StructureDefinition/indv-measurereport-deqm";
+
     private final FhirContext fhirContext;
     private final MeasureEvaluationOptions options;
     @Getter
@@ -114,7 +118,7 @@ public class MeasureEvaluator {
                 ? periodStart.getValue().toInstant().atZone(ZoneOffset.UTC) : null;
         ZonedDateTime end = periodEnd != null && periodEnd.getValue() != null
                 ? periodEnd.getValue().toInstant().atZone(ZoneOffset.UTC) : null;
-        return measureService.evaluate(
+        MeasureReport measureReport = measureService.evaluate(
                 Eithers.forRight3(measure),
                 start,
                 end,
@@ -128,6 +132,23 @@ public class MeasureEvaluator {
                 null,
                 null,
                 null);
+        addIndividualMeasureReportProfile(measureReport);
+        return measureReport;
+    }
+
+    /**
+     * Ensures the generated MeasureReport declares the DEQM individual MeasureReport profile in
+     * Meta.Profile, adding it only if not already present so the profile is never duplicated.
+     */
+    private static void addIndividualMeasureReportProfile(MeasureReport measureReport) {
+        if (measureReport == null) {
+            return;
+        }
+        boolean alreadyPresent = measureReport.getMeta().getProfile().stream()
+                .anyMatch(profile -> INDIVIDUAL_MEASURE_REPORT_PROFILE.equals(profile.getValue()));
+        if (!alreadyPresent) {
+            measureReport.getMeta().addProfile(INDIVIDUAL_MEASURE_REPORT_PROFILE);
+        }
     }
 
     public MeasureReport evaluate(Date periodStart, Date periodEnd, String patientId, Bundle additionalData) {

--- a/Java/measureeval/src/test/java/com/lantanagroup/link/measureeval/services/MeasureEvaluatorEvaluationTests.java
+++ b/Java/measureeval/src/test/java/com/lantanagroup/link/measureeval/services/MeasureEvaluatorEvaluationTests.java
@@ -296,6 +296,22 @@ class MeasureEvaluatorEvaluationTests {
         Assertions.assertEquals("Encounter/simple-encounter", report.getEvaluatedResourceFirstRep().getReference());
     }
 
+
+    @Test
+    void generatedMeasureReportHasIndividualProfileTest() {
+        var measurePackage = KnowledgeArtifactBuilder.SimpleCohortMeasureTrue.bundle();
+        validateMeasurePackage(measurePackage);
+        var evaluator = MeasureEvaluator.compile(fhirContext, measurePackage, false);
+        var report = evaluator.evaluate(new DateTimeType("2024-01-01"), new DateTimeType("2024-12-31"),
+                new StringType("Patient/simple-patient"), PatientDataBuilder.simplePatientOnlyBundle());
+
+        var matchingProfiles = report.getMeta().getProfile().stream()
+                .filter(profile -> MeasureEvaluator.INDIVIDUAL_MEASURE_REPORT_PROFILE.equals(profile.getValue()))
+                .toList();
+        Assertions.assertEquals(1, matchingProfiles.size(),
+                "Generated MeasureReport must declare the DEQM individual-measurereport profile exactly once");
+    }
+
     /**
      * Validates the measure package for errors using the MeasureDefinitionBundleValidator. Asserts that the measure
      * package has no validation errors.


### PR DESCRIPTION

### 🛠️ Description of Changes

MeasureEval - Add Meta MeasureReport profile for each evaluated report

### 🧪 Testing Performed

Tested locally

### 🧑‍🔬 Unit Testing

- [ x] I have written or updated unit tests to cover my changes
- Coverage: 88.9%

### 📓 Documentation Updated

Please update any relevant sections in the project documentation that were impacted by the changes in the PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Generated MeasureReport resources now automatically include the required DEQM individual measure report profile declaration in their metadata, ensuring compliance with profile standards.

* **Tests**
  * Added test to verify MeasureReport resources correctly include the required profile declaration without duplication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
