### PR TITLE
TECH_DEBT: Persist `fhir_server` data to volume

### DIFF
--- a/Dockerfile.hapi
+++ b/Dockerfile.hapi
@@ -1,5 +1,0 @@
-FROM busybox:musl AS busybox
-
-FROM hapiproject/hapi:latest
-
-COPY --from=busybox /bin/wget /usr/local/bin/wget

--- a/docker-compose.dcproj
+++ b/docker-compose.dcproj
@@ -103,7 +103,6 @@
     <Content Include="Azure_Pipelines\_deploy_all_services.yml" />
     <Content Include="Azure_Pipelines\_summarize_delta.yaml" />
     <Content Include="Dockerfile.aspnet8-run" />
-    <Content Include="Dockerfile.hapi" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Tests\AutomationUI.Pipeline\" />

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,9 +38,20 @@ services:
   ###########################################
   ### FHIR Server (HAPI) - For testing
   ###########################################
+  fhir_server_prep:
+    image: alpine:latest
+    volumes:
+      - fhir_data:/data
+    # Give HAPI's (non-root) user access to the volume
+    command: >-
+      chown 65532:65532 /data
+
   fhir_server:
     image: hapiproject/hapi:v8.10.0-2
     container_name: fhir-server
+    depends_on:
+      fhir_server_prep:
+        condition: service_completed_successfully
     ports:
       - "6157:8080"
     environment:
@@ -65,6 +76,7 @@ services:
       - hapi.fhir.binary_storage_enabled=false
       - hapi.fhir.validation.requests_enabled=false
       - hapi.fhir.validation.responses_enabled=false
+      - spring.datasource.url=jdbc:h2:file:/data/h2
     volumes:
       - fhir_data:/data
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,10 +39,7 @@ services:
   ### FHIR Server (HAPI) - For testing
   ###########################################
   fhir_server:
-    build:
-      context: .
-      dockerfile: Dockerfile.hapi
-    image: link-fhir-server
+    image: hapiproject/hapi:v8.10.0-2
     container_name: fhir-server
     ports:
       - "6157:8080"
@@ -73,7 +70,7 @@ services:
     networks:
       - link-nw
     healthcheck:
-      test: ["CMD", "wget", "-q", "--timeout=5", "--tries=1", "--spider", "http://localhost:8080/fhir/metadata"]
+      test: ["CMD", "java", "-cp", "/app", "HealthCheck"]
       interval: 10s
       timeout: 5s
       retries: 5


### PR DESCRIPTION
### 🛠️ Description of Changes

  - Use built-in HAPI health check
  - Persist `fhir_server` data to volume

Previously, the `fhir_data` was mounted but unused, since HAPI was using its default configuration of an in-memory H2 database.

### 🧪 Testing Performed

Ran an end-to-end test locally.

### 🧑‍🔬 Unit Testing

- Coverage: 0.0%

N/A (affects Compose file only)

### 📓 Documentation Updated

N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the FHIR Server deployment setup to use a pinned runtime image.
  * Added a startup preparation step to set the correct permissions on shared data storage.
  * Changed the server’s database location to a persistent file-based H2 setup.
  * Updated health checks to use an internal Java-based check instead of an HTTP probe.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
