### PR TITLE
LEGLINK-371: Record queried Location resources in the mapping table during acquisition

### DIFF
--- a/DotNet/DataAcquisition.Domain/Application/Managers/OrganizationLocationMappingManager.cs
+++ b/DotNet/DataAcquisition.Domain/Application/Managers/OrganizationLocationMappingManager.cs
@@ -1,6 +1,8 @@
 ﻿using LantanaGroup.Link.DataAcquisition.Domain.Application.Models;
 using LantanaGroup.Link.DataAcquisition.Domain.Infrastructure;
+using LantanaGroup.Link.DataAcquisition.Domain.Infrastructure.Context;
 using LantanaGroup.Link.DataAcquisition.Domain.Infrastructure.Entities;
+using Microsoft.EntityFrameworkCore;
 
 namespace LantanaGroup.Link.DataAcquisition.Domain.Application.Managers;
 
@@ -12,15 +14,21 @@ public interface IOrganizationLocationMappingManager
     Task DeleteByIdAsync(int locationMappingId);
     Task DeleteByFacilityIdAsync(string facilityId);
     Task DeleteByFacilityIdAndLocationIdAsync(string facilityId, string locationId);
+
+    Task<int> SetPartOfIdForChildrenAsync(
+        string facilityId, string parentLocationId, int parentLocationMappingId,
+        CancellationToken cancellationToken = default);
 }
 
 public class OrganizationLocationMappingManager : IOrganizationLocationMappingManager
 {
     private readonly IDatabase _database;
+    private readonly DataAcquisitionDbContext _dbContext;
 
-    public OrganizationLocationMappingManager(IDatabase database)
+    public OrganizationLocationMappingManager(IDatabase database, DataAcquisitionDbContext dbContext)
     {
         _database = database ?? throw new ArgumentNullException(nameof(database));
+        _dbContext = dbContext ?? throw new ArgumentNullException(nameof(dbContext));
     }
 
     public async Task<OrganizationLocationMappingModel> CreateAsync(CreateOrganizationLocationMappingModel model)
@@ -40,7 +48,20 @@ public class OrganizationLocationMappingManager : IOrganizationLocationMappingMa
         };
 
         await _database.LocationMappingRepository.AddAsync(entity);
-        await _database.SaveChangesAsync();
+
+        try
+        {
+            await _database.SaveChangesAsync();
+        }
+        catch
+        {
+            // A failed insert (e.g. a concurrent unique-constraint violation) otherwise leaves the
+            // entity tracked in Added state on this scoped DbContext, so the next SaveChangesAsync
+            // (e.g. the caller's recovery update) would retry the duplicate insert and fail again.
+            // Detach it so callers can cleanly recover via re-read + update.
+            _dbContext.Entry(entity).State = EntityState.Detached;
+            throw;
+        }
 
         return ProjectToModel(entity);
     }
@@ -107,6 +128,19 @@ public class OrganizationLocationMappingManager : IOrganizationLocationMappingMa
             await _database.SaveChangesAsync();
         }
     }
