### PR TITLE
LEGLINK-418: Validate EncounterMapping create model and surface invalid location ids

### DIFF
--- a/DotNet/DataAcquisition.Domain/Application/Managers/EncounterMappingManager.cs
+++ b/DotNet/DataAcquisition.Domain/Application/Managers/EncounterMappingManager.cs
@@ -28,6 +28,12 @@ public class EncounterMappingManager : IEncounterMappingManager
 
     public async Task<EncounterMappingModel> CreateAsync(CreateEncounterMappingModel model)
     {
+        ArgumentNullException.ThrowIfNull(model);
+
+        ArgumentException.ThrowIfNullOrEmpty(model.FacilityId, nameof(model.FacilityId));
+        ArgumentException.ThrowIfNullOrEmpty(model.EncounterId, nameof(model.EncounterId));
+        ArgumentException.ThrowIfNullOrEmpty(model.PatientId, nameof(model.PatientId));
+
         var now = DateTime.UtcNow;
         var entity = new EncounterMapping
         {

--- a/DotNet/DataAcquisition.Domain/Application/Managers/EncounterMappingManager.cs
+++ b/DotNet/DataAcquisition.Domain/Application/Managers/EncounterMappingManager.cs
@@ -86,6 +86,23 @@ public class EncounterMappingManager : IEncounterMappingManager
                 throw new EntityAlreadyExistsException($"An EncounterMapping already exists for FacilityId {model.FacilityId} and EncounterId {model.EncounterId}");
             }
 
+            // Not a duplicate. Check to see if it's a foreign key failure where the location id is invalid, if
+            // so, return the invalid ids
+            if (model.OrganizationLocationMappingIds is { Count: > 0 })
+            {
+                var requestedIds = model.OrganizationLocationMappingIds.Distinct().ToList();
+                var existingIds = (await _database.LocationMappingRepository
+                        .FindAsync(m => requestedIds.Contains(m.LocationMappingId)))
+                    .Select(m => m.LocationMappingId)
+                    .ToHashSet();
+
+                var missingIds = requestedIds.Where(id => !existingIds.Contains(id)).ToList();
+                if (missingIds.Count > 0)
+                {
+                    throw new BadRequestException($"Invalid OrganizationLocationMappingId(s): {string.Join(", ", missingIds)}");
+                }
+            }
+
             throw;
         }
 

--- a/DotNet/DataAcquisition.Domain/Application/Models/CreateEncounterMappingModel.cs
+++ b/DotNet/DataAcquisition.Domain/Application/Models/CreateEncounterMappingModel.cs
@@ -1,13 +1,20 @@
-﻿using System.Diagnostics.CodeAnalysis;
+﻿using System.ComponentModel.DataAnnotations;
+using System.Diagnostics.CodeAnalysis;
 
 namespace LantanaGroup.Link.DataAcquisition.Domain.Application.Models;
 
 [ExcludeFromCodeCoverage]
 public class CreateEncounterMappingModel
 {
+    [Required(AllowEmptyStrings = false)]
     public required string FacilityId { get; set; }
+
+    [Required(AllowEmptyStrings = false)]
     public required string PatientId { get; set; }
+
+    [Required(AllowEmptyStrings = false)] 
     public required string EncounterId { get; set; }
+    
     public bool MappedToOrg { get; set; }
     public List<int>? OrganizationLocationMappingIds { get; set; }
 }

--- a/DotNet/DataAcquisition/Controllers/EncounterMappingController.cs
+++ b/DotNet/DataAcquisition/Controllers/EncounterMappingController.cs
@@ -316,7 +316,9 @@ public class EncounterMappingController : Controller
         try
         {
             if (model == null)
+            {
                 throw new BadRequestException("Request body is required.");
+            }
 
             model.FacilityId = model.FacilityId.SanitizeAndRemove();
             model.PatientId = model.PatientId.SanitizeAndRemove();

--- a/DotNet/DataAcquisition/Controllers/EncounterMappingController.cs
+++ b/DotNet/DataAcquisition/Controllers/EncounterMappingController.cs
@@ -324,6 +324,13 @@ public class EncounterMappingController : Controller
             model.PatientId = model.PatientId.SanitizeAndRemove();
             model.EncounterId = model.EncounterId.SanitizeAndRemove();
 
+            // re-evaluate after sanitization
+            ModelState.Clear(); 
+            if (!TryValidateModel(model))
+            {
+                return ValidationProblem(ModelState);
+            }
+
             var created = await _manager.CreateAsync(model);
             return CreatedAtAction(nameof(GetByIdAsync), new { id = created.EncounterMappingId }, created);
         }

