### PR TITLE
TECH_DEBT: Guard OCE catch blocks

### DIFF
--- a/DotNet/Census/Listeners/CernerPatientsAcquiredListener.cs
+++ b/DotNet/Census/Listeners/CernerPatientsAcquiredListener.cs
@@ -79,7 +79,7 @@ namespace LantanaGroup.Link.Census.Listeners
                             {
                                 _transientExceptionHandler.HandleException(result, ex, facilityId);
                             }
-                            catch (OperationCanceledException)
+                            catch (OperationCanceledException) when (consumeCancellationToken.IsCancellationRequested)
                             {
                                 throw;
                             }
@@ -108,7 +108,7 @@ namespace LantanaGroup.Link.Census.Listeners
                         var offset = ex.ConsumerRecord?.TopicPartitionOffset;
                         consumer.Commit(offset == null ? new List<TopicPartitionOffset>() : new List<TopicPartitionOffset> { offset });
                     }
-                    catch (OperationCanceledException)
+                    catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
                     {
                         throw;
                     }

--- a/DotNet/Census/Listeners/CernerPatientsAcquiredListener.cs
+++ b/DotNet/Census/Listeners/CernerPatientsAcquiredListener.cs
@@ -83,6 +83,10 @@ namespace LantanaGroup.Link.Census.Listeners
                             {
                                 throw;
                             }
+                            catch (OperationCanceledException ex)
+                            {
+                                _transientExceptionHandler.HandleException(result, new TransientException("Operation canceled (non-shutdown): " + ex.Message, ex), facilityId);
+                            }
                             catch (Exception ex)
                             {
                                 _deadLetterExceptionHandler.HandleException(result, new DeadLetterException(ClassName + " Exception thrown: " + ex.Message), facilityId);

--- a/DotNet/Census/Listeners/PatientListsAcquiredListener.cs
+++ b/DotNet/Census/Listeners/PatientListsAcquiredListener.cs
@@ -158,7 +158,7 @@ public class PatientListsAcquiredListener : BackgroundService
                             _transientExceptionHandler.Topic = rawmessage?.Topic + "-Retry";
                             _transientExceptionHandler.HandleException(rawmessage, ex, rawmessage.Key);
                         }
-                        catch (OperationCanceledException)
+                        catch (OperationCanceledException) when (consumeCancellationToken.IsCancellationRequested)
                         {
                             throw;
                         }
@@ -191,7 +191,7 @@ public class PatientListsAcquiredListener : BackgroundService
                     var offset = ex.ConsumerRecord?.TopicPartitionOffset;
                     kafkaConsumer.Commit(offset == null ? new List<TopicPartitionOffset>() : new List<TopicPartitionOffset> { offset });
                 }
-                catch (OperationCanceledException)
+                catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
                 {
                     throw;
                 }

--- a/DotNet/Normalization/Listeners/ResourcesAcquiredListener.cs
+++ b/DotNet/Normalization/Listeners/ResourcesAcquiredListener.cs
@@ -123,7 +123,7 @@ public class ResourcesAcquiredListener : BackgroundService
                     {
                         _transientExceptionHandler.HandleException(result, ex, result.Message.Key?.FacilityId ?? string.Empty);
                     }
-                    catch (OperationCanceledException)
+                    catch (OperationCanceledException) when (consumeCancellationToken.IsCancellationRequested)
                     {
                         throw;
                     }

--- a/DotNet/QueryDispatch/Domain/Managers/PatientDispatchManager.cs
+++ b/DotNet/QueryDispatch/Domain/Managers/PatientDispatchManager.cs
@@ -74,7 +74,7 @@ namespace QueryDispatch.Domain.Managers
 
                 return patientDispatch.FacilityId;
             }
-            catch (OperationCanceledException)
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
             {
                 throw;
             }

--- a/DotNet/QueryDispatch/Listeners/PatientEventListener.cs
+++ b/DotNet/QueryDispatch/Listeners/PatientEventListener.cs
@@ -166,7 +166,7 @@ namespace LantanaGroup.Link.QueryDispatch.Listeners
                                     _transientExceptionHandler.HandleException(consumeResult, ex, HtmlInputSanitizer.Sanitize(consumeResult.Key));
                                     _patientEventConsumer.Commit(consumeResult);
                                 }
-                                catch (OperationCanceledException)
+                                catch (OperationCanceledException) when (consumeCancellationToken.IsCancellationRequested)
                                 {
                                     throw;
                                 }

--- a/DotNet/QueryDispatch/Listeners/ReportScheduledEventListener.cs
+++ b/DotNet/QueryDispatch/Listeners/ReportScheduledEventListener.cs
@@ -128,7 +128,7 @@ namespace LantanaGroup.Link.QueryDispatch.Listeners
                                     _deadLetterExceptionHandler.HandleException(consumeResult, ex, consumeResult.Key);
                                     _reportScheduledConsumer.Commit(consumeResult);
                                 }
-                                catch (OperationCanceledException)
+                                catch (OperationCanceledException) when (consumeCancellationToken.IsCancellationRequested)
                                 {
                                     throw;
                                 }

--- a/DotNet/Report/Listeners/GenerateReportListener.cs
+++ b/DotNet/Report/Listeners/GenerateReportListener.cs
@@ -387,7 +387,7 @@ namespace LantanaGroup.Link.Report.Listeners
                 var transientException = new TransientException(exceptionMessage, ex);
                 _transientExceptionHandler.HandleException(result, transientException, facilityId);
             }
-            catch (OperationCanceledException)
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
             {
                 throw;
             }

