### PR TITLE
LEGLINK-564: Prevent duplicate resources in ABSResourceCache.cs

### DIFF
--- a/DotNet/Shared/Application/Services/ResourceCache/ABSResourceCache.cs
+++ b/DotNet/Shared/Application/Services/ResourceCache/ABSResourceCache.cs
@@ -42,7 +42,7 @@ namespace LantanaGroup.Link.Shared.Application.Services.ResourceCache
             // This is necessary because we want to append new resources to the existing blob, 
             // and we don't want to write duplicate resource references if there are multiple 
             // resources of the same type in the same batch.
-            List<string> existingIds = new List<string>();
+            HashSet<string> existingIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             var readBlobClient = _containerClient.GetBlobClient(idsBlobName);
             if(readBlobClient.Exists())
             {
@@ -60,43 +60,40 @@ namespace LantanaGroup.Link.Shared.Application.Services.ResourceCache
                 }
             }
 
-            var idsToWrite = new List<string>();
+            var resourcesToWrite = new Dictionary<string, DomainResource>();
             foreach(var resource in resources)
             {
                 var referenceId = resource.TypeName + "/" + resource.Id;
-                if (!existingIds.Contains(referenceId, StringComparer.OrdinalIgnoreCase))
+                if (!existingIds.Contains(referenceId))
                 {
-                    idsToWrite.Add(referenceId);
+                    resourcesToWrite[referenceId] = resource;
                 }
             }
 
-            if(!idsToWrite.Any())
+            if(!resourcesToWrite.Any())
                 return;
 
             AppendBlobClient writeBlobClient = _containerClient.GetAppendBlobClient(blobName);
             AppendBlobClient writeIdsBlobClient = _containerClient.GetAppendBlobClient(idsBlobName);
             writeBlobClient.CreateIfNotExists();
             writeIdsBlobClient.CreateIfNotExists();
-
-            using (Stream ids_write_stream = writeIdsBlobClient.OpenWrite(false))
-            using (StreamWriter ids_writer = new StreamWriter(ids_write_stream))
-            {
-                foreach(var id in idsToWrite)
-                {
-                    ids_writer.WriteLine(id);
-                }
-            }
             
             using (Stream write_stream = writeBlobClient.OpenWrite(false))
             using (StreamWriter writer = new StreamWriter(write_stream)) 
             {
-                foreach (var resource in resources) 
+                foreach (var resourceToWrite in resourcesToWrite)
                 {
-                    var referenceId = resource.TypeName + "/" + resource.Id;
-                    if (existingIds.Contains(referenceId, StringComparer.OrdinalIgnoreCase))
-                        continue;
-                    writer.WriteLine(referenceId);
-                    writer.WriteLine(resource.ToJson());
+                    writer.WriteLine(resourceToWrite.Key);
+                    writer.WriteLine(resourceToWrite.Value.ToJson());
+                }
+            }
+
+            using (Stream ids_write_stream = writeIdsBlobClient.OpenWrite(false))
+            using (StreamWriter ids_writer = new StreamWriter(ids_write_stream))
+            {
+                foreach(var id in resourcesToWrite.Keys)
+                {
+                    ids_writer.WriteLine(id);
                 }
             }
         }

--- a/DotNet/Shared/Application/Services/ResourceCache/ABSResourceCache.cs
+++ b/DotNet/Shared/Application/Services/ResourceCache/ABSResourceCache.cs
@@ -30,19 +30,72 @@ namespace LantanaGroup.Link.Shared.Application.Services.ResourceCache
         private string GetBlobKey(string key) =>
             string.IsNullOrEmpty(_settings.BlobRoot) ? key : $"{_settings.BlobRoot}/{key}";
 
