### PR TITLE
LEGPROG-238: Submission Update to Support June Release

### DIFF
--- a/DotNet/Report/Application/Configs/PatientAggregatorSettings.cs
+++ b/DotNet/Report/Application/Configs/PatientAggregatorSettings.cs
@@ -1,0 +1,9 @@
+namespace LantanaGroup.Link.Report.Application.Options
+{
+    public class PatientAggregatorSettings
+    {
+        public const string Key = "PatientAggregator";
+
+        public bool IncludeOrganizationResource { get; set; }
+    }
+}

--- a/DotNet/Report/Application/Core/PatientAggregator.cs
+++ b/DotNet/Report/Application/Core/PatientAggregator.cs
@@ -9,6 +9,9 @@ using LantanaGroup.Link.Report.Domain.Enums;
 using LantanaGroup.Link.Report.Domain.Managers;
 using LantanaGroup.Link.Report.Models;
 using LantanaGroup.Link.Report.Services;
+using LantanaGroup.Link.Report.Settings;
+using LantanaGroup.Link.Shared.Application.Services;
+using LantanaGroup.Link.Shared.Application.Utilities;
 using Microsoft.Extensions.Options;
 using System.Text;
 
@@ -21,16 +24,22 @@ namespace LantanaGroup.Link.Report.Application.Core
         private readonly BlobStorageService _blobStorageService;
         private readonly BlobContainerClient _containerClient;
         private readonly BlobStorageSettings _settings;
+        private readonly ITenantApiService _tenantApiService;
+        private readonly PatientAggregatorSettings _aggregatorSettings;
 
         public PatientAggregator(
             IReportServiceMetrics metrics,
             IReportEntryManager reportEntryManager,
             BlobStorageService blobStorageService,
-            IOptions<BlobStorageSettings> settings)
+            IOptions<BlobStorageSettings> settings,
+            ITenantApiService tenantApiService,
+            IOptions<PatientAggregatorSettings> aggregatorSettings)
         {
             _metrics = metrics ?? throw new ArgumentException(nameof(metrics));
             _reportEntryManager = reportEntryManager;
             _blobStorageService = blobStorageService;
+            _tenantApiService = tenantApiService;
+            _aggregatorSettings = aggregatorSettings.Value;
 
             _settings = settings.Value;
             _containerClient = new BlobContainerClient(_settings.ConnectionString, _settings.BlobContainerName);
@@ -137,6 +146,24 @@ namespace LantanaGroup.Link.Report.Application.Core
                                 new KeyValuePair<string, object?>("measure", measureReport.Measure)
                             });
                         }
+                    }
+                }
+
+                if (_aggregatorSettings.IncludeOrganizationResource)
+                {
+                    var facilityConfig = await _tenantApiService.GetFacilityConfig(reportSchedule.FacilityId);
+                    if (facilityConfig != null)
+                    {
+                        var organization = FhirHelperMethods.CreateOrganization(
+                            facilityConfig.FacilityName,
+                            reportSchedule.FacilityId,
+                            ReportConstants.BundleSettings.SubmittingOrganizationProfile,
+                            ReportConstants.BundleSettings.OrganizationTypeSystem,
+                            ReportConstants.BundleSettings.CdcOrgIdSystem,
+                            ReportConstants.BundleSettings.DataAbsentReasonExtensionUrl,
+                            ReportConstants.BundleSettings.DataAbsentReasonUnknownCode);
+                        var serializer = new FhirJsonSerializer();
+                        writer.WriteLine(serializer.SerializeToString(organization));
                     }
                 }
             }

--- a/DotNet/Report/Program.cs
+++ b/DotNet/Report/Program.cs
@@ -95,6 +95,7 @@ static void RegisterServices(WebApplicationBuilder builder)
     builder.Services.Configure<CorsSettings>(builder.Configuration.GetSection(ConfigurationConstants.AppSettings.CORS));
     builder.Services.Configure<LinkTokenServiceSettings>(builder.Configuration.GetSection(ConfigurationConstants.AppSettings.LinkTokenService));
     builder.Services.Configure<BlobStorageSettings>(builder.Configuration.GetSection(BlobStorageSettings.Key));
+    builder.Services.Configure<PatientAggregatorSettings>(builder.Configuration.GetSection(PatientAggregatorSettings.Key));
 
 
     string? connectionString = builder.Configuration.GetConnectionString("DatabaseConnection");

--- a/DotNet/Report/appsettings.json
+++ b/DotNet/Report/appsettings.json
@@ -102,5 +102,8 @@
     "ConsumerRetryDuration": [ "PT20S", "PT60S", "PT120S" ],
     "DisableRetryConsumer": false,
     "DisableConsumer": false
+  },
+  "PatientAggregator": {
+    "IncludeOrganizationResource": false
   }
 }

--- a/DotNet/ServiceTests/IntegrationTests/Report/Core/PatientAggregatorTests.cs
+++ b/DotNet/ServiceTests/IntegrationTests/Report/Core/PatientAggregatorTests.cs
@@ -1,18 +1,25 @@
-﻿using Azure.Storage.Blobs.Specialized;
+﻿using Azure.Storage.Blobs;
+using Azure.Storage.Blobs.Specialized;
 using LantanaGroup.Link.Report.Application.Core;
+using LantanaGroup.Link.Report.Application.Interfaces;
+using LantanaGroup.Link.Report.Application.Options;
 using LantanaGroup.Link.Report.Data;
 using LantanaGroup.Link.Report.Data.Entities;
 using LantanaGroup.Link.Report.Domain.Enums;
+using LantanaGroup.Link.Report.Domain.Managers;
 using LantanaGroup.Link.Report.Models;
 using LantanaGroup.Link.Report.Services;
 using LantanaGroup.Link.Shared.Application.Enums;
 using LantanaGroup.Link.Shared.Application.Models;
 using LantanaGroup.Link.Shared.Application.Models.Integration.Report;
