### PR TITLE
LEGLINK-418: Validate facility and patient association on EncounterMapping create

### DIFF
--- a/DotNet/DataAcquisition.Domain/Application/Managers/EncounterMappingManager.cs
+++ b/DotNet/DataAcquisition.Domain/Application/Managers/EncounterMappingManager.cs
@@ -34,6 +34,29 @@ public class EncounterMappingManager : IEncounterMappingManager
         ArgumentException.ThrowIfNullOrEmpty(model.EncounterId, nameof(model.EncounterId));
         ArgumentException.ThrowIfNullOrEmpty(model.PatientId, nameof(model.PatientId));
 
+        // EncounterMapping rows are normally written by the acquisition pipeline, where the
+        // (FacilityId, PatientId) pair is always internally consistent. A manual create can supply
+        // arbitrary values, so guard the two integrity cases the pipeline itself can never produce:
+        //   1. a FacilityId that isn't a configured facility, and
+        //   2. a PatientId that was never acquired for that facility (e.g. it belongs to a sibling
+        //      facility sharing the same FHIR endpoint).
+        // Both surface as NotFoundException -> 404, matching the DataAcquisition convention for a
+        // well-formed request that references a resource which doesn't exist.
+        var facilityIsKnown = await _database.FhirQueryConfigurationRepository
+            .AnyAsync(c => c.FacilityId == model.FacilityId);
+        if (!facilityIsKnown)
+        {
+            throw new NotFoundException($"FacilityId {model.FacilityId} is invalid.");
+        }
+
+        var patientBelongsToFacility = await _database.DataAcquisitionLogRepository
+            .AnyAsync(l => l.FacilityId == model.FacilityId && l.PatientId == model.PatientId);
+        if (!patientBelongsToFacility)
+        {
+            throw new NotFoundException(
+                $"PatientId {model.PatientId} is not associated with FacilityId {model.FacilityId}.");
+        }
+
         var now = DateTime.UtcNow;
         var entity = new EncounterMapping
         {

--- a/DotNet/DataAcquisition/Controllers/EncounterMappingController.cs
+++ b/DotNet/DataAcquisition/Controllers/EncounterMappingController.cs
@@ -309,6 +309,7 @@ public class EncounterMappingController : Controller
     [ValidateAntiForgeryOrBearerToken]
     [ProducesResponseType(typeof(EncounterMappingModel), StatusCodes.Status201Created)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
     [ProducesResponseType(StatusCodes.Status409Conflict)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
     public async Task<ActionResult> CreateAsync([FromBody] CreateEncounterMappingModel model)
@@ -340,6 +341,11 @@ public class EncounterMappingController : Controller
             return Problem(title: "Conflict",
                 detail: "The request could not be completed because it conflicts with the current state of the resource.",
                 statusCode: (int)HttpStatusCode.Conflict);
+        }
+        catch (NotFoundException ex)
+        {
+            _logger.LogError(ex, "NotFoundException occurred.");
+            return Problem(title: "Not Found", detail: ex.Message, statusCode: (int)HttpStatusCode.NotFound);
         }
         catch (BadRequestException ex)
         {

--- a/DotNet/ServiceTests/IntegrationTests/DataAcquisition/Managers/EncounterMappingManagerTests.cs
+++ b/DotNet/ServiceTests/IntegrationTests/DataAcquisition/Managers/EncounterMappingManagerTests.cs
@@ -4,6 +4,7 @@ using LantanaGroup.Link.DataAcquisition.Domain.Application.Models.Exceptions;
 using LantanaGroup.Link.DataAcquisition.Domain.Application.Queries;
 using LantanaGroup.Link.DataAcquisition.Domain.Infrastructure;
 using LantanaGroup.Link.DataAcquisition.Domain.Infrastructure.Context;
+using LantanaGroup.Link.DataAcquisition.Domain.Infrastructure.Entities;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Task = System.Threading.Tasks.Task;
@@ -35,12 +36,41 @@ public class EncounterMappingManagerTests
 
     private static string NewFacilityId(string prefix) => $"{prefix}_{Guid.NewGuid():N}";
 
+    /// <summary>
+    /// CreateAsync rejects a facility that isn't configured and a patient that wasn't acquired for it.
+    /// Seed the minimal rows those checks read: a FhirQueryConfiguration for the facility and a
+    /// DataAcquisitionLog per (facility, patient).
+    /// </summary>
+    private static async Task SeedFacilityAndPatientsAsync(IServiceScope scope, string facilityId, params string[] patientIds)
+    {
+        var dbContext = scope.ServiceProvider.GetRequiredService<DataAcquisitionDbContext>();
+
+        dbContext.Set<FhirQueryConfiguration>().Add(new FhirQueryConfiguration
+        {
+            Id = Guid.NewGuid(),
+            FacilityId = facilityId,
+            FhirServerBaseUrl = "https://example.org/fhir"
+        });
+
+        foreach (var patientId in patientIds)
+        {
+            dbContext.Set<DataAcquisitionLog>().Add(new DataAcquisitionLog
+            {
+                FacilityId = facilityId,
+                PatientId = patientId
+            });
+        }
+
+        await dbContext.SaveChangesAsync();
+    }
+
     [Fact]
     public async Task CreateAsync_ValidModel_ReturnsModel()
     {
         using var scope = _fixture.ServiceProvider.CreateScope();
         var dbContext = scope.ServiceProvider.GetRequiredService<DataAcquisitionDbContext>();
         var facilityId = NewFacilityId("Facility-ABC");
+        await SeedFacilityAndPatientsAsync(scope, facilityId, "Patient-123");
 
         var locationMappingManager = scope.ServiceProvider.GetRequiredService<IOrganizationLocationMappingManager>();
         var loc1 = await locationMappingManager.CreateAsync(new CreateOrganizationLocationMappingModel
@@ -88,6 +118,7 @@ public class EncounterMappingManagerTests
         using var scope = _fixture.ServiceProvider.CreateScope();
         var dbContext = scope.ServiceProvider.GetRequiredService<DataAcquisitionDbContext>();
         var facilityId = NewFacilityId("Test-Fac");
+        await SeedFacilityAndPatientsAsync(scope, facilityId, "Test-Pat");
 
         var locationMappingManager = scope.ServiceProvider.GetRequiredService<IOrganizationLocationMappingManager>();
         var loc10 = await locationMappingManager.CreateAsync(new CreateOrganizationLocationMappingModel
@@ -135,6 +166,8 @@ public class EncounterMappingManagerTests
         var queries = CreateQueries(scope);
         var fac1 = NewFacilityId("Fac-1");
         var fac2 = NewFacilityId("Fac-2");
+        await SeedFacilityAndPatientsAsync(scope, fac1, "Pat-1", "Pat-2");
+        await SeedFacilityAndPatientsAsync(scope, fac2, "Pat-3");
 
         await manager.CreateAsync(new CreateEncounterMappingModel
         {
@@ -164,6 +197,8 @@ public class EncounterMappingManagerTests
         var queries = CreateQueries(scope);
         var deleteFac = NewFacilityId("Delete-Fac");
         var otherFac = NewFacilityId("Other-Fac");
+        await SeedFacilityAndPatientsAsync(scope, deleteFac, "P1", "P2");
+        await SeedFacilityAndPatientsAsync(scope, otherFac, "P3");
 
         await manager.CreateAsync(new CreateEncounterMappingModel
         {
@@ -192,9 +227,11 @@ public class EncounterMappingManagerTests
     {
         using var scope = _fixture.ServiceProvider.CreateScope();
         var manager = CreateManager(scope);
+        var facilityId = NewFacilityId("Fac-1");
+        await SeedFacilityAndPatientsAsync(scope, facilityId, "Pat-1");
         var model = new CreateEncounterMappingModel
         {
-            FacilityId = NewFacilityId("Fac-1"), EncounterId = "Enc-1", PatientId = "Pat-1"
+            FacilityId = facilityId, EncounterId = "Enc-1", PatientId = "Pat-1"
         };
 
         await manager.CreateAsync(model);
@@ -222,6 +259,8 @@ public class EncounterMappingManagerTests
         var fac2 = NewFacilityId("F2");
         var targetPatient = $"Target-Pat-{Guid.NewGuid():N}";
         var otherPatient = $"Other-Pat-{Guid.NewGuid():N}";
+        await SeedFacilityAndPatientsAsync(scope, fac1, targetPatient, otherPatient);
+        await SeedFacilityAndPatientsAsync(scope, fac2, targetPatient);
 
         await manager.CreateAsync(new CreateEncounterMappingModel { FacilityId = fac1, EncounterId = "E1", PatientId = targetPatient });
         await manager.CreateAsync(new CreateEncounterMappingModel { FacilityId = fac2, EncounterId = "E2", PatientId = targetPatient });
@@ -241,9 +280,11 @@ public class EncounterMappingManagerTests
     {
         using var scope = _fixture.ServiceProvider.CreateScope();
         var manager = CreateManager(scope);
+        var facilityId = NewFacilityId("F1");
+        await SeedFacilityAndPatientsAsync(scope, facilityId, "P1");
         var model = new CreateEncounterMappingModel
         {
-            FacilityId = NewFacilityId("F1"),
+            FacilityId = facilityId,
             EncounterId = "E1",
             PatientId = "P1",
             OrganizationLocationMappingIds = new List<int> { int.MaxValue } // Non-existent ID
@@ -261,6 +302,7 @@ public class EncounterMappingManagerTests
         using var scope = _fixture.ServiceProvider.CreateScope();
         var dbContext = scope.ServiceProvider.GetRequiredService<DataAcquisitionDbContext>();
         var facilityId = NewFacilityId("F1");
+        await SeedFacilityAndPatientsAsync(scope, facilityId, "P1");
 
         var locMappingManager = scope.ServiceProvider.GetRequiredService<IOrganizationLocationMappingManager>();
         var loc1 = await locMappingManager.CreateAsync(new CreateOrganizationLocationMappingModel { FacilityId = facilityId, LocationId = "L1" });
@@ -286,6 +328,7 @@ public class EncounterMappingManagerTests
         var manager = CreateManager(scope);
         var queries = CreateQueries(scope);
         var facilityId = NewFacilityId("F1");
+        await SeedFacilityAndPatientsAsync(scope, facilityId, "P1");
 
         await manager.CreateAsync(new CreateEncounterMappingModel { FacilityId = facilityId, EncounterId = "E1", PatientId = "P1" });
 
@@ -302,6 +345,7 @@ public class EncounterMappingManagerTests
         using var scope = _fixture.ServiceProvider.CreateScope();
         var dbContext = scope.ServiceProvider.GetRequiredService<DataAcquisitionDbContext>();
         var facilityId = NewFacilityId("F1");
+        await SeedFacilityAndPatientsAsync(scope, facilityId, "P1");
 
         var locMappingManager = scope.ServiceProvider.GetRequiredService<IOrganizationLocationMappingManager>();
         var loc1 = await locMappingManager.CreateAsync(new CreateOrganizationLocationMappingModel { FacilityId = facilityId, LocationId = "L1" });
@@ -325,6 +369,7 @@ public class EncounterMappingManagerTests
     {
         using var scope = _fixture.ServiceProvider.CreateScope();
         var facilityId = NewFacilityId("F1");
+        await SeedFacilityAndPatientsAsync(scope, facilityId, "P1");
 
         var locMappingManager = scope.ServiceProvider.GetRequiredService<IOrganizationLocationMappingManager>();
         var loc1 = await locMappingManager.CreateAsync(new CreateOrganizationLocationMappingModel { FacilityId = facilityId, LocationId = "L1" });

--- a/DotNet/ServiceTests/UnitTests/DataAcquisition/Controllers/EncounterMappingControllerTests.cs
+++ b/DotNet/ServiceTests/UnitTests/DataAcquisition/Controllers/EncounterMappingControllerTests.cs
@@ -652,6 +652,29 @@ public class EncounterMappingControllerTests
     }
 
     [Fact]
+    public async Task CreateAsync_FacilityOrPatientNotFound_ReturnsNotFound()
+    {
+        // The manager rejects an invalid facility or a patient not associated with the facility
+        // by throwing NotFoundException, which the controller maps to 404.
+        var mocker = new AutoMocker();
+        mocker.GetMock<IEncounterMappingManager>()
+            .Setup(m => m.CreateAsync(It.IsAny<CreateEncounterMappingModel>()))
+            .ThrowsAsync(new NotFoundException("PatientId patient-46869 is not associated with FacilityId 10566."));
+
+        var controller = CreatePostController(mocker);
+
+        var result = await controller.CreateAsync(new CreateEncounterMappingModel
+        {
+            FacilityId = FacilityId,
+            EncounterId = EncounterId,
+            PatientId = PatientId
+        });
+
+        var objectResult = Assert.IsType<ObjectResult>(result);
+        Assert.Equal((int)HttpStatusCode.NotFound, objectResult.StatusCode);
+    }
+
+    [Fact]
     public async Task CreateAsync_MappingAlreadyExists_ReturnsConflict()
     {
         var mocker = new AutoMocker();

--- a/DotNet/ServiceTests/UnitTests/DataAcquisition/Managers/EncounterMappingManagerUnitTests.cs
+++ b/DotNet/ServiceTests/UnitTests/DataAcquisition/Managers/EncounterMappingManagerUnitTests.cs
@@ -20,6 +20,8 @@ public class EncounterMappingManagerUnitTests
     private readonly Mock<IEntityRepository<EncounterMapping>> _mockMappingRepo;
     private readonly Mock<IEntityRepository<EncounterLocation>> _mockLocationRepo;
     private readonly Mock<IEntityRepository<OrganizationLocationMapping>> _mockOrgLocationRepo;
+    private readonly Mock<IEntityRepository<FhirQueryConfiguration>> _mockFhirQueryConfigRepo;
+    private readonly Mock<IEntityRepository<DataAcquisitionLog>> _mockDataAcqLogRepo;
     private readonly EncounterMappingManager _manager;
 
     public EncounterMappingManagerUnitTests()
@@ -28,10 +30,24 @@ public class EncounterMappingManagerUnitTests
         _mockMappingRepo = new Mock<IEntityRepository<EncounterMapping>>();
         _mockLocationRepo = new Mock<IEntityRepository<EncounterLocation>>();
         _mockOrgLocationRepo = new Mock<IEntityRepository<OrganizationLocationMapping>>();
+        _mockFhirQueryConfigRepo = new Mock<IEntityRepository<FhirQueryConfiguration>>();
+        _mockDataAcqLogRepo = new Mock<IEntityRepository<DataAcquisitionLog>>();
 
         _mockDatabase.Setup(d => d.EncounterMappingRepository).Returns(_mockMappingRepo.Object);
         _mockDatabase.Setup(d => d.EncounterLocationRepository).Returns(_mockLocationRepo.Object);
         _mockDatabase.Setup(d => d.LocationMappingRepository).Returns(_mockOrgLocationRepo.Object);
+        _mockDatabase.Setup(d => d.FhirQueryConfigurationRepository).Returns(_mockFhirQueryConfigRepo.Object);
+        _mockDatabase.Setup(d => d.DataAcquisitionLogRepository).Returns(_mockDataAcqLogRepo.Object);
+
+        // CreateAsync validates the facility/patient before anything else. Default both checks to
+        // "valid" so the existing create tests exercise their own scenarios; the validation-failure
+        // tests below override these per case.
+        _mockFhirQueryConfigRepo
+            .Setup(r => r.AnyAsync(It.IsAny<Expression<Func<FhirQueryConfiguration, bool>>>()))
+            .ReturnsAsync(true);
+        _mockDataAcqLogRepo
+            .Setup(r => r.AnyAsync(It.IsAny<Expression<Func<DataAcquisitionLog, bool>>>()))
+            .ReturnsAsync(true);
 
         _manager = new EncounterMappingManager(_mockDatabase.Object);
     }
@@ -126,6 +142,46 @@ public class EncounterMappingManagerUnitTests
         var model = new CreateEncounterMappingModel { FacilityId = "Fac1", EncounterId = "Enc1", PatientId = string.Empty };
 
         await Assert.ThrowsAsync<ArgumentException>(() => _manager.CreateAsync(model));
+    }
+
+    [Fact]
+    public async Task CreateAsync_UnknownFacility_ThrowsNotFoundException()
+    {
+        // Arrange: the FacilityId isn't a configured facility (no FhirQueryConfiguration).
+        var model = new CreateEncounterMappingModel { FacilityId = "blahblahblah", EncounterId = "Enc1", PatientId = "Pat1" };
+
+        _mockFhirQueryConfigRepo
+            .Setup(r => r.AnyAsync(It.IsAny<Expression<Func<FhirQueryConfiguration, bool>>>()))
+            .ReturnsAsync(false);
+
+        // Act
+        var ex = await Assert.ThrowsAsync<NotFoundException>(() => _manager.CreateAsync(model));
+
+        // Assert
+        Assert.Contains("blahblahblah", ex.Message);
+        _mockMappingRepo.Verify(r => r.AddAsync(It.IsAny<EncounterMapping>()), Times.Never);
+        _mockDatabase.Verify(d => d.SaveChangesAsync(), Times.Never);
+    }
+
+    [Fact]
+    public async Task CreateAsync_PatientNotAssociatedWithFacility_ThrowsNotFoundException()
+    {
+        // Arrange: facility is valid, but the patientId belongs to a different facility (no
+        // DataAcquisitionLog ties this patient to this facility). Mirrors TestRail 9137.
+        var model = new CreateEncounterMappingModel { FacilityId = "Fac1", EncounterId = "Enc1", PatientId = "Pat-from-Fac2" };
+
+        _mockDataAcqLogRepo
+            .Setup(r => r.AnyAsync(It.IsAny<Expression<Func<DataAcquisitionLog, bool>>>()))
+            .ReturnsAsync(false);
+
+        // Act
+        var ex = await Assert.ThrowsAsync<NotFoundException>(() => _manager.CreateAsync(model));
+
+        // Assert
+        Assert.Contains("Pat-from-Fac2", ex.Message);
+        Assert.Contains("Fac1", ex.Message);
+        _mockMappingRepo.Verify(r => r.AddAsync(It.IsAny<EncounterMapping>()), Times.Never);
+        _mockDatabase.Verify(d => d.SaveChangesAsync(), Times.Never);
     }
 
     [Fact]


### PR DESCRIPTION
## Description of Changes

Fixes LEGLINK-418. The Create Org Encounter Mapping endpoint (`POST /api/data/encounter-mappings`) previously returned `201` for a facility that doesn't exist or a patient that isn't associated with the facility. `EncounterMapping` rows are normally written by the acquisition pipeline, where the `(FacilityId, PatientId)` pair is always internally consistent — these mismatches can only be produced through the manual POST, so they are now guarded explicitly.

- `EncounterMappingManager.CreateAsync` validates before creating, throwing `NotFoundException` for:
  1. an unknown facility (no `FhirQueryConfiguration` for the `FacilityId`), and
  2. a patient not acquired for the facility (no `DataAcquisitionLog` for `(FacilityId, PatientId)`) — covers the facility1/patient2 mismatch in TestRail 9137.
- `EncounterMappingController.CreateAsync` maps `NotFoundException` to `404` and documents the `404` response type.

Both checks are local to Data Acquisition (no cross-service call).

## Testing Performed

- `dotnet test` — all 73 EncounterMapping unit + integration tests pass.
- Added manager unit tests for both validation branches (unknown facility, patient/facility mismatch) and a controller test asserting the `404` mapping.
- Updated the manager integration tests to seed `FhirQueryConfiguration` + `DataAcquisitionLog` so existing create paths satisfy the new validation.
- Tested with Postman

## Unit Testing

- [x] Unit tests added/updated

## Documentation Updated

- [ ] N/A — no config keys or public docs changed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation so encounter mappings can only be created for known facilities and patients already linked to that facility.
  * Requests now return a clear **404 Not Found** when the facility or patient association is missing, instead of failing with a generic error.

* **Tests**
  * Expanded automated tests to cover the new not-found scenarios and confirm no mapping is saved when validation fails.
  * Updated integration test setup to include the required facility and patient records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->