### PR TITLE
LEGLINK-497: Admin UI: Creating duplicate Removal Operations should not be allowed.

### DIFF
--- a/Web/Admin.UI/src/app/components/normalization/operations/remove-extensions/remove-extensions-csv-import-dialog/remove-extensions-csv-import-dialog.component.html
+++ b/Web/Admin.UI/src/app/components/normalization/operations/remove-extensions/remove-extensions-csv-import-dialog/remove-extensions-csv-import-dialog.component.html
@@ -8,10 +8,37 @@
       (column 2). Each unique resource type creates a separate Remove Extensions operation.
     </p>
     <file-upload (fileChange)="onFileSelected($event)"></file-upload>
+    @if (isChecking) {
+      <div class="checking-indicator">
+        <mat-spinner diameter="20"></mat-spinner>
+        Checking for existing operations&hellip;
+      </div>
+    }
     @if (parseError) {
       <div class="parse-error">
         <mat-icon>error_outline</mat-icon>
         {{ parseError }}
+      </div>
+    }
+    @if (conflicts.length > 0) {
+      <div class="conflict-error">
+        <div class="conflict-header">
+          <mat-icon>block</mat-icon>
+          Import rejected &mdash; {{ conflicts.length }} duplicate(s) found. The following
+          resource type / URL combination(s) already exist:
+        </div>
+        <div class="conflict-groups">
+          @for (group of conflictGroups; track group.resourceType) {
+            <div class="conflict-group">
+              <strong>{{ group.resourceType }}</strong>
+              <ul>
+                @for (url of group.urls; track url) {
+                  <li>{{ url }}</li>
+                }
+              </ul>
+            </div>
+          }
+        </div>
       </div>
     }
   }

--- a/Web/Admin.UI/src/app/components/normalization/operations/remove-extensions/remove-extensions-csv-import-dialog/remove-extensions-csv-import-dialog.component.scss
+++ b/Web/Admin.UI/src/app/components/normalization/operations/remove-extensions/remove-extensions-csv-import-dialog/remove-extensions-csv-import-dialog.component.scss
@@ -14,6 +14,15 @@ $border: #e0e0e0;
   line-height: 1.5;
 }
 