+using LantanaGroup.Link.Shared.Application.Models.Tenant;
 using ReportingStatus = LantanaGroup.Link.Report.Domain.Enums.ReportingStatus;
 using SubmissionStatus = LantanaGroup.Link.Report.Domain.Enums.SubmissionStatus;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Moq;
 using System.Text;
-using SystemTask = System.Threading.Tasks.Task;
+using Task = System.Threading.Tasks.Task;
 
 namespace IntegrationTests.Report.Core
 {
@@ -46,7 +53,7 @@ namespace IntegrationTests.Report.Core
             };
         }
 
-        private static async SystemTask SeedScheduleAsync(ReportDbContext context, ReportScheduleModel schedule)
+        private static async Task SeedScheduleAsync(ReportDbContext context, ReportScheduleModel schedule)
         {
             var entity = new ReportSchedule
             {
@@ -69,7 +76,7 @@ namespace IntegrationTests.Report.Core
             context.ChangeTracker.Clear();
         }
 
-        private static async SystemTask SeedReportEntryAsync(
+        private static async Task SeedReportEntryAsync(
             ReportDbContext context,
             Guid reportScheduleId,
             string facilityId,
@@ -108,7 +115,7 @@ namespace IntegrationTests.Report.Core
         /// line 1 = resource reference (e.g. "MeasureReport/abc-123"),
         /// line 2 = serialized FHIR JSON.
         /// </summary>
-        private async SystemTask UploadPatientBlobAsync(
+        private async Task UploadPatientBlobAsync(
             string blobName,
             params (string resourceReference, string fhirJson)[] lines)
         {
@@ -137,11 +144,188 @@ namespace IntegrationTests.Report.Core
         }
 
         // ------------------------------------------------------------------ //
+        //  Helpers — IncludeOrganizationResource tests
+        // ------------------------------------------------------------------ //
+
+        private PatientAggregator BuildAggregator(IServiceScope scope, bool includeOrganization)
+        {
+            var metrics = scope.ServiceProvider.GetRequiredService<IReportServiceMetrics>();
+            var reportEntryManager = scope.ServiceProvider.GetRequiredService<IReportEntryManager>();
+            var blobService = scope.ServiceProvider.GetRequiredService<BlobStorageService>();
+            var blobSettings = scope.ServiceProvider.GetRequiredService<IOptions<BlobStorageSettings>>();
+            var aggregatorSettings = Options.Create(new PatientAggregatorSettings { IncludeOrganizationResource = includeOrganization });
+            return new PatientAggregator(metrics, reportEntryManager, blobService, blobSettings, _fixture.TenantApiServiceMock.Object, aggregatorSettings);
+        }
+
+        private static Hl7.Fhir.Model.MeasureReport BuildMeasureReport() => new()
+        {
+            Id = Guid.NewGuid().ToString(),
+            Measure = "http://example.com/Measure/DE-111",
+            Status = Hl7.Fhir.Model.MeasureReport.MeasureReportStatus.Complete,
+            Type = Hl7.Fhir.Model.MeasureReport.MeasureReportType.Individual,
+            Group =
+            {
+                new Hl7.Fhir.Model.MeasureReport.GroupComponent
+                {
+                    Population =
+                    {
+                        new Hl7.Fhir.Model.MeasureReport.PopulationComponent
+                        {
+                            ElementId = "initial-population",
+                            Code = new CodeableConcept("http://terminology.hl7.org/CodeSystem/measure-population", "initial-population"),
+                            Count = 1
+                        }
+                    }
+                }
+            }
+        };
+
+        private async Task<string[]> ReadOutputBlobLinesAsync(string blobName)
+        {
+            var containerClient = new BlobContainerClient(_fixture.AzuriteConnectionString, "report-test-container");
+            var response = await containerClient.GetBlobClient(blobName).DownloadAsync();
+            using var reader = new StreamReader(response.Value.Content);
+            var content = await reader.ReadToEndAsync();
+            return content.Split('\n', StringSplitOptions.RemoveEmptyEntries);
+        }
+
+        // ------------------------------------------------------------------ //
+        //  IncludeOrganizationResource = false → no Organization in blob
+        // ------------------------------------------------------------------ //
+
+        [Fact]
+        public async Task AggregateToABS_IncludeOrganizationResource_False_DoesNotWriteOrganizationToBlob()
+        {
+            _fixture.TenantApiServiceMock.Reset();
+
+            using var scope = _fixture.ScopeFactory.CreateScope();
+            var context = scope.ServiceProvider.GetRequiredService<ReportDbContext>();
+            var blobService = scope.ServiceProvider.GetRequiredService<BlobStorageService>();
+
+            var facilityId = "pat-agg-facility-006";
+            var patientId = "patient-006";
+            var schedule = BuildSchedule(facilityId);
+            await SeedScheduleAsync(context, schedule);
+
+            var measureReport = BuildMeasureReport();
+            var mrJson = new FhirJsonSerializer().SerializeToString(measureReport);
+            var reportName = blobService.GetReportName(schedule);
+            var entryBlobName = blobService.GetBlobName(reportName, $"patient-{patientId}-DE-111.mr");
+            await UploadPatientBlobAsync(entryBlobName, ($"MeasureReport/{measureReport.Id}", mrJson));
+            await SeedReportEntryAsync(context, schedule.Id, facilityId, patientId,
+                ("DE-111", MeasureReportStatus.ReadyForValidation, measureReport.Id, entryBlobName));
+
+            var aggregator = BuildAggregator(scope, includeOrganization: false);
+            var result = await aggregator.AggregateToABS(patientId, schedule);
+
+            var parser = new FhirJsonParser();
+            var lines = await ReadOutputBlobLinesAsync(result.BlobName);
+            var hasOrganization = lines.Any(line =>
+            {
+                try { return parser.Parse<Resource>(line) is Organization; }
+                catch { return false; }
+            });
+            Assert.False(hasOrganization);
+        }
+
+        // ------------------------------------------------------------------ //
+        //  IncludeOrganizationResource = true → Organization appended
+        // ------------------------------------------------------------------ //
+
+        [Fact]
+        public async Task AggregateToABS_IncludeOrganizationResource_True_AppendsOrganizationToBlob()
+        {
+            _fixture.TenantApiServiceMock.Reset();
+
+            var facilityId = "pat-agg-facility-007";
+            var patientId = "patient-007";
+            var facilityName = "Test Hospital";
+
+            _fixture.TenantApiServiceMock
+                .Setup(x => x.GetFacilityConfig(facilityId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new FacilityModel { FacilityName = facilityName, FacilityId = facilityId });
+
+            using var scope = _fixture.ScopeFactory.CreateScope();
+            var context = scope.ServiceProvider.GetRequiredService<ReportDbContext>();
+            var blobService = scope.ServiceProvider.GetRequiredService<BlobStorageService>();
+
+            var schedule = BuildSchedule(facilityId);
+            await SeedScheduleAsync(context, schedule);
+
+            var measureReport = BuildMeasureReport();
+            var mrJson = new FhirJsonSerializer().SerializeToString(measureReport);
+            var reportName = blobService.GetReportName(schedule);
+            var entryBlobName = blobService.GetBlobName(reportName, $"patient-{patientId}-DE-111.mr");
+            await UploadPatientBlobAsync(entryBlobName, ($"MeasureReport/{measureReport.Id}", mrJson));
+            await SeedReportEntryAsync(context, schedule.Id, facilityId, patientId,
+                ("DE-111", MeasureReportStatus.ReadyForValidation, measureReport.Id, entryBlobName));
+
+            var aggregator = BuildAggregator(scope, includeOrganization: true);
+            var result = await aggregator.AggregateToABS(patientId, schedule);
+
+            var parser = new FhirJsonParser();
+            var lines = await ReadOutputBlobLinesAsync(result.BlobName);
+            var orgLine = lines.FirstOrDefault(line =>
+            {
+                try { return parser.Parse<Resource>(line) is Organization; }
+                catch { return false; }
+            });
+            Assert.NotNull(orgLine);
+            var org = parser.Parse<Organization>(orgLine);
+            Assert.Equal(facilityName, org.Name);
+            Assert.Equal(facilityId, org.Identifier.First().Value);
+        }
+
+        // ------------------------------------------------------------------ //
+        //  IncludeOrganizationResource = true, null facility config → no Organization
+        // ------------------------------------------------------------------ //
+
+        [Fact]
+        public async Task AggregateToABS_IncludeOrganizationResource_True_NullFacilityConfig_DoesNotAppendOrganization()
+        {
+            _fixture.TenantApiServiceMock.Reset();
+
+            var facilityId = "pat-agg-facility-008";
+            var patientId = "patient-008";
+
+            _fixture.TenantApiServiceMock
+                .Setup(x => x.GetFacilityConfig(facilityId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync((FacilityModel?)null);
+
+            using var scope = _fixture.ScopeFactory.CreateScope();
+            var context = scope.ServiceProvider.GetRequiredService<ReportDbContext>();
+            var blobService = scope.ServiceProvider.GetRequiredService<BlobStorageService>();
+
+            var schedule = BuildSchedule(facilityId);
+            await SeedScheduleAsync(context, schedule);
+
+            var measureReport = BuildMeasureReport();
+            var mrJson = new FhirJsonSerializer().SerializeToString(measureReport);
+            var reportName = blobService.GetReportName(schedule);
+            var entryBlobName = blobService.GetBlobName(reportName, $"patient-{patientId}-DE-111.mr");
+            await UploadPatientBlobAsync(entryBlobName, ($"MeasureReport/{measureReport.Id}", mrJson));
+            await SeedReportEntryAsync(context, schedule.Id, facilityId, patientId,
+                ("DE-111", MeasureReportStatus.ReadyForValidation, measureReport.Id, entryBlobName));
+
+            var aggregator = BuildAggregator(scope, includeOrganization: true);
+            var result = await aggregator.AggregateToABS(patientId, schedule);
+
+            var parser = new FhirJsonParser();
+            var lines = await ReadOutputBlobLinesAsync(result.BlobName);
+            var hasOrganization = lines.Any(line =>
+            {
+                try { return parser.Parse<Resource>(line) is Organization; }
+                catch { return false; }
+            });
+            Assert.False(hasOrganization);
+        }
+
+        // ------------------------------------------------------------------ //
         //  No entry found ? throws
         // ------------------------------------------------------------------ //
 
         [Fact]
-        public async SystemTask AggregateToABS_EntryMissing_ThrowsException()
+        public async Task AggregateToABS_EntryMissing_ThrowsException()
         {
             using var scope = _fixture.ScopeFactory.CreateScope();
             var context = scope.ServiceProvider.GetRequiredService<ReportDbContext>();
@@ -163,7 +347,7 @@ namespace IntegrationTests.Report.Core
         // ------------------------------------------------------------------ //
 
         [Fact]
-        public async SystemTask AggregateToABS_NoReadyForValidationMeasureReports_ReturnsEmptyResults()
+        public async Task AggregateToABS_NoReadyForValidationMeasureReports_ReturnsEmptyResults()
         {
             using var scope = _fixture.ScopeFactory.CreateScope();
             var context = scope.ServiceProvider.GetRequiredService<ReportDbContext>();
@@ -190,7 +374,7 @@ namespace IntegrationTests.Report.Core
         // ------------------------------------------------------------------ //
 
         [Fact]
-        public async SystemTask AggregateToABS_SingleReadyMeasureReport_AggregatesCorrectly()
+        public async Task AggregateToABS_SingleReadyMeasureReport_AggregatesCorrectly()
         {
             using var scope = _fixture.ScopeFactory.CreateScope();
             var context = scope.ServiceProvider.GetRequiredService<ReportDbContext>();
@@ -259,7 +443,7 @@ namespace IntegrationTests.Report.Core
         // ------------------------------------------------------------------ //
 
         [Fact]
-        public async SystemTask AggregateToABS_DuplicateResources_AreSkipped()
+        public async Task AggregateToABS_DuplicateResources_AreSkipped()
         {
             using var scope = _fixture.ScopeFactory.CreateScope();
             var context = scope.ServiceProvider.GetRequiredService<ReportDbContext>();
@@ -331,7 +515,7 @@ namespace IntegrationTests.Report.Core
         // ------------------------------------------------------------------ //
 
         [Fact]
-        public async SystemTask AggregateToABS_MixedStatuses_OnlyProcessesReadyForValidation()
+        public async Task AggregateToABS_MixedStatuses_OnlyProcessesReadyForValidation()
         {
             using var scope = _fixture.ScopeFactory.CreateScope();
             var context = scope.ServiceProvider.GetRequiredService<ReportDbContext>();

--- a/DotNet/ServiceTests/ServiceTests.csproj
+++ b/DotNet/ServiceTests/ServiceTests.csproj
@@ -63,6 +63,7 @@
     <ProjectReference Include="..\QueryDispatch\QueryDispatch.csproj" />
     <ProjectReference Include="..\Report\Report.csproj" />
     <ProjectReference Include="..\Shared\Shared.csproj" />
+    <ProjectReference Include="..\Submission\Submission.csproj" />
     <ProjectReference Include="..\Tenant\Tenant.csproj" />
     <ProjectReference Include="..\Terminology\Terminology.csproj" />
     <ProjectReference Include="..\LinkSdk\LinkSdk.csproj" />

--- a/DotNet/ServiceTests/UnitTests/Submission/BlobStorageServiceTests.cs
+++ b/DotNet/ServiceTests/UnitTests/Submission/BlobStorageServiceTests.cs
@@ -1,0 +1,41 @@
+using LantanaGroup.Link.Submission.Application.Services;
+
+namespace UnitTests.Submission
+{
+    [Trait("Category", "UnitTests")]
+    public class BlobStorageServiceTests
+    {
+        [Theory]
+        [InlineData("root", "facilityid_ach_20240101_abc", "manifest.ndjson", false, "root/facilityid_ach_20240101_abc/manifest.ndjson")]
+        [InlineData("root", "facilityid_ach_20240101_abc", "manifest.ndjson", true,  "root/facilityid_ach_20240101_abc_manifest.ndjson")]
+        [InlineData("root", "facilityid_ach_20240101_abc", "patient-p001.ndjson", false, "root/facilityid_ach_20240101_abc/patient-p001.ndjson")]
+        [InlineData("root", "facilityid_ach_20240101_abc", "patient-p001.ndjson", true,  "root/facilityid_ach_20240101_abc_patient-p001.ndjson")]
+        [InlineData(null,   "facilityid_ach_20240101_abc", "manifest.ndjson", false, "facilityid_ach_20240101_abc/manifest.ndjson")]
+        [InlineData(null,   "facilityid_ach_20240101_abc", "manifest.ndjson", true,  "facilityid_ach_20240101_abc_manifest.ndjson")]
+        public void GetExternalBlobName_ReturnsExpectedPath(
+            string? blobRoot, string reportName, string bundleName, bool flatten, string expected)
+        {
+            var result = BlobStorageService.GetExternalBlobName(blobRoot, reportName, bundleName, flatten);
+
+            Assert.Equal(expected, result);
+        }
+
+        [Fact]
+        public void GetExternalBlobName_FlattenFalse_ProducesThreeSlashSegments()
+        {
+            var result = BlobStorageService.GetExternalBlobName("root", "report", "bundle.ndjson", false);
+
+            Assert.Equal(3, result.Split('/').Length);
+            Assert.EndsWith("/bundle.ndjson", result);
+        }
+
+        [Fact]
+        public void GetExternalBlobName_FlattenTrue_ProducesTwoSlashSegments()
+        {
+            var result = BlobStorageService.GetExternalBlobName("root", "report", "bundle.ndjson", true);
+
+            Assert.Equal(2, result.Split('/').Length);
+            Assert.EndsWith("_bundle.ndjson", result);
+        }
+    }
+}

--- a/DotNet/ServiceTests/UnitTests/Submission/SubmitPayloadListenerTests.cs
+++ b/DotNet/ServiceTests/UnitTests/Submission/SubmitPayloadListenerTests.cs
@@ -1,0 +1,169 @@
+using Confluent.Kafka;
+using LantanaGroup.Link.Shared.Application.Enums;
+using LantanaGroup.Link.Shared.Application.Error.Interfaces;
+using LantanaGroup.Link.Shared.Application.Interfaces;
+using LantanaGroup.Link.Shared.Application.Models;
+using LantanaGroup.Link.Shared.Application.Models.Kafka;
+using LantanaGroup.Link.Submission.Application.Config;
+using LantanaGroup.Link.Submission.Application.Interfaces;
+using LantanaGroup.Link.Submission.KafkaProducers;
+using LantanaGroup.Link.Submission.Listeners;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+using Task = System.Threading.Tasks.Task;
+
+namespace UnitTests.Submission;
+
+[Trait("Category", "UnitTests")]
+public class SubmitPayloadListenerTests
+{
+    private readonly Mock<ILogger<SubmitPayloadListener>> _loggerMock = new();
+    private readonly Mock<IKafkaConsumerFactory<SubmitPayloadKey, SubmitPayloadValue>> _consumerFactoryMock = new();
+    private readonly Mock<IConsumer<SubmitPayloadKey, SubmitPayloadValue>> _consumerMock = new();
+    private readonly Mock<ITransientExceptionHandler<SubmitPayloadListener, SubmitPayloadKey, SubmitPayloadValue>> _transientHandlerMock = new();
+    private readonly Mock<IDeadLetterExceptionHandler<SubmitPayloadListener, SubmitPayloadKey, SubmitPayloadValue>> _deadLetterHandlerMock = new();
+    private readonly Mock<IStorageService> _storageServiceMock = new();
+    private readonly Mock<ISubmissionServiceMetrics> _metricsMock = new();
+    private readonly Mock<IProducer<PayloadSubmittedKey, PayloadSubmittedValue>> _payloadProducerMock = new();
+    private readonly Mock<ILogger<AuditableEventOccurredProducer>> _auditLoggerMock = new();
+    private readonly Mock<IProducer<string, AuditEventMessage>> _auditProducerMock = new();
+
+    public SubmitPayloadListenerTests()
+    {
+        _consumerFactoryMock
+            .Setup(f => f.CreateConsumer(
+                It.IsAny<ConsumerConfig>(),
+                It.IsAny<IDeserializer<SubmitPayloadKey>?>(),
+                It.IsAny<IDeserializer<SubmitPayloadValue>?>()))
+            .Returns(_consumerMock.Object);
+
+        _metricsMock
+            .Setup(m => m.BuildTags(It.IsAny<string?>(), It.IsAny<Guid>(), It.IsAny<string?>(), It.IsAny<string>(), It.IsAny<string>()))
+            .Returns([]);
+
+        _storageServiceMock.Setup(s => s.DestinationType).Returns("test");
+        _storageServiceMock.Setup(s => s.HasInternalClient()).Returns(true);
+        _storageServiceMock
+            .Setup(s => s.DownloadFromInternalAsync(It.IsAny<SubmitPayloadValue>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new byte[] { 1, 2, 3 });
+        _storageServiceMock
+            .Setup(s => s.UploadToExternalAsync(It.IsAny<SubmitPayloadKey>(), It.IsAny<SubmitPayloadValue>(), It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+    }
+
+    private SubmitPayloadListener CreateListener(bool suppressManifest) =>
+        new(
+            _loggerMock.Object,
+            _consumerFactoryMock.Object,
+            _transientHandlerMock.Object,
+            _deadLetterHandlerMock.Object,
+            _storageServiceMock.Object,
+            _metricsMock.Object,
+            new PayloadSubmittedProducer(_payloadProducerMock.Object),
+            new AuditableEventOccurredProducer(_auditLoggerMock.Object, _auditProducerMock.Object),
+            Options.Create(new ExternalBlobStorageSettings { SuppressManifest = suppressManifest }));
+
+    private static ConsumeResult<SubmitPayloadKey, SubmitPayloadValue> BuildConsumeResult(
+        string facilityId, PayloadType payloadType) =>
+        new()
+        {
+            Message = new Message<SubmitPayloadKey, SubmitPayloadValue>
+            {
+                Key = new SubmitPayloadKey { FacilityId = facilityId, ReportScheduleId = Guid.NewGuid() },
+                Value = new SubmitPayloadValue
+                {
+                    PayloadType = payloadType,
+                    PayloadUri = "some/uri",
+                    ReportTypes = ["ACH"]
+                },
+                Headers = new Headers()
+            }
+        };
+
+    private static Task InvokeConsumeAsync(
+        SubmitPayloadListener listener,
+        ConsumeResult<SubmitPayloadKey, SubmitPayloadValue> result)
+    {
+        var method = typeof(SubmitPayloadListener)
+            .GetMethod("ConsumeAsync", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        return (Task)method.Invoke(listener, [result, CancellationToken.None])!;
+    }
+
+    [Fact]
+    public async Task ConsumeAsync_SuppressManifestTrue_ReportSchedule_SkipsBlobStorage()
+    {
+        var listener = CreateListener(suppressManifest: true);
+        var result = BuildConsumeResult("facility-1", PayloadType.ReportSchedule);
+
+        await InvokeConsumeAsync(listener, result);
+
+        _storageServiceMock.Verify(
+            s => s.DownloadFromInternalAsync(It.IsAny<SubmitPayloadValue>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        _storageServiceMock.Verify(
+            s => s.UploadToExternalAsync(It.IsAny<SubmitPayloadKey>(), It.IsAny<SubmitPayloadValue>(), It.IsAny<byte[]>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task ConsumeAsync_SuppressManifestTrue_ReportSchedule_StillProducesPayloadSubmitted()
+    {
+        var listener = CreateListener(suppressManifest: true);
+        var result = BuildConsumeResult("facility-1", PayloadType.ReportSchedule);
+
+        await InvokeConsumeAsync(listener, result);
+
+        _payloadProducerMock.Verify(
+            p => p.Produce(
+                It.IsAny<string>(),
+                It.Is<Message<PayloadSubmittedKey, PayloadSubmittedValue>>(
+                    m => m.Value.PayloadType == PayloadType.ReportSchedule),
+                It.IsAny<Action<DeliveryReport<PayloadSubmittedKey, PayloadSubmittedValue>>>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task ConsumeAsync_SuppressManifestFalse_ReportSchedule_PerformsBlobStorage()
+    {
+        var listener = CreateListener(suppressManifest: false);
+        var result = BuildConsumeResult("facility-1", PayloadType.ReportSchedule);
+
+        await InvokeConsumeAsync(listener, result);
+
+        _storageServiceMock.Verify(
+            s => s.DownloadFromInternalAsync(It.IsAny<SubmitPayloadValue>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+        _storageServiceMock.Verify(
+            s => s.UploadToExternalAsync(It.IsAny<SubmitPayloadKey>(), It.IsAny<SubmitPayloadValue>(), It.IsAny<byte[]>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+        _payloadProducerMock.Verify(
+            p => p.Produce(
+                It.IsAny<string>(),
+                It.IsAny<Message<PayloadSubmittedKey, PayloadSubmittedValue>>(),
+                It.IsAny<Action<DeliveryReport<PayloadSubmittedKey, PayloadSubmittedValue>>>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task ConsumeAsync_SuppressManifestTrue_MeasureReportSubmissionEntry_PerformsBlobStorage()
+    {
+        var listener = CreateListener(suppressManifest: true);
+        var result = BuildConsumeResult("facility-1", PayloadType.MeasureReportSubmissionEntry);
+
+        await InvokeConsumeAsync(listener, result);
+
+        _storageServiceMock.Verify(
+            s => s.DownloadFromInternalAsync(It.IsAny<SubmitPayloadValue>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+        _storageServiceMock.Verify(
+            s => s.UploadToExternalAsync(It.IsAny<SubmitPayloadKey>(), It.IsAny<SubmitPayloadValue>(), It.IsAny<byte[]>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+        _payloadProducerMock.Verify(
+            p => p.Produce(
+                It.IsAny<string>(),
+                It.IsAny<Message<PayloadSubmittedKey, PayloadSubmittedValue>>(),
+                It.IsAny<Action<DeliveryReport<PayloadSubmittedKey, PayloadSubmittedValue>>>()),
+            Times.Once);
+    }
+}

--- a/DotNet/ServiceTests/packages.lock.json
+++ b/DotNet/ServiceTests/packages.lock.json
@@ -447,6 +447,11 @@
         "resolved": "2.14.2",
         "contentHash": "8GRCTOKqCfwAyMSWmJ8c/wJc4PYm1lXAnRUWKQhaUtkz+JJUnDygxwtWPDqBMgS2YMxcrkaubFPTkhddt3RPOQ=="
       },
+      "MediatR.Contracts": {
+        "type": "Transitive",
+        "resolved": "2.0.1",
+        "contentHash": "FYv95bNT4UwcNA+G/J1oX5OpRiSUxteXaUt2BJbRSdRNiIUNbggJF69wy6mnk2wYToaanpdXZdCwVylt96MpwQ=="
+      },
       "Microsoft.AspNetCore.Authentication.Abstractions": {
         "type": "Transitive",
         "resolved": "2.3.0",
@@ -2254,6 +2259,11 @@
           "runtime.native.System.Security.Cryptography.OpenSsl": "4.3.0"
         }
       },
+      "System.Security.Cryptography.Pkcs": {
+        "type": "Transitive",
+        "resolved": "8.0.1",
+        "contentHash": "CoCRHFym33aUSf/NtWSVSZa99dkd0Hm7OCZUxORBjRB16LNhIEOf8THPqzIYlvKM0nNDAPTRBa1FxEECrgaxxA=="
+      },
       "System.Security.Cryptography.Primitives": {
         "type": "Transitive",
         "resolved": "4.3.0",
@@ -2303,6 +2313,14 @@
           "runtime.native.System": "4.3.0",
           "runtime.native.System.Net.Http": "4.3.0",
           "runtime.native.System.Security.Cryptography.OpenSsl": "4.3.0"
+        }
+      },
+      "System.Security.Cryptography.Xml": {
+        "type": "Transitive",
+        "resolved": "8.0.2",
+        "contentHash": "aDM/wm0ZGEZ6ZYJLzgqjp2FZdHbDHh6/OmpGfb7AdZ105zYmPn/83JRU2xLIbwgoNz9U1SLUTJN0v5th3qmvjA==",
+        "dependencies": {
+          "System.Security.Cryptography.Pkcs": "8.0.1"
         }
       },
       "System.Security.Principal.Windows": {
@@ -2779,6 +2797,37 @@
           "com.lantanagroup.link.Shared": "[0.4.0, )"
         }
       },
+      "submission": {
+        "type": "Project",
+        "dependencies": {
+          "AspNetCore.HealthChecks.UI.Client": "[9.0.0, )",
+          "Azure.Identity": "[1.21.0, )",
+          "Azure.Storage.Blobs": "[12.29.0, )",
+          "Confluent.Kafka": "[2.14.2, )",
+          "Confluent.Kafka.Extensions.OpenTelemetry": "[0.4.0, )",
+          "MediatR": "[12.5.0, )",
+          "Microsoft.Extensions.DependencyInjection": "[10.0.3, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.0.3, )",
+          "Microsoft.VisualStudio.Azure.Containers.Tools.Targets": "[1.23.0, )",
+          "Quartz": "[3.18.1, )",
+          "Serilog.AspNetCore": "[8.0.3, )",
+          "Serilog.Enrichers.Span": "[3.1.0, )",
+          "Serilog.Exceptions": "[8.4.0, )",
+          "Serilog.Expressions": "[4.0.0, )",
+          "Serilog.Sinks.Grafana.Loki": "[8.3.2, )",
+          "Submission.Data": "[1.0.0, )",
+          "Swashbuckle.AspNetCore": "[6.9.0, )",
+          "System.ServiceModel.Primitives": "[8.1.2, )",
+          "com.lantanagroup.link.Shared": "[0.4.0, )"
+        }
+      },
+      "submission.data": {
+        "type": "Project",
+        "dependencies": {
+          "Quartz": "[3.18.1, )",
+          "com.lantanagroup.link.Shared": "[0.4.0, )"
+        }
+      },
       "tenant": {
         "type": "Project",
         "dependencies": {
@@ -3147,6 +3196,16 @@
         "requested": "[1.2.11, )",
         "resolved": "1.2.11",
         "contentHash": "jQXu7G9Ik6BDcS5506RV1CI184pG5eHwvqzrB5zEivciW7KiZ9iHM8ZTyu5o/TGt55woagJGUVsJYw4aBjRfEQ=="
+      },
+      "MediatR": {
+        "type": "CentralTransitive",
+        "requested": "[12.5.0, )",
+        "resolved": "12.5.0",
+        "contentHash": "vqm2H8/nqL5NAJHPhsG1JOPwfkmbVrPyh4svdoRzu+uZh6Ex7PRoHBGsLYC0/RWCEJFqD1ohHNpteQvql9OktA==",
+        "dependencies": {
+          "MediatR.Contracts": "[2.0.1, 3.0.0)",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.0"
+        }
       },
       "Microsoft.AspNetCore.Authentication.JwtBearer": {
         "type": "CentralTransitive",
@@ -3833,6 +3892,16 @@
         "dependencies": {
           "Microsoft.IdentityModel.JsonWebTokens": "7.7.1",
           "Microsoft.IdentityModel.Tokens": "7.7.1"
+        }
+      },
+      "System.ServiceModel.Primitives": {
+        "type": "CentralTransitive",
+        "requested": "[8.1.2, )",
+        "resolved": "8.1.2",
+        "contentHash": "xlJ07FAUSDjPL/GhvVY1/KVPWn2ce056X4nHPwqAa5rkNLiNN5rqh6VcgMUoF6J7ckwhkVJ1vVx/K/47nyyR9g==",
+        "dependencies": {
+          "Microsoft.Extensions.ObjectPool": "8.0.10",
+          "System.Security.Cryptography.Xml": "8.0.2"
         }
       },
       "System.Text.Encodings.Web": {

--- a/DotNet/Submission/Application/Config/ExternalBlobStorageSettings.cs
+++ b/DotNet/Submission/Application/Config/ExternalBlobStorageSettings.cs
@@ -3,5 +3,7 @@
     public class ExternalBlobStorageSettings : BlobStorageSettings
     {
         public const string Key = "ExternalBlobStorage";
+
+        public bool FlattenHierarchy { get; set; }
     }
 }

--- a/DotNet/Submission/Application/Config/ExternalBlobStorageSettings.cs
+++ b/DotNet/Submission/Application/Config/ExternalBlobStorageSettings.cs
@@ -5,5 +5,7 @@
         public const string Key = "ExternalBlobStorage";
 
         public bool FlattenHierarchy { get; set; }
+
+        public bool SuppressManifest { get; set; }
     }
 }

--- a/DotNet/Submission/Application/Services/BlobStorageService.cs
+++ b/DotNet/Submission/Application/Services/BlobStorageService.cs
@@ -62,6 +62,14 @@ namespace LantanaGroup.Link.Submission.Application.Services
             {
                 blobName = blobName.Substring(_internalSettings.BlobRoot.Length);
             }
+            if (_externalSettings.FlattenHierarchy)
+            {
+                int index = blobName.LastIndexOf('/');
+                if (index != -1)
+                {
+                    blobName = $"{blobName[..index]}_{blobName[(index + 1)..]}";
+                }
+            }
             return GetBlobName(_externalSettings.BlobRoot, blobName);
         }
 

--- a/DotNet/Submission/Application/Services/BlobStorageService.cs
+++ b/DotNet/Submission/Application/Services/BlobStorageService.cs
@@ -29,6 +29,11 @@ namespace LantanaGroup.Link.Submission.Application.Services
             return new BlobContainerClient(settings.ConnectionString, settings.BlobContainerName);
         }
 
+        internal static string GetExternalBlobName(string? blobRoot, string reportName, string bundleName, bool flatten) =>
+            flatten
+                ? GetBlobName(blobRoot, $"{reportName}_{bundleName}")
+                : GetBlobName(blobRoot, reportName, bundleName);
+
         private static string GetBlobName(string? blobRoot, params string[] segments)
         {
             IEnumerable<string> enumerable = segments;
@@ -113,7 +118,7 @@ namespace LantanaGroup.Link.Submission.Application.Services
                     PayloadType.ReportSchedule => "manifest.ndjson",
                     _ => $"{Guid.NewGuid()}.ndjson"
                 };
-                blobName = GetBlobName(_externalSettings.BlobRoot, reportName, bundleName);
+                blobName = GetExternalBlobName(_externalSettings.BlobRoot, reportName, bundleName, _externalSettings.FlattenHierarchy);
             }
             else
             {

--- a/DotNet/Submission/Listeners/SubmitPayloadListener.cs
+++ b/DotNet/Submission/Listeners/SubmitPayloadListener.cs
@@ -11,10 +11,12 @@ using LantanaGroup.Link.Shared.Application.Interfaces;
 using LantanaGroup.Link.Shared.Application.Models;
 using LantanaGroup.Link.Shared.Application.Models.Kafka;
 using LantanaGroup.Link.Shared.Application.Utilities;
+using LantanaGroup.Link.Submission.Application.Config;
 using LantanaGroup.Link.Submission.Application.Interfaces;
 using LantanaGroup.Link.Submission.Application.Services;
 using LantanaGroup.Link.Submission.KafkaProducers;
 using LantanaGroup.Link.Submission.Settings;
+using Microsoft.Extensions.Options;
 using Task = System.Threading.Tasks.Task;
 
 namespace LantanaGroup.Link.Submission.Listeners
@@ -34,6 +36,7 @@ namespace LantanaGroup.Link.Submission.Listeners
         private readonly ISubmissionServiceMetrics _metrics;
         private readonly PayloadSubmittedProducer _payloadSubmittedProducer;
         private readonly AuditableEventOccurredProducer _auditableEventOccurredProducer;
+        private readonly ExternalBlobStorageSettings _externalBlobStorageSettings;
 
         public SubmitPayloadListener(
             ILogger<SubmitPayloadListener> logger,
@@ -43,7 +46,8 @@ namespace LantanaGroup.Link.Submission.Listeners
             IStorageService blobStorageService,
             ISubmissionServiceMetrics metrics,
             PayloadSubmittedProducer payloadSubmittedProducer,
-            AuditableEventOccurredProducer auditableEventOccurredProducer)
+            AuditableEventOccurredProducer auditableEventOccurredProducer,
+            IOptions<ExternalBlobStorageSettings> externalBlobStorageSettings)
         {
             _logger = logger;
 
@@ -66,6 +70,7 @@ namespace LantanaGroup.Link.Submission.Listeners
             _payloadSubmittedProducer = payloadSubmittedProducer;
 
             _auditableEventOccurredProducer = auditableEventOccurredProducer;
+            _externalBlobStorageSettings = externalBlobStorageSettings.Value;
         }
 
         protected override Task ExecuteAsync(CancellationToken stoppingToken)
@@ -149,6 +154,17 @@ namespace LantanaGroup.Link.Submission.Listeners
                 if (value.ReportTypes == null || value.ReportTypes.Count == 0)
                 {
                     throw new DeadLetterException("Measure IDs not specified.");
+                }
+
+                if (_externalBlobStorageSettings.SuppressManifest && value.PayloadType == PayloadType.ReportSchedule)
+                {
+                    _payloadSubmittedProducer.Produce(
+                        correlationId,
+                        facilityId,
+                        key.ReportScheduleId,
+                        value.PayloadType,
+                        value.PatientId);
+                    return;
                 }
 
                 byte[]? content = null;

--- a/DotNet/Submission/Submission.csproj
+++ b/DotNet/Submission/Submission.csproj
@@ -51,6 +51,10 @@
 		<ProjectReference Include="..\Submission.Data\Submission.Data.csproj" />
 	</ItemGroup>
 
+	<ItemGroup>
+		<InternalsVisibleTo Include="ServiceTests" />
+	</ItemGroup>
+
 
 </Project>
 

--- a/DotNet/Submission/appsettings.json
+++ b/DotNet/Submission/appsettings.json
@@ -122,10 +122,15 @@
     "DisableRetryConsumer": false,
     "DisableConsumer": false
   },
+  "InternalBlobStorage": {
+    "ConnectionString": null,
+    "BlobContainerName": null,
+    "BlobRoot": null
+  },
   "ExternalBlobStorage": {
-    "ConnectionString": "",
-    "BlobContainerName": "",
-    "BlobRoot": "",
+    "ConnectionString": null,
+    "BlobContainerName": null,
+    "BlobRoot": null,
     "FlattenHierarchy": false,
     "SuppressManifest": false
   }

--- a/DotNet/Submission/appsettings.json
+++ b/DotNet/Submission/appsettings.json
@@ -126,6 +126,7 @@
     "ConnectionString": "",
     "BlobContainerName": "",
     "BlobRoot": "",
-    "FlattenHierarchy": false
+    "FlattenHierarchy": false,
+    "SuppressManifest": false
   }
 }

--- a/DotNet/Submission/appsettings.json
+++ b/DotNet/Submission/appsettings.json
@@ -121,5 +121,11 @@
     "ConsumerRetryDuration": [ "PT20S", "PT60S", "PT120S" ],
     "DisableRetryConsumer": false,
     "DisableConsumer": false
+  },
+  "ExternalBlobStorage": {
+    "ConnectionString": "",
+    "BlobContainerName": "",
+    "BlobRoot": "",
+    "FlattenHierarchy": false
   }
 }

--- a/app-config.yaml
+++ b/app-config.yaml
@@ -257,6 +257,9 @@ services:
     - key: "EnhancedQueryLoggingSettings:EnableEnhancedQueryLogging"
       description: "Boolean flag to enable detailed logging of database queries."
       required: true
+    - key: "PatientAggregator:IncludeOrganizationResource"
+      description: "Whether to include the submitting Organization in patient bundles."
+      required: false
   Submission:
     - key: "SubmissionServiceConfig:SubmissionDirectory"
       description: "The local or network path where submission files are stored."

--- a/app-config.yaml
+++ b/app-config.yaml
@@ -264,12 +264,24 @@ services:
     - key: "SubmissionServiceConfig:PatientBundleBatchSize"
       description: "The number of patient bundles to process in a single batch."
       required: true
+    - key: "InternalBlobStorage:ConnectionString"
+      description: "The connection string for the internal Azure Blob Storage (where submissions are stored)."
+      required: true
+    - key: "InternalBlobStorage:BlobContainerName"
+      description: "The name of the blob container used for internal storage."
+      required: true
     - key: "ExternalBlobStorage:ConnectionString"
       description: "The connection string for the external Azure Blob Storage (where submissions are stored)."
       required: true
     - key: "ExternalBlobStorage:BlobContainerName"
       description: "The name of the blob container used for external storage."
       required: true
+    - key: "ExternalBlobStorage:FlattenHierarchy"
+      description: "Whether to flatten the submission hierarchy (i.e., upload all bundles to the blob root)."
+      required: false
+    - key: "ExternalBlobStorage:SuppressManifest"
+      description: "Whether to suppress submission of manifest bundles."
+      required: false
   Tenant:
     - key: "FacilityIdSettings:NumericOnlyFacilityId"
       description: "Boolean flag to restrict facility IDs to numeric values only."


### PR DESCRIPTION
### 🛠️ Description of Changes

  - LEGLINK-215: Report: Add service app setting configuration that adds Organization resource to each patient aggregate file
  - LEGLINK-216: Submission: Add service app setting configuration that submits to a single directory of the Azure Blob Storage container
  - LEGLINK-217: Submission: Add service app setting configuration that disables manifest submissions to the external ABS container

### 🧪 Testing Performed

Tested locally.

### 🧑‍🔬 Unit Testing

- Coverage: 82.9%

- [X] I have written or updated unit tests to cover my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configuration options for report aggregation and external blob storage behavior.
  * Enabled optional inclusion of an organization resource in aggregated report output.
  * Added support for flattening external blob paths and suppressing manifest processing.

* **Bug Fixes**
  * Improved payload handling so schedule messages can skip unnecessary blob transfer steps when manifest suppression is enabled.
  * Updated blob naming behavior to better match flattened and non-flattened storage layouts.

* **Tests**
  * Expanded automated coverage for aggregation, payload handling, and blob path generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

