### PR TITLE
LEGLINK-142: Share ICacheService across DataAcquisition service and worker via Redis

### DIFF
--- a/DotNet/DataAcquisition.AcquisitionWorker/appsettings.Docker.json
+++ b/DotNet/DataAcquisition.AcquisitionWorker/appsettings.Docker.json
@@ -15,6 +15,9 @@
   "ConnectionStrings": {
     "Redis": "redis_cache:6379"
   },
+  "Cache": {
+    "Type": "Redis"
+  },
   "Serilog": {
     "WriteTo": [
       {

--- a/DotNet/DataAcquisition.Domain/Extensions/GeneralStartupExtensions.cs
+++ b/DotNet/DataAcquisition.Domain/Extensions/GeneralStartupExtensions.cs
@@ -27,6 +27,7 @@ using LantanaGroup.Link.Shared.Application.Error.Handlers;
 using LantanaGroup.Link.Shared.Application.Error.Interfaces;
 using LantanaGroup.Link.Shared.Application.Extensions;
 using LantanaGroup.Link.Shared.Application.Extensions.Caching;
+using LantanaGroup.Link.Shared.Application.Extensions.ExternalServices;
 using LantanaGroup.Link.Shared.Application.Extensions.Quartz;
 using LantanaGroup.Link.Shared.Application.Factories;
 using LantanaGroup.Link.Shared.Application.Interfaces;
@@ -59,6 +60,11 @@ using LantanaGroup.Link.Shared.Application.Services.ResourceCache;
 namespace LantanaGroup.Link.DataAcquisition.Domain.Extensions;
 public static class GeneralStartupExtensions
 {
+    // Shared (not per-service) Redis key prefix for ICacheService. The DataAcquisition service and the
+    // AcquisitionWorker must use the SAME value so their keys resolve identically for cross-process
+    // sharing; isolating it from other services on the same Redis instance is the goal.
+    private const string CacheKeyPrefix = "DataAcquisition:";
+
     public static void RegisterAll(
         this WebApplicationBuilder builder,
         string serviceName,
@@ -86,7 +92,7 @@ public static class GeneralStartupExtensions
 
         builder.Services.RegisterSecretManager(builder.Configuration);
 
-        builder.Services.RegisterInMemoryCache();
+        builder.RegisterCacheService();
         builder.Services.RegisterHittpClient();
         builder.Services.RegisterFhirAuthHandlers();
         builder.Services.RegisterExceptionHandlers();
@@ -182,6 +188,47 @@ public static class GeneralStartupExtensions
         //in-memory cache
         services.AddMemoryCache();
         services.AddSingleton<ICacheService, InMemoryCacheService>();
+    }
+
+    /// <summary>
+    /// Registers the <see cref="ICacheService"/> backend selected by the <c>Cache:Type</c> config key
+    /// (defaults to <c>InMemory</c>). Set <c>Cache:Type=Redis</c> to back it with the shared Redis cache
+    /// so that the DataAcquisition service and the AcquisitionWorker — separate processes — see each
+    /// other's writes/evictions (e.g. the org-location conditions cache invalidated on a config change),
+    /// instead of each keeping its own per-process copy until the entry's TTL expires.
+    /// </summary>
+    public static void RegisterCacheService(this WebApplicationBuilder builder)
+    {
+        var cacheType = builder.Configuration.GetValue<string>("Cache:Type") ?? "InMemory";
+
+        if (!string.Equals(cacheType, "Redis", StringComparison.OrdinalIgnoreCase))
+        {
+            builder.Services.RegisterInMemoryCache();
+            return;
+        }
+
+        builder.Services.AddRedisCache(options =>
+        {
+            options.Environment = builder.Environment;
+
+            var redisConnection = builder.Configuration
+                .GetConnectionString(ConfigurationConstants.DatabaseConnections.RedisConnection);
+            if (string.IsNullOrEmpty(redisConnection))
+                throw new InvalidOperationException(
+                    $"ConnectionStrings:{ConfigurationConstants.DatabaseConnections.RedisConnection} is required when Cache:Type is Redis.");
+
+            options.ConnectionString = redisConnection;
+            options.Password = builder.Configuration.GetValue<string>("Redis:Password");
+
+            // Namespace this service's ICacheService keys so they can't collide with other
+            // services sharing the same Redis instance (notably the bare "{facilityId}" auth-token
+            // key). This prefix is deliberately a single fixed value — NOT per-service — because the
+            // DataAcquisition service and the AcquisitionWorker must resolve to the same Redis keys
+            // for cross-process sharing (e.g. org-location conditions invalidation) to work.
+            options.InstanceName = CacheKeyPrefix;
+        });
+
+        builder.Services.AddSingleton<ICacheService, RedisCacheService>();
     }
 
     public static void RegisterHittpClient(this IServiceCollection services)

--- a/DotNet/DataAcquisition/appsettings.Docker.json
+++ b/DotNet/DataAcquisition/appsettings.Docker.json
@@ -15,6 +15,9 @@
   "ConnectionStrings": {
     "Redis": "redis_cache:6379"
   },
+  "Cache": {
+    "Type": "Redis"
+  },
   "SecretManagement": {
     "Manager": "Local",
     "ManagerUri": ""

--- a/Tests/Postman/LEGLINK-142-NonReportable.postman_collection.json
+++ b/Tests/Postman/LEGLINK-142-NonReportable.postman_collection.json
@@ -6,28 +6,8 @@
   },
   "variable": [
     {
-      "key": "adminbff",
-      "value": "http://localhost:8063",
-      "type": "string"
-    },
-    {
-      "key": "terminology",
-      "value": "http://localhost:8076",
-      "type": "string"
-    },
-    {
-      "key": "fhirHost",
-      "value": "http://localhost:6157/fhir",
-      "type": "string"
-    },
-    {
-      "key": "fhirInternal",
-      "value": "http://fhir-server:8080/fhir",
-      "type": "string"
-    },
-    {
       "key": "facilityId",
-      "value": "leglink142-postman",
+      "value": "{{facility-id}}",
       "type": "string"
     },
     {
@@ -60,7 +40,7 @@
                 "value": "application/json"
               }
             ],
-            "url": "{{adminbff}}/api/measureeval/measure-definition",
+            "url": "{{link-admin-bff-base}}/api/measureeval/measure-definition",
             "description": "Loads the Measure + Libraries (embedded). A pre-request script fetches the 5 referenced NHSN ValueSets from the terminology service ({{terminology}}) and injects them before sending, so the CQL engine can evaluate Initial Population. ValueSets are sourced from terminology (network/ABS volume), not the repo. The patients' emergency (EMER) encounters satisfy Initial Population via the [Encounter: class ~ 'emergency'] arm. Measure definitions are global to MeasureEval.",
             "body": {
               "mode": "raw",
@@ -81,7 +61,7 @@
                   "// Enrich the measure bundle with its NHSN ValueSets fetched from the terminology service.",
                   "// Without these the CQL engine throws 'Unable to locate ValueSet' and Initial Population = 0.",
                   "var oids = [\"2.16.840.1.113762.1.4.1046.265\", \"2.16.840.1.113883.3.117.1.7.1.292\", \"2.16.840.1.113883.3.666.5.307\", \"2.16.840.1.113762.1.4.1111.143\", \"2.16.840.1.113762.1.4.1046.274\"];",
-                  "var base = pm.variables.replaceIn('{{terminology}}/api/terminology/fhir/ValueSet/');",
+                  "var base = pm.variables.replaceIn('{{terminology-api-base}}/api/terminology/fhir/ValueSet/');",
                   "var measure = JSON.parse(pm.request.body.raw);",
                   "var remaining = oids.length;",
                   "oids.forEach(function (oid) {",
@@ -115,7 +95,7 @@
                 "value": "application/json"
               }
             ],
-            "url": "{{adminbff}}/api/Facility",
+            "url": "{{link-admin-bff-base}}/api/Facility",
             "description": "Creates the facility/tenant. Vendor is required (Epic).",
             "body": {
               "mode": "raw",
@@ -138,7 +118,7 @@
                 "value": "application/json"
               }
             ],
-            "url": "{{adminbff}}/api/data/{{facilityId}}/QueryPlan",
+            "url": "{{link-admin-bff-base}}/api/data/{{facilityId}}/QueryPlan",
             "description": "INITIAL: Encounter (Parameter) + Condition (Parameter, depends on Encounter ids) + Location (Reference). SUPPLEMENTAL: a throwaway Observation (validator requires >=1). Parameter queries must precede Reference queries.",
             "body": {
               "mode": "raw",
@@ -161,7 +141,7 @@
                 "value": "application/json"
               }
             ],
-            "url": "{{adminbff}}/api/data/fhirQueryConfiguration",
+            "url": "{{link-admin-bff-base}}/api/data/fhirQueryConfiguration",
             "description": "Points the facility at fhir-server:8080 and turns on EnableLocationResolutionMapping so encounter Locations are resolved and evaluated against the org-location conditions.",
             "body": {
               "mode": "raw",
@@ -189,7 +169,7 @@
                 "value": "application/json"
               }
             ],
