### PR TITLE
LEGLINK-414: Admin UI showing Cache status as "N/A" for Java service …

### DIFF
--- a/DotNet/Admin.BFF/Application/Clients/MeasureEvalService.cs
+++ b/DotNet/Admin.BFF/Application/Clients/MeasureEvalService.cs
@@ -78,7 +78,13 @@ namespace LantanaGroup.Link.LinkAdmin.BFF.Application.Clients
                             ? HealthStatus.Healthy
                             : HealthStatus.Unhealthy;
 
-                        report.Entries[ToPascalCase(component.Key)] = new LinkServiceHealthReportEntry
+                        // Spring auto-configures the Redis health indicator under the "redis"
+                        // component; map it to the "Cache" entry the UI's Cache column expects.
+                        var key = component.Key.Equals("redis", StringComparison.OrdinalIgnoreCase)
+                            ? "Cache"
+                            : ToPascalCase(component.Key);
+
+                        report.Entries[key] = new LinkServiceHealthReportEntry
                         {
                             Status = componentStatus,
                             Duration = TimeSpan.Zero

--- a/DotNet/Admin.BFF/Application/Clients/ValidationService.cs
+++ b/DotNet/Admin.BFF/Application/Clients/ValidationService.cs
@@ -86,8 +86,8 @@ public class ValidationService
                     // component "redis"; map them to the Database/Cache entries the UI expects.
                     var key = component.Key switch
                     {
-                        "db" => "Database",
-                        "redis" => "Cache",
+                        var k when k.Equals("db", StringComparison.OrdinalIgnoreCase) => "Database",
+                        var k when k.Equals("redis", StringComparison.OrdinalIgnoreCase) => "Cache",
                         _ => ToPascalCase(component.Key)
                     };
 

--- a/DotNet/Admin.BFF/Application/Clients/ValidationService.cs
+++ b/DotNet/Admin.BFF/Application/Clients/ValidationService.cs
@@ -82,7 +82,14 @@ public class ValidationService
             {
                 foreach (var component in health.Components)
                 {
-                    var key = component.Key == "db" ? "Database" : ToPascalCase(component.Key);
+                    // Spring names the Mongo component "db" and the auto-configured Redis
+                    // component "redis"; map them to the Database/Cache entries the UI expects.
+                    var key = component.Key switch
+                    {
+                        "db" => "Database",
+                        "redis" => "Cache",
+                        _ => ToPascalCase(component.Key)
+                    };
 
                     var componentStatus = component.Value?.Status?.ToUpperInvariant() == HealthUp
                         ? HealthStatus.Healthy

--- a/DotNet/Admin.BFF/Presentation/Endpoints/System/Hanlders/GetSystemHealth.cs
+++ b/DotNet/Admin.BFF/Presentation/Endpoints/System/Hanlders/GetSystemHealth.cs
@@ -58,10 +58,8 @@ public static class GetSystemHealth
         //TODO: improve integration with java services
         var measureEvalHealthCheckResult = await measureEvalService.LinkServiceHealthCheck(context.RequestAborted);
         var measureEvalHealthSummary = LinkServiceHealthReportExtensions.FromDomain(measureEvalHealthCheckResult);
-        measureEvalHealthSummary.CacheConnection = LinkServiceHealthStatus.NotApplicable;
         var validationHealthCheckResult = await validationService.LinkServiceHealthCheck(context.RequestAborted);
         var validationHealthSummary = LinkServiceHealthReportExtensions.FromDomain(validationHealthCheckResult);
-        validationHealthSummary.CacheConnection = LinkServiceHealthStatus.NotApplicable;
 
         var healthSummary = results.Select(LinkServiceHealthReportExtensions.FromDomain).ToList();
         healthSummary.Add(LinkServiceHealthReportExtensions.FromDomain(bffLinkReport));


### PR DESCRIPTION


### 🛠️ Description of Changes

Admin UI showing Cache status as "N/A" for Java service impacted by Post Acquisition Optimization changes.

### 🧪 Testing Performed

Teste locally

### 🧑‍🔬 Unit Testing

- [ ] I have written or updated unit tests to cover my changes
- Coverage: 0.0%

### 📓 Documentation Updated

Please update any relevant sections in the project documentation that were impacted by the changes in the PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**Bug Fixes**
- Fixed system health status reporting to correctly map component names to UI-expected values: cache components display as "Cache", database components as "Database", with all other components standardized via consistent formatting.
- Resolved redundant status overrides that prevented proper health information propagation from health check services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