+        private string GetBlobIdsKey(string key) =>
+            GetBlobKey(key) + "_ids";
+
         public void UpdateCorrelationCache(string correlationId, List<DomainResource> resources, ResourceType resourceType)
         {
             string blobName = GetBlobKey(correlationId);
+            string idsBlobName = GetBlobIdsKey(correlationId);
+            
+            //First read the existing blob to get the list of resource references that are already in the cache. 
+            // This is necessary because we want to append new resources to the existing blob, 
+            // and we don't want to write duplicate resource references if there are multiple 
+            // resources of the same type in the same batch.
+            List<string> existingIds = new List<string>();
+            var readBlobClient = _containerClient.GetBlobClient(idsBlobName);
+            if(readBlobClient.Exists())
+            {
+                using (Stream read_stream = readBlobClient.OpenRead())
+                using (StreamReader reader = new StreamReader(read_stream))
+                {
+                    while (reader.Peek() >= 0)
+                    {
+                        string? id = reader.ReadLine();
+                        if(!string.IsNullOrEmpty(id))
+                        {
+                            existingIds.Add(id);
+                        }
+                    }
+                }
+            }
+
+            var idsToWrite = new List<string>();
+            foreach(var resource in resources)
+            {
+                var referenceId = resource.TypeName + "/" + resource.Id;
+                if (!existingIds.Contains(referenceId, StringComparer.OrdinalIgnoreCase))
+                {
+                    idsToWrite.Add(referenceId);
+                }
+            }
+
+            if(!idsToWrite.Any())
+                return;
 
             AppendBlobClient writeBlobClient = _containerClient.GetAppendBlobClient(blobName);
+            AppendBlobClient writeIdsBlobClient = _containerClient.GetAppendBlobClient(idsBlobName);
             writeBlobClient.CreateIfNotExists();
+            writeIdsBlobClient.CreateIfNotExists();
 
+            using (Stream ids_write_stream = writeIdsBlobClient.OpenWrite(false))
+            using (StreamWriter ids_writer = new StreamWriter(ids_write_stream))
+            {
+                foreach(var id in idsToWrite)
+                {
+                    ids_writer.WriteLine(id);
+                }
+            }
+            
             using (Stream write_stream = writeBlobClient.OpenWrite(false))
             using (StreamWriter writer = new StreamWriter(write_stream)) 
             {
                 foreach (var resource in resources) 
                 {
-                    writer.WriteLine(resource.TypeName + "/" + resource.Id);
+                    var referenceId = resource.TypeName + "/" + resource.Id;
+                    if (existingIds.Contains(referenceId, StringComparer.OrdinalIgnoreCase))
+                        continue;
+                    writer.WriteLine(referenceId);
                     writer.WriteLine(resource.ToJson());
                 }
             }
@@ -155,6 +208,7 @@ namespace LantanaGroup.Link.Shared.Application.Services.ResourceCache
             foreach (var cacheKey in cacheKeys)
             {
                 _containerClient.DeleteBlobIfExists(GetBlobKey(cacheKey));
+                _containerClient.DeleteBlobIfExists(GetBlobIdsKey(cacheKey));
             }
         }
     }


### PR DESCRIPTION
### 🛠️ Description of Changes

Update ABSResourceCache so that it does not allow for duplicate resources. This brings it in line with the RedisResourceCache functionality.

Introduce a separate "_ids" append-blob to track written resource references and avoid duplicate entries when appending resources. Added GetBlobIdsKey helper, logic to read existing IDs (case-insensitive), compute new IDs to write, early-return when nothing to append, and write both IDs and resource JSON to their respective append blobs (CreateIfNotExists used). Also ensure the IDs blob is deleted when clearing cache keys. This prevents duplicate resource references when multiple resources of the same type appear in the same batch.

### 🧪 Testing Performed

Checked for regressions with unit tests and integration tests.

### 🧑‍🔬 Unit Testing

- [ ] I have written or updated unit tests to cover my changes
- Coverage: 72.4%

### 📓 Documentation Updated

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved cache updates to avoid storing duplicate resource references.
  - Cache deletions now fully remove related cached data, preventing leftover entries.
  - Reduced unnecessary writes when no new cache items are added.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
