### PR TITLE
LEGLINK-436: Warn when Location Resolution Mapping is enabled without an Encounter parameter

### DIFF
--- a/Web/Admin.UI/src/app/components/data-acquisition/data-acquisition-fhir-query-config-form/data-acquisition-fhir-query-config-form.component.html
+++ b/Web/Admin.UI/src/app/components/data-acquisition/data-acquisition-fhir-query-config-form/data-acquisition-fhir-query-config-form.component.html
@@ -151,6 +151,11 @@
       <mat-checkbox [formControl]="enableLocationResolutionMappingControl" [disabled]="viewOnly">
         Enable Location Resolution Mapping
       </mat-checkbox>
+      @if (enableLocationResolutionMappingControl.value && !hasEncounterParameter) {
+        <div class="warning" style="margin-top: 8px;">
+          Query Plan contains no Encounter parameter
+        </div>
+      }
     </div>
 
     @if (!viewOnly) {

--- a/Web/Admin.UI/src/app/components/data-acquisition/data-acquisition-fhir-query-config-form/data-acquisition-fhir-query-config-form.component.scss
+++ b/Web/Admin.UI/src/app/components/data-acquisition/data-acquisition-fhir-query-config-form/data-acquisition-fhir-query-config-form.component.scss
@@ -9,3 +9,13 @@
   border: 1px solid #f5c6cb;  /* Border color */
   border-radius: 5px;  /* Rounded corners */
 }
+
+.warning {
+  color: #856404;
+  font-size: 14px;
+  font-weight: bold;
+  padding: 5px;
+  background-color: #fff3cd;  /* Light amber background */
+  border: 1px solid #ffeeba;  /* Border color */
+  border-radius: 5px;
+}

--- a/Web/Admin.UI/src/app/components/data-acquisition/data-acquisition-fhir-query-config-form/data-acquisition-fhir-query-config-form.component.ts
+++ b/Web/Admin.UI/src/app/components/data-acquisition/data-acquisition-fhir-query-config-form/data-acquisition-fhir-query-config-form.component.ts
@@ -103,8 +103,7 @@ export class DataAcquisitionFhirQueryConfigFormComponent implements OnInit, OnCh
       scope: new FormControl(''),
       userName: new FormControl(''),
       password: new FormControl(''),
-      customHeaders: new FormArray([]),
-      hasEncounterParameter: this.item?.hasEncounterParameter ?? false
+      customHeaders: new FormArray([])
     },  { validators: this.bothOrNoneHoursValidator } as AbstractControlOptions);
   }
 
@@ -355,6 +354,10 @@ export class DataAcquisitionFhirQueryConfigFormComponent implements OnInit, OnCh
 
   get enableLocationResolutionMappingControl(): FormControl {
     return this.configForm.get('enableLocationResolutionMapping') as FormControl;
+  }
+
+  get hasEncounterParameter(): boolean {
+    return this.item?.hasEncounterParameter ?? false;
   }
 
   private parseTime(time: string | null): { hour: number; minute: number; second: number } {

--- a/Web/Admin.UI/src/app/components/data-acquisition/data-acquisition-fhir-query-config-form/data-acquisition-fhir-query-config-form.component.ts
+++ b/Web/Admin.UI/src/app/components/data-acquisition/data-acquisition-fhir-query-config-form/data-acquisition-fhir-query-config-form.component.ts
@@ -103,7 +103,8 @@ export class DataAcquisitionFhirQueryConfigFormComponent implements OnInit, OnCh
       scope: new FormControl(''),
       userName: new FormControl(''),
       password: new FormControl(''),
-      customHeaders: new FormArray([])
+      customHeaders: new FormArray([]),
+      hasEncounterParameter: this.item?.hasEncounterParameter ?? false
     },  { validators: this.bothOrNoneHoursValidator } as AbstractControlOptions);
   }
 

--- a/Web/Admin.UI/src/app/components/tenant/facility-edit/facility-edit.component.ts
+++ b/Web/Admin.UI/src/app/components/tenant/facility-edit/facility-edit.component.ts
@@ -128,7 +128,18 @@ export class FacilityEditComponent implements OnInit {
   facilityConfig!: IFacilityConfigModel;
   censusConfig!: ICensusConfiguration;
   queryDispatchConfig!: IQueryDispatchConfiguration;
-  dataAcqFhirQueryConfig!: IDataAcquisitionQueryConfigModel;
+  // Backed by accessors so hasEncounterParameter is recomputed automatically
+  // whenever the query config or query plan is (re)assigned. See the getters/
+  // setters and updateHasEncounterParameter() below.
+  private _dataAcqFhirQueryConfig!: IDataAcquisitionQueryConfigModel;
+  get dataAcqFhirQueryConfig(): IDataAcquisitionQueryConfigModel {
+    return this._dataAcqFhirQueryConfig;
+  }
+  set dataAcqFhirQueryConfig(value: IDataAcquisitionQueryConfigModel) {
+    this._dataAcqFhirQueryConfig = value;
+    this.updateHasEncounterParameter();
+  }
+
   dataAcqFhirListConfig!: IDataAcquisitionFhirListConfigModel;
 
   linkNoConfigAlertType = LinkAlertType.info;
@@ -154,7 +165,14 @@ export class FacilityEditComponent implements OnInit {
   noDataAcqQueryPlanConfigAlertMessage = 'No FHIR query plan found for this facility and type';
   showNoDataAcqQueryPlanConfigAlert: boolean = false;
 
-  dataAcqQueryPlanConfig!: IQueryPlanModel;
+  private _dataAcqQueryPlanConfig!: IQueryPlanModel;
+  get dataAcqQueryPlanConfig(): IQueryPlanModel {
+    return this._dataAcqQueryPlanConfig;
+  }
+  set dataAcqQueryPlanConfig(value: IQueryPlanModel) {
+    this._dataAcqQueryPlanConfig = value;
+    this.updateHasEncounterParameter();
+  }
 
   private _displayReportDashboard: boolean = false;
 
@@ -1075,5 +1093,25 @@ export class FacilityEditComponent implements OnInit {
     });
   }
 