--- a/DotNet/ServiceTests/IntegrationTests/DataAcquisition/Managers/EncounterMappingManagerTests.cs
+++ b/DotNet/ServiceTests/IntegrationTests/DataAcquisition/Managers/EncounterMappingManagerTests.cs
@@ -237,7 +237,7 @@ public class EncounterMappingManagerTests
     }
 
     [Fact]
-    public async Task CreateAsync_InvalidLocationMappingId_ThrowsException()
+    public async Task CreateAsync_InvalidLocationMappingId_ThrowsBadRequestException()
     {
         using var scope = _fixture.ServiceProvider.CreateScope();
         var manager = CreateManager(scope);
@@ -249,7 +249,10 @@ public class EncounterMappingManagerTests
             OrganizationLocationMappingIds = new List<int> { int.MaxValue } // Non-existent ID
         };
 
-        await Assert.ThrowsAsync<Microsoft.EntityFrameworkCore.DbUpdateException>(() => manager.CreateAsync(model));
+        // The EncounterLocation -> OrganizationLocationMapping FK violation is translated into a
+        // BadRequestException that names the invalid id (rather than surfacing the raw DbUpdateException).
+        var ex = await Assert.ThrowsAsync<BadRequestException>(() => manager.CreateAsync(model));
+        Assert.Contains(int.MaxValue.ToString(), ex.Message);
     }
 
     [Fact]

--- a/DotNet/ServiceTests/UnitTests/DataAcquisition/Controllers/EncounterMappingControllerTests.cs
+++ b/DotNet/ServiceTests/UnitTests/DataAcquisition/Controllers/EncounterMappingControllerTests.cs
@@ -5,7 +5,12 @@ using LantanaGroup.Link.DataAcquisition.Domain.Application.Models.Exceptions;
 using LantanaGroup.Link.DataAcquisition.Domain.Application.Queries;
 using LantanaGroup.Link.DataAcquisition.Models;
 using LantanaGroup.Link.Shared.Application.Models.Responses;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Controllers;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
+using Microsoft.AspNetCore.Mvc.ModelBinding.Validation;
+using Microsoft.Extensions.DependencyInjection;
 using Moq;
 using Moq.AutoMock;
 using System.Net;
@@ -19,6 +24,35 @@ public class EncounterMappingControllerTests
     private const string FacilityId = "test-facility-id";
     private const string EncounterId = "test-encounter-id";
     private const string PatientId = "test-patient-id";
+
+    // Real MVC services so CreateAsync's TryValidateModel/ValidationProblem run against the
+    // actual DataAnnotations validator and ProblemDetailsFactory instead of throwing NRE.
+    private static readonly IServiceProvider MvcServices = BuildMvcServices();
+
+    private static IServiceProvider BuildMvcServices()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddControllers();
+        return services.BuildServiceProvider();
+    }
+
+    /// <summary>
+    /// Builds a controller wired for the POST path: ControllerContext (for CreatedAtAction URL
+    /// generation), ObjectValidator (for TryValidateModel) and ProblemDetailsFactory (for ValidationProblem).
+    /// </summary>
+    private static EncounterMappingController CreatePostController(AutoMocker mocker)
+    {
+        var controller = mocker.CreateInstance<EncounterMappingController>();
+        controller.ControllerContext = new ControllerContext
+        {
+            ActionDescriptor = new ControllerActionDescriptor(),
+            HttpContext = new DefaultHttpContext { RequestServices = MvcServices }
+        };
+        controller.ObjectValidator = MvcServices.GetRequiredService<IObjectModelValidator>();
+        controller.ProblemDetailsFactory = MvcServices.GetRequiredService<ProblemDetailsFactory>();
+        return controller;
+    }
 
     #region GET /encounter-mappings/{id}
 