+.checking-indicator {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-top: 12px;
+  color: #555;
+  font-size: 13px;
+}
+
 .parse-error {
   display: flex;
   align-items: center;
@@ -21,6 +30,52 @@ $border: #e0e0e0;
   color: $error;
   margin-top: 12px;
   font-size: 13px;
+}
+
+.conflict-error {
+  margin-top: 12px;
+  border: 1px solid #ffccbc;
+  border-radius: 4px;
+  background: #fff8f6;
+
+  .conflict-header {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 10px 14px;
+    color: $error;
+    font-size: 13px;
+    font-weight: 500;
+    border-bottom: 1px solid #ffccbc;
+
+    mat-icon { color: $error; }
+  }
+
+  .conflict-groups {
+    padding: 10px 14px;
+    max-height: 220px;
+    overflow-y: auto;
+  }
+
+  .conflict-group {
+    margin-bottom: 10px;
+
+    &:last-child { margin-bottom: 0; }
+
+    strong {
+      font-size: 13px;
+      color: #333;
+    }
+
+    ul {
+      list-style: disc;
+      margin: 4px 0 0 16px;
+      padding: 0;
+      font-size: 12px;
+      font-family: monospace;
+      color: $error;
+    }
+  }
 }
 
 .summary {

--- a/Web/Admin.UI/src/app/components/normalization/operations/remove-extensions/remove-extensions-csv-import-dialog/remove-extensions-csv-import-dialog.component.ts
+++ b/Web/Admin.UI/src/app/components/normalization/operations/remove-extensions/remove-extensions-csv-import-dialog/remove-extensions-csv-import-dialog.component.ts
@@ -8,7 +8,8 @@ import {OperationService} from '../../../../../services/gateway/normalization/op
 import {ISaveOperationModel} from '../../../../../interfaces/normalization/operation-save-model.interface';
 import {OperationType} from '../../../../../interfaces/normalization/operation-type-enumeration';
 import {RemoveExtensionsOperation} from '../../../../../interfaces/normalization/remove-extensions-operation-interface';
-import {firstValueFrom} from 'rxjs';
+import {firstValueFrom, forkJoin, map} from 'rxjs';
+import {IOperationModel} from '../../../../../interfaces/normalization/operation-get-model.interface';
 import * as Papa from 'papaparse';
 
 interface CsvOperationGroup {
@@ -17,6 +18,11 @@ interface CsvOperationGroup {
   invalidUrls: string[];
   status: 'pending' | 'submitting' | 'success' | 'error';
   errorMessage?: string;
+}
+
+interface ConflictInfo {
+  resourceType: string;
+  url: string;
 }
 
 export interface CsvImportDialogData {
@@ -41,6 +47,8 @@ export class RemoveExtensionsCsvImportDialogComponent {
 
   stage: 'upload' | 'preview' | 'submitting' | 'results' = 'upload';
   groups: CsvOperationGroup[] = [];
+  conflicts: ConflictInfo[] = [];
+  isChecking = false;
   parseError = '';
   created = 0;
   failed = 0;
@@ -60,10 +68,20 @@ export class RemoveExtensionsCsvImportDialogComponent {
     return this.groups.some(g => g.invalidUrls.length > 0);
   }
 
+  get conflictGroups(): {resourceType: string; urls: string[]}[] {
+    const grouped = new Map<string, string[]>();
+    for (const c of this.conflicts) {
+      if (!grouped.has(c.resourceType)) grouped.set(c.resourceType, []);
+      grouped.get(c.resourceType)!.push(c.url);
+    }
+    return Array.from(grouped.entries()).map(([resourceType, urls]) => ({resourceType, urls}));
+  }
+
   onFileSelected(file: File | null): void {
+    this.conflicts = [];
+    this.parseError = '';
     if (!file) {
       this.groups = [];
-      this.parseError = '';
       return;
     }
     if (!file.name.toLowerCase().endsWith('.csv')) {
@@ -71,7 +89,6 @@ export class RemoveExtensionsCsvImportDialogComponent {
       this.groups = [];
       return;
     }
-    this.parseError = '';
     const reader = new FileReader();
     reader.readAsText(file);
     reader.onload = () => {
@@ -106,10 +123,28 @@ export class RemoveExtensionsCsvImportDialogComponent {
 
     if (this.groups.length === 0) {
       this.parseError = 'No valid rows found. Ensure column 1 is the resource type and column 2 is the URL.';
-    } else {
-      this.stage = 'preview';
+      this.cdr.detectChanges();
+      return;
     }
+
+    this.isChecking = true;
     this.cdr.detectChanges();
+
+    this.checkForConflicts()
+      .then(conflicts => {
+        this.isChecking = false;
+        if (conflicts.length > 0) {
+          this.conflicts = conflicts;
+        } else {
+          this.stage = 'preview';
+        }
+        this.cdr.detectChanges();
+      })
+      .catch(() => {
+        this.isChecking = false;
+        this.parseError = 'Failed to check for existing operations. Please try again.';
+        this.cdr.detectChanges();
+      });
   }
 
   private isAbsoluteUrl(url: string): boolean {
@@ -121,9 +156,65 @@ export class RemoveExtensionsCsvImportDialogComponent {
     }
   }
 
+  private async checkForConflicts(): Promise<ConflictInfo[]> {
+    const existing = await this.fetchExistingOperations();
+    const conflicts: ConflictInfo[] = [];
+
+    const csvPairs = new Set<string>();
+    for (const group of this.groups) {
+      for (const url of group.urls) {
+        csvPairs.add(`${group.resourceType}::${url}`);
+      }
+    }
+
+    for (const op of existing) {
+      const parsedOp = op.parsedOperationJson as RemoveExtensionsOperation;
+      const resourceTypes = op.operationResourceTypes
+        ?.map(rt => rt.resource?.resourceName)
+        .filter((n): n is string => !!n) ?? [];
+      const urls = parsedOp?.ExtensionUrls ?? [];
+
+      for (const rt of resourceTypes) {
+        for (const url of urls) {
+          if (csvPairs.has(`${rt}::${url}`)) {
+            conflicts.push({resourceType: rt, url});
+          }
+        }
+      }
+    }
+
+    return conflicts;
+  }
+
+  private fetchExistingOperations(): Promise<IOperationModel[]> {
+    if (!this.data.isVendorMode) {
+      return firstValueFrom(
+        this.operationService.searchGlobalOperations(
+          this.data.facilityId ?? null,
+          OperationType.RemoveExtensions,
+          null, null, null, null, null, null, 1000, 0
+        ).pipe(map(r => r.records))
+      );
+    }
+
+    if (!this.data.vendorIds?.length) return Promise.resolve([]);
+
+    return firstValueFrom(
+      forkJoin(
+        this.data.vendorIds.map(vendorId =>
+          this.operationService.searchGlobalOperations(
+            null, OperationType.RemoveExtensions,
+            null, null, null, vendorId, null, null, 1000, 0
+          ).pipe(map(r => r.records))
+        )
+      ).pipe(map(results => results.flat()))
+    );
+  }
+
   back(): void {
     this.stage = 'upload';
     this.groups = [];
+    this.conflicts = [];
     this.parseError = '';
   }
 

--- a/Web/Admin.UI/src/app/components/normalization/operations/remove-extensions/remove-extensions-csv-import-dialog/remove-extensions-csv-import-dialog.component.ts
+++ b/Web/Admin.UI/src/app/components/normalization/operations/remove-extensions/remove-extensions-csv-import-dialog/remove-extensions-csv-import-dialog.component.ts
@@ -8,7 +8,7 @@ import {OperationService} from '../../../../../services/gateway/normalization/op
 import {ISaveOperationModel} from '../../../../../interfaces/normalization/operation-save-model.interface';
 import {OperationType} from '../../../../../interfaces/normalization/operation-type-enumeration';
 import {RemoveExtensionsOperation} from '../../../../../interfaces/normalization/remove-extensions-operation-interface';
-import {firstValueFrom, forkJoin, map} from 'rxjs';
+import {firstValueFrom, map} from 'rxjs';
 import {IOperationModel} from '../../../../../interfaces/normalization/operation-get-model.interface';
 import * as Papa from 'papaparse';
 
@@ -189,29 +189,46 @@ export class RemoveExtensionsCsvImportDialogComponent {
     return conflicts;
   }
 
-  private fetchExistingOperations(): Promise<IOperationModel[]> {
+  private async fetchExistingOperations(): Promise<IOperationModel[]> {
     if (!this.data.isVendorMode) {
-      return firstValueFrom(
-        this.operationService.searchGlobalOperations(
-          this.data.facilityId ?? null,
-          OperationType.RemoveExtensions,
-          null, null, null, null, null, null, 1000, 0
-        ).pipe(map(r => r.records))
-      );
+      return this.fetchAllOperationPages(this.data.facilityId ?? null, null);
     }
 
-    if (!this.data.vendorIds?.length) return Promise.resolve([]);
+    if (!this.data.vendorIds?.length) return [];
 
-    return firstValueFrom(
-      forkJoin(
-        this.data.vendorIds.map(vendorId =>
-          this.operationService.searchGlobalOperations(
-            null, OperationType.RemoveExtensions,
-            null, null, null, vendorId, null, null, 1000, 0
-          ).pipe(map(r => r.records))
-        )
-      ).pipe(map(results => results.flat()))
+    const results = await Promise.all(
+      this.data.vendorIds.map(vendorId => this.fetchAllOperationPages(null, vendorId))
     );
+    return results.flat();
+  }
+
+  private async fetchAllOperationPages(facilityId: string | null, vendorId: string | null): Promise<IOperationModel[]> {
+    const pageSize = 1000;
+    const firstPage = await firstValueFrom(
+      this.operationService.searchGlobalOperations(
+        facilityId, OperationType.RemoveExtensions,
+        null, null, null, vendorId, null, null, pageSize, 0
+      )
+    );
+
+    const records = [...firstPage.records];
+    const totalPages = firstPage.metadata?.totalPages ?? 1;
+
+    if (totalPages > 1) {
+      const remainingPages = await Promise.all(
+        Array.from({length: totalPages - 1}, (_, i) =>
+          firstValueFrom(
+            this.operationService.searchGlobalOperations(
+              facilityId, OperationType.RemoveExtensions,
+              null, null, null, vendorId, null, null, pageSize, i + 1
+            ).pipe(map(r => r.records))
+          )
+        )
+      );
+      records.push(...remainingPages.flat());
+    }
+
+    return records;
   }
 
   back(): void {

--- a/Web/Admin.UI/src/app/components/normalization/operations/remove-extensions/remove-extensions-csv-import-dialog/remove-extensions-csv-import-dialog.component.ts
+++ b/Web/Admin.UI/src/app/components/normalization/operations/remove-extensions/remove-extensions-csv-import-dialog/remove-extensions-csv-import-dialog.component.ts
@@ -167,6 +167,7 @@ export class RemoveExtensionsCsvImportDialogComponent {
       }
     }
 
+    const matchedPairs = new Set<string>();
     for (const op of existing) {
       const parsedOp = op.parsedOperationJson as RemoveExtensionsOperation;
       const resourceTypes = op.operationResourceTypes
@@ -176,7 +177,9 @@ export class RemoveExtensionsCsvImportDialogComponent {
 
       for (const rt of resourceTypes) {
         for (const url of urls) {
-          if (csvPairs.has(`${rt}::${url}`)) {
+          const pairKey = `${rt}::${url}`;
+          if (csvPairs.has(pairKey) && !matchedPairs.has(pairKey)) {
+            matchedPairs.add(pairKey);
             conflicts.push({resourceType: rt, url});
           }
         }


### PR DESCRIPTION
### 🛠️ Description of Changes

Added a check for duplicate extension URLs during CSV import for the Remove Extensions operation.  The entire import is rejected if any resource type/extension URL pair matches an existing operation.

### 🧪 Testing Performed

Tested locally.

### 🧑‍🔬 Unit Testing

- Coverage: 0.0%

N/A (UI only)

### 📓 Documentation Updated

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * CSV imports now show a checking state while existing operations are validated.
  * Import conflicts are now detected and displayed before continuing, grouped by resource type and URL.
* **Bug Fixes**
  * Improved import flow so previously entered errors and conflicts are cleared when selecting a new file or going back.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->