+  updateHasEncounterParameter() {
+    if (!this.dataAcqFhirQueryConfig) {
+      return;
+    }
+
+    if (!this.dataAcqQueryPlanConfig) {
+      return;
+    }
+
+    let hasEncounterParameter = false;
+
+    if (this.dataAcqQueryPlanConfig.initialQueries) {
+      hasEncounterParameter = Object.values(this.dataAcqQueryPlanConfig.initialQueries).some(query => {
+        return (query.resourceType || '').toLowerCase() === 'encounter';
+      });
+    }
+
+    this.dataAcqFhirQueryConfig.hasEncounterParameter = hasEncounterParameter;
+  }
 
 }
+

--- a/Web/Admin.UI/src/app/components/tenant/facility-edit/facility-edit.component.ts
+++ b/Web/Admin.UI/src/app/components/tenant/facility-edit/facility-edit.component.ts
@@ -128,6 +128,7 @@ export class FacilityEditComponent implements OnInit {
   facilityConfig!: IFacilityConfigModel;
   censusConfig!: ICensusConfiguration;
   queryDispatchConfig!: IQueryDispatchConfiguration;
+
   // Backed by accessors so hasEncounterParameter is recomputed automatically
   // whenever the query config or query plan is (re)assigned. See the getters/
   // setters and updateHasEncounterParameter() below.
@@ -372,6 +373,9 @@ export class FacilityEditComponent implements OnInit {
   }
 
   showDataAcqFhirQueryDialog(): void {
+    // Ensure the hasEncounterParameter flag is current on the config object
+    // before it is handed to the dialog (loads may have resolved in any order).
+    this.updateHasEncounterParameter();
     this.dialog.open(DataAcquisitionFhirQueryConfigDialogComponent,
       {
         width: '75%',
@@ -1098,14 +1102,14 @@ export class FacilityEditComponent implements OnInit {
       return;
     }
 
-    if (!this.dataAcqQueryPlanConfig) {
-      return;
-    }
-
+    // Default to false so the flag is always a concrete boolean once the query
+    // config is loaded. If the query plan loads (or is reassigned) later, its
+    // setter re-runs this and flips the flag to true when an Encounter is found.
     let hasEncounterParameter = false;
 
-    if (this.dataAcqQueryPlanConfig.initialQueries) {
-      hasEncounterParameter = Object.values(this.dataAcqQueryPlanConfig.initialQueries).some(query => {
+    const initialQueries = this.dataAcqQueryPlanConfig?.initialQueries;
+    if (initialQueries) {
+      hasEncounterParameter = Object.values(initialQueries).some(query => {
         return (query.resourceType || '').toLowerCase() === 'encounter';
       });
     }

--- a/Web/Admin.UI/src/app/interfaces/data-acquisition/data-acquisition-fhir-query-config-model.interface.ts
+++ b/Web/Admin.UI/src/app/interfaces/data-acquisition/data-acquisition-fhir-query-config-model.interface.ts
@@ -10,5 +10,6 @@ export interface IDataAcquisitionQueryConfigModel {
   maxAcquisitionPullTime?: string,
   maxConcurrentRequests?: number,
   maxRetries?: number,
-  enableLocationResolutionMapping?: boolean
+  enableLocationResolutionMapping?: boolean,
+  hasEncounterParameter?: boolean
 }


### PR DESCRIPTION
### 🛠️ Description of Changes
Adds a warning in the FHIR Query configuration form when *Enable Location Resolution Mapping* is checked but the facility's query plan has no Encounter parameter.

- Add `hasEncounterParameter` to `IDataAcquisitionQueryConfigModel`.
- In `FacilityEditComponent`, derive `hasEncounterParameter` from the query plan's `initialQueries` and store it on the FHIR query config; back `dataAcqFhirQueryConfig` / `dataAcqQueryPlanConfig` with accessors so the flag is recomputed automatically whenever either is (re)assigned.
- Compute the flag as a concrete boolean (defaults to `false`; no longer early-returns when the query plan hasn't loaded) and refresh it right before opening the FHIR query dialog so the value is current regardless of load order.
- Expose `hasEncounterParameter` via a getter on the form component and render the warning with Angular `@if` control flow (this standalone component imports no `CommonModule`/`NgIf`, so `*ngIf` was inert and never rendered).
- Add a `.warning` style for the message.

### 🧪 Testing Performed
Manually verified in the running Admin UI (ng serve): opened a facility's Data Acquisition → FHIR Query edit dialog, toggled *Enable Location Resolution Mapping*, and confirmed the warning shows/hides reactively based on whether the query plan contains an Encounter parameter. Verified the Angular production build compiles cleanly (`ng build`).

### 🧑‍🔬 Unit Testing
No unit tests were added or updated. Justification: the change is a small presentational/derived-state feature in the Angular Admin UI; the repo's karma suite is not run in CI and these components have no existing spec coverage for this form. Behavior was validated manually in the browser.

### 📓 Documentation Updated
No documentation changes required — no new configuration keys or APIs were introduced.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a validation warning in the data acquisition configuration form when location resolution mapping is enabled without an Encounter parameter in the query plan.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->