--- a/DotNet/Report/Listeners/MeasureReportGeneratedListener.cs
+++ b/DotNet/Report/Listeners/MeasureReportGeneratedListener.cs
@@ -99,7 +99,7 @@ namespace LantanaGroup.Link.Report.Listeners
                             {
                                 _transientExceptionHandler.HandleException(result, ex, facilityId);
                             }
-                            catch (OperationCanceledException)
+                            catch (OperationCanceledException) when (consumeCancellationToken.IsCancellationRequested)
                             {
                                 throw;
                             }

--- a/DotNet/Report/Listeners/PatientEventListener.cs
+++ b/DotNet/Report/Listeners/PatientEventListener.cs
@@ -214,7 +214,7 @@ namespace LantanaGroup.Link.Report.Listeners
             {
                 _transientExceptionHandler.HandleException(result, ex, facilityId);
             }
-            catch (OperationCanceledException)
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
             {
                 throw;
             }

--- a/DotNet/Report/Listeners/PayloadSubmittedListener.cs
+++ b/DotNet/Report/Listeners/PayloadSubmittedListener.cs
@@ -156,7 +156,7 @@ public class PayloadSubmittedListener(
             var transientException = new TransientException(exceptionMessage, ex);
             transientExceptionHandler.HandleException(result, transientException, facilityId);
         }
-        catch (OperationCanceledException)
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
             throw;
         }

--- a/DotNet/Report/Listeners/ReportScheduledListener.cs
+++ b/DotNet/Report/Listeners/ReportScheduledListener.cs
@@ -203,7 +203,7 @@ namespace LantanaGroup.Link.Report.Listeners
                 var transientException = new TransientException(exceptionMessage, ex);
                 _transientExceptionHandler.HandleException(result, transientException, facilityId);
             }
-            catch (OperationCanceledException)
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
             {
                 throw;
             }

--- a/DotNet/Report/Listeners/ValidationCompleteListener.cs
+++ b/DotNet/Report/Listeners/ValidationCompleteListener.cs
@@ -114,7 +114,7 @@ namespace LantanaGroup.Link.Report.Listeners
                                 _transientExceptionHandler.HandleException(result, transientException, facilityId);
                                 consumer.SafeCommit(result, _logger);
                             }
-                            catch (OperationCanceledException)
+                            catch (OperationCanceledException) when (consumeCancellationToken.IsCancellationRequested)
                             {
                                 throw;
                             }

--- a/DotNet/Shared/Application/BaseListener.cs
+++ b/DotNet/Shared/Application/BaseListener.cs
@@ -86,7 +86,7 @@ public abstract class BaseListener<MessageType, ConsumeKeyType, ConsumeValueType
                         {
                             TransientExceptionHandler.HandleException(consumeResult, ex, ExtractFacilityId(consumeResult));
                         }
-                        catch (OperationCanceledException)
+                        catch (OperationCanceledException) when (consumeCancellationToken.IsCancellationRequested)
                         {
                             throw;
                         }

--- a/DotNet/Shared/Application/Listeners/RetryListener.cs
+++ b/DotNet/Shared/Application/Listeners/RetryListener.cs
@@ -121,7 +121,7 @@ namespace LantanaGroup.Link.Shared.Application.Listeners
                                 _deadLetterExceptionHandler.Topic = consumeResult.Topic.Replace("-Retry", "-Error");
                                 _deadLetterExceptionHandler.HandleException(consumeResult, ex, facilityId);
                             }
-                            catch (OperationCanceledException)
+                            catch (OperationCanceledException) when (consumeCancellationToken.IsCancellationRequested)
                             {
                                 throw;
                             }

--- a/DotNet/Submission/Listeners/SubmitPayloadListener.cs
+++ b/DotNet/Submission/Listeners/SubmitPayloadListener.cs
@@ -179,7 +179,7 @@ namespace LantanaGroup.Link.Submission.Listeners
                     {
                         content = await _blobStorageService.DownloadFromInternalAsync(value, cancellationToken);
                     }
-                    catch (OperationCanceledException)
+                    catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
                     {
                         throw;
                     }
@@ -206,7 +206,7 @@ namespace LantanaGroup.Link.Submission.Listeners
                     _metrics.RecordUploadSize(content.LongLength, metricTags);
                     uploaded = true;
                 }
-                catch (OperationCanceledException)
+                catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
                 {
                     throw;
                 }
@@ -236,7 +236,7 @@ namespace LantanaGroup.Link.Submission.Listeners
             {
                 _deadLetterExceptionHandler.HandleException(result, ex, facilityId!);
             }
-            catch (OperationCanceledException)
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
             {
                 throw;
             }


### PR DESCRIPTION
### 🛠️ Description of Changes

When catching `OperationCanceledException` for rethrow, ensure that the "active" cancellation token is canceled.  I.e., catch/rethrow on service shutdown *only*, not in other circumstances where OCE is thrown (e.g., HTTP client timeouts).

### 🧪 Testing Performed

N/A

### 🧑‍🔬 Unit Testing

- Coverage: 0.0%

N/A

### 📓 Documentation Updated

N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cancellation handling across background listeners, message consumers, and report/payload processing.
  * Cancellation-related exceptions are now rethrown only when the relevant cancellation token is actually signaled, instead of being treated uniformly.
  * Non-requested cancellation scenarios now follow the standard error handling flow, improving behavior for transient failures, retries, and dead-letter routing.
  * Listener shutdown and per-message cancellation behave more consistently, reducing unintended interruption during processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