-            "url": "{{adminbff}}/api/data/location-config/facility/{{facilityId}}",
+            "url": "{{link-admin-bff-base}}/api/data/location-config/facility/{{facilityId}}",
             "description": "Active org-location config. FhirPath: a Location is an org location when its identifier (system 'http://hospital.example.org/locations') value is hosp-a or hosp-b. Children inherit org status through partOf.",
             "body": {
               "mode": "raw",
@@ -217,7 +197,7 @@
                 "value": "application/json"
               }
             ],
-            "url": "{{fhirHost}}",
+            "url": "{{fhir-base}}/fhir",
             "description": "Transaction bundle: 6 identifier-bearing Locations (hosp-a/b/c + er-a/er-b partOf hosp-a + er-c partOf hosp-c) and 3 Patients, each with an Encounter at hosp-a/hosp-b/hosp-c respectively plus a Condition. Loaded to HAPI on the host.",
             "body": {
               "mode": "raw",
@@ -245,7 +225,7 @@
                 "value": "application/json"
               }
             ],
-            "url": "{{adminbff}}/api/Facility/{{facilityId}}/AdHocReport",
+            "url": "{{link-admin-bff-base}}/api/Facility/{{facilityId}}/AdHocReport",
             "description": "Kicks off one acquisition over all three patients. Wait ~60-90s before folder 5 so DataAcq + MeasureEval + Report settle.",
             "body": {
               "mode": "raw",
@@ -268,7 +248,7 @@
           "request": {
             "method": "GET",
             "header": [],
-            "url": "{{adminbff}}/api/data/encounter-mappings/facilities/{{facilityId}}/patients/patient-a",
+            "url": "{{link-admin-bff-base}}/api/data/encounter-mappings/facilities/{{facilityId}}/patients/patient-a",
             "description": "Encounter at org location hosp-a -> mappedToOrg true."
           },
           "event": [
@@ -291,7 +271,7 @@
           "request": {
             "method": "GET",
             "header": [],
-            "url": "{{adminbff}}/api/data/encounter-mappings/facilities/{{facilityId}}/patients/patient-b",
+            "url": "{{link-admin-bff-base}}/api/data/encounter-mappings/facilities/{{facilityId}}/patients/patient-b",
             "description": "Encounter at org location hosp-b -> mappedToOrg true."
           },
           "event": [
@@ -314,7 +294,7 @@
           "request": {
             "method": "GET",
             "header": [],
-            "url": "{{adminbff}}/api/data/encounter-mappings/facilities/{{facilityId}}/patients/patient-c",
+            "url": "{{link-admin-bff-base}}/api/data/encounter-mappings/facilities/{{facilityId}}/patients/patient-c",
             "description": "Encounter at non-org location hosp-c -> mappedToOrg false."
           },
           "event": [
@@ -337,7 +317,7 @@
           "request": {
             "method": "GET",
             "header": [],
-            "url": "{{adminbff}}/api/data/acquisition-logs/facility/{{facilityId}}/patient/patient-c",
+            "url": "{{link-admin-bff-base}}/api/data/acquisition-logs/facility/{{facilityId}}/patient/patient-c",
             "description": "Non-org patient: dependent Condition log is preempted (NotReportable)."
           },
           "event": [
@@ -359,7 +339,7 @@
           "request": {
             "method": "GET",
             "header": [],
-            "url": "{{adminbff}}/api/entries/patients/patient-a",
+            "url": "{{link-admin-bff-base}}/api/entries/patients/patient-a",
             "description": "Reportable patient: a report entry exists with reportingStatus != NotReportable(1)."
           },
           "event": [
@@ -383,7 +363,7 @@
           "request": {
             "method": "GET",
             "header": [],
-            "url": "{{adminbff}}/api/entries/patients/patient-b",
+            "url": "{{link-admin-bff-base}}/api/entries/patients/patient-b",
             "description": "Reportable patient: a report entry exists with reportingStatus != NotReportable(1)."
           },
           "event": [
@@ -407,7 +387,7 @@
           "request": {
             "method": "GET",
             "header": [],
-            "url": "{{adminbff}}/api/entries/patients/patient-c",
+            "url": "{{link-admin-bff-base}}/api/entries/patients/patient-c",
             "description": "Non-org patient: the non-org encounter is stripped before MeasureEval, so reportingStatus === NotReportable(1) and no aggregate report is produced."
           },
           "event": [

--- a/app-config.yaml
+++ b/app-config.yaml
@@ -163,6 +163,9 @@ services:
     - key: "DistributedLockSettings:Expiration"
       description: "The expiration time in minutes for distributed locks."
       required: true
+    - key: "Cache:Type"
+      description: "ICacheService backend. Defaults to InMemory (per-process); set to Redis to share the cache (e.g. org-location conditions) across the DataAcquisition service and AcquisitionWorker so a config change in one is seen by the other. Redis requires ConnectionStrings:Redis."
+      required: false
     - key: "ResourceCache:CacheImplementation"
       description: "The resource cache implementation to register. Defaults to Hybrid; supported values are Hybrid, Redis, and ABS."
       required: false
@@ -191,6 +194,9 @@ services:
     - key: "AcquisitionWorkerProcessorSettings:WorkChannelCapacity"
       description: "The capacity of the internal work channel for acquisition tasks."
       required: true
+    - key: "Cache:Type"
+      description: "ICacheService backend. Defaults to InMemory (per-process); set to Redis to share the cache (e.g. org-location conditions) across the DataAcquisition service and AcquisitionWorker so a config change in one is seen by the other. Redis requires ConnectionStrings:Redis."
+      required: false
     - key: "ResourceCache:CacheImplementation"
       description: "The resource cache implementation to register. Defaults to Hybrid; supported values are Hybrid, Redis, and ABS."
       required: false


### PR DESCRIPTION
## Description of Changes

The DataAcquisition **service** and the **AcquisitionWorker** run as separate processes but share `DataAcquisition.Domain`, which registered `InMemoryCacheService` unconditionally. That made every `ICacheService` entry per-process — so when the service invalidated the org-location **conditions** cache on a config change, the worker kept its stale copy until the 1h TTL expired (and vice versa).

This change lets the two processes share one cache:

- **`RegisterCacheService`** now selects the `ICacheService` backend by the `Cache:Type` config key (defaults to `InMemory`). `Cache:Type=Redis` backs it with the shared Redis cache, so the service and worker see each other''s writes/evictions immediately — closing the stale-conditions gap across processes.
- **Fixed Redis key prefix** (`DataAcquisition:`) namespaces these keys so they cannot collide with other services on the same Redis instance (notably the bare `{facilityId}` auth-token key in `OAuth`/`EpicAuth`). The prefix is deliberately **not** per-service: both processes register through the same `GeneralStartupExtensions`, so they resolve to identical keys and sharing works.
- **Enabled Redis** in both Docker `appsettings` and **documented** `Cache:Type` in `app-config.yaml`.
- Minor: renamed variables in the NonReportable Postman collection.

`ICacheService` consumers affected by the flag in these services: org-location conditions cache (`LocationMappingService`/`OrganizationLocationConfigurationManager`) and the EHR bearer-token caches (`OAuth`/`EpicAuth`). `IResourceCache` (FHIR bodies) is a separate abstraction and is unaffected.

## Testing Performed

- `dotnet build DotNet/DataAcquisition.Domain/DataAcquisition.Domain.csproj` — clean (0 errors).
- Default (no config / `Cache:Type` unset) still registers `InMemoryCacheService` — no behavior change unless Redis is explicitly enabled.
- In Docker both services point at `redis_cache:6379` with `Cache:Type=Redis`; QA App Config already exposes the global `Cache:Type=Redis` and `ConnectionStrings:Redis`, so deploying this code closes the gap without an App Config change.

## Unit Testing

- [ ] N/A — wiring/config change; covered by existing build + integration fixture, which defaults to InMemory.

## Documentation Updated

- [x] `app-config.yaml` updated with the `Cache:Type` key for both DataAcquisition and DataAcquisitionWorker.