### PR TITLE
LEGLINK-518: Align Chart/Graph colors with Pill Status colors

### DIFF
--- a/DotNet/Automation.UI/Views/Runs/Index.cshtml
+++ b/DotNet/Automation.UI/Views/Runs/Index.cshtml
@@ -85,7 +85,7 @@
                             <div class="fw-semibold">@run.RunName</div>
                             <div class="small text-muted">@run.PatientCount patients &middot; seed @run.Seed</div>
                             <div class="d-flex justify-content-between align-items-center mt-2">
-                                <span class="badge au-badge-muted">@run.Status</span>
+                                <span class="badge @(run.Status == AutomationRunStatus.Running ? "au-badge-active" : "au-badge-muted")">@run.Status</span>
                                 <span class="small text-muted js-elapsed" data-created-at="@run.CreatedAt.ToString("o")">@elapsed.ToString(@"mm\:ss") elapsed</span>
                             </div>
                             <a href="@Url.Action("Details", "Runs", new { id = run.RunId })" class="btn btn-sm btn-au-action mt-2 w-100">
@@ -265,6 +265,7 @@
         if (s === 'succeeded' || s === '3') return 'au-badge-success';
         if (s === 'failed' || s === '4') return 'au-badge-danger';
         if (s === 'cancelled' || s === '2') return 'au-badge-warning';
+        if (s === 'running' || s === '1') return 'au-badge-active';
         return 'au-badge-muted';
     }
 
@@ -422,7 +423,7 @@
                 '<div class="fw-semibold">' + escapeHtml(run.runName) + '</div>' +
                 '<div class="small text-muted">' + (run.patientCount || 0) + ' patients &middot; seed ' + (run.seed || 0) + '</div>' +
                 '<div class="d-flex justify-content-between align-items-center mt-2">' +
-                '<span class="badge au-badge-muted">' + escapeHtml(String(run.status)) + '</span>' +
+                '<span class="badge ' + statusBadgeClass(run.status) + '">' + escapeHtml(String(run.status)) + '</span>' +
                 '<span class="small text-muted js-elapsed" data-created-at="' + escapeHtml(String(run.createdAt)) + '">' + elapsedStr + ' elapsed</span>' +
                 '</div>' +
                 '<a href="' + url + '" class="btn btn-sm btn-au-action mt-2 w-100"><i class="bi bi-box-arrow-up-right me-1"></i>View Details</a>' +

--- a/DotNet/Automation.UI/Views/Runs/_RecentRunsTable.cshtml
+++ b/DotNet/Automation.UI/Views/Runs/_RecentRunsTable.cshtml
@@ -65,7 +65,7 @@
                     <td>@run.PatientCount</td>
                     <td>@run.Seed</td>
                     <td>
-                        <span class="badge run-status-badge @(run.Status == AutomationRunStatus.Succeeded ? "au-badge-success" : run.Status == AutomationRunStatus.Failed ? "au-badge-danger" : run.Status == AutomationRunStatus.Cancelled ? "au-badge-warning" : "au-badge-muted")" data-run-id="@run.RunId">@run.Status</span>
+                        <span class="badge run-status-badge @(run.Status == AutomationRunStatus.Succeeded ? "au-badge-success" : run.Status == AutomationRunStatus.Failed ? "au-badge-danger" : run.Status == AutomationRunStatus.Cancelled ? "au-badge-warning" : run.Status == AutomationRunStatus.Running ? "au-badge-active" : "au-badge-muted")" data-run-id="@run.RunId">@run.Status</span>
                     </td>
                     <td class="small text-muted">@(run.Duration ?? "–")</td>
                     <td>@run.CreatedAt.LocalDateTime</td>

--- a/DotNet/Automation.UI/wwwroot/css/site.css
+++ b/DotNet/Automation.UI/wwwroot/css/site.css
@@ -90,6 +90,7 @@ body { margin-bottom: 60px; background: var(--au-bg); color: #222; }
 .au-badge-success  { background: var(--au-success) !important; }
 .au-badge-danger   { background: var(--au-danger)  !important; }
 .au-badge-warning  { background: var(--au-warning) !important; color: #111 !important; }
+.au-badge-active   { background: var(--au-accent)  !important; }
 .au-badge-muted    { background: var(--au-muted)   !important; }
 .au-badge-skip     { background: #6c757d !important; color: #fff !important; }
 


### PR DESCRIPTION
### 🛠️ Description of Changes

Align Chart/Graph colors with Pill Status colors

### 🧪 Testing Performed

Ran locally and observed.

### 🧑‍🔬 Unit Testing
N/A
- [ ] I have written or updated unit tests to cover my changes
- Coverage: 0.0%

### 📓 Documentation Updated

Please update any relevant sections in the project documentation that were impacted by the changes in the PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Active run status badges now stand out with a highlighted color when a run is in progress.
  * Live updates for active runs now keep the status badge styling in sync with the current run state.

* **Bug Fixes**
  * Improved badge styling so running items are no longer shown with a muted appearance.
  * Minor display cleanup in the recent runs table.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