@@ -514,13 +548,7 @@ public class EncounterMappingControllerTests
             .Setup(m => m.CreateAsync(It.IsAny<CreateEncounterMappingModel>()))
             .ReturnsAsync(created);
 
-        var controller = mocker.CreateInstance<EncounterMappingController>();
-        // ControllerContext is needed for CreatedAtAction URL generation
-        controller.ControllerContext = new ControllerContext
-        {
-            ActionDescriptor = new Microsoft.AspNetCore.Mvc.Controllers.ControllerActionDescriptor(),
-            HttpContext = new Microsoft.AspNetCore.Http.DefaultHttpContext()
-        };
+        var controller = CreatePostController(mocker);
 
         var result = await controller.CreateAsync(new CreateEncounterMappingModel
         {
@@ -547,6 +575,61 @@ public class EncounterMappingControllerTests
         Assert.Equal((int)HttpStatusCode.BadRequest, objectResult.StatusCode);
     }
 
+    [Theory]
+    [InlineData("", EncounterId, PatientId)]   // FacilityId sanitizes to empty
+    [InlineData(FacilityId, "", PatientId)]    // EncounterId sanitizes to empty
+    [InlineData(FacilityId, EncounterId, "")]  // PatientId sanitizes to empty
+    public async Task CreateAsync_RequiredFieldEmptyAfterSanitization_ReturnsValidationProblem(
+        string facilityId, string encounterId, string patientId)
+    {
+        var mocker = new AutoMocker();
+        var controller = CreatePostController(mocker);
+
+        // "!!!" survives HTML sanitization but the [^a-zA-Z0-9-_. ] removal in SanitizeAndRemove
+        // strips it to an empty string, so the [Required(AllowEmptyStrings = false)] re-validation should reject it.
+        var result = await controller.CreateAsync(new CreateEncounterMappingModel
+        {
+            FacilityId = string.IsNullOrEmpty(facilityId) ? "!!!" : facilityId,
+            EncounterId = string.IsNullOrEmpty(encounterId) ? "!!!" : encounterId,
+            PatientId = string.IsNullOrEmpty(patientId) ? "!!!" : patientId
+        });
+
+        var objectResult = Assert.IsAssignableFrom<ObjectResult>(result);
+        Assert.Equal((int)HttpStatusCode.BadRequest, objectResult.StatusCode);
+        Assert.IsAssignableFrom<ValidationProblemDetails>(objectResult.Value);
+
+        // The manager must never be invoked when post-sanitization validation fails.
+        mocker.GetMock<IEncounterMappingManager>()
+            .Verify(m => m.CreateAsync(It.IsAny<CreateEncounterMappingModel>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task CreateAsync_SanitizesFieldsBeforeCreating()
+    {
+        var mocker = new AutoMocker();
+        CreateEncounterMappingModel? captured = null;
+        mocker.GetMock<IEncounterMappingManager>()
+            .Setup(m => m.CreateAsync(It.IsAny<CreateEncounterMappingModel>()))
+            .Callback<CreateEncounterMappingModel>(m => captured = m)
+            .ReturnsAsync(new EncounterMappingModel { EncounterMappingId = 1 });
+
+        var controller = CreatePostController(mocker);
+
+        var result = await controller.CreateAsync(new CreateEncounterMappingModel
+        {
+            // Trailing disallowed characters are stripped; the alphanumeric/-_. remainder survives.
+            FacilityId = "facility-1!!!",
+            EncounterId = "encounter-1@@@",
+            PatientId = "patient-1###"
+        });
+
+        Assert.IsType<CreatedAtActionResult>(result);
+        Assert.NotNull(captured);
+        Assert.Equal("facility-1", captured!.FacilityId);
+        Assert.Equal("encounter-1", captured.EncounterId);
+        Assert.Equal("patient-1", captured.PatientId);
+    }
+
     [Fact]
     public async Task CreateAsync_GenericException_ReturnsInternalServerError()
     {
@@ -555,7 +638,7 @@ public class EncounterMappingControllerTests
             .Setup(m => m.CreateAsync(It.IsAny<CreateEncounterMappingModel>()))
             .ThrowsAsync(new Exception("boom"));
 
-        var controller = mocker.CreateInstance<EncounterMappingController>();
+        var controller = CreatePostController(mocker);
 
         var result = await controller.CreateAsync(new CreateEncounterMappingModel
         {
@@ -576,7 +659,7 @@ public class EncounterMappingControllerTests
             .Setup(m => m.CreateAsync(It.IsAny<CreateEncounterMappingModel>()))
             .ThrowsAsync(new EntityAlreadyExistsException());
 
-        var controller = mocker.CreateInstance<EncounterMappingController>();
+        var controller = CreatePostController(mocker);
 
         var result = await controller.CreateAsync(new CreateEncounterMappingModel
         {

--- a/DotNet/ServiceTests/UnitTests/DataAcquisition/Managers/EncounterMappingManagerUnitTests.cs
+++ b/DotNet/ServiceTests/UnitTests/DataAcquisition/Managers/EncounterMappingManagerUnitTests.cs
@@ -19,6 +19,7 @@ public class EncounterMappingManagerUnitTests
     private readonly Mock<IDatabase> _mockDatabase;
     private readonly Mock<IEntityRepository<EncounterMapping>> _mockMappingRepo;
     private readonly Mock<IEntityRepository<EncounterLocation>> _mockLocationRepo;
+    private readonly Mock<IEntityRepository<OrganizationLocationMapping>> _mockOrgLocationRepo;
     private readonly EncounterMappingManager _manager;
 
     public EncounterMappingManagerUnitTests()
@@ -26,9 +27,11 @@ public class EncounterMappingManagerUnitTests
         _mockDatabase = new Mock<IDatabase>();
         _mockMappingRepo = new Mock<IEntityRepository<EncounterMapping>>();
         _mockLocationRepo = new Mock<IEntityRepository<EncounterLocation>>();
+        _mockOrgLocationRepo = new Mock<IEntityRepository<OrganizationLocationMapping>>();
 
         _mockDatabase.Setup(d => d.EncounterMappingRepository).Returns(_mockMappingRepo.Object);
         _mockDatabase.Setup(d => d.EncounterLocationRepository).Returns(_mockLocationRepo.Object);
+        _mockDatabase.Setup(d => d.LocationMappingRepository).Returns(_mockOrgLocationRepo.Object);
 
         _manager = new EncounterMappingManager(_mockDatabase.Object);
     }
@@ -117,6 +120,70 @@ public class EncounterMappingManagerUnitTests
         var model = new CreateEncounterMappingModel { FacilityId = "Fac1", EncounterId = "Enc1", PatientId = string.Empty };
 
         await Assert.ThrowsAsync<ArgumentException>(() => _manager.CreateAsync(model));
+    }
+
+    [Fact]
+    public async Task CreateAsync_NonExistentOrganizationLocationMappingId_ThrowsBadRequestException()
+    {
+        // Arrange: not a duplicate, but the insert trips the EncounterLocation -> OrganizationLocationMapping
+        // FK constraint because one of the requested location ids (99) does not exist. The catch re-checks
+        // which ids are missing and surfaces a BadRequestException (same re-check shape as the duplicate path).
+        var model = new CreateEncounterMappingModel
+        {
+            FacilityId = "Fac1",
+            EncounterId = "Enc1",
+            PatientId = "Pat1",
+            OrganizationLocationMappingIds = new List<int> { 5, 99 }
+        };
+
+        _mockMappingRepo.Setup(r => r.FirstOrDefaultAsync(It.IsAny<Expression<Func<EncounterMapping, bool>>>()))
+            .ReturnsAsync((EncounterMapping)null!);
+
+        _mockDatabase.Setup(d => d.SaveChangesAsync())
+            .ThrowsAsync(new DbUpdateException("FK violation", new Exception()));
+
+        // Re-check: only id 5 exists; 99 is the missing reference.
+        _mockOrgLocationRepo.Setup(r => r.FindAsync(It.IsAny<Expression<Func<OrganizationLocationMapping, bool>>>()))
+            .ReturnsAsync(new List<OrganizationLocationMapping>
+            {
+                new() { LocationMappingId = 5, FacilityId = "Fac1", LocationId = "Loc5" }
+            });
+
+        // Act
+        var ex = await Assert.ThrowsAsync<BadRequestException>(() => _manager.CreateAsync(model));
+        Assert.Contains("99", ex.Message);
+    }
+
+    [Fact]
+    public async Task CreateAsync_ValidOrganizationLocationMappingIds_AddsEncounterLocations()
+    {
+        // Arrange: all requested location ids exist, so SaveChanges succeeds and no exception is translated.
+        var model = new CreateEncounterMappingModel
+        {
+            FacilityId = "Fac1",
+            EncounterId = "Enc1",
+            PatientId = "Pat1",
+            OrganizationLocationMappingIds = new List<int> { 5, 6 }
+        };
+
+        _mockMappingRepo.Setup(r => r.FirstOrDefaultAsync(It.IsAny<Expression<Func<EncounterMapping, bool>>>()))
+            .ReturnsAsync((EncounterMapping)null!);
+
+        EncounterMapping capturedEntity = null!;
+        _mockMappingRepo
+            .Setup(r => r.AddAsync(It.IsAny<EncounterMapping>()))
+            .Callback<EncounterMapping>(e => capturedEntity = e)
+            .ReturnsAsync((EncounterMapping e) => e);
+
+        // Act
+        await _manager.CreateAsync(model);
+
+        // Assert
+        Assert.NotNull(capturedEntity);
+        Assert.Equal(2, capturedEntity.EncounterLocations.Count);
+        Assert.Contains(capturedEntity.EncounterLocations, l => l.OrganizationLocationMappingId == 5);
+        Assert.Contains(capturedEntity.EncounterLocations, l => l.OrganizationLocationMappingId == 6);
+        _mockDatabase.Verify(d => d.SaveChangesAsync(), Times.Once);
     }
 
     [Fact]

--- a/DotNet/ServiceTests/UnitTests/DataAcquisition/Managers/EncounterMappingManagerUnitTests.cs
+++ b/DotNet/ServiceTests/UnitTests/DataAcquisition/Managers/EncounterMappingManagerUnitTests.cs
@@ -75,6 +75,12 @@ public class EncounterMappingManagerUnitTests
     }
 
     [Fact]
+    public async Task CreateAsync_NullModel_ThrowsArgumentNullException()
+    {
+        await Assert.ThrowsAsync<ArgumentNullException>(() => _manager.CreateAsync(null!));
+    }
+
+    [Fact]
     public async Task CreateAsync_NullFacilityId_ThrowsArgumentNullException()
     {
         var model = new CreateEncounterMappingModel { FacilityId = null!, EncounterId = "Enc1", PatientId = "Pat1" };

--- a/DotNet/ServiceTests/UnitTests/DataAcquisition/Managers/EncounterMappingManagerUnitTests.cs
+++ b/DotNet/ServiceTests/UnitTests/DataAcquisition/Managers/EncounterMappingManagerUnitTests.cs
@@ -72,6 +72,54 @@ public class EncounterMappingManagerUnitTests
     }
 
     [Fact]
+    public async Task CreateAsync_NullFacilityId_ThrowsArgumentNullException()
+    {
+        var model = new CreateEncounterMappingModel { FacilityId = null!, EncounterId = "Enc1", PatientId = "Pat1" };
+
+        await Assert.ThrowsAsync<ArgumentNullException>(() => _manager.CreateAsync(model));
+    }
+
+    [Fact]
+    public async Task CreateAsync_EmptyFacilityId_ThrowsArgumentException()
+    {
+        var model = new CreateEncounterMappingModel { FacilityId = string.Empty, EncounterId = "Enc1", PatientId = "Pat1" };
+
+        await Assert.ThrowsAsync<ArgumentException>(() => _manager.CreateAsync(model));
+    }
+
+    [Fact]
+    public async Task CreateAsync_NullEncounterId_ThrowsArgumentNullException()
+    {
+        var model = new CreateEncounterMappingModel { FacilityId = "Fac1", EncounterId = null!, PatientId = "Pat1" };
+
+        await Assert.ThrowsAsync<ArgumentNullException>(() => _manager.CreateAsync(model));
+    }
+
+    [Fact]
+    public async Task CreateAsync_EmptyEncounterId_ThrowsArgumentException()
+    {
+        var model = new CreateEncounterMappingModel { FacilityId = "Fac1", EncounterId = string.Empty, PatientId = "Pat1" };
+
+        await Assert.ThrowsAsync<ArgumentException>(() => _manager.CreateAsync(model));
+    }
+
+    [Fact]
+    public async Task CreateAsync_NullPatientId_ThrowsArgumentNullException()
+    {
+        var model = new CreateEncounterMappingModel { FacilityId = "Fac1", EncounterId = "Enc1", PatientId = null! };
+
+        await Assert.ThrowsAsync<ArgumentNullException>(() => _manager.CreateAsync(model));
+    }
+
+    [Fact]
+    public async Task CreateAsync_EmptyPatientId_ThrowsArgumentException()
+    {
+        var model = new CreateEncounterMappingModel { FacilityId = "Fac1", EncounterId = "Enc1", PatientId = string.Empty };
+
+        await Assert.ThrowsAsync<ArgumentException>(() => _manager.CreateAsync(model));
+    }
+
+    [Fact]
     public async Task CreateAsync_DuplicateMapping_ThrowsEntityAlreadyExistsException()
     {
         // Arrange


### PR DESCRIPTION
### 🛠️ Description of Changes

Hardens `POST /api/data/encounter-mappings` (EncounterMapping creation) with input validation at both the API and manager layers. Also resolves **LEGLINK-420** and **LEGLINK-419** (same code changes apply)

**Controller (`EncounterMappingController.CreateAsync`)**
- Re-validates the model *after* HTML sanitization (`ModelState.Clear()` + `TryValidateModel`) so a required field reduced to empty by `SanitizeAndRemove()` is rejected as a 400 `ValidationProblem` instead of slipping through.

**Model (`CreateEncounterMappingModel`)**
- Adds `[Required(AllowEmptyStrings = false)]` to `FacilityId`, `PatientId`, and `EncounterId`.

**Manager (`EncounterMappingManager.CreateAsync`)**
- Guards `FacilityId`, `EncounterId`, `PatientId` with `ArgumentException.ThrowIfNullOrEmpty` (null → `ArgumentNullException`, empty → `ArgumentException`).
- On the `EncounterLocation → OrganizationLocationMapping` FK violation, re-checks `LocationMappingRepository` inside the existing `DbUpdateException` handler and throws `BadRequestException` naming the missing id(s) (maps to 400); rethrows the original if nothing is actually missing. This mirrors the existing duplicate-key re-check pattern.

### 🧪 Testing Performed

- `dotnet test DotNet/ServiceTests/ServiceTests.csproj --filter FullyQualifiedName~EncounterMapping` — all unit tests pass.
- Updated the existing `CreateAsync_InvalidLocationMappingId` integration test to assert the new `BadRequestException` contract (requires the local stack / Docker to execute).
- Tested scenarios with Postman

### 🧑‍🔬 Unit Testing

- [x] I have written or updated unit tests to cover my changes
- Coverage:
  - Controller: valid create, null body, required-field-empty-after-sanitization (theory over each field), sanitization-before-create, generic exception, conflict.
  - Manager: null/empty guards for each of the three required fields, non-existent location id → `BadRequestException`, valid location ids → adds `EncounterLocation`s.
  - Integration: invalid location id now asserts `BadRequestException`.

### 📓 Documentation Updated

No documentation changes required.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Invalid location mapping IDs now return specific error messages instead of generic database errors
  * Required fields (Facility ID, Encounter ID, Patient ID) are now properly validated and reject empty values with clear feedback

* **Improvements**
  * Enhanced input sanitization workflow for encounter mapping creation
  * Stricter validation ensures data quality before processing requests

<!-- end of auto-generated comment: release notes by coderabbit.ai -->