### PR TITLE
LEGLINK-470: Parse CodeSystem CSV status column case-insensitively

### DIFF
--- a/DotNet/ServiceTests/UnitTests/Terminology/Services/CodeGroupCacheServiceTests.cs
+++ b/DotNet/ServiceTests/UnitTests/Terminology/Services/CodeGroupCacheServiceTests.cs
@@ -502,6 +502,48 @@ http://test.system,123,Test Display,Extra Value";
         Assert.All(codes, code => Assert.Equal(CodeStatus.Active, ((CodeSystemCode)code).Status));
     }
 
+    [Fact]
+    public async Task LoadCache_MixedCaseStatus_ParsesCaseInsensitively()
+    {
+        // Use a real memory cache and the real service (only the file-system seams are
+        // overridden) so LoadCache/ProcessCodeSystemCsv/SetCodeGroup are all exercised.
+        using var memoryCache = new MemoryCache(new MemoryCacheOptions());
+        var mockConfig = new Mock<IOptions<TerminologyConfig>>();
+        mockConfig.Setup(x => x.Value).Returns(_config);
+
+        var directoryFiles = new Dictionary<string, string[]>
+        {
+            ["/test/path/cs"] = new[] { "cs.json", "cs.csv" }
+        };
+        var fileContents = new Dictionary<string, string>
+        {
+            ["cs.json"] = "{ \"resourceType\": \"CodeSystem\", \"id\": \"test-cs\", " +
+                          "\"url\": \"http://test.codesystem\", \"version\": \"1.0\" }",
+            // Status values in varied casing must all parse and canonicalize to the enum.
+            ["cs.csv"] = "code,display,status\r\n" +
+                         "123,Test Display,active\r\n" +
+                         "456,Another Display,INACTIVE\r\n" +
+                         "789,Third Display,Inactive\r\n"
+        };
+
+        var service = new TestableCodeGroupCacheService(
+            _loggerMock.Object, memoryCache, mockConfig.Object, directoryFiles, fileContents);
+
+        // Act
+        await service.LoadCache();
+
+        // Assert - lowercase/uppercase/mixed-case status all load and normalize correctly.
+        var codeGroup = service.GetCodeGroup(
+            CodeGroup.CodeGroupTypes.CodeSystem, "http://test.codesystem");
+
+        Assert.NotNull(codeGroup);
+        var codes = codeGroup.Codes["http://test.codesystem"];
+        Assert.Equal(3, codes.Count);
+        Assert.Equal(CodeStatus.Active, ((CodeSystemCode)codes[0]).Status);
+        Assert.Equal(CodeStatus.Inactive, ((CodeSystemCode)codes[1]).Status);
+        Assert.Equal(CodeStatus.Inactive, ((CodeSystemCode)codes[2]).Status);
+    }
+
     /// <summary>
     /// Real <see cref="CodeGroupCacheService"/> with only the file-system seams overridden,
     /// so LoadCache and everything it calls run against the actual implementation.

--- a/DotNet/Terminology/Application/Models/CsvCodeSystemRecord.cs
+++ b/DotNet/Terminology/Application/Models/CsvCodeSystemRecord.cs
@@ -35,5 +35,6 @@ public class CsvCodeSystemRecord
     /// </summary>
     [Index(2)]
     [Default(CodeStatus.Active)]
+    [EnumIgnoreCase]
     public CodeStatus Status { get; set; } = CodeStatus.Active;
 }


### PR DESCRIPTION
### 🛠️ Description of Changes

Makes the Terminology service parse the optional `status` column in CodeSystem CSVs case-insensitively so mixed-case values load correctly instead of silently failing.

- Add `[EnumIgnoreCase]` to `CsvCodeSystemRecord.Status` (`DotNet/Terminology/Application/Models/CsvCodeSystemRecord.cs`). CsvHelper's default `EnumConverter` is case-sensitive, so only exact `Active`/`Inactive` parsed; any other casing (`active`, `ACTIVE`, `inactive`, `INACTIVE`) threw a `TypeConverterException` that was swallowed by the per-directory `try/catch` in `CodeGroupCacheService.LoadCache`, causing the **entire code group for that CSV to silently fail to load** at startup.
- With the fix, any casing parses and canonicalizes to the `CodeStatus` enum. Because the value is stored as the enum and serialized via `JsonStringEnumConverter`, the cached-code lookup endpoint `GET /api/terminology/config/code-systems/{id}/codes/{code}` now always returns `"Active"`/`"Inactive"` regardless of CSV casing — no endpoint change needed.
- Add `LoadCache_MixedCaseStatus_ParsesCaseInsensitively` regression test covering lowercase/uppercase/mixed-case status values.

### 🧪 Testing Performed

- `dotnet test DotNet/ServiceTests/ServiceTests.csproj --filter FullyQualifiedName~Terminology` → **27 passed, 0 failed**. The new mixed-case test passes and the three existing status tests (`LoadCache_PopulatesCacheWithRetrievableCodeSystem`, `LoadCache_BlankStatus_DefaultsToActive`, `LoadCache_NoStatusColumn_AllRowsDefaultToActive`) still pass — no regression.
- Reproduces the QA-reported failure (TestRail 10373/10374): a CSV whose status column uses lowercase/mixed case now imports successfully rather than dropping the whole code group.

### 🧑‍🔬 Unit Testing

- Coverage: 0.0%

- [x] Added `LoadCache_MixedCaseStatus_ParsesCaseInsensitively` verifying `active` → `Active`, `INACTIVE` → `Inactive`, `Inactive` → `Inactive` through the real `LoadCache`/`ProcessCodeSystemCsv` path.

### 📓 Documentation Updated

No documentation changes required


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * CSV status values are now parsed case-insensitively, so mixed-case entries are handled correctly during import.
  * Cache loading now consistently normalizes status values to the expected active/inactive values, even across multiple records.

* **Tests**
  * Added coverage for mixed-case status parsing to verify cache behavior with real data inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