+
+    public async Task<int> SetPartOfIdForChildrenAsync(
+        string facilityId, string parentLocationId, int parentLocationMappingId, CancellationToken cancellationToken = default)
+    {
+        return await _dbContext.OrganizationLocationMappings
+            .Where(m => m.FacilityId == facilityId
+                    && m.PartOfValue == parentLocationId
+                    && m.PartOfId == null)
+            .ExecuteUpdateAsync(setters => setters
+                .SetProperty(m => m.PartOfId, parentLocationMappingId)
+                .SetProperty(m => m.ModifiedDate, DateTime.UtcNow),
+            cancellationToken);
+    }    
 
     private void ApplyUpdate(OrganizationLocationMapping entity, UpdateOrganizationLocationMappingModel model)
     {

--- a/DotNet/DataAcquisition.Domain/Application/Models/OrganizationLocationConditionModel.cs
+++ b/DotNet/DataAcquisition.Domain/Application/Models/OrganizationLocationConditionModel.cs
@@ -7,6 +7,10 @@ public class OrganizationLocationConditionModel
 {
     public int ConditionId { get; set; }
     public string? FhirPath { get; set; }
+    
+    /// <summary>
+    /// The order that conditions are evaluated in.  Since all conditions are an OR, this is only used for performance in evaluations.
+    /// </summary>
     public int Priority { get; set; }
     public DateTime CreatedOn { get; set; }
     public DateTime ModifiedOn { get; set; }

--- a/DotNet/DataAcquisition.Domain/Application/Queries/OrganizationLocationMappingQueries.cs
+++ b/DotNet/DataAcquisition.Domain/Application/Queries/OrganizationLocationMappingQueries.cs
@@ -8,7 +8,7 @@ namespace LantanaGroup.Link.DataAcquisition.Domain.Application.Queries;
 public interface IOrganizationLocationMappingQueries
 {
     Task<OrganizationLocationMappingModel> GetByIdAsync(int locationMappingId);
-    Task<OrganizationLocationMappingModel> GetByFacilityIdAndLocationIdAsync(string facilityId, string locationId);
+    Task<OrganizationLocationMappingModel?> GetByFacilityIdAndLocationIdAsync(string facilityId, string locationId);
     Task<List<OrganizationLocationMappingModel>> GetByFacilityIdAsync(string facilityId);
     Task<PagedConfigModel<OrganizationLocationMappingModel>> SearchAsync(
         OrganizationLocationMappingSearchModel search,
@@ -49,7 +49,7 @@ public class OrganizationLocationMappingQueries : IOrganizationLocationMappingQu
             .SingleAsync();
     }
 
-    public async Task<OrganizationLocationMappingModel> GetByFacilityIdAndLocationIdAsync(string facilityId, string locationId)
+    public async Task<OrganizationLocationMappingModel?> GetByFacilityIdAndLocationIdAsync(string facilityId, string locationId)
     {
         return await _context.OrganizationLocationMappings
             .Where(m => m.FacilityId == facilityId && m.LocationId == locationId)

--- a/DotNet/DataAcquisition.Domain/Application/Services/FhirApi/FhirApiService.cs
+++ b/DotNet/DataAcquisition.Domain/Application/Services/FhirApi/FhirApiService.cs
@@ -151,10 +151,12 @@ public class FhirApiService : IFhirApiService
                 AccumulateDiscoveredReferences(refResources, referenceAccumulator);
             }
 
-            if (resource is Location location && fhirQueryConfiguration.EnableLocationResolutionMapping)
+            if (resource is Location location && 
+                await _locationMappingService.IsConfigured(log.FacilityId, cancellationToken))
             {
                 await _locationMappingService.UpdateLocationMappingAsync(
-                    log.FacilityId, location,
+                    log.FacilityId, 
+                    location,
                     cancellationToken: cancellationToken);
             }
 
@@ -319,7 +321,8 @@ public class FhirApiService : IFhirApiService
                 {
                     InsertDateExtension((DomainResource)resource);
 
-                    if (resource is Location location && fhirQueryConfiguration.EnableLocationResolutionMapping)
+                    if (resource is Location location &&
+                        await _locationMappingService.IsConfigured(log.FacilityId, cancellationToken))
                     {
                         await _locationMappingService.UpdateLocationMappingAsync(
                             log.FacilityId, location,

--- a/DotNet/DataAcquisition.Domain/Application/Services/FhirApi/FhirApiService.cs
+++ b/DotNet/DataAcquisition.Domain/Application/Services/FhirApi/FhirApiService.cs
@@ -48,6 +48,7 @@ public class FhirApiService : IFhirApiService
     private readonly IResourceCache _resourceCache;
     private readonly IEncounterMappingQueries _encounterMappingQueries;
     private readonly IOrganizationLocationConfigurationQueries _organizationLocationConfigurationQueries;
+    private readonly ILocationMappingService _locationMappingService;
 
     public FhirApiService(
         IReferenceResourcesManager referenceResourceManager,
@@ -57,7 +58,8 @@ public class FhirApiService : IFhirApiService
         ILogger<FhirApiService> logger,
         IResourceCache resourceCache,
         IEncounterMappingQueries encounterMappingQueries,
-        IOrganizationLocationConfigurationQueries organizationLocationConfigurationQueries)
+        IOrganizationLocationConfigurationQueries organizationLocationConfigurationQueries,
+        ILocationMappingService locationMappingService)
     {
         _referenceResourceManager = referenceResourceManager;
         _referenceResourcesQueries = referenceResourcesQueries;
@@ -67,6 +69,7 @@ public class FhirApiService : IFhirApiService
         _resourceCache = resourceCache;
         _encounterMappingQueries = encounterMappingQueries;
         _organizationLocationConfigurationQueries = organizationLocationConfigurationQueries;
+        _locationMappingService = locationMappingService;
     }
 
     #region Interface Implementation
@@ -309,6 +312,13 @@ public class FhirApiService : IFhirApiService
                 {
                     InsertDateExtension((DomainResource)resource);
 
+                    if (resource is Location location && fhirQueryConfiguration.EnableLocationResolutionMapping)
+                    {
+                        await _locationMappingService.UpdateLocationMappingAsync(
+                            log.FacilityId, location,
+                            cancellationToken:cancellationToken);
+                    }
+                    
                     AddResourceToCache(new ResourceAcquired
                     {
                         Resource = resource,

--- a/DotNet/DataAcquisition.Domain/Application/Services/FhirApi/FhirApiService.cs
+++ b/DotNet/DataAcquisition.Domain/Application/Services/FhirApi/FhirApiService.cs
@@ -151,6 +151,13 @@ public class FhirApiService : IFhirApiService
                 AccumulateDiscoveredReferences(refResources, referenceAccumulator);
             }
 
+            if (resource is Location location && fhirQueryConfiguration.EnableLocationResolutionMapping)
+            {
+                await _locationMappingService.UpdateLocationMappingAsync(
+                    log.FacilityId, location,
+                    cancellationToken: cancellationToken);
+            }
+
             AddResourceToCache(new ResourceAcquired
             {
                 Resource = resource,

--- a/DotNet/DataAcquisition.Domain/Application/Services/FhirApi/FhirApiService.cs
+++ b/DotNet/DataAcquisition.Domain/Application/Services/FhirApi/FhirApiService.cs
@@ -83,7 +83,7 @@ public class FhirApiService : IFhirApiService
         activity?.SetTag(DiagnosticNames.ResourceType, resourceType.ToString());
 
         var resourceIds = new List<string>();
-        List<string> resourceIdsToAcquire =
+        var resourceIdsToAcquire =
             fhirQuery.IsReference.GetValueOrDefault()
             ? fhirQuery.IdQueryParameterValues.ToList()
             : [resourceType == ResourceType.Patient ? log.PatientId.SplitReference() : log.ResourceId];
@@ -317,12 +317,14 @@ public class FhirApiService : IFhirApiService
                     await PersistAcquiredReferenceResourcesAsync(log, resources, cancellationToken);
                 }
 
+                var locationMappingConfigured =
+                    await _locationMappingService.IsConfigured(log.FacilityId, cancellationToken);
+
                 foreach (var resource in resources)
                 {
                     InsertDateExtension((DomainResource)resource);
 
-                    if (resource is Location location &&
-                        await _locationMappingService.IsConfigured(log.FacilityId, cancellationToken))
+                    if (locationMappingConfigured && resource is Location location)
                     {
                         await _locationMappingService.UpdateLocationMappingAsync(
                             log.FacilityId, location,

--- a/DotNet/DataAcquisition.Domain/Application/Services/LocationMappingService.cs
+++ b/DotNet/DataAcquisition.Domain/Application/Services/LocationMappingService.cs
@@ -4,6 +4,7 @@ using Hl7.Fhir.Model;
 using Hl7.FhirPath;
 using LantanaGroup.Link.DataAcquisition.Domain.Application.Managers;
 using LantanaGroup.Link.DataAcquisition.Domain.Application.Models;
+using LantanaGroup.Link.DataAcquisition.Domain.Application.Models.Exceptions;
 using LantanaGroup.Link.DataAcquisition.Domain.Application.Queries;
 using LantanaGroup.Link.Shared.Application.Interfaces;
 using LantanaGroup.Link.Shared.Application.Models.Configs;
@@ -21,6 +22,14 @@ namespace LantanaGroup.Link.DataAcquisition.Domain.Application.Services;
 public interface ILocationMappingService
 {
     /// <summary>
+    /// Checks to see if this facility has any active location mappings
+    /// </summary>
+    /// <param name="facilityId">The facility ID that the mapping is for</param>
+    /// <param name="cancellationToken">Used to signal a cancellation in the request</param>
+    /// <returns>True if the facility has location mappings</returns>
+    Task<bool> IsConfigured(string facilityId, CancellationToken cancellationToken);
+
+    /// <summary>
     /// Updates or adds the location mapping for a given facility and location. This method is called when a new location resource is acquired from the FHIR API, and is responsible for updating the mapping between the facility and the location in the database.
     /// </summary>
     /// <param name="facilityId">The facility id that the mapping is for</param>
@@ -28,6 +37,7 @@ public interface ILocationMappingService
     /// <param name="locationAlias">An alias to use for the location</param>
     /// <param name="cancellationToken">Used to signal a cancellation in the request</param>
     /// <returns>The OrganizationLocationMappingModel for the mapping</returns>
+    /// <exception cref="NotFoundException">Thrown when the facility doesn't have any active mapping configurations</exception>
     Task<OrganizationLocationMappingModel> UpdateLocationMappingAsync(string facilityId, Location location, string? locationAlias = null, CancellationToken cancellationToken = default);
 }
 
@@ -37,15 +47,17 @@ public class LocationMappingService(
     IOrganizationLocationConfigurationQueries organizationLocationConfigurationQueries,
     ICacheService cacheService,
     ILogger<LocationMappingService> logger) : ILocationMappingService
-    
+
 {
-    private readonly IOrganizationLocationMappingManager _organizationLocationMappingManager = 
+    private readonly IOrganizationLocationMappingManager _organizationLocationMappingManager =
         organizationLocationMappingManager;
-    private readonly IOrganizationLocationMappingQueries _organizationLocationMappingQueries = 
+
+    private readonly IOrganizationLocationMappingQueries _organizationLocationMappingQueries =
         organizationLocationMappingQueries;
-    private readonly IOrganizationLocationConfigurationQueries _organizationLocationConfigurationQueries = 
+
+    private readonly IOrganizationLocationConfigurationQueries _organizationLocationConfigurationQueries =
         organizationLocationConfigurationQueries;
-    
+
     private readonly ICacheService _cacheService = cacheService;
     private readonly ILogger<LocationMappingService> _logger = logger;
 
@@ -53,16 +65,22 @@ public class LocationMappingService(
     // facility, so caching the compiled expression avoids recompiling per Location in the acquire loop.
     private static readonly ConcurrentDictionary<string, CompiledExpression> CompiledFhirPaths = new();
 
-    
+
     private const string OrgLocationConditionsCacheKeyPrefix = "org-location-conditions:";
     private static readonly TimeSpan OrgLocationConditionsTtl = TimeSpan.FromHours(1);
 
     public async Task<OrganizationLocationMappingModel> UpdateLocationMappingAsync(string facilityId, Location location,
         string? locationAlias = null, CancellationToken cancellationToken = default)
     {
+        var conditions = await GetActiveConditionsForFacility(facilityId);
+        if (conditions.Count == 0)
+        {
+            throw new NotFoundException($"FacilityId {facilityId} does not have any location mappings configured");
+        }
+
         var locationMapping =
             await _organizationLocationMappingQueries.GetByFacilityIdAndLocationIdAsync(
-                facilityId: facilityId, 
+                facilityId: facilityId,
                 locationId: location.Id);
 
         // See if the PartOf has an record already so we can set the Id on the location mapping
@@ -79,10 +97,10 @@ public class LocationMappingService(
         if (locationMapping is null)
         {
             locationMapping = await AddMapping(
-                facilityId, 
-                location, 
-                isOrgLocation, 
-                locationAlias, 
+                facilityId,
+                location,
+                isOrgLocation,
+                locationAlias,
                 partOf,
                 cancellationToken);
         }
@@ -94,7 +112,15 @@ public class LocationMappingService(
         return locationMapping;
     }
 
-    private async Task<OrganizationLocationMappingModel> UpdateMapping(Location location, bool isOrgLocation, OrganizationLocationMappingModel locationMapping, OrganizationLocationMappingModel? partOf)
+    public async Task<bool> IsConfigured(string facilityId, CancellationToken cancellationToken)
+    {
+        var mappings = await GetActiveConditionsForFacility(facilityId);
+
+        return mappings.Count != 0;
+    }
+
+    private async Task<OrganizationLocationMappingModel> UpdateMapping(Location location, bool isOrgLocation,
+        OrganizationLocationMappingModel locationMapping, OrganizationLocationMappingModel? partOf)
     {
         if (locationMapping.LocationName != location.Name ||
             locationMapping.PartOfValue != location.PartOf?.Reference?.SplitReference() ||
@@ -123,10 +149,10 @@ public class LocationMappingService(
     }
 
     private async Task<OrganizationLocationMappingModel> AddMapping(
-        string facilityId, 
+        string facilityId,
         Location location,
         bool isOrgLocation,
-        string? locationAlias, 
+        string? locationAlias,
         OrganizationLocationMappingModel? partOf,
         CancellationToken cancellationToken)
     {
@@ -157,7 +183,7 @@ public class LocationMappingService(
             if (existing is null)
             {
                 // not a duplicate — a real failure, rethrow
-                throw; 
+                throw;
             }
 
             locationMapping = await UpdateMapping(location, isOrgLocation, existing, partOf);
@@ -168,7 +194,7 @@ public class LocationMappingService(
             location.Id,
             locationMapping.LocationMappingId,
             cancellationToken: cancellationToken);
-        
+
         return locationMapping;
     }
 
@@ -191,7 +217,7 @@ public class LocationMappingService(
     }
 
     private async Task<bool> IsOrgLocationAsync(
-        string facilityId, 
+        string facilityId,
         Location? location)
     {
         if (location is null)
@@ -199,41 +225,18 @@ public class LocationMappingService(
             return false;
         }
 
-        var cacheKey = OrgLocationConditionsCacheKeyPrefix + facilityId;
+        var conditions = await GetActiveConditionsForFacility(facilityId);
 
-        var conditions = _cacheService.Get<List<OrganizationLocationConditionModel>>(cacheKey);
-
-        if (conditions is null)
-        {
-            var configs = await _organizationLocationConfigurationQueries.GetByFacilityIdAsync(facilityId);
-
-            conditions = configs
-                .Where(c => c.IsActive)
-                .SelectMany(c => c.Conditions)
-                .Where(c => !string.IsNullOrWhiteSpace(c.FhirPath))
-                .OrderBy(c => c.Priority)
-                .ToList();
-
-            _cacheService.Set(cacheKey, conditions, OrgLocationConditionsTtl, ExpirationType.Absolute);
-        }
-
-        return IsOrgLocation(location, conditions); 
-    }
-
-    private bool IsOrgLocation(Location? location, IReadOnlyList<OrganizationLocationConditionModel>? conditions)
-    {
-        if (location is null || conditions is null || conditions.Count == 0)
+        if (conditions.Count == 0)
         {
             return false;
         }
 
         var element = location.ToTypedElement();
 
-        // Conditions arrive ordered by Priority (ascending). First-match-wins: evaluate in priority
-        // order; the first condition that matches marks the location as an org location and stops.
-        // NOTE: with positive-only FhirPath matchers this produces the same boolean as "any match".
-        // Priority becomes truly decisive only if a condition can carry a verdict (include vs
-        // exclude), which the current schema can't express — pending architecture confirmation.
+        // A location is an org location if it matches
+        // ANY active condition. Priority is not decisive — it only affects evaluation order, so we
+        // stop at the first match.
         foreach (var condition in conditions)
         {
             if (!EvaluatesTrue(element, condition.FhirPath!))
@@ -249,6 +252,31 @@ public class LocationMappingService(
         }
 
         return false;
+    }
+
+    private async Task<List<OrganizationLocationConditionModel>> GetActiveConditionsForFacility(string facilityId)
+    {
+        var cacheKey = OrgLocationConditionsCacheKeyPrefix + facilityId;
+
+        var conditions = _cacheService.Get<List<OrganizationLocationConditionModel>?>(cacheKey);
+
+        if (conditions is not null)
+        {
+            return conditions;
+        }
+
+        var configs = await _organizationLocationConfigurationQueries.GetByFacilityIdAsync(facilityId);
+
+        conditions = configs
+            .Where(c => c.IsActive)
+            .SelectMany(c => c.Conditions)
+            .Where(c => !string.IsNullOrWhiteSpace(c.FhirPath))
+            .OrderBy(c => c.Priority)
+            .ToList();
+
+        _cacheService.Set(cacheKey, conditions, OrgLocationConditionsTtl, ExpirationType.Absolute);
+
+        return conditions;
     }
 
     private bool EvaluatesTrue(ITypedElement element, string fhirPath)
@@ -268,7 +296,7 @@ public class LocationMappingService(
             // Node-selecting expression (e.g. "identifier.where(system=...)"): non-empty → match.
             return true;
         }
-        catch(Exception exception)
+        catch (Exception exception)
         {
             // Conditions are syntax-validated when the config is saved, so a runtime failure here
             // means the expression didn't fit this resource shape — treat as no-match, not fatal.

--- a/DotNet/DataAcquisition.Domain/Application/Services/LocationMappingService.cs
+++ b/DotNet/DataAcquisition.Domain/Application/Services/LocationMappingService.cs
@@ -287,11 +287,16 @@ public class LocationMappingService(
             var results = compiled(element, new EvaluationContext()).ToList();
 
             if (results.Count == 0)
-                return false; // empty result → no match
+            {
+                // empty result → no match
+                return false; 
+            }
 
             // Boolean predicate (e.g. "...exists()"): honor the returned boolean.
-            if (results.Count == 1 && results[0].Value is bool b)
-                return b;
+            if (results.Count == 1 && results[0].Value is bool isMatch)
+            {
+                return isMatch;
+            }
 
             // Node-selecting expression (e.g. "identifier.where(system=...)"): non-empty → match.
             return true;

--- a/DotNet/DataAcquisition.Domain/Application/Services/LocationMappingService.cs
+++ b/DotNet/DataAcquisition.Domain/Application/Services/LocationMappingService.cs
@@ -122,10 +122,15 @@ public class LocationMappingService(
     private async Task<OrganizationLocationMappingModel> UpdateMapping(Location location, bool isOrgLocation,
         OrganizationLocationMappingModel locationMapping, OrganizationLocationMappingModel? partOf)
     {
+        var incomingAlias = location.Alias?.FirstOrDefault();
+
+        // Only treat the alias as changed when the resource actually carries one that differs.
+        // A missing alias is preserved (UpdateByIdAsync ignores a null alias), so comparing the
+        // stored alias against null would otherwise fire a redundant update on every re-acquire.
         if (locationMapping.LocationName != location.Name ||
             locationMapping.PartOfValue != location.PartOf?.Reference?.SplitReference() ||
             locationMapping.PartOfId != partOf?.LocationMappingId ||
-            locationMapping.LocationAlias != location.Alias?.FirstOrDefault() ||
+            (incomingAlias != null && locationMapping.LocationAlias != incomingAlias) ||
             locationMapping.IsOrgLocation != isOrgLocation)
         {
             // Something changed, update the record
@@ -133,7 +138,7 @@ public class LocationMappingService(
             {
                 IsActive = locationMapping.IsActive,
                 IsOrgLocation = isOrgLocation,
-                LocationAlias = location.Alias?.FirstOrDefault(),
+                LocationAlias = incomingAlias,
                 LocationName = location.Name,
                 PartOfValue = location.PartOf?.Reference?.SplitReference(),
                 PartOfId = partOf?.LocationMappingId

--- a/DotNet/DataAcquisition.Domain/Application/Services/LocationMappingService.cs
+++ b/DotNet/DataAcquisition.Domain/Application/Services/LocationMappingService.cs
@@ -1,0 +1,283 @@
+using System.Collections.Concurrent;
+using Hl7.Fhir.ElementModel;
+using Hl7.Fhir.Model;
+using Hl7.FhirPath;
+using LantanaGroup.Link.DataAcquisition.Domain.Application.Managers;
+using LantanaGroup.Link.DataAcquisition.Domain.Application.Models;
+using LantanaGroup.Link.DataAcquisition.Domain.Application.Queries;
+using LantanaGroup.Link.Shared.Application.Interfaces;
+using LantanaGroup.Link.Shared.Application.Models.Configs;
+using LantanaGroup.Link.Shared.Application.Utilities;
+using Microsoft.Data.SqlClient;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Task = System.Threading.Tasks.Task;
+
+namespace LantanaGroup.Link.DataAcquisition.Domain.Application.Services;
+
+/// <summary>
+/// Manages location mapping records
+/// </summary>
+public interface ILocationMappingService
+{
+    /// <summary>
+    /// Updates or adds the location mapping for a given facility and location. This method is called when a new location resource is acquired from the FHIR API, and is responsible for updating the mapping between the facility and the location in the database.
+    /// </summary>
+    /// <param name="facilityId">The facility id that the mapping is for</param>
+    /// <param name="location">The location resource from the FHIR object</param>
+    /// <param name="locationAlias">An alias to use for the location</param>
+    /// <param name="cancellationToken">Used to signal a cancellation in the request</param>
+    /// <returns>The OrganizationLocationMappingModel for the mapping</returns>
+    Task<OrganizationLocationMappingModel> UpdateLocationMappingAsync(string facilityId, Location location, string? locationAlias = null, CancellationToken cancellationToken = default);
+}
+
+public class LocationMappingService(
+    IOrganizationLocationMappingManager organizationLocationMappingManager,
+    IOrganizationLocationMappingQueries organizationLocationMappingQueries,
+    IOrganizationLocationConfigurationQueries organizationLocationConfigurationQueries,
+    ICacheService cacheService,
+    ILogger<LocationMappingService> logger) : ILocationMappingService
+    
+{
+    private readonly IOrganizationLocationMappingManager _organizationLocationMappingManager = 
+        organizationLocationMappingManager;
+    private readonly IOrganizationLocationMappingQueries _organizationLocationMappingQueries = 
+        organizationLocationMappingQueries;
+    private readonly IOrganizationLocationConfigurationQueries _organizationLocationConfigurationQueries = 
+        organizationLocationConfigurationQueries;
+    
+    private readonly ICacheService _cacheService = cacheService;
+    private readonly ILogger<LocationMappingService> _logger = logger;
+
+    // FhirPath strings are validated (compiled) at config-write time and are low-cardinality per
+    // facility, so caching the compiled expression avoids recompiling per Location in the acquire loop.
+    private static readonly ConcurrentDictionary<string, CompiledExpression> CompiledFhirPaths = new();
+
+    
+    private const string OrgLocationConditionsCacheKeyPrefix = "org-location-conditions:";
+    private static readonly TimeSpan OrgLocationConditionsTtl = TimeSpan.FromHours(1);
+
+    public async Task<OrganizationLocationMappingModel> UpdateLocationMappingAsync(string facilityId, Location location,
+        string? locationAlias = null, CancellationToken cancellationToken = default)
+    {
+        var locationMapping =
+            await _organizationLocationMappingQueries.GetByFacilityIdAndLocationIdAsync(
+                facilityId: facilityId, 
+                locationId: location.Id);
+
+        // See if the PartOf has an record already so we can set the Id on the location mapping
+        OrganizationLocationMappingModel? partOf = null;
+        if (location.PartOf?.Reference != null)
+        {
+            partOf = await _organizationLocationMappingQueries.GetByFacilityIdAndLocationIdAsync(
+                facilityId: facilityId,
+                locationId: location.PartOf.Reference.SplitReference());
+        }
+
+        var isOrgLocation = await IsOrgLocationAsync(facilityId, location);
+
+        if (locationMapping is null)
+        {
+            locationMapping = await AddMapping(
+                facilityId, 
+                location, 
+                isOrgLocation, 
+                locationAlias, 
+                partOf,
+                cancellationToken);
+        }
+        else
+        {
+            locationMapping = await UpdateMapping(location, isOrgLocation, locationMapping, partOf);
+        }
+
+        return locationMapping;
+    }
+
+    private async Task<OrganizationLocationMappingModel> UpdateMapping(Location location, bool isOrgLocation, OrganizationLocationMappingModel locationMapping, OrganizationLocationMappingModel? partOf)
+    {
+        if (locationMapping.LocationName != location.Name ||
+            locationMapping.PartOfValue != location.PartOf?.Reference?.SplitReference() ||
+            locationMapping.PartOfId != partOf?.LocationMappingId ||
+            locationMapping.LocationAlias != location.Alias?.FirstOrDefault() ||
+            locationMapping.IsOrgLocation != isOrgLocation)
+        {
+            // Something changed, update the record
+            var updateRecord = new UpdateOrganizationLocationMappingModel
+            {
+                IsActive = locationMapping.IsActive,
+                IsOrgLocation = isOrgLocation,
+                LocationAlias = location.Alias?.FirstOrDefault(),
+                LocationName = location.Name,
+                PartOfValue = location.PartOf?.Reference?.SplitReference(),
+                PartOfId = partOf?.LocationMappingId
+            };
+
+            locationMapping =
+                await _organizationLocationMappingManager.UpdateByIdAsync(
+                    locationMapping.LocationMappingId,
+                    updateRecord);
+        }
+
+        return locationMapping;
+    }
+
+    private async Task<OrganizationLocationMappingModel> AddMapping(
+        string facilityId, 
+        Location location,
+        bool isOrgLocation,
+        string? locationAlias, 
+        OrganizationLocationMappingModel? partOf,
+        CancellationToken cancellationToken)
+    {
+        var newMapping = new CreateOrganizationLocationMappingModel
+        {
+            FacilityId = facilityId,
+            IsActive = true,
+            IsOrgLocation = isOrgLocation,
+            LocationAlias = locationAlias ?? location.Alias?.FirstOrDefault() ?? location.Name,
+            LocationId = location.Id,
+            LocationName = location.Name,
+            PartOfValue = location.PartOf?.Reference.SplitReference(),
+            PartOfId = partOf?.LocationMappingId
+        };
+
+        OrganizationLocationMappingModel locationMapping;
+        try
+        {
+            locationMapping = await _organizationLocationMappingManager.CreateAsync(newMapping);
+        }
+        catch (DbUpdateException ex) when (IsUniqueConstraintViolation(ex))
+        {
+            // A concurrent work item inserted the same (facility, location) between our null-check
+            // and SaveChanges. That's expected for shared Locations — re-read and update instead of failing.
+            var existing = await _organizationLocationMappingQueries
+                .GetByFacilityIdAndLocationIdAsync(facilityId, location.Id);
+
+            if (existing is null)
+            {
+                // not a duplicate — a real failure, rethrow
+                throw; 
+            }
+
+            locationMapping = await UpdateMapping(location, isOrgLocation, existing, partOf);
+        }
+
+        await UpdatePartOfIdsOnRecordsWithThisPartOfValue(
+            facilityId,
+            location.Id,
+            locationMapping.LocationMappingId,
+            cancellationToken: cancellationToken);
+        
+        return locationMapping;
+    }
+
+    private async Task UpdatePartOfIdsOnRecordsWithThisPartOfValue(
+        string facilityId, string? locationId, int locationMappingId, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrEmpty(locationId))
+        {
+            return;
+        }
+
+        var adopted = await _organizationLocationMappingManager
+            .SetPartOfIdForChildrenAsync(facilityId, locationId, locationMappingId, cancellationToken);
+
+        if (adopted > 0)
+        {
+            _logger.LogDebug("Adopted {Count} child location(s) under mapping {LocationMappingId}", adopted,
+                locationMappingId);
+        }
+    }
+
+    private async Task<bool> IsOrgLocationAsync(
+        string facilityId, 
+        Location? location)
+    {
+        if (location is null)
+        {
+            return false;
+        }
+
+        var cacheKey = OrgLocationConditionsCacheKeyPrefix + facilityId;
+
+        var conditions = _cacheService.Get<List<OrganizationLocationConditionModel>>(cacheKey);
+
+        if (conditions is null)
+        {
+            var configs = await _organizationLocationConfigurationQueries.GetByFacilityIdAsync(facilityId);
+
+            conditions = configs
+                .Where(c => c.IsActive)
+                .SelectMany(c => c.Conditions)
+                .Where(c => !string.IsNullOrWhiteSpace(c.FhirPath))
+                .OrderBy(c => c.Priority)
+                .ToList();
+
+            _cacheService.Set(cacheKey, conditions, OrgLocationConditionsTtl, ExpirationType.Absolute);
+        }
+
+        return IsOrgLocation(location, conditions); 
+    }
+
+    private bool IsOrgLocation(Location? location, IReadOnlyList<OrganizationLocationConditionModel>? conditions)
+    {
+        if (location is null || conditions is null || conditions.Count == 0)
+        {
+            return false;
+        }
+
+        var element = location.ToTypedElement();
+
+        // Conditions arrive ordered by Priority (ascending). First-match-wins: evaluate in priority
+        // order; the first condition that matches marks the location as an org location and stops.
+        // NOTE: with positive-only FhirPath matchers this produces the same boolean as "any match".
+        // Priority becomes truly decisive only if a condition can carry a verdict (include vs
+        // exclude), which the current schema can't express — pending architecture confirmation.
+        foreach (var condition in conditions)
+        {
+            if (!EvaluatesTrue(element, condition.FhirPath!))
+            {
+                continue;
+            }
+
+            _logger.LogDebug(
+                "Location {LocationId} matched org-location condition {ConditionId} (priority {Priority})",
+                location.Id, condition.ConditionId, condition.Priority);
+
+            return true;
+        }
+
+        return false;
+    }
+
+    private bool EvaluatesTrue(ITypedElement element, string fhirPath)
+    {
+        try
+        {
+            var compiled = CompiledFhirPaths.GetOrAdd(fhirPath, fp => new FhirPathCompiler().Compile(fp));
+            var results = compiled(element, new EvaluationContext()).ToList();
+
+            if (results.Count == 0)
+                return false; // empty result → no match
+
+            // Boolean predicate (e.g. "...exists()"): honor the returned boolean.
+            if (results.Count == 1 && results[0].Value is bool b)
+                return b;
+
+            // Node-selecting expression (e.g. "identifier.where(system=...)"): non-empty → match.
+            return true;
+        }
+        catch(Exception exception)
+        {
+            // Conditions are syntax-validated when the config is saved, so a runtime failure here
+            // means the expression didn't fit this resource shape — treat as no-match, not fatal.
+            _logger.LogDebug("Error searching on fhirPath {FhirPath}:{Message}", fhirPath, exception.Message);
+            return false;
+        }
+    }
+
+    // SQL Server: 2627 = unique constraint, 2601 = unique index
+    private static bool IsUniqueConstraintViolation(DbUpdateException ex) =>
+        ex.InnerException is SqlException { Number: 2601 or 2627 };
+}

--- a/DotNet/DataAcquisition.Domain/Extensions/GeneralStartupExtensions.cs
+++ b/DotNet/DataAcquisition.Domain/Extensions/GeneralStartupExtensions.cs
@@ -271,6 +271,7 @@ public static class GeneralStartupExtensions
         services.AddTransient<ITenantApiService, TenantApiService>();
         services.AddTransient<IValidateFacilityConnectionService, ValidateFacilityConnectionService>();
         services.AddTransient<IFhirApiService, FhirApiService>();
+        services.AddTransient<ILocationMappingService, LocationMappingService>();
         services.AddTransient<IPatientDataService, PatientDataService>();
         services.AddTransient<IPatientCensusService, PatientCensusService>();
         services.AddTransient<IReferenceResourceService, ReferenceResourceService>();

--- a/DotNet/DataAcquisition.Domain/Infrastructure/Context/DataAcquisitionDbContext.cs
+++ b/DotNet/DataAcquisition.Domain/Infrastructure/Context/DataAcquisitionDbContext.cs
@@ -485,6 +485,12 @@ public class DataAcquisitionDbContext : DbContext
 
             entity.HasIndex(e => e.PartOfId, "IX_LocationMapping_PartOfId").HasFilter("([PartOfId] IS NOT NULL)");
 
+            // Supports the orphan-adoption backfill (SetPartOfIdForChildrenAsync), which filters on
+            // (FacilityId, PartOfValue) for rows whose PartOfId is not yet resolved. Filtered to the
+            // unresolved rows so the index stays small and the update is a seek rather than a scan.
+            entity.HasIndex(e => new { e.FacilityId, e.PartOfValue }, "IX_LocationMapping_FacilityId_PartOfValue")
+                .HasFilter("([PartOfId] IS NULL)");
+
             entity.Property(e => e.CreateDate).HasDefaultValueSql("(getutcdate())");
             entity.Property(e => e.IsActive).HasDefaultValue(true);
             entity.Property(e => e.ModifiedDate).HasDefaultValueSql("(getutcdate())");

--- a/DotNet/DataAcquisition.Domain/Migrations/20260617220031_AddLocationMappingPartOfValueIndex.Designer.cs
+++ b/DotNet/DataAcquisition.Domain/Migrations/20260617220031_AddLocationMappingPartOfValueIndex.Designer.cs
@@ -4,6 +4,7 @@ using LantanaGroup.Link.DataAcquisition.Domain.Infrastructure.Context;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace DataAcquisition.Domain.Migrations
 {
     [DbContext(typeof(DataAcquisitionDbContext))]
-    partial class DataAcquisitionDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260617220031_AddLocationMappingPartOfValueIndex")]
+    partial class AddLocationMappingPartOfValueIndex
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/DotNet/DataAcquisition.Domain/Migrations/20260617220031_AddLocationMappingPartOfValueIndex.cs
+++ b/DotNet/DataAcquisition.Domain/Migrations/20260617220031_AddLocationMappingPartOfValueIndex.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace DataAcquisition.Domain.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddLocationMappingPartOfValueIndex : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateIndex(
+                name: "IX_LocationMapping_FacilityId_PartOfValue",
+                table: "OrganizationLocationMapping",
+                columns: new[] { "FacilityId", "PartOfValue" },
+                filter: "([PartOfId] IS NULL)");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_LocationMapping_FacilityId_PartOfValue",
+                table: "OrganizationLocationMapping");
+        }
+    }
+}

--- a/DotNet/ServiceTests/IntegrationTests/Census/QueryTests.cs
+++ b/DotNet/ServiceTests/IntegrationTests/Census/QueryTests.cs
@@ -399,10 +399,14 @@ public class QueryTests
         var queries = _fixture.ServiceProvider.GetRequiredService<IPatientEventQueries>();
         var patientEncounterQueries = _fixture.ServiceProvider.GetRequiredService<IPatientEncounterQueries>();
 
-        // Clear existing data from patient encounters table and related tables
+        // Clear existing data from patient encounters table and related tables.
+        // PatientEvents must be cleared too: RebuildPatientEncounterTable rebuilds from EVERY
+        // event in the table, so foreign events left by other tests in the shared collection DB
+        // would otherwise pollute the rebuild and the FirstOrDefaultAsync() sample below.
         dbContext.PatientIdentifiers.RemoveRange(dbContext.PatientIdentifiers);
         dbContext.PatientVisitIdentifiers.RemoveRange(dbContext.PatientVisitIdentifiers);
         dbContext.PatientEncounters.RemoveRange(dbContext.PatientEncounters);
+        dbContext.PatientEvents.RemoveRange(dbContext.PatientEvents);
         await dbContext.SaveChangesAsync();
 
         // Seed the database with patient events

--- a/DotNet/ServiceTests/IntegrationTests/DataAcquisition/Managers/DataAcquisitionLogManagerTests.cs
+++ b/DotNet/ServiceTests/IntegrationTests/DataAcquisition/Managers/DataAcquisitionLogManagerTests.cs
@@ -204,9 +204,11 @@ public class DataAcquisitionLogManagerTests
         // Arrange
         using var scope = _fixture.ServiceProvider.CreateScope();
         var manager = CreateManager(scope);
+        // Negative id is guaranteed absent: SQL Server identity values are always positive,
+        // so this stays "not found" regardless of how many logs prior tests left in the shared DB.
         var updateModel = new UpdateDataAcquisitionLogModel
         {
-            Id = 999,
+            Id = -1,
             Status = RequestStatus.Completed
         };
 
@@ -302,7 +304,9 @@ public class DataAcquisitionLogManagerTests
         // Arrange
         using var scope = _fixture.ServiceProvider.CreateScope();
         var manager = CreateManager(scope);
-        var logIds = new List<long> { 999 };
+        // Negative id is guaranteed absent: SQL Server identity values are always positive,
+        // so this stays "not found" regardless of how many logs prior tests left in the shared DB.
+        var logIds = new List<long> { -1 };
 
         // Act & Assert
         await Assert.ThrowsAsync<NotFoundException>(() => manager.UpdateTailFlagForFacilityCorrelationIdReportTrackingId(logIds, "TestFacility", "TestCorr", Guid.NewGuid().ToString()));

--- a/DotNet/ServiceTests/IntegrationTests/DataAcquisition/Managers/OrganizationLocationMappingManagerTests.cs
+++ b/DotNet/ServiceTests/IntegrationTests/DataAcquisition/Managers/OrganizationLocationMappingManagerTests.cs
@@ -2,6 +2,7 @@ using LantanaGroup.Link.DataAcquisition.Domain.Application.Managers;
 using LantanaGroup.Link.DataAcquisition.Domain.Application.Models;
 using LantanaGroup.Link.DataAcquisition.Domain.Application.Queries;
 using LantanaGroup.Link.DataAcquisition.Domain.Infrastructure;
+using LantanaGroup.Link.DataAcquisition.Domain.Infrastructure.Context;
 using Microsoft.Extensions.DependencyInjection;
 using Task = System.Threading.Tasks.Task;
 
@@ -21,7 +22,8 @@ public class OrganizationLocationMappingManagerTests
     private IOrganizationLocationMappingManager CreateManager(IServiceScope scope)
     {
         var database = scope.ServiceProvider.GetRequiredService<IDatabase>();
-        return new OrganizationLocationMappingManager(database);
+        var dbContext = scope.ServiceProvider.GetRequiredService<DataAcquisitionDbContext>();
+        return new OrganizationLocationMappingManager(database, dbContext);
     }
 
     private static string NewFacilityId(string prefix) => $"{prefix}_{Guid.NewGuid():N}";

--- a/DotNet/ServiceTests/IntegrationTests/DataAcquisition/Services/LocationMappingAcquisitionTests.cs
+++ b/DotNet/ServiceTests/IntegrationTests/DataAcquisition/Services/LocationMappingAcquisitionTests.cs
@@ -1,0 +1,313 @@
+using Hl7.Fhir.Model;
+using LantanaGroup.Link.DataAcquisition.Domain.Application.Managers;
+using LantanaGroup.Link.DataAcquisition.Domain.Application.Models;
+using LantanaGroup.Link.DataAcquisition.Domain.Application.Queries;
+using LantanaGroup.Link.DataAcquisition.Domain.Application.Services;
+using LantanaGroup.Link.Shared.Application.Extensions.Caching;
+using LantanaGroup.Link.Shared.Application.Interfaces;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Task = System.Threading.Tasks.Task;
+
+namespace IntegrationTests.DataAcquisition.Services;
+
+/// <summary>
+/// LEGLINK-139: "Add to mapping table when Location resources are queried."
+///
+/// When a facility is configured for Encounter Location resolution, Data Acquisition must
+/// store each queried Location into the OrganizationLocationMapping table. For each
+/// Location.Id, the mapping is inserted only when it does not already exist, and there must
+/// never be more than one entry per (FacilityId, Location.Id).
+///
+/// These tests drive the production <see cref="LocationMappingService"/> against the real
+/// configuration and mapping tables (via the fixture's SQL Server) and a real
+/// <see cref="InMemoryCacheService"/>. Only the FHIR API / Kafka edges are absent — the
+/// insert-or-skip decision, the org-location classification, and the database write are all
+/// exercised end-to-end, which is what the existing unit tests cannot cover.
+/// </summary>
+[Collection("IntegrationTests")]
+[Trait("Category", "IntegrationTests")]
+public class LocationMappingAcquisitionTests
+{
+    private readonly DataAcquisitionIntegrationTestFixture _fixture;
+
+    public LocationMappingAcquisitionTests(DataAcquisitionIntegrationTestFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    private static string NewFacilityId(string prefix) => $"{prefix}_{Guid.NewGuid():N}";
+    private static string NewLocationId(string prefix) => $"{prefix}_{Guid.NewGuid():N}";
+
+    /// <summary>
+    /// Builds the real service from scope-resolved dependencies, mirroring how DataAcquisition
+    /// wires it in production. Each call uses a fresh <see cref="InMemoryCacheService"/> so cached
+    /// conditions never leak across assertions within a test.
+    /// </summary>
+    private static LocationMappingService CreateService(IServiceScope scope)
+    {
+        return new LocationMappingService(
+            scope.ServiceProvider.GetRequiredService<IOrganizationLocationMappingManager>(),
+            scope.ServiceProvider.GetRequiredService<IOrganizationLocationMappingQueries>(),
+            scope.ServiceProvider.GetRequiredService<IOrganizationLocationConfigurationQueries>(),
+            new InMemoryCacheService(new MemoryCache(new MemoryCacheOptions { SizeLimit = 1024 })),
+            NullLogger<LocationMappingService>.Instance);
+    }
+
+    /// <summary>
+    /// Seeds an active Location configuration whose single condition flags a Location as an
+    /// org-location when its managingOrganization points at <paramref name="orgReference"/>.
+    /// This is the configuration the requirement gates on ("configured to perform Encounter
+    /// Location resolutions").
+    /// </summary>
+    private async Task SeedActiveConfigAsync(string facilityId, string orgReference)
+    {
+        using var scope = _fixture.ServiceProvider.CreateScope();
+        var configManager = scope.ServiceProvider.GetRequiredService<IOrganizationLocationConfigurationManager>();
+        await configManager.CreateAsync(new CreateOrganizationLocationConfigurationModel
+        {
+            FacilityId = facilityId,
+            Description = "Integration test config",
+            IsActive = true,
+            Conditions = new List<CreateOrganizationLocationConditionModel>
+            {
+                new() { FhirPath = $"managingOrganization.reference = '{orgReference}'", Priority = 1 }
+            }
+        });
+    }
+
+    [Fact]
+    public async Task IsConfigured_NoActiveConfiguration_ReturnsFalse()
+    {
+        var facilityId = NewFacilityId("Unconfigured");
+
+        using var scope = _fixture.ServiceProvider.CreateScope();
+        var service = CreateService(scope);
+
+        Assert.False(await service.IsConfigured(facilityId, CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task IsConfigured_WithActiveConfiguration_ReturnsTrue()
+    {
+        var facilityId = NewFacilityId("Configured");
+        await SeedActiveConfigAsync(facilityId, "Organization/org-1");
+
+        using var scope = _fixture.ServiceProvider.CreateScope();
+        var service = CreateService(scope);
+
+        Assert.True(await service.IsConfigured(facilityId, CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task UpdateLocationMappingAsync_ConfiguredFacilityNewLocation_InsertsMapping()
+    {
+        var facilityId = NewFacilityId("Insert");
+        var orgReference = "Organization/org-1";
+        await SeedActiveConfigAsync(facilityId, orgReference);
+
+        var locationId = NewLocationId("Loc");
+        var location = new Location
+        {
+            Id = locationId,
+            Name = "Med-Surg Unit 3",
+            ManagingOrganization = new ResourceReference(orgReference)
+        };
+
+        using (var scope = _fixture.ServiceProvider.CreateScope())
+        {
+            var service = CreateService(scope);
+            var result = await service.UpdateLocationMappingAsync(facilityId, location, cancellationToken: CancellationToken.None);
+
+            Assert.Equal(facilityId, result.FacilityId);
+            Assert.Equal(locationId, result.LocationId);
+            Assert.Equal("Med-Surg Unit 3", result.LocationName);
+            Assert.True(result.IsActive);
+            // managingOrganization matched the active condition, so it is flagged as an org-location.
+            Assert.True(result.IsOrgLocation);
+        }
+
+        // The row is durable: a fresh scope re-reads exactly one persisted mapping.
+        using var verifyScope = _fixture.ServiceProvider.CreateScope();
+        var queries = verifyScope.ServiceProvider.GetRequiredService<IOrganizationLocationMappingQueries>();
+        var rows = await queries.GetByFacilityIdAsync(facilityId);
+        var row = Assert.Single(rows);
+        Assert.Equal(locationId, row.LocationId);
+        Assert.Equal("Med-Surg Unit 3", row.LocationName);
+    }
+
+    [Fact]
+    public async Task UpdateLocationMappingAsync_SameLocationQueriedTwice_DoesNotDuplicate()
+    {
+        var facilityId = NewFacilityId("NoDup");
+        var orgReference = "Organization/org-1";
+        await SeedActiveConfigAsync(facilityId, orgReference);
+
+        var locationId = NewLocationId("Loc");
+
+        // Two separate acquisitions of the same Location.Id (e.g. it appears across patients/runs).
+        // The second query carries an updated name to prove the existing row is updated in place,
+        // not inserted again.
+        using (var scope1 = _fixture.ServiceProvider.CreateScope())
+        {
+            var service = CreateService(scope1);
+            await service.UpdateLocationMappingAsync(
+                facilityId,
+                new Location { Id = locationId, Name = "Original Name", ManagingOrganization = new ResourceReference(orgReference) },
+                cancellationToken: CancellationToken.None);
+        }
+
+        using (var scope2 = _fixture.ServiceProvider.CreateScope())
+        {
+            var service = CreateService(scope2);
+            await service.UpdateLocationMappingAsync(
+                facilityId,
+                new Location { Id = locationId, Name = "Renamed", ManagingOrganization = new ResourceReference(orgReference) },
+                cancellationToken: CancellationToken.None);
+        }
+
+        // Requirement: at most one entry per (FacilityId, Location.Id).
+        using var verifyScope = _fixture.ServiceProvider.CreateScope();
+        var queries = verifyScope.ServiceProvider.GetRequiredService<IOrganizationLocationMappingQueries>();
+        var rows = await queries.GetByFacilityIdAsync(facilityId);
+        var row = Assert.Single(rows);
+        Assert.Equal(locationId, row.LocationId);
+        Assert.Equal("Renamed", row.LocationName);
+    }
+
+    [Fact]
+    public async Task UpdateLocationMappingAsync_ParentQueriedAfterChild_BackfillsChildPartOfId()
+    {
+        var facilityId = NewFacilityId("Backfill");
+        var orgReference = "Organization/org-1";
+        await SeedActiveConfigAsync(facilityId, orgReference);
+
+        var parentLocationId = NewLocationId("Parent");
+        var childLocationId = NewLocationId("Child");
+
+        // The child arrives first, referencing a parent that is not yet in the mapping table.
+        // Its PartOfValue records the unresolved parent id; PartOfId stays null until the parent appears.
+        using (var scope = _fixture.ServiceProvider.CreateScope())
+        {
+            var service = CreateService(scope);
+            await service.UpdateLocationMappingAsync(
+                facilityId,
+                new Location
+                {
+                    Id = childLocationId,
+                    Name = "Bed 12",
+                    ManagingOrganization = new ResourceReference(orgReference),
+                    PartOf = new ResourceReference($"Location/{parentLocationId}")
+                },
+                cancellationToken: CancellationToken.None);
+        }
+
+        // Precondition: the child is an orphan — PartOfValue points at the parent, PartOfId is unresolved.
+        using (var preScope = _fixture.ServiceProvider.CreateScope())
+        {
+            var preQueries = preScope.ServiceProvider.GetRequiredService<IOrganizationLocationMappingQueries>();
+            var orphan = await preQueries.GetByFacilityIdAndLocationIdAsync(facilityId, childLocationId);
+            Assert.NotNull(orphan);
+            Assert.Equal(parentLocationId, orphan.PartOfValue);
+            Assert.Null(orphan.PartOfId);
+        }
+
+        // The parent is queried later. Inserting it must adopt the waiting child.
+        using (var scope = _fixture.ServiceProvider.CreateScope())
+        {
+            var service = CreateService(scope);
+            await service.UpdateLocationMappingAsync(
+                facilityId,
+                new Location { Id = parentLocationId, Name = "Med-Surg Unit 3", ManagingOrganization = new ResourceReference(orgReference) },
+                cancellationToken: CancellationToken.None);
+        }
+
+        // The child's PartOfId is backfilled to the parent's mapping id, with PartOfValue unchanged.
+        using var verifyScope = _fixture.ServiceProvider.CreateScope();
+        var queries = verifyScope.ServiceProvider.GetRequiredService<IOrganizationLocationMappingQueries>();
+        var parent = await queries.GetByFacilityIdAndLocationIdAsync(facilityId, parentLocationId);
+        var child = await queries.GetByFacilityIdAndLocationIdAsync(facilityId, childLocationId);
+
+        Assert.NotNull(parent);
+        Assert.NotNull(child);
+        Assert.Equal(parentLocationId, child.PartOfValue);
+        Assert.Equal(parent.LocationMappingId, child.PartOfId);
+    }
+
+    [Fact]
+    public async Task UpdateLocationMappingAsync_ChildQueriedAfterParent_LinksPartOfIdOnInsert()
+    {
+        var facilityId = NewFacilityId("ForwardLink");
+        var orgReference = "Organization/org-1";
+        await SeedActiveConfigAsync(facilityId, orgReference);
+
+        var parentLocationId = NewLocationId("Parent");
+        var childLocationId = NewLocationId("Child");
+
+        // Parent first this time: when the child is inserted, the parent already exists, so the
+        // PartOfId is resolved at insert rather than via the backfill adoption path.
+        using (var scope = _fixture.ServiceProvider.CreateScope())
+        {
+            var service = CreateService(scope);
+            await service.UpdateLocationMappingAsync(
+                facilityId,
+                new Location { Id = parentLocationId, Name = "Med-Surg Unit 3", ManagingOrganization = new ResourceReference(orgReference) },
+                cancellationToken: CancellationToken.None);
+            await service.UpdateLocationMappingAsync(
+                facilityId,
+                new Location
+                {
+                    Id = childLocationId,
+                    Name = "Bed 12",
+                    ManagingOrganization = new ResourceReference(orgReference),
+                    PartOf = new ResourceReference($"Location/{parentLocationId}")
+                },
+                cancellationToken: CancellationToken.None);
+        }
+
+        using var verifyScope = _fixture.ServiceProvider.CreateScope();
+        var queries = verifyScope.ServiceProvider.GetRequiredService<IOrganizationLocationMappingQueries>();
+        var parent = await queries.GetByFacilityIdAndLocationIdAsync(facilityId, parentLocationId);
+        var child = await queries.GetByFacilityIdAndLocationIdAsync(facilityId, childLocationId);
+
+        Assert.NotNull(parent);
+        Assert.NotNull(child);
+        Assert.Equal(parentLocationId, child.PartOfValue);
+        Assert.Equal(parent.LocationMappingId, child.PartOfId);
+    }
+
+    [Fact]
+    public async Task UpdateLocationMappingAsync_DistinctLocations_InsertsOneRowEach()
+    {
+        var facilityId = NewFacilityId("MultiLoc");
+        var orgReference = "Organization/org-1";
+        await SeedActiveConfigAsync(facilityId, orgReference);
+
+        var locationIdA = NewLocationId("LocA");
+        var locationIdB = NewLocationId("LocB");
+
+        using (var scope = _fixture.ServiceProvider.CreateScope())
+        {
+            var service = CreateService(scope);
+            await service.UpdateLocationMappingAsync(
+                facilityId,
+                new Location { Id = locationIdA, Name = "Location A", ManagingOrganization = new ResourceReference(orgReference) },
+                cancellationToken: CancellationToken.None);
+            await service.UpdateLocationMappingAsync(
+                facilityId,
+                new Location { Id = locationIdB, Name = "Location B", ManagingOrganization = new ResourceReference("Organization/other") },
+                cancellationToken: CancellationToken.None);
+        }
+
+        using var verifyScope = _fixture.ServiceProvider.CreateScope();
+        var queries = verifyScope.ServiceProvider.GetRequiredService<IOrganizationLocationMappingQueries>();
+        var rows = await queries.GetByFacilityIdAsync(facilityId);
+
+        Assert.Equal(2, rows.Count);
+        Assert.Contains(rows, r => r.LocationId == locationIdA && r.IsOrgLocation);
+        // Location B's managingOrganization did not match the condition, so it is not an org-location,
+        // but it is still recorded in the mapping table.
+        Assert.Contains(rows, r => r.LocationId == locationIdB && !r.IsOrgLocation);
+    }
+}

--- a/DotNet/ServiceTests/IntegrationTests/DataAcquisition/Services/LocationMappingServiceIntegrationTests.cs
+++ b/DotNet/ServiceTests/IntegrationTests/DataAcquisition/Services/LocationMappingServiceIntegrationTests.cs
@@ -80,6 +80,7 @@ public class LocationMappingServiceIntegrationTests
         var facilityId = NewId("Fac");
         var locationId = NewId("Loc");
 
+        // Create a real mapping in the database for the row we are about to insert
         int seededId;
         using (var seedScope = _fixture.ServiceProvider.CreateScope())
         {
@@ -98,6 +99,9 @@ public class LocationMappingServiceIntegrationTests
         using var scope = _fixture.ServiceProvider.CreateScope();
         var manager = scope.ServiceProvider.GetRequiredService<IOrganizationLocationMappingManager>();
 
+        // Fake two results in sequence to the GetByFacilityIdandLoactionID
+        // - first returns null
+        // - second returns a record (that was created above)
         var mockQueries = new Mock<IOrganizationLocationMappingQueries>();
         mockQueries
             .SetupSequence(q => q.GetByFacilityIdAndLocationIdAsync(facilityId, locationId))
@@ -117,11 +121,20 @@ public class LocationMappingServiceIntegrationTests
             .Setup(q => q.GetByFacilityIdAsync(It.IsAny<string>()))
             .ReturnsAsync(new List<OrganizationLocationConfigurationModel>());
 
+        // The facility must have at least one active condition, otherwise UpdateLocationMappingAsync
+        // short-circuits with NotFoundException before reaching the race-recovery path under test.
+        // The FhirPath deliberately doesn't match the bare test Location, so it stays a non-org location.
         var mockCache = new Mock<ICacheService>();
         mockCache
             .Setup(c => c.Get<List<OrganizationLocationConditionModel>>(It.IsAny<string>()))
-            .Returns(new List<OrganizationLocationConditionModel>());
+            .Returns(new List<OrganizationLocationConditionModel>
+            {
+                new() { FhirPath = "managingOrganization.reference = 'Organization/never'", Priority = 1 }
+            });
 
+        // Make the real call, the code checks if the records exists and the mock returns nothing
+        // then it does an add which fails because a record does exist.  So it gets the 
+        // record and does an update instead.
         var service = new LocationMappingService(
             manager,
             mockQueries.Object,

--- a/DotNet/ServiceTests/IntegrationTests/DataAcquisition/Services/LocationMappingServiceIntegrationTests.cs
+++ b/DotNet/ServiceTests/IntegrationTests/DataAcquisition/Services/LocationMappingServiceIntegrationTests.cs
@@ -1,0 +1,145 @@
+using Hl7.Fhir.Model;
+using LantanaGroup.Link.DataAcquisition.Domain.Application.Managers;
+using LantanaGroup.Link.DataAcquisition.Domain.Application.Models;
+using LantanaGroup.Link.DataAcquisition.Domain.Application.Queries;
+using LantanaGroup.Link.DataAcquisition.Domain.Application.Services;
+using LantanaGroup.Link.Shared.Application.Interfaces;
+using Microsoft.Data.SqlClient;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Task = System.Threading.Tasks.Task;
+
+namespace IntegrationTests.DataAcquisition.Services;
+
+[Collection("IntegrationTests")]
+[Trait("Category", "IntegrationTests")]
+public class LocationMappingServiceIntegrationTests
+{
+    private readonly DataAcquisitionIntegrationTestFixture _fixture;
+
+    public LocationMappingServiceIntegrationTests(DataAcquisitionIntegrationTestFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    private static string NewId(string prefix) => $"{prefix}_{Guid.NewGuid():N}";
+
+    /// <summary>
+    /// Validates the precondition the service's recovery filter depends on: a duplicate
+    /// (FacilityId, LocationId) insert produces a DbUpdateException whose inner SqlException
+    /// carries error number 2601/2627. This is the exact shape IsUniqueConstraintViolation keys
+    /// on and cannot be constructed in a pure unit test.
+    /// </summary>
+    [Fact]
+    public async Task CreateAsync_DuplicateFacilityAndLocation_ThrowsUniqueConstraintViolation()
+    {
+        var facilityId = NewId("Fac");
+        var locationId = NewId("Loc");
+
+        using (var seedScope = _fixture.ServiceProvider.CreateScope())
+        {
+            var seedManager = seedScope.ServiceProvider.GetRequiredService<IOrganizationLocationMappingManager>();
+            await seedManager.CreateAsync(new CreateOrganizationLocationMappingModel
+            {
+                FacilityId = facilityId,
+                LocationId = locationId,
+                LocationName = "Original",
+                IsActive = true,
+                IsOrgLocation = false
+            });
+        }
+
+        using var scope = _fixture.ServiceProvider.CreateScope();
+        var manager = scope.ServiceProvider.GetRequiredService<IOrganizationLocationMappingManager>();
+
+        var ex = await Assert.ThrowsAsync<DbUpdateException>(() => manager.CreateAsync(new CreateOrganizationLocationMappingModel
+        {
+            FacilityId = facilityId,
+            LocationId = locationId,
+            LocationName = "Duplicate",
+            IsActive = true,
+            IsOrgLocation = false
+        }));
+
+        var sqlException = Assert.IsType<SqlException>(ex.InnerException);
+        Assert.Contains(sqlException.Number, new[] { 2601, 2627 });
+    }
+
+    /// <summary>
+    /// End-to-end recovery: when the initial existence check misses but a concurrent insert
+    /// has already created the row, CreateAsync trips the unique constraint and the service must
+    /// recover by re-reading and updating instead of failing. The queries are mocked to reproduce
+    /// the race timing (null on the first read, the existing row on the recovery re-read) while the
+    /// manager + database are real so the genuine SqlException flows through the filter.
+    /// </summary>
+    [Fact]
+    public async Task UpdateLocationMappingAsync_WhenInsertRacesUniqueConstraint_RecoversByUpdating()
+    {
+        var facilityId = NewId("Fac");
+        var locationId = NewId("Loc");
+
+        int seededId;
+        using (var seedScope = _fixture.ServiceProvider.CreateScope())
+        {
+            var seedManager = seedScope.ServiceProvider.GetRequiredService<IOrganizationLocationMappingManager>();
+            var seeded = await seedManager.CreateAsync(new CreateOrganizationLocationMappingModel
+            {
+                FacilityId = facilityId,
+                LocationId = locationId,
+                LocationName = "Original",
+                IsActive = true,
+                IsOrgLocation = false
+            });
+            seededId = seeded.LocationMappingId;
+        }
+
+        using var scope = _fixture.ServiceProvider.CreateScope();
+        var manager = scope.ServiceProvider.GetRequiredService<IOrganizationLocationMappingManager>();
+
+        var mockQueries = new Mock<IOrganizationLocationMappingQueries>();
+        mockQueries
+            .SetupSequence(q => q.GetByFacilityIdAndLocationIdAsync(facilityId, locationId))
+            .ReturnsAsync((OrganizationLocationMappingModel?)null)              // initial check misses
+            .ReturnsAsync(new OrganizationLocationMappingModel                  // recovery re-read finds it
+            {
+                LocationMappingId = seededId,
+                FacilityId = facilityId,
+                LocationId = locationId,
+                LocationName = "Original",
+                IsActive = true,
+                IsOrgLocation = false
+            });
+
+        var mockConfigQueries = new Mock<IOrganizationLocationConfigurationQueries>();
+        mockConfigQueries
+            .Setup(q => q.GetByFacilityIdAsync(It.IsAny<string>()))
+            .ReturnsAsync(new List<OrganizationLocationConfigurationModel>());
+
+        var mockCache = new Mock<ICacheService>();
+        mockCache
+            .Setup(c => c.Get<List<OrganizationLocationConditionModel>>(It.IsAny<string>()))
+            .Returns(new List<OrganizationLocationConditionModel>());
+
+        var service = new LocationMappingService(
+            manager,
+            mockQueries.Object,
+            mockConfigQueries.Object,
+            mockCache.Object,
+            new Mock<ILogger<LocationMappingService>>().Object);
+
+        var location = new Location { Id = locationId, Name = "Updated Name" };
+
+        var result = await service.UpdateLocationMappingAsync(facilityId, location);
+
+        Assert.Equal("Updated Name", result.LocationName);
+
+        // Exactly one row remains, carrying the updated name — the duplicate insert did not persist.
+        using var verifyScope = _fixture.ServiceProvider.CreateScope();
+        var verifyQueries = verifyScope.ServiceProvider.GetRequiredService<IOrganizationLocationMappingQueries>();
+        var rows = await verifyQueries.GetByFacilityIdAsync(facilityId);
+        Assert.Single(rows);
+        Assert.Equal("Updated Name", rows[0].LocationName);
+    }
+}

--- a/DotNet/ServiceTests/IntegrationTests/Normalization/OperationServiceTests.cs
+++ b/DotNet/ServiceTests/IntegrationTests/Normalization/OperationServiceTests.cs
@@ -17,10 +17,11 @@ namespace IntegrationTests.Normalization
 {
     [Collection("IntegrationTests")]
     [Trait("Category", "IntegrationTests")]
-    public class OperationServiceTests
+    public class OperationServiceTests : IDisposable
     {
         private readonly ITestOutputHelper _output;
         private readonly NormalizationIntegrationTestFixture _fixture;
+        private readonly IServiceScope _scope;
         private readonly IDatabase _database;
         private readonly IOperationManager _operationManager;
         private readonly IOperationQueries _operationQueries;
@@ -35,15 +36,22 @@ namespace IntegrationTests.Normalization
             _fixture = fixture;
             _output = output;
 
-            _database = _fixture.ServiceProvider.GetRequiredService<IDatabase>();
-            _operationManager = _fixture.ServiceProvider.GetRequiredService<IOperationManager>();
-            _operationQueries = _fixture.ServiceProvider.GetRequiredService<IOperationQueries>();
-            _copyOperationService = _fixture.ServiceProvider.GetRequiredService<CopyPropertyOperationService>();
-            _codeMapOperationService = _fixture.ServiceProvider.GetRequiredService<CodeMapOperationService>();
-            _conditionalTransformService = _fixture.ServiceProvider.GetRequiredService<ConditionalTransformOperationService>();
-            _copyLocationOperationService = _fixture.ServiceProvider.GetRequiredService<CopyLocationOperationService>();
-            _removeExtensionsOperationService = _fixture.ServiceProvider.GetRequiredService<RemoveExtensionsOperationService>();
+            // Resolve scoped services from a per-test scope rather than the root provider, so the
+            // tests pass under DI scope validation (enabled when DOTNET_ENVIRONMENT=Development).
+            _scope = fixture.ServiceProvider.CreateScope();
+            var sp = _scope.ServiceProvider;
+
+            _database = sp.GetRequiredService<IDatabase>();
+            _operationManager = sp.GetRequiredService<IOperationManager>();
+            _operationQueries = sp.GetRequiredService<IOperationQueries>();
+            _copyOperationService = sp.GetRequiredService<CopyPropertyOperationService>();
+            _codeMapOperationService = sp.GetRequiredService<CodeMapOperationService>();
+            _conditionalTransformService = sp.GetRequiredService<ConditionalTransformOperationService>();
+            _copyLocationOperationService = sp.GetRequiredService<CopyLocationOperationService>();
+            _removeExtensionsOperationService = sp.GetRequiredService<RemoveExtensionsOperationService>();
         }
+
+        public void Dispose() => _scope.Dispose();
 
         [Fact]
         public async Task Integration_CopyPropertyOperation_Location_Identifier_To_Type_Create_TargetElement()

--- a/DotNet/ServiceTests/IntegrationTests/Normalization/VendorTests.cs
+++ b/DotNet/ServiceTests/IntegrationTests/Normalization/VendorTests.cs
@@ -62,8 +62,9 @@ namespace IntegrationTests.Normalization
         [Fact]
         public async Task CreateVendorVersion_Valid_CreatesSuccessfully()
         {
-            var vendorManager = _fixture.ServiceProvider.GetRequiredService<IVendorManager>();
-            var vendorQueries = _fixture.ServiceProvider.GetRequiredService<IVendorQueries>();
+            using var scope = _fixture.ServiceProvider.CreateScope();
+            var vendorManager = scope.ServiceProvider.GetRequiredService<IVendorManager>();
+            var vendorQueries = scope.ServiceProvider.GetRequiredService<IVendorQueries>();
 
             string vendorName = Guid.NewGuid().ToString();
             var vendor = await vendorManager.CreateVendor(vendorName);
@@ -81,9 +82,10 @@ namespace IntegrationTests.Normalization
         {
             await EnsureResourcesCreated();
 
-            var vendorManager = _fixture.ServiceProvider.GetRequiredService<IVendorManager>();
-            var vendorQueries = _fixture.ServiceProvider.GetRequiredService<IVendorQueries>();
-            var operationManager = _fixture.ServiceProvider.GetRequiredService<IOperationManager>();
+            using var scope = _fixture.ServiceProvider.CreateScope();
+            var vendorManager = scope.ServiceProvider.GetRequiredService<IVendorManager>();
+            var vendorQueries = scope.ServiceProvider.GetRequiredService<IVendorQueries>();
+            var operationManager = scope.ServiceProvider.GetRequiredService<IOperationManager>();
 
             // Create vendor and version
             string vendorName = Guid.NewGuid().ToString();

--- a/DotNet/ServiceTests/IntegrationTests/Tenant/FacilityControllerTests.cs
+++ b/DotNet/ServiceTests/IntegrationTests/Tenant/FacilityControllerTests.cs
@@ -27,10 +27,11 @@ namespace IntegrationTests.Tenant;
 
 [Collection("IntegrationTests")]
 [Trait("Category", "IntegrationTests")]
-public class FacilityControllerTests
+public class FacilityControllerTests : IDisposable
 {
     private readonly ITestOutputHelper _output;
     private readonly TenantIntegrationTestFixture _fixture;
+    private readonly IServiceScope _scope;
     private readonly FacilityController _controller;
 
     public FacilityControllerTests(TenantIntegrationTestFixture fixture, ITestOutputHelper output)
@@ -38,16 +39,26 @@ public class FacilityControllerTests
         _fixture = fixture;
         _output = output;
 
-        var logger = _fixture.ServiceProvider.GetRequiredService<ILogger<FacilityController>>();
-        var scheduleService = _fixture.ServiceProvider.GetRequiredService<ScheduleService>();
-        var producerFactory = _fixture.ServiceProvider.GetRequiredService<IKafkaProducerFactory<string, GenerateReportValue>>();
-        var serviceRegistry = _fixture.ServiceProvider.GetRequiredService<IOptions<ServiceRegistry>>();
-        var httpClientFactory = _fixture.ServiceProvider.GetRequiredService<IHttpClientFactory>();
-        var linkTokenServiceConfig = _fixture.ServiceProvider.GetRequiredService<IOptions<LinkTokenServiceSettings>>();
-        var createSystemToken = _fixture.ServiceProvider.GetRequiredService<ICreateSystemToken>();
-        var linkBearerServiceOptions = _fixture.ServiceProvider.GetRequiredService<IOptions<LinkBearerServiceOptions>>();
-        var queries = _fixture.ServiceProvider.GetRequiredService<IFacilityQueries>();
-        var manager = _fixture.ServiceProvider.GetRequiredService<IFacilityManager>();
+        // Resolve scoped services from a per-test scope rather than the root provider, so the
+        // tests pass under DI scope validation (enabled when DOTNET_ENVIRONMENT=Development).
+        _scope = fixture.ServiceProvider.CreateScope();
+        var sp = _scope.ServiceProvider;
+
+        var logger = sp.GetRequiredService<ILogger<FacilityController>>();
+        var scheduleService = sp.GetRequiredService<ScheduleService>();
+
+        // The controller calls into ScheduleService, whose Quartz scheduler is only initialized in
+        // StartAsync. Start it here so these tests don't depend on another test class (e.g.
+        // ScheduleServiceTests) having started the shared singleton first. StartAsync is idempotent.
+        scheduleService.StartAsync(CancellationToken.None).GetAwaiter().GetResult();
+        var producerFactory = sp.GetRequiredService<IKafkaProducerFactory<string, GenerateReportValue>>();
+        var serviceRegistry = sp.GetRequiredService<IOptions<ServiceRegistry>>();
+        var httpClientFactory = sp.GetRequiredService<IHttpClientFactory>();
+        var linkTokenServiceConfig = sp.GetRequiredService<IOptions<LinkTokenServiceSettings>>();
+        var createSystemToken = sp.GetRequiredService<ICreateSystemToken>();
+        var linkBearerServiceOptions = sp.GetRequiredService<IOptions<LinkBearerServiceOptions>>();
+        var queries = sp.GetRequiredService<IFacilityQueries>();
+        var manager = sp.GetRequiredService<IFacilityManager>();
 
         _controller = new FacilityController(logger, manager, queries, scheduleService, producerFactory, serviceRegistry, httpClientFactory, linkTokenServiceConfig, createSystemToken, linkBearerServiceOptions);
 
@@ -63,6 +74,8 @@ public class FacilityControllerTests
 
     }
 
+    public void Dispose() => _scope.Dispose();
+
     [Fact]
     public async Task GetFacilities_Success()
     {
@@ -75,7 +88,7 @@ public class FacilityControllerTests
             TimeZone = "America/Chicago",
             ScheduledReports = new ScheduledReportModel { Daily = new string[] { }, Weekly = new string[] { }, Monthly = new string[] { } }
         };
-        await _fixture.ServiceProvider.GetRequiredService<IFacilityManager>().CreateAsync(facility, CancellationToken.None);
+        await _scope.ServiceProvider.GetRequiredService<IFacilityManager>().CreateAsync(facility, CancellationToken.None);
 
         var result = await _controller.GetFacilities(facilityId, facilityName, null, null, null, null, 10, 1, false, CancellationToken.None);
 
@@ -96,7 +109,7 @@ public class FacilityControllerTests
             TimeZone = "America/Chicago",
             ScheduledReports = new ScheduledReportModel { Daily = new string[] { }, Weekly = new string[] { }, Monthly = new string[] { } }
         };
-        await _fixture.ServiceProvider.GetRequiredService<IFacilityManager>().CreateAsync(facility, CancellationToken.None);
+        await _scope.ServiceProvider.GetRequiredService<IFacilityManager>().CreateAsync(facility, CancellationToken.None);
 
         var result = await _controller.GetFacilityList(facilityId);
         var okResult = Assert.IsType<OkObjectResult>(result);
@@ -133,7 +146,7 @@ public class FacilityControllerTests
             TimeZone = "America/Chicago",
             ScheduledReports = new ScheduledReportModel { Daily = new string[] { }, Weekly = new string[] { }, Monthly = new string[] { } }
         };
-        await _fixture.ServiceProvider.GetRequiredService<IFacilityManager>().CreateAsync(facility, CancellationToken.None);
+        await _scope.ServiceProvider.GetRequiredService<IFacilityManager>().CreateAsync(facility, CancellationToken.None);
 
         var updateConfig = new FacilityModel
         {
@@ -163,7 +176,7 @@ public class FacilityControllerTests
             TimeZone = "America/Chicago",
             ScheduledReports = new ScheduledReportModel { Daily = new string[] { }, Weekly = new string[] { }, Monthly = new string[] { } }
         };
-        await _fixture.ServiceProvider.GetRequiredService<IFacilityManager>().CreateAsync(facility, CancellationToken.None);
+        await _scope.ServiceProvider.GetRequiredService<IFacilityManager>().CreateAsync(facility, CancellationToken.None);
 
         var result = await _controller.DeleteFacility(facilityId, CancellationToken.None);
         Assert.IsType<NoContentResult>(result);
@@ -181,7 +194,7 @@ public class FacilityControllerTests
             TimeZone = "America/Chicago",
             ScheduledReports = new ScheduledReportModel { Daily = new string[] { }, Weekly = new string[] { }, Monthly = new string[] { } }
         };
-        await _fixture.ServiceProvider.GetRequiredService<IFacilityManager>().CreateAsync(facility, CancellationToken.None);
+        await _scope.ServiceProvider.GetRequiredService<IFacilityManager>().CreateAsync(facility, CancellationToken.None);
 
         var result = await _controller.SoftDeleteFacility(facilityId, CancellationToken.None);
         Assert.IsType<NoContentResult>(result);
@@ -210,7 +223,7 @@ public class FacilityControllerTests
             TimeZone = "America/Chicago",
             ScheduledReports = new ScheduledReportModel { Daily = new string[] { }, Weekly = new string[] { }, Monthly = new string[] { } }
         };
-        var manager = _fixture.ServiceProvider.GetRequiredService<IFacilityManager>();
+        var manager = _scope.ServiceProvider.GetRequiredService<IFacilityManager>();
         await manager.CreateAsync(facility, CancellationToken.None);
 
         // Soft delete the facility first
@@ -244,7 +257,7 @@ public class FacilityControllerTests
             TimeZone = "America/Chicago",
             ScheduledReports = new ScheduledReportModel { Daily = new string[] { }, Weekly = new string[] { }, Monthly = new string[] { } }
         };
-        await _fixture.ServiceProvider.GetRequiredService<IFacilityManager>().CreateAsync(facility, CancellationToken.None);
+        await _scope.ServiceProvider.GetRequiredService<IFacilityManager>().CreateAsync(facility, CancellationToken.None);
 
         // Try to restore a facility that is not deleted
         var result = await _controller.RestoreFacility(facilityId, CancellationToken.None);
@@ -265,7 +278,7 @@ public class FacilityControllerTests
             TimeZone = "America/Chicago",
             ScheduledReports = new ScheduledReportModel { Daily = new string[] { }, Weekly = new string[] { }, Monthly = new string[] { } }
         };
-        await _fixture.ServiceProvider.GetRequiredService<IFacilityManager>().CreateAsync(facility, CancellationToken.None);
+        await _scope.ServiceProvider.GetRequiredService<IFacilityManager>().CreateAsync(facility, CancellationToken.None);
 
         var request = new AdHocReportRequest
         {
@@ -297,7 +310,7 @@ public class FacilityControllerTests
             TimeZone = "America/Chicago",
             ScheduledReports = new ScheduledReportModel { Daily = new string[] { }, Weekly = new string[] { }, Monthly = new string[] { } }
         };
-        await _fixture.ServiceProvider.GetRequiredService<IFacilityManager>().CreateAsync(facility, CancellationToken.None);
+        await _scope.ServiceProvider.GetRequiredService<IFacilityManager>().CreateAsync(facility, CancellationToken.None);
 
         // Stub HttpClient response
         var handler = new StubHttpMessageHandler(new HttpResponseMessage

--- a/DotNet/ServiceTests/IntegrationTests/Tenant/ScheduleServiceTests.cs
+++ b/DotNet/ServiceTests/IntegrationTests/Tenant/ScheduleServiceTests.cs
@@ -14,10 +14,11 @@ namespace IntegrationTests.Tenant
 {
     [Collection("IntegrationTests")]
     [Trait("Category", "IntegrationTests")]
-    public class ScheduleServiceTests
+    public class ScheduleServiceTests : IDisposable
     {
         private readonly ITestOutputHelper _output;
         private readonly TenantIntegrationTestFixture _fixture;
+        private readonly IServiceScope _scope;
         private readonly ScheduleService _service;
         private readonly TenantDbContext _dbContext;
         private readonly ISchedulerFactory _schedulerFactory;
@@ -27,11 +28,18 @@ namespace IntegrationTests.Tenant
             _fixture = fixture;
             _output = output;
 
-            _service = _fixture.ServiceProvider.GetRequiredService<ScheduleService>();
+            // Resolve scoped services from a per-test scope rather than the root provider, so the
+            // tests pass under DI scope validation (enabled when DOTNET_ENVIRONMENT=Development).
+            _scope = fixture.ServiceProvider.CreateScope();
+            var sp = _scope.ServiceProvider;
+
+            _service = sp.GetRequiredService<ScheduleService>();
             _service.StartAsync(CancellationToken.None).Wait();
-            _dbContext = _fixture.ServiceProvider.GetRequiredService<TenantDbContext>();
-            _schedulerFactory = _fixture.ServiceProvider.GetRequiredService<ISchedulerFactory>();
+            _dbContext = sp.GetRequiredService<TenantDbContext>();
+            _schedulerFactory = sp.GetRequiredService<ISchedulerFactory>();
         }
+
+        public void Dispose() => _scope.Dispose();
 
         [Fact]
         public async Task StartAsync_LoadsFacilitiesAndAddsJobs()

--- a/DotNet/ServiceTests/IntegrationTests/Tenant/TenantBusinessTests.cs
+++ b/DotNet/ServiceTests/IntegrationTests/Tenant/TenantBusinessTests.cs
@@ -13,10 +13,11 @@ namespace IntegrationTests.Tenant
 {
     [Collection("IntegrationTests")]
     [Trait("Category", "IntegrationTests")]
-    public class TenantBusinessTests
+    public class TenantBusinessTests : IDisposable
     {
         private readonly ITestOutputHelper _output;
         private readonly TenantIntegrationTestFixture _fixture;
+        private readonly IServiceScope _scope;
         private readonly IFacilityManager _manager;
         private readonly IFacilityQueries _queries;
         private readonly IEntityRepository<Facility> _repo;
@@ -27,11 +28,18 @@ namespace IntegrationTests.Tenant
             _fixture = fixture;
             _output = output;
 
-            _manager = _fixture.ServiceProvider.GetRequiredService<IFacilityManager>();
-            _queries = _fixture.ServiceProvider.GetRequiredService<IFacilityQueries>();
-            _repo = _fixture.ServiceProvider.GetRequiredService<IEntityRepository<Facility>>();
-            _mapper = _fixture.ServiceProvider.GetRequiredService<IMapper>();
+            // Resolve scoped services from a per-test scope rather than the root provider, so the
+            // tests pass under DI scope validation (enabled when DOTNET_ENVIRONMENT=Development).
+            _scope = fixture.ServiceProvider.CreateScope();
+            var sp = _scope.ServiceProvider;
+
+            _manager = sp.GetRequiredService<IFacilityManager>();
+            _queries = sp.GetRequiredService<IFacilityQueries>();
+            _repo = sp.GetRequiredService<IEntityRepository<Facility>>();
+            _mapper = sp.GetRequiredService<IMapper>();
         }
+
+        public void Dispose() => _scope.Dispose();
 
         [Fact]
         public async Task CreateFacility_Success()

--- a/DotNet/ServiceTests/UnitTests/DataAcquisition/FhirApiServiceTests.cs
+++ b/DotNet/ServiceTests/UnitTests/DataAcquisition/FhirApiServiceTests.cs
@@ -129,6 +129,7 @@ public class FhirApiServiceTests
         var kafkaProducer = new Mock<IProducer<ResourceKey, ResourcesAcquired>>();
         var logger = new Mock<ILogger<FhirApiService>>();
         var resourceCache = new Mock<IResourceCache>();
+        var locationMappingService = new Mock<ILocationMappingService>();
 
         var service = new FhirApiService(
             referenceResourceManager.Object,
@@ -138,7 +139,8 @@ public class FhirApiServiceTests
             logger.Object,
             resourceCache.Object,
             new Mock<IEncounterMappingQueries>().Object,
-            new Mock<IOrganizationLocationConfigurationQueries>().Object
+            new Mock<IOrganizationLocationConfigurationQueries>().Object,
+            locationMappingService.Object
         );
 
         var resource = new Patient();
@@ -179,7 +181,8 @@ public class FhirApiServiceTests
             logger.Object,
             resourceCache.Object,
             new Mock<IEncounterMappingQueries>().Object,
-            new Mock<IOrganizationLocationConfigurationQueries>().Object
+            new Mock<IOrganizationLocationConfigurationQueries>().Object,
+            new Mock<ILocationMappingService>().Object
         );
 
         var resource = new Patient();
@@ -234,7 +237,8 @@ public class FhirApiServiceTests
             logger.Object,
             resourceCache.Object,
             new Mock<IEncounterMappingQueries>().Object,
-            new Mock<IOrganizationLocationConfigurationQueries>().Object
+            new Mock<IOrganizationLocationConfigurationQueries>().Object,
+            new Mock<ILocationMappingService>().Object
         );
 
         var log = new DataAcquisitionLogModel
@@ -281,7 +285,8 @@ public class FhirApiServiceTests
             new Mock<ILogger<FhirApiService>>().Object,
             new Mock<IResourceCache>().Object,
             new Mock<IEncounterMappingQueries>().Object,
-            new Mock<IOrganizationLocationConfigurationQueries>().Object
+            new Mock<IOrganizationLocationConfigurationQueries>().Object,
+            new Mock<ILocationMappingService>().Object
         );
 
         var log = new DataAcquisitionLogModel { FacilityId = "123", ResourceId = "res-1" };
@@ -311,7 +316,8 @@ public class FhirApiServiceTests
             new Mock<ILogger<FhirApiService>>().Object,
             new Mock<IResourceCache>().Object,
             new Mock<IEncounterMappingQueries>().Object,
-            new Mock<IOrganizationLocationConfigurationQueries>().Object
+            new Mock<IOrganizationLocationConfigurationQueries>().Object,
+            new Mock<ILocationMappingService>().Object
         );
 
         var log = new DataAcquisitionLogModel { FacilityId = "123", CorrelationId = "c-1" };
@@ -342,7 +348,8 @@ public class FhirApiServiceTests
             new Mock<ILogger<FhirApiService>>().Object,
             resourceCache.Object,
             new Mock<IEncounterMappingQueries>().Object,
-            new Mock<IOrganizationLocationConfigurationQueries>().Object
+            new Mock<IOrganizationLocationConfigurationQueries>().Object,
+            new Mock<ILocationMappingService>().Object
         );
 
         var patient = new Patient { Id = "p1" };
@@ -455,7 +462,8 @@ public class FhirApiServiceTests
             new Mock<ILogger<FhirApiService>>().Object,
             resourceCache.Object,
             encounterMappingQueries.Object,
-            organizationLocationConfigurationQueries.Object
+            organizationLocationConfigurationQueries.Object,
+            new Mock<ILocationMappingService>().Object
         );
 
         var log = new DataAcquisitionLogModel
@@ -524,7 +532,8 @@ public class FhirApiServiceTests
             new Mock<ILogger<FhirApiService>>().Object,
             new Mock<IResourceCache>().Object,
             encounterMappingQueries.Object,
-            organizationLocationConfigurationQueries.Object
+            organizationLocationConfigurationQueries.Object,
+            new Mock<ILocationMappingService>().Object
         );
 
         var log = new DataAcquisitionLogModel
@@ -605,7 +614,8 @@ public class FhirApiServiceTests
             new Mock<ILogger<FhirApiService>>().Object,
             resourceCache.Object,
             encounterMappingQueries.Object,
-            organizationLocationConfigurationQueries.Object
+            organizationLocationConfigurationQueries.Object,
+            new Mock<ILocationMappingService>().Object
         );
 
         var log = new DataAcquisitionLogModel
@@ -703,7 +713,8 @@ public class FhirApiServiceTests
             logger.Object,
             resourceCache.Object,
             new Mock<IEncounterMappingQueries>().Object,
-            new Mock<IOrganizationLocationConfigurationQueries>().Object
+            new Mock<IOrganizationLocationConfigurationQueries>().Object,
+            new Mock<ILocationMappingService>().Object
         );
 
         var log = new DataAcquisitionLogModel
@@ -735,6 +746,124 @@ public class FhirApiServiceTests
         Assert.Contains(":Location", capturedCacheKey);
         Assert.DoesNotContain(":Patient", capturedCacheKey);
 
+    }
+
+    [Fact]
+    public async Task ExecuteSearch_LocationResource_WhenResolutionMappingEnabled_CallsLocationMappingService()
+    {
+        // Arrange
+        var searchFhirCommand = new Mock<ISearchFhirCommand>();
+        var locationMappingService = new Mock<ILocationMappingService>();
+        var service = new FhirApiService(
+            new Mock<IReferenceResourcesManager>().Object,
+            new Mock<IReferenceResourcesQueries>().Object,
+            searchFhirCommand.Object,
+            new Mock<IReadFhirCommand>().Object,
+            new Mock<ILogger<FhirApiService>>().Object,
+            new Mock<IResourceCache>().Object,
+            new Mock<IEncounterMappingQueries>().Object,
+            new Mock<IOrganizationLocationConfigurationQueries>().Object,
+            locationMappingService.Object
+        );
+
+        var location = new Location { Id = "loc-1", Name = "ICU" };
+        var bundle = new Bundle
+        {
+            Entry = new List<Bundle.EntryComponent> { new Bundle.EntryComponent { Resource = location } }
+        };
+        searchFhirCommand.Setup(x => x.ExecuteAsync(It.IsAny<SearchFhirCommandRequest>(), It.IsAny<CancellationToken>()))
+            .Returns(GetBundleAsync(bundle));
+
+        var log = new DataAcquisitionLogModel { FacilityId = "fac-1", CorrelationId = "c1", ScheduledReport = new ScheduledReport(), ReportableEvent = ReportableEvent.Adhoc };
+        var fhirQuery = new FhirQueryModel { IsReference = false, ResourceReferenceTypes = new List<ResourceReferenceTypeModel>() };
+        var config = new FhirQueryConfigurationModel { FhirServerBaseUrl = "http://test", EnableLocationResolutionMapping = true };
+
+        // Act
+        await service.ExecuteSearch(log, fhirQuery, config, ResourceType.Location);
+
+        // Assert
+        locationMappingService.Verify(s => s.UpdateLocationMappingAsync(
+            "fac-1",
+            It.Is<Location>(l => l.Id == "loc-1"),
+            It.IsAny<string>(),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task ExecuteSearch_NonLocationResource_DoesNotCallLocationMappingService()
+    {
+        // Arrange
+        var searchFhirCommand = new Mock<ISearchFhirCommand>();
+        var locationMappingService = new Mock<ILocationMappingService>();
+        var service = new FhirApiService(
+            new Mock<IReferenceResourcesManager>().Object,
+            new Mock<IReferenceResourcesQueries>().Object,
+            searchFhirCommand.Object,
+            new Mock<IReadFhirCommand>().Object,
+            new Mock<ILogger<FhirApiService>>().Object,
+            new Mock<IResourceCache>().Object,
+            new Mock<IEncounterMappingQueries>().Object,
+            new Mock<IOrganizationLocationConfigurationQueries>().Object,
+            locationMappingService.Object
+        );
+
+        var patient = new Patient { Id = "p1" };
+        var bundle = new Bundle
+        {
+            Entry = new List<Bundle.EntryComponent> { new Bundle.EntryComponent { Resource = patient } }
+        };
+        searchFhirCommand.Setup(x => x.ExecuteAsync(It.IsAny<SearchFhirCommandRequest>(), It.IsAny<CancellationToken>()))
+            .Returns(GetBundleAsync(bundle));
+
+        var log = new DataAcquisitionLogModel { FacilityId = "fac-1", CorrelationId = "c1", ScheduledReport = new ScheduledReport(), ReportableEvent = ReportableEvent.Adhoc };
+        var fhirQuery = new FhirQueryModel { IsReference = false, ResourceReferenceTypes = new List<ResourceReferenceTypeModel>() };
+        // Even with resolution mapping enabled, a non-Location resource must not reach the service.
+        var config = new FhirQueryConfigurationModel { FhirServerBaseUrl = "http://test", EnableLocationResolutionMapping = true };
+
+        // Act
+        await service.ExecuteSearch(log, fhirQuery, config, ResourceType.Patient);
+
+        // Assert
+        locationMappingService.Verify(s => s.UpdateLocationMappingAsync(
+            It.IsAny<string>(), It.IsAny<Location>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task ExecuteSearch_LocationResource_WhenResolutionMappingDisabled_DoesNotCallLocationMappingService()
+    {
+        // Arrange
+        var searchFhirCommand = new Mock<ISearchFhirCommand>();
+        var locationMappingService = new Mock<ILocationMappingService>();
+        var service = new FhirApiService(
+            new Mock<IReferenceResourcesManager>().Object,
+            new Mock<IReferenceResourcesQueries>().Object,
+            searchFhirCommand.Object,
+            new Mock<IReadFhirCommand>().Object,
+            new Mock<ILogger<FhirApiService>>().Object,
+            new Mock<IResourceCache>().Object,
+            new Mock<IEncounterMappingQueries>().Object,
+            new Mock<IOrganizationLocationConfigurationQueries>().Object,
+            locationMappingService.Object
+        );
+
+        var location = new Location { Id = "loc-1", Name = "ICU" };
+        var bundle = new Bundle
+        {
+            Entry = new List<Bundle.EntryComponent> { new Bundle.EntryComponent { Resource = location } }
+        };
+        searchFhirCommand.Setup(x => x.ExecuteAsync(It.IsAny<SearchFhirCommandRequest>(), It.IsAny<CancellationToken>()))
+            .Returns(GetBundleAsync(bundle));
+
+        var log = new DataAcquisitionLogModel { FacilityId = "fac-1", CorrelationId = "c1", ScheduledReport = new ScheduledReport(), ReportableEvent = ReportableEvent.Adhoc };
+        var fhirQuery = new FhirQueryModel { IsReference = false, ResourceReferenceTypes = new List<ResourceReferenceTypeModel>() };
+        var config = new FhirQueryConfigurationModel { FhirServerBaseUrl = "http://test", EnableLocationResolutionMapping = false };
+
+        // Act
+        await service.ExecuteSearch(log, fhirQuery, config, ResourceType.Location);
+
+        // Assert
+        locationMappingService.Verify(s => s.UpdateLocationMappingAsync(
+            It.IsAny<string>(), It.IsAny<Location>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 
     private static async IAsyncEnumerable<Bundle> GetBundleAsync(Bundle bundle)

--- a/DotNet/ServiceTests/UnitTests/DataAcquisition/FhirApiServiceTests.cs
+++ b/DotNet/ServiceTests/UnitTests/DataAcquisition/FhirApiServiceTests.cs
@@ -749,11 +749,13 @@ public class FhirApiServiceTests
     }
 
     [Fact]
-    public async Task ExecuteSearch_LocationResource_WhenResolutionMappingEnabled_CallsLocationMappingService()
+    public async Task ExecuteSearch_LocationResource_WhenFacilityConfigured_CallsLocationMappingService()
     {
         // Arrange
         var searchFhirCommand = new Mock<ISearchFhirCommand>();
         var locationMappingService = new Mock<ILocationMappingService>();
+        locationMappingService.Setup(s => s.IsConfigured("fac-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
         var service = new FhirApiService(
             new Mock<IReferenceResourcesManager>().Object,
             new Mock<IReferenceResourcesQueries>().Object,
@@ -776,7 +778,7 @@ public class FhirApiServiceTests
 
         var log = new DataAcquisitionLogModel { FacilityId = "fac-1", CorrelationId = "c1", ScheduledReport = new ScheduledReport(), ReportableEvent = ReportableEvent.Adhoc };
         var fhirQuery = new FhirQueryModel { IsReference = false, ResourceReferenceTypes = new List<ResourceReferenceTypeModel>() };
-        var config = new FhirQueryConfigurationModel { FhirServerBaseUrl = "http://test", EnableLocationResolutionMapping = true };
+        var config = new FhirQueryConfigurationModel { FhirServerBaseUrl = "http://test" };
 
         // Act
         await service.ExecuteSearch(log, fhirQuery, config, ResourceType.Location);
@@ -817,8 +819,7 @@ public class FhirApiServiceTests
 
         var log = new DataAcquisitionLogModel { FacilityId = "fac-1", CorrelationId = "c1", ScheduledReport = new ScheduledReport(), ReportableEvent = ReportableEvent.Adhoc };
         var fhirQuery = new FhirQueryModel { IsReference = false, ResourceReferenceTypes = new List<ResourceReferenceTypeModel>() };
-        // Even with resolution mapping enabled, a non-Location resource must not reach the service.
-        var config = new FhirQueryConfigurationModel { FhirServerBaseUrl = "http://test", EnableLocationResolutionMapping = true };
+        var config = new FhirQueryConfigurationModel { FhirServerBaseUrl = "http://test" };
 
         // Act
         await service.ExecuteSearch(log, fhirQuery, config, ResourceType.Patient);
@@ -829,11 +830,13 @@ public class FhirApiServiceTests
     }
 
     [Fact]
-    public async Task ExecuteSearch_LocationResource_WhenResolutionMappingDisabled_DoesNotCallLocationMappingService()
+    public async Task ExecuteSearch_LocationResource_WhenFacilityNotConfigured_DoesNotCallLocationMappingService()
     {
         // Arrange
         var searchFhirCommand = new Mock<ISearchFhirCommand>();
         var locationMappingService = new Mock<ILocationMappingService>();
+        locationMappingService.Setup(s => s.IsConfigured(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
         var service = new FhirApiService(
             new Mock<IReferenceResourcesManager>().Object,
             new Mock<IReferenceResourcesQueries>().Object,
@@ -856,7 +859,7 @@ public class FhirApiServiceTests
 
         var log = new DataAcquisitionLogModel { FacilityId = "fac-1", CorrelationId = "c1", ScheduledReport = new ScheduledReport(), ReportableEvent = ReportableEvent.Adhoc };
         var fhirQuery = new FhirQueryModel { IsReference = false, ResourceReferenceTypes = new List<ResourceReferenceTypeModel>() };
-        var config = new FhirQueryConfigurationModel { FhirServerBaseUrl = "http://test", EnableLocationResolutionMapping = false };
+        var config = new FhirQueryConfigurationModel { FhirServerBaseUrl = "http://test" };
 
         // Act
         await service.ExecuteSearch(log, fhirQuery, config, ResourceType.Location);
@@ -867,11 +870,13 @@ public class FhirApiServiceTests
     }
 
     [Fact]
-    public async Task ExecuteRead_LocationResource_WhenResolutionMappingEnabled_CallsLocationMappingService()
+    public async Task ExecuteRead_LocationResource_WhenFacilityConfigured_CallsLocationMappingService()
     {
         // Arrange
         var readFhirCommand = new Mock<IReadFhirCommand>();
         var locationMappingService = new Mock<ILocationMappingService>();
+        locationMappingService.Setup(s => s.IsConfigured("fac-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
         var service = new FhirApiService(
             new Mock<IReferenceResourcesManager>().Object,
             new Mock<IReferenceResourcesQueries>().Object,
@@ -879,6 +884,8 @@ public class FhirApiServiceTests
             readFhirCommand.Object,
             new Mock<ILogger<FhirApiService>>().Object,
             new Mock<IResourceCache>().Object,
+            new Mock<IEncounterMappingQueries>().Object,
+            new Mock<IOrganizationLocationConfigurationQueries>().Object,
             locationMappingService.Object
         );
 
@@ -888,7 +895,7 @@ public class FhirApiServiceTests
 
         var log = new DataAcquisitionLogModel { FacilityId = "fac-1", ResourceId = "loc-1", CorrelationId = "c1", ScheduledReport = new ScheduledReport(), ReportableEvent = ReportableEvent.Adhoc };
         var fhirQuery = new FhirQueryModel { IsReference = false, ResourceReferenceTypes = new List<ResourceReferenceTypeModel>() };
-        var config = new FhirQueryConfigurationModel { FhirServerBaseUrl = "http://test", EnableLocationResolutionMapping = true };
+        var config = new FhirQueryConfigurationModel { FhirServerBaseUrl = "http://test" };
 
         // Act
         await service.ExecuteRead(log, fhirQuery, ResourceType.Location, config);
@@ -902,11 +909,13 @@ public class FhirApiServiceTests
     }
 
     [Fact]
-    public async Task ExecuteRead_LocationResource_WhenResolutionMappingDisabled_DoesNotCallLocationMappingService()
+    public async Task ExecuteRead_LocationResource_WhenFacilityNotConfigured_DoesNotCallLocationMappingService()
     {
         // Arrange
         var readFhirCommand = new Mock<IReadFhirCommand>();
         var locationMappingService = new Mock<ILocationMappingService>();
+        locationMappingService.Setup(s => s.IsConfigured(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
         var service = new FhirApiService(
             new Mock<IReferenceResourcesManager>().Object,
             new Mock<IReferenceResourcesQueries>().Object,
@@ -914,6 +923,8 @@ public class FhirApiServiceTests
             readFhirCommand.Object,
             new Mock<ILogger<FhirApiService>>().Object,
             new Mock<IResourceCache>().Object,
+            new Mock<IEncounterMappingQueries>().Object,
+            new Mock<IOrganizationLocationConfigurationQueries>().Object,
             locationMappingService.Object
         );
 
@@ -923,7 +934,7 @@ public class FhirApiServiceTests
 
         var log = new DataAcquisitionLogModel { FacilityId = "fac-1", ResourceId = "loc-1", CorrelationId = "c1", ScheduledReport = new ScheduledReport(), ReportableEvent = ReportableEvent.Adhoc };
         var fhirQuery = new FhirQueryModel { IsReference = false, ResourceReferenceTypes = new List<ResourceReferenceTypeModel>() };
-        var config = new FhirQueryConfigurationModel { FhirServerBaseUrl = "http://test", EnableLocationResolutionMapping = false };
+        var config = new FhirQueryConfigurationModel { FhirServerBaseUrl = "http://test" };
 
         // Act
         await service.ExecuteRead(log, fhirQuery, ResourceType.Location, config);

--- a/DotNet/ServiceTests/UnitTests/DataAcquisition/FhirApiServiceTests.cs
+++ b/DotNet/ServiceTests/UnitTests/DataAcquisition/FhirApiServiceTests.cs
@@ -866,6 +866,73 @@ public class FhirApiServiceTests
             It.IsAny<string>(), It.IsAny<Location>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 
+    [Fact]
+    public async Task ExecuteRead_LocationResource_WhenResolutionMappingEnabled_CallsLocationMappingService()
+    {
+        // Arrange
+        var readFhirCommand = new Mock<IReadFhirCommand>();
+        var locationMappingService = new Mock<ILocationMappingService>();
+        var service = new FhirApiService(
+            new Mock<IReferenceResourcesManager>().Object,
+            new Mock<IReferenceResourcesQueries>().Object,
+            new Mock<ISearchFhirCommand>().Object,
+            readFhirCommand.Object,
+            new Mock<ILogger<FhirApiService>>().Object,
+            new Mock<IResourceCache>().Object,
+            locationMappingService.Object
+        );
+
+        var location = new Location { Id = "loc-1", Name = "ICU" };
+        readFhirCommand.Setup(x => x.ExecuteAsync(It.IsAny<ReadFhirCommandRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(location);
+
+        var log = new DataAcquisitionLogModel { FacilityId = "fac-1", ResourceId = "loc-1", CorrelationId = "c1", ScheduledReport = new ScheduledReport(), ReportableEvent = ReportableEvent.Adhoc };
+        var fhirQuery = new FhirQueryModel { IsReference = false, ResourceReferenceTypes = new List<ResourceReferenceTypeModel>() };
+        var config = new FhirQueryConfigurationModel { FhirServerBaseUrl = "http://test", EnableLocationResolutionMapping = true };
+
+        // Act
+        await service.ExecuteRead(log, fhirQuery, ResourceType.Location, config);
+
+        // Assert
+        locationMappingService.Verify(s => s.UpdateLocationMappingAsync(
+            "fac-1",
+            It.Is<Location>(l => l.Id == "loc-1"),
+            It.IsAny<string>(),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task ExecuteRead_LocationResource_WhenResolutionMappingDisabled_DoesNotCallLocationMappingService()
+    {
+        // Arrange
+        var readFhirCommand = new Mock<IReadFhirCommand>();
+        var locationMappingService = new Mock<ILocationMappingService>();
+        var service = new FhirApiService(
+            new Mock<IReferenceResourcesManager>().Object,
+            new Mock<IReferenceResourcesQueries>().Object,
+            new Mock<ISearchFhirCommand>().Object,
+            readFhirCommand.Object,
+            new Mock<ILogger<FhirApiService>>().Object,
+            new Mock<IResourceCache>().Object,
+            locationMappingService.Object
+        );
+
+        var location = new Location { Id = "loc-1", Name = "ICU" };
+        readFhirCommand.Setup(x => x.ExecuteAsync(It.IsAny<ReadFhirCommandRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(location);
+
+        var log = new DataAcquisitionLogModel { FacilityId = "fac-1", ResourceId = "loc-1", CorrelationId = "c1", ScheduledReport = new ScheduledReport(), ReportableEvent = ReportableEvent.Adhoc };
+        var fhirQuery = new FhirQueryModel { IsReference = false, ResourceReferenceTypes = new List<ResourceReferenceTypeModel>() };
+        var config = new FhirQueryConfigurationModel { FhirServerBaseUrl = "http://test", EnableLocationResolutionMapping = false };
+
+        // Act
+        await service.ExecuteRead(log, fhirQuery, ResourceType.Location, config);
+
+        // Assert
+        locationMappingService.Verify(s => s.UpdateLocationMappingAsync(
+            It.IsAny<string>(), It.IsAny<Location>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
     private static async IAsyncEnumerable<Bundle> GetBundleAsync(Bundle bundle)
     {
         yield return bundle;

--- a/DotNet/ServiceTests/UnitTests/DataAcquisition/Services/LocationMappingServiceTests.cs
+++ b/DotNet/ServiceTests/UnitTests/DataAcquisition/Services/LocationMappingServiceTests.cs
@@ -1,5 +1,6 @@
 using LantanaGroup.Link.DataAcquisition.Domain.Application.Managers;
 using LantanaGroup.Link.DataAcquisition.Domain.Application.Models;
+using LantanaGroup.Link.DataAcquisition.Domain.Application.Models.Exceptions;
 using LantanaGroup.Link.DataAcquisition.Domain.Application.Queries;
 using LantanaGroup.Link.DataAcquisition.Domain.Application.Services;
 using LantanaGroup.Link.Shared.Application.Interfaces;
@@ -22,6 +23,13 @@ public class LocationMappingServiceTests
     private readonly Mock<IOrganizationLocationConfigurationQueries> _mockConfigQueries = new();
     private readonly Mock<ICacheService> _mockCache = new();
     private readonly Mock<ILogger<LocationMappingService>> _mockLogger = new();
+
+    // Stateful conditions-cache backing field. Seeded with a non-matching condition so the facility
+    // reads as "configured" (non-empty) while generic test locations are not org locations.
+    private List<OrganizationLocationConditionModel>? _cachedConditions =
+    [
+        new() { ConditionId = 99, Priority = 1, FhirPath = "Location.name = 'ORG-THAT-DOES-NOT-MATCH'" }
+    ];
 
     private readonly LocationMappingService _service;
 
@@ -68,11 +76,16 @@ public class LocationMappingServiceTests
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(0);
 
-        // Default: conditions cache hit with an empty list → IsOrgLocation evaluates to false
-        // without touching the config queries.
+        // Stateful cache: Get returns the last Set value (seeded above with a non-matching
+        // condition so the facility is "configured" but generic locations are not org locations).
         _mockCache
             .Setup(c => c.Get<List<OrganizationLocationConditionModel>>(It.IsAny<string>()))
-            .Returns(new List<OrganizationLocationConditionModel>());
+            .Returns(() => _cachedConditions);
+        _mockCache
+            .Setup(c => c.Set(It.IsAny<string>(), It.IsAny<List<OrganizationLocationConditionModel>>(),
+                It.IsAny<TimeSpan>(), It.IsAny<ExpirationType>()))
+            .Callback<string, List<OrganizationLocationConditionModel>, TimeSpan, ExpirationType>(
+                (_, value, _, _) => _cachedConditions = value);
 
         _service = new LocationMappingService(
             _mockManager.Object,
@@ -263,12 +276,10 @@ public class LocationMappingServiceTests
     {
         // Arrange
         var location = NewLocation("loc-1", name: "University Hospital");
-        _mockCache
-            .Setup(c => c.Get<List<OrganizationLocationConditionModel>>(It.IsAny<string>()))
-            .Returns(new List<OrganizationLocationConditionModel>
-            {
-                new() { ConditionId = 1, Priority = 1, FhirPath = "Location.name = 'University Hospital'" }
-            });
+        _cachedConditions =
+        [
+            new() { ConditionId = 1, Priority = 1, FhirPath = "Location.name = 'University Hospital'" }
+        ];
 
         // Act
         await _service.UpdateLocationMappingAsync(FacilityId, location);
@@ -283,12 +294,10 @@ public class LocationMappingServiceTests
     {
         // Arrange
         var location = NewLocation("loc-1", name: "Some Ward");
-        _mockCache
-            .Setup(c => c.Get<List<OrganizationLocationConditionModel>>(It.IsAny<string>()))
-            .Returns(new List<OrganizationLocationConditionModel>
-            {
-                new() { ConditionId = 1, Priority = 1, FhirPath = "Location.name = 'University Hospital'" }
-            });
+        _cachedConditions =
+        [
+            new() { ConditionId = 1, Priority = 1, FhirPath = "Location.name = 'University Hospital'" }
+        ];
 
         // Act
         await _service.UpdateLocationMappingAsync(FacilityId, location);
@@ -299,18 +308,17 @@ public class LocationMappingServiceTests
     }
 
     [Fact]
-    public async Task UpdateLocationMappingAsync_HonorsConditionPriority_FirstMatchWins()
+    public async Task UpdateLocationMappingAsync_WhenAnyConditionMatches_MarksAsOrgLocation()
     {
         // Arrange
-        // Higher-priority (1) condition matches; a malformed lower-priority condition must never run.
+        // OR semantics: one matching condition is enough; evaluation short-circuits on the first
+        // match, so a malformed sibling condition is never reached.
         var location = NewLocation("loc-1", name: "University Hospital");
-        _mockCache
-            .Setup(c => c.Get<List<OrganizationLocationConditionModel>>(It.IsAny<string>()))
-            .Returns(new List<OrganizationLocationConditionModel>
-            {
-                new() { ConditionId = 1, Priority = 1, FhirPath = "Location.name = 'University Hospital'" },
-                new() { ConditionId = 2, Priority = 2, FhirPath = "this.is.not.valid.fhirpath(" }
-            });
+        _cachedConditions =
+        [
+            new() { ConditionId = 1, Priority = 1, FhirPath = "Location.name = 'University Hospital'" },
+            new() { ConditionId = 2, Priority = 2, FhirPath = "this.is.not.valid.fhirpath(" }
+        ];
 
         // Act
         await _service.UpdateLocationMappingAsync(FacilityId, location);
@@ -327,9 +335,7 @@ public class LocationMappingServiceTests
         var location = NewLocation("loc-1", name: "University Hospital");
 
         // Cache miss → must load config and re-cache.
-        _mockCache
-            .Setup(c => c.Get<List<OrganizationLocationConditionModel>>(It.IsAny<string>()))
-            .Returns((List<OrganizationLocationConditionModel>?)null);
+        _cachedConditions = null;
 
         _mockConfigQueries
             .Setup(q => q.GetByFacilityIdAsync(FacilityId))
@@ -387,5 +393,46 @@ public class LocationMappingServiceTests
             Times.Never);
         _mockManager.Verify(m => m.SetPartOfIdForChildrenAsync(
             It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task IsConfigured_WhenFacilityHasActiveConditions_ReturnsTrue()
+    {
+        // Arrange — the default cache is seeded with one active condition.
+
+        // Act
+        var configured = await _service.IsConfigured(FacilityId, CancellationToken.None);
+
+        // Assert
+        Assert.True(configured);
+    }
+
+    [Fact]
+    public async Task IsConfigured_WhenFacilityHasNoActiveConditions_ReturnsFalse()
+    {
+        // Arrange
+        _cachedConditions = [];
+
+        // Act
+        var configured = await _service.IsConfigured(FacilityId, CancellationToken.None);
+
+        // Assert
+        Assert.False(configured);
+    }
+
+    [Fact]
+    public async Task UpdateLocationMappingAsync_WhenFacilityNotConfigured_ThrowsNotFound()
+    {
+        // Arrange — no active conditions → the facility is not configured for location mapping.
+        _cachedConditions = [];
+        var location = NewLocation("loc-1", name: "ICU");
+
+        // Act & Assert
+        await Assert.ThrowsAsync<NotFoundException>(() =>
+            _service.UpdateLocationMappingAsync(FacilityId, location));
+
+        _mockManager.Verify(m => m.CreateAsync(It.IsAny<CreateOrganizationLocationMappingModel>()), Times.Never);
+        _mockManager.Verify(m => m.UpdateByIdAsync(It.IsAny<int>(), It.IsAny<UpdateOrganizationLocationMappingModel>()),
+            Times.Never);
     }
 }

--- a/DotNet/ServiceTests/UnitTests/DataAcquisition/Services/LocationMappingServiceTests.cs
+++ b/DotNet/ServiceTests/UnitTests/DataAcquisition/Services/LocationMappingServiceTests.cs
@@ -1,0 +1,391 @@
+using LantanaGroup.Link.DataAcquisition.Domain.Application.Managers;
+using LantanaGroup.Link.DataAcquisition.Domain.Application.Models;
+using LantanaGroup.Link.DataAcquisition.Domain.Application.Queries;
+using LantanaGroup.Link.DataAcquisition.Domain.Application.Services;
+using LantanaGroup.Link.Shared.Application.Interfaces;
+using LantanaGroup.Link.Shared.Application.Models.Configs;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Task = System.Threading.Tasks.Task;
+
+namespace ServiceTests.UnitTests.DataAcquisition.Services;
+
+[Trait("Category", "UnitTests")]
+public class LocationMappingServiceTests
+{
+    private const string FacilityId = "facility-1";
+    private const int NewMappingId = 42;
+
+    private readonly Mock<IOrganizationLocationMappingManager> _mockManager = new();
+    private readonly Mock<IOrganizationLocationMappingQueries> _mockQueries = new();
+    private readonly Mock<IOrganizationLocationConfigurationQueries> _mockConfigQueries = new();
+    private readonly Mock<ICacheService> _mockCache = new();
+    private readonly Mock<ILogger<LocationMappingService>> _mockLogger = new();
+
+    private readonly LocationMappingService _service;
+
+    public LocationMappingServiceTests()
+    {
+        // Default: no existing mapping for any (facility, location) lookup.
+        _mockQueries
+            .Setup(q => q.GetByFacilityIdAndLocationIdAsync(It.IsAny<string>(), It.IsAny<string>()))!
+            .ReturnsAsync((OrganizationLocationMappingModel?)null);
+
+        // Default: CreateAsync echoes the inbound model back with a generated id.
+        _mockManager
+            .Setup(m => m.CreateAsync(It.IsAny<CreateOrganizationLocationMappingModel>()))
+            .ReturnsAsync((CreateOrganizationLocationMappingModel m) => new OrganizationLocationMappingModel
+            {
+                LocationMappingId = NewMappingId,
+                FacilityId = m.FacilityId,
+                LocationId = m.LocationId,
+                LocationName = m.LocationName,
+                LocationAlias = m.LocationAlias,
+                PartOfValue = m.PartOfValue,
+                PartOfId = m.PartOfId,
+                IsOrgLocation = m.IsOrgLocation,
+                IsActive = m.IsActive
+            });
+
+        // Default: UpdateByIdAsync echoes the update back.
+        _mockManager
+            .Setup(m => m.UpdateByIdAsync(It.IsAny<int>(), It.IsAny<UpdateOrganizationLocationMappingModel>()))
+            .ReturnsAsync((int id, UpdateOrganizationLocationMappingModel m) => new OrganizationLocationMappingModel
+            {
+                LocationMappingId = id,
+                FacilityId = FacilityId,
+                LocationName = m.LocationName,
+                LocationAlias = m.LocationAlias,
+                PartOfValue = m.PartOfValue,
+                PartOfId = m.PartOfId,
+                IsOrgLocation = m.IsOrgLocation ?? false,
+                IsActive = m.IsActive ?? true
+            });
+
+        _mockManager
+            .Setup(m => m.SetPartOfIdForChildrenAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(0);
+
+        // Default: conditions cache hit with an empty list → IsOrgLocation evaluates to false
+        // without touching the config queries.
+        _mockCache
+            .Setup(c => c.Get<List<OrganizationLocationConditionModel>>(It.IsAny<string>()))
+            .Returns(new List<OrganizationLocationConditionModel>());
+
+        _service = new LocationMappingService(
+            _mockManager.Object,
+            _mockQueries.Object,
+            _mockConfigQueries.Object,
+            _mockCache.Object,
+            _mockLogger.Object);
+    }
+
+    private static Location NewLocation(
+        string id,
+        string? name = null,
+        string? partOfReference = null,
+        params string[] aliases)
+    {
+        var location = new Location { Id = id, Name = name };
+        if (partOfReference != null)
+        {
+            location.PartOf = new ResourceReference(partOfReference);
+        }
+
+        if (aliases.Length > 0)
+        {
+            location.Alias = aliases.ToList();
+        }
+
+        return location;
+    }
+
+    [Fact]
+    public async Task UpdateLocationMappingAsync_WhenNoExistingMapping_CreatesNewMapping()
+    {
+        // Arrange
+        var location = NewLocation("loc-1", name: "ICU");
+
+        // Act
+        var result = await _service.UpdateLocationMappingAsync(FacilityId, location);
+
+        // Assert
+        _mockManager.Verify(m => m.CreateAsync(It.Is<CreateOrganizationLocationMappingModel>(c =>
+            c.FacilityId == FacilityId &&
+            c.LocationId == "loc-1" &&
+            c.LocationName == "ICU" &&
+            c.IsActive &&
+            !c.IsOrgLocation)), Times.Once);
+        _mockManager.Verify(m => m.UpdateByIdAsync(It.IsAny<int>(), It.IsAny<UpdateOrganizationLocationMappingModel>()),
+            Times.Never);
+        Assert.Equal(NewMappingId, result.LocationMappingId);
+    }
+
+    [Fact]
+    public async Task UpdateLocationMappingAsync_NormalizesLocationIdAndPartOfToBareIds()
+    {
+        // Arrange
+        // PartOf is a type-prefixed FHIR reference; LocationId/PartOfValue must be stored bare.
+        var location = NewLocation("ed-1", name: "ED", partOfReference: "Location/hosp-1");
+
+        // Parent already mapped → PartOfId should be resolved from it.
+        _mockQueries
+            .Setup(q => q.GetByFacilityIdAndLocationIdAsync(FacilityId, "hosp-1"))
+            .ReturnsAsync(new OrganizationLocationMappingModel { LocationMappingId = 5, LocationId = "hosp-1" });
+
+        // Act
+        await _service.UpdateLocationMappingAsync(FacilityId, location);
+
+        // Assert
+        // "Location/" stripped
+        _mockManager.Verify(m => m.CreateAsync(It.Is<CreateOrganizationLocationMappingModel>(c =>
+            c.LocationId == "ed-1" &&
+            c.PartOfValue == "hosp-1" && 
+            c.PartOfId == 5)), Times.Once);
+    }
+
+    [Fact]
+    public async Task UpdateLocationMappingAsync_WhenParentNotYetMapped_LeavesPartOfIdNull()
+    {
+        // Arrange
+        var location = NewLocation("ed-1", name: "ED", partOfReference: "Location/hosp-1");
+        // Parent lookup returns null (default) → PartOfId unresolved, PartOfValue still recorded.
+
+        // Act
+        await _service.UpdateLocationMappingAsync(FacilityId, location);
+
+        // Assert
+        _mockManager.Verify(m => m.CreateAsync(It.Is<CreateOrganizationLocationMappingModel>(c =>
+            c.PartOfValue == "hosp-1" &&
+            c.PartOfId == null)), Times.Once);
+    }
+
+    [Fact]
+    public async Task UpdateLocationMappingAsync_AfterAdd_RunsChildBackfillWithOwnLocationId()
+    {
+        // Arrange
+        var location = NewLocation("hosp-1", name: "Hospital");
+
+        // Act
+        await _service.UpdateLocationMappingAsync(FacilityId, location);
+
+        // Assert
+        // Adopt orphans whose PartOfValue points at THIS location's id, under the new mapping id.
+        _mockManager.Verify(m => m.SetPartOfIdForChildrenAsync(
+            FacilityId, "hosp-1", NewMappingId, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task UpdateLocationMappingAsync_PrefersProvidedAlias_OverFhirAlias()
+    {
+        // Arrange
+        var location = NewLocation("loc-1", name: "ICU", aliases: "FHIR-ALIAS");
+
+        // Act
+        await _service.UpdateLocationMappingAsync(FacilityId, location, locationAlias: "OVERRIDE");
+
+        // Assert
+        _mockManager.Verify(m => m.CreateAsync(It.Is<CreateOrganizationLocationMappingModel>(c =>
+            c.LocationAlias == "OVERRIDE")), Times.Once);
+    }
+
+    [Fact]
+    public async Task UpdateLocationMappingAsync_FallsBackToFhirAlias_WhenNoOverride()
+    {
+        // Arrange
+        var location = NewLocation("loc-1", name: "ICU", aliases: "FHIR-ALIAS");
+
+        // Act
+        await _service.UpdateLocationMappingAsync(FacilityId, location);
+
+        // Assert
+        _mockManager.Verify(m => m.CreateAsync(It.Is<CreateOrganizationLocationMappingModel>(c =>
+            c.LocationAlias == "FHIR-ALIAS")), Times.Once);
+    }
+
+    [Fact]
+    public async Task UpdateLocationMappingAsync_WhenExistingMappingUnchanged_DoesNotUpdate()
+    {
+        // Arrange
+        var location = NewLocation("loc-1", name: "ICU");
+        _mockQueries
+            .Setup(q => q.GetByFacilityIdAndLocationIdAsync(FacilityId, "loc-1"))
+            .ReturnsAsync(new OrganizationLocationMappingModel
+            {
+                LocationMappingId = 7,
+                FacilityId = FacilityId,
+                LocationId = "loc-1",
+                LocationName = "ICU",
+                LocationAlias = null,
+                PartOfValue = null,
+                PartOfId = null,
+                IsOrgLocation = false
+            });
+
+        // Act
+        var result = await _service.UpdateLocationMappingAsync(FacilityId, location);
+
+        // Assert
+        _mockManager.Verify(m => m.UpdateByIdAsync(It.IsAny<int>(), It.IsAny<UpdateOrganizationLocationMappingModel>()),
+            Times.Never);
+        _mockManager.Verify(m => m.CreateAsync(It.IsAny<CreateOrganizationLocationMappingModel>()), Times.Never);
+        Assert.Equal(7, result.LocationMappingId);
+    }
+
+    [Fact]
+    public async Task UpdateLocationMappingAsync_WhenExistingMappingChanged_UpdatesWithNewValues()
+    {
+        // Arrange
+        var location = NewLocation("loc-1", name: "ICU - Renamed");
+        _mockQueries
+            .Setup(q => q.GetByFacilityIdAndLocationIdAsync(FacilityId, "loc-1"))
+            .ReturnsAsync(new OrganizationLocationMappingModel
+            {
+                LocationMappingId = 7,
+                FacilityId = FacilityId,
+                LocationId = "loc-1",
+                LocationName = "ICU", // old name differs → triggers update
+                IsOrgLocation = false
+            });
+
+        // Act
+        await _service.UpdateLocationMappingAsync(FacilityId, location);
+
+        // Assert
+        _mockManager.Verify(m => m.UpdateByIdAsync(7, It.Is<UpdateOrganizationLocationMappingModel>(u =>
+            u.LocationName == "ICU - Renamed")), Times.Once);
+    }
+
+    [Fact]
+    public async Task UpdateLocationMappingAsync_WhenLocationMatchesOrgCondition_MarksAsOrgLocation()
+    {
+        // Arrange
+        var location = NewLocation("loc-1", name: "University Hospital");
+        _mockCache
+            .Setup(c => c.Get<List<OrganizationLocationConditionModel>>(It.IsAny<string>()))
+            .Returns(new List<OrganizationLocationConditionModel>
+            {
+                new() { ConditionId = 1, Priority = 1, FhirPath = "Location.name = 'University Hospital'" }
+            });
+
+        // Act
+        await _service.UpdateLocationMappingAsync(FacilityId, location);
+
+        // Assert
+        _mockManager.Verify(m => m.CreateAsync(It.Is<CreateOrganizationLocationMappingModel>(c =>
+            c.IsOrgLocation)), Times.Once);
+    }
+
+    [Fact]
+    public async Task UpdateLocationMappingAsync_WhenLocationDoesNotMatchOrgCondition_NotOrgLocation()
+    {
+        // Arrange
+        var location = NewLocation("loc-1", name: "Some Ward");
+        _mockCache
+            .Setup(c => c.Get<List<OrganizationLocationConditionModel>>(It.IsAny<string>()))
+            .Returns(new List<OrganizationLocationConditionModel>
+            {
+                new() { ConditionId = 1, Priority = 1, FhirPath = "Location.name = 'University Hospital'" }
+            });
+
+        // Act
+        await _service.UpdateLocationMappingAsync(FacilityId, location);
+
+        // Assert
+        _mockManager.Verify(m => m.CreateAsync(It.Is<CreateOrganizationLocationMappingModel>(c =>
+            !c.IsOrgLocation)), Times.Once);
+    }
+
+    [Fact]
+    public async Task UpdateLocationMappingAsync_HonorsConditionPriority_FirstMatchWins()
+    {
+        // Arrange
+        // Higher-priority (1) condition matches; a malformed lower-priority condition must never run.
+        var location = NewLocation("loc-1", name: "University Hospital");
+        _mockCache
+            .Setup(c => c.Get<List<OrganizationLocationConditionModel>>(It.IsAny<string>()))
+            .Returns(new List<OrganizationLocationConditionModel>
+            {
+                new() { ConditionId = 1, Priority = 1, FhirPath = "Location.name = 'University Hospital'" },
+                new() { ConditionId = 2, Priority = 2, FhirPath = "this.is.not.valid.fhirpath(" }
+            });
+
+        // Act
+        await _service.UpdateLocationMappingAsync(FacilityId, location);
+
+        // Assert
+        _mockManager.Verify(m => m.CreateAsync(It.Is<CreateOrganizationLocationMappingModel>(c =>
+            c.IsOrgLocation)), Times.Once);
+    }
+
+    [Fact]
+    public async Task UpdateLocationMappingAsync_WhenConditionsNotCached_LoadsActiveConditionsAndCaches()
+    {
+        // Arrange
+        var location = NewLocation("loc-1", name: "University Hospital");
+
+        // Cache miss → must load config and re-cache.
+        _mockCache
+            .Setup(c => c.Get<List<OrganizationLocationConditionModel>>(It.IsAny<string>()))
+            .Returns((List<OrganizationLocationConditionModel>?)null);
+
+        _mockConfigQueries
+            .Setup(q => q.GetByFacilityIdAsync(FacilityId))
+            .ReturnsAsync(new List<OrganizationLocationConfigurationModel>
+            {
+                new()
+                {
+                    FacilityId = FacilityId,
+                    IsActive = true,
+                    Conditions = new List<OrganizationLocationConditionModel>
+                    {
+                        new() { ConditionId = 1, Priority = 1, FhirPath = "Location.name = 'University Hospital'" }
+                    }
+                },
+                new()
+                {
+                    FacilityId = FacilityId,
+                    IsActive = false, // inactive config must be ignored
+                    Conditions = new List<OrganizationLocationConditionModel>
+                    {
+                        new() { ConditionId = 2, Priority = 1, FhirPath = "Location.name = 'Something Else'" }
+                    }
+                }
+            });
+
+        // Act
+        await _service.UpdateLocationMappingAsync(FacilityId, location);
+
+        // Assert
+        _mockConfigQueries.Verify(q => q.GetByFacilityIdAsync(FacilityId), Times.Once);
+        _mockCache.Verify(c => c.Set(
+            It.IsAny<string>(),
+            It.Is<List<OrganizationLocationConditionModel>>(l => l.Count == 1 && l[0].ConditionId == 1),
+            It.IsAny<TimeSpan>(),
+            ExpirationType.Absolute), Times.Once);
+        _mockManager.Verify(m => m.CreateAsync(It.Is<CreateOrganizationLocationMappingModel>(c =>
+            c.IsOrgLocation)), Times.Once);
+    }
+
+    [Fact]
+    public async Task UpdateLocationMappingAsync_WhenCreateThrowsNonUniqueDbUpdateException_Propagates()
+    {
+        // Arrange
+        var location = NewLocation("loc-1", name: "ICU");
+        _mockManager
+            .Setup(m => m.CreateAsync(It.IsAny<CreateOrganizationLocationMappingModel>()))
+            .ThrowsAsync(new DbUpdateException("boom", new InvalidOperationException("not a unique violation")));
+
+        // Act & Assert
+        // The when-filter only catches unique-constraint violations; anything else must surface.
+        await Assert.ThrowsAsync<DbUpdateException>(() =>
+            _service.UpdateLocationMappingAsync(FacilityId, location));
+
+        _mockManager.Verify(m => m.UpdateByIdAsync(It.IsAny<int>(), It.IsAny<UpdateOrganizationLocationMappingModel>()),
+            Times.Never);
+        _mockManager.Verify(m => m.SetPartOfIdForChildrenAsync(
+            It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+}


### PR DESCRIPTION
### 🛠️ Description of Changes

Implements LEGLINK-371: when a facility has active Location mapping configuration, DataAcquisition now records each queried `Location` into the `OrganizationLocationMapping` table (insert-on-first-query, unique per `(facility, Location.Id)`), with parent/child `PartOf` resolution.

**Core feature**
- Add `LocationMappingService` (`ILocationMappingService`): `IsConfigured` gate + `UpdateLocationMappingAsync` (insert-or-update), org-location classification via configured FhirPath conditions, and `PartOf` parent lookup.
- Call the service from `FhirApiService` on both the read and search acquisition paths when a `Location` is acquired and the facility has active Location mapping configuration.
- Gate Location mapping on **configured mappings/conditions**, not the deprecated `EnableLocationResolutionMapping` flag.
- Harden `OrganizationLocationMappingManager.CreateAsync` unique-constraint recovery and add child `PartOfId` backfill (`SetPartOfIdForChildrenAsync`) so a parent queried after its children adopts them.
- Mark `GetByFacilityIdAndLocationIdAsync` return type nullable; document `Priority` semantics on `OrganizationLocationConditionModel`.
- Register `ILocationMappingService` in DI (Transient) — `FhirApiService` depends on it.

**Schema**
- Add a filtered index on `OrganizationLocationMapping(FacilityId, PartOfValue) WHERE PartOfId IS NULL` for the orphan-adoption lookup, with EF migration (up + down).

**Test reliability / infra fixes** (made while validating the above)
- Resolve scoped services from a per-test `IServiceScope` instead of the root provider in the Normalization/Tenant integration tests (`OperationServiceTests`, `VendorTests`, `TenantBusinessTests`, `ScheduleServiceTests`, `FacilityControllerTests`) so the suite passes under DI scope validation (`DOTNET_ENVIRONMENT=Development`); `FacilityControllerTests` also starts the shared `ScheduleService`.
- Make order-dependent tests deterministic against the shared collection database: negative ids in `DataAcquisitionLogManagerTests` "not found" tests; clear `PatientEvents` in the Census `RebuildPatientEncounterTable` test.

### 🧪 Testing Performed

- Full `ServiceTests` **unit** suite: passing.
- `DataAcquisition` **integration** tests (Testcontainers SQL Server): **217/217 passing**.
- Full integration collection green under **both** the default (Production) environment and `DOTNET_ENVIRONMENT=Development` (DI scope validation on) — previously 79 failures under Development.
- `FhirApiServiceTests`: **21/21** (feature encounter-mapping resolution + new location-mapping recording + configured-conditions gating coexisting).
- Branch rebased onto `feature/LocationMapping`; solution builds clean.

### 🧑‍🔬 Unit Testing

- [x] `LocationMappingServiceTests` — added (insert/update, org-location classification, PartOf, recovery).
- [x] `FhirApiServiceTests` — updated for the location-recording call + constructor.
- [x] `LocationMappingServiceIntegrationTests` / `LocationMappingAcquisitionTests` — added (real DB: insert, per-facility uniqueness, PartOf backfill both orderings).
- [x] Reliability fixes to existing `DataAcquisitionLogManagerTests`, Census `QueryTests`, and the scope fixes above.

### 📓 Documentation Updated

- No `app-config.yaml` changes — no new required config keys (gating moved from the deprecated `EnableLocationResolutionMapping` flag to existing Location configuration mappings).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatic location mapping persistence when fetching FHIR location resources.
  * Enhanced parent-child location relationship tracking and backfilling.

* **Bug Fixes**
  * Improved concurrent insert handling with automatic recovery for duplicate mapping attempts.
  * Better error handling for failed mapping operations.

* **Tests**
  * Comprehensive integration and unit test coverage for location mapping workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->