### PR TITLE
LEGLINK-591: Return Problem Details for cached CodeSystem code lookup edge cases

### DIFF
--- a/DotNet/ServiceTests/UnitTests/Terminology/Controllers/ConfigControllerTests.cs
+++ b/DotNet/ServiceTests/UnitTests/Terminology/Controllers/ConfigControllerTests.cs
@@ -1,0 +1,180 @@
+using LantanaGroup.Link.Terminology.Application.Models;
+using LantanaGroup.Link.Terminology.Application.Settings;
+using LantanaGroup.Link.Terminology.Controllers;
+using LantanaGroup.Link.Terminology.Services;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+using Code = LantanaGroup.Link.Terminology.Application.Models.Code;
+
+namespace UnitTests.Terminology;
+
+/// <summary>
+/// Unit tests for <see cref="ConfigController.GetCodeSystemCode"/> (LEGLINK-591), which returns
+/// RFC 7807/9457 Problem Details for its validation and not-found edge cases instead of bare
+/// status codes with plain-string bodies.
+/// </summary>
+/// <remarks>
+/// No <see cref="Microsoft.AspNetCore.Http.HttpContext"/> is wired up: when the controller's
+/// <see cref="Microsoft.AspNetCore.Mvc.Infrastructure.ProblemDetailsFactory"/> is null (the
+/// unit-testing scenario), <c>ControllerBase.Problem</c>/<c>ValidationProblem</c> build a plain
+/// <see cref="ProblemDetails"/>/<see cref="ValidationProblemDetails"/> from their arguments, so the
+/// results can be asserted directly. The runtime <c>traceId</c> is injected by the app's configured
+/// <c>ProblemDetailsFactory</c> and is therefore out of scope for these tests.
+/// </remarks>
+public class ConfigControllerTests
+{
+    private readonly Mock<CodeGroupCacheService> _mockCacheService;
+    private readonly ConfigController _controller;
+
+    private const string CodeSystemId = "v3-ActCode";
+    private const string SystemUri = "http://terminology.hl7.org/CodeSystem/v3-ActCode";
+
+    public ConfigControllerTests()
+    {
+        var mockCacheLogger = new Mock<ILogger<CodeGroupCacheService>>();
+        var mockCache = new Mock<IMemoryCache>();
+        var mockConfig = new Mock<IOptions<TerminologyConfig>>();
+        mockConfig.Setup(x => x.Value).Returns(new TerminologyConfig { Path = "/test/path" });
+
+        // GetCodeGroupById is virtual, so the concrete service can be mocked directly.
+        _mockCacheService = new Mock<CodeGroupCacheService>(
+            mockCacheLogger.Object, mockCache.Object, mockConfig.Object);
+
+        _controller = new ConfigController(_mockCacheService.Object, Mock.Of<ILogger<ConfigController>>());
+    }
+
+    private static CodeGroup CodeSystemWithCodes(params Code[] codes) => new()
+    {
+        Type = CodeGroup.CodeGroupTypes.CodeSystem,
+        Id = CodeSystemId,
+        Url = SystemUri,
+        Version = "1.0",
+        Codes = new Dictionary<string, List<Code>> { [SystemUri] = codes.ToList() }
+    };
+
+    [Fact]
+    public void GetCodeSystemCode_MissingId_ReturnsValidationProblemWithIdError()
+    {
+        var result = _controller.GetCodeSystemCode(" ", "12345");
+
+        var objectResult = Assert.IsAssignableFrom<ObjectResult>(result.Result);
+        Assert.Equal(StatusCodes.Status400BadRequest, objectResult.StatusCode);
+
+        var problem = Assert.IsAssignableFrom<ValidationProblemDetails>(objectResult.Value);
+        Assert.Equal("Bad Request", problem.Title);
+        Assert.Equal("https://datatracker.ietf.org/doc/html/rfc9457#section-3", problem.Type);
+        Assert.Contains("id", problem.Errors.Keys);
+    }
+
+    [Fact]
+    public void GetCodeSystemCode_MissingCode_ReturnsValidationProblemWithCodeError()
+    {
+        var result = _controller.GetCodeSystemCode(CodeSystemId, " ");
+
+        var objectResult = Assert.IsAssignableFrom<ObjectResult>(result.Result);
+        Assert.Equal(StatusCodes.Status400BadRequest, objectResult.StatusCode);
+
+        var problem = Assert.IsAssignableFrom<ValidationProblemDetails>(objectResult.Value);
+        Assert.Contains("code", problem.Errors.Keys);
+    }
+
+    [Fact]
+    public void GetCodeSystemCode_MissingIdAndCode_ReturnsValidationProblemWithBothErrors()
+    {
+        // Both errors are accumulated into ModelState before returning, rather than
+        // short-circuiting on the first missing value.
+        var result = _controller.GetCodeSystemCode(" ", " ");
+
+        var problem = Assert.IsAssignableFrom<ValidationProblemDetails>(
+            Assert.IsAssignableFrom<ObjectResult>(result.Result).Value);
+        Assert.Contains("id", problem.Errors.Keys);
+        Assert.Contains("code", problem.Errors.Keys);
+
+        // Not-found lookups must never run when the request itself is invalid.
+        _mockCacheService.Verify(
+            x => x.GetCodeGroupById(It.IsAny<CodeGroup.CodeGroupTypes>(), It.IsAny<string>(), It.IsAny<string?>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public void GetCodeSystemCode_CodeSystemNotFound_Returns404ProblemDetails()
+    {
+        _mockCacheService
+            .Setup(x => x.GetCodeGroupById(CodeGroup.CodeGroupTypes.CodeSystem, CodeSystemId, null))
+            .Returns((CodeGroup?)null);
+
+        var result = _controller.GetCodeSystemCode(CodeSystemId, "12345");
+
+        var objectResult = Assert.IsAssignableFrom<ObjectResult>(result.Result);
+        Assert.Equal(StatusCodes.Status404NotFound, objectResult.StatusCode);
+
+        var problem = Assert.IsAssignableFrom<ProblemDetails>(objectResult.Value);
+        Assert.Equal("CodeSystem Not Found", problem.Title);
+        Assert.Equal("https://tools.ietf.org/html/rfc9110#section-15.5.5", problem.Type);
+        Assert.Contains(CodeSystemId, problem.Detail);
+        Assert.Contains("latest", problem.Detail);
+    }
+
+    [Fact]
+    public void GetCodeSystemCode_CodeSystemNotFoundWithVersion_DetailIncludesVersion()
+    {
+        _mockCacheService
+            .Setup(x => x.GetCodeGroupById(CodeGroup.CodeGroupTypes.CodeSystem, CodeSystemId, "2.0"))
+            .Returns((CodeGroup?)null);
+
+        var result = _controller.GetCodeSystemCode(CodeSystemId, "12345", "2.0");
+
+        var objectResult = Assert.IsAssignableFrom<ObjectResult>(result.Result);
+        Assert.Equal(StatusCodes.Status404NotFound, objectResult.StatusCode);
+
+        var problem = Assert.IsAssignableFrom<ProblemDetails>(objectResult.Value);
+        Assert.Contains("2.0", problem.Detail);
+
+        // The requested version must be forwarded to the cache lookup.
+        _mockCacheService.Verify(
+            x => x.GetCodeGroupById(CodeGroup.CodeGroupTypes.CodeSystem, CodeSystemId, "2.0"),
+            Times.Once);
+    }
+
+    [Fact]
+    public void GetCodeSystemCode_CodeNotFoundInCodeSystem_Returns404ProblemDetails()
+    {
+        var codeGroup = CodeSystemWithCodes(new Code { Value = "99999", Display = "Something else" });
+        _mockCacheService
+            .Setup(x => x.GetCodeGroupById(CodeGroup.CodeGroupTypes.CodeSystem, CodeSystemId, null))
+            .Returns(codeGroup);
+
+        var result = _controller.GetCodeSystemCode(CodeSystemId, "12345");
+
+        var objectResult = Assert.IsAssignableFrom<ObjectResult>(result.Result);
+        Assert.Equal(StatusCodes.Status404NotFound, objectResult.StatusCode);
+
+        var problem = Assert.IsAssignableFrom<ProblemDetails>(objectResult.Value);
+        Assert.Equal("Code Not Found", problem.Title);
+        Assert.Equal("https://tools.ietf.org/html/rfc9110#section-15.5.5", problem.Type);
+        Assert.Contains("12345", problem.Detail);
+    }
+
+    [Fact]
+    public void GetCodeSystemCode_Match_ReturnsOkWithCode()
+    {
+        var expected = new Code { Value = "12345", Display = "Matching code" };
+        var codeGroup = CodeSystemWithCodes(
+            new Code { Value = "99999", Display = "Something else" }, expected);
+        _mockCacheService
+            .Setup(x => x.GetCodeGroupById(CodeGroup.CodeGroupTypes.CodeSystem, CodeSystemId, null))
+            .Returns(codeGroup);
+
+        var result = _controller.GetCodeSystemCode(CodeSystemId, "12345");
+
+        var ok = Assert.IsType<OkObjectResult>(result.Result);
+        var code = Assert.IsType<Code>(ok.Value);
+        Assert.Equal("12345", code.Value);
+        Assert.Equal("Matching code", code.Display);
+    }
+}

--- a/DotNet/Terminology/Controllers/ConfigController.cs
+++ b/DotNet/Terminology/Controllers/ConfigController.cs
@@ -1,4 +1,5 @@
-﻿using LantanaGroup.Link.Shared.Application.Services.Security;
+﻿using System.Net;
+using LantanaGroup.Link.Shared.Application.Services.Security;
 using LantanaGroup.Link.Terminology.Application.Models;
 using LantanaGroup.Link.Terminology.Services;
 using Microsoft.AspNetCore.Mvc;
@@ -51,25 +52,52 @@ public class ConfigController(CodeGroupCacheService cacheService, ILogger<Config
     {
         var cleanId = id?.Sanitize();
         var cleanCode = code?.Sanitize();
+
         // Treat a blank/whitespace-only ?version= the same as omitting it (null == latest version).
         var cleanVersion = string.IsNullOrWhiteSpace(version) ? null : version.Sanitize();
 
         if (string.IsNullOrWhiteSpace(cleanId))
-            return BadRequest("A CodeSystem 'id' is required.");
+        {
+            ModelState.AddModelError("id", "A CodeSystem 'id' is required.");
+        }
 
         if (string.IsNullOrWhiteSpace(cleanCode))
-            return BadRequest("A 'code' is required.");
+        {
+            ModelState.AddModelError("code","A 'code' is required.");
+        }
+
+        if (!ModelState.IsValid)
+        {
+            return ValidationProblem(
+                title: "Bad Request",
+                type: "https://datatracker.ietf.org/doc/html/rfc9457#section-3",
+                detail: "One or more parameters were invalid.",
+                statusCode: (int)HttpStatusCode.BadRequest,
+                modelStateDictionary: ModelState);
+        }
 
         var codeGroup = cacheService.GetCodeGroupById(CodeGroup.CodeGroupTypes.CodeSystem, cleanId, cleanVersion);
         if (codeGroup == null)
-            return NotFound($"No CodeSystem found in the cache with id '{cleanId}'.");
+        {
+            return Problem(
+                detail: $"No CodeSystem found in the cache with id '{cleanId}' and version '{cleanVersion ?? "latest"}'.",
+                statusCode: StatusCodes.Status404NotFound,
+                title: "CodeSystem Not Found",
+                type: "https://tools.ietf.org/html/rfc9110#section-15.5.5");
+        }
 
         var match = codeGroup.Codes.Values
             .SelectMany(codes => codes)
             .FirstOrDefault(c => string.Equals(c.Value, cleanCode, StringComparison.Ordinal));
 
         if (match == null)
-            return NotFound($"Code '{cleanCode}' was not found in CodeSystem '{cleanId}'.");
+        {
+            return Problem(
+                detail: $"Code '{cleanCode}' was not found in CodeSystem '{cleanId}'.",
+                statusCode: StatusCodes.Status404NotFound,
+                title: "Code Not Found",
+                type: "https://tools.ietf.org/html/rfc9110#section-15.5.5");
+        }
 
         return Ok(match);
     }


### PR DESCRIPTION
### 🛠️ Description of Changes

Fixes LEGLINK-591: the cached-CodeSystem code lookup endpoint (`GET /api/terminology/config/code-systems/{id}/codes/{code}`) returned bare status codes with plain-string bodies for its validation and not-found edge cases. This reworks `ConfigController.GetCodeSystemCode` to return RFC 7807/9457 Problem Details instead, so every error response carries a structured body (and a `traceId` injected by the shared `ProblemDetailsFactory` / `AddProblemDetailsService`).

- Missing `id` and/or `code` now accumulate into `ModelState` and return a single **400** `ValidationProblem` carrying **both** errors (rather than short-circuiting on the first, and rather than a bare `BadRequest("...")`).
- "CodeSystem not found" and "Code not found" now return **404** Problem Details (`title`, `detail`, `type`) instead of `NotFound("...")`. The CodeSystem-not-found detail reports the requested version (or `"latest"` when omitted).

### 🧪 Testing Performed

- Added `ConfigControllerTests` (7 tests) — run via `dotnet test DotNet/ServiceTests/ServiceTests.csproj --filter FullyQualifiedName~UnitTests.Terminology.ConfigControllerTests`; all pass.
  - Covers: missing `id`, missing `code`, missing both (asserts both errors present and that no cache lookup runs), CodeSystem-not-found and Code-not-found (status/title/type/detail), version forwarded to the cache lookup, and the happy path returning `200` with the matching code.

### 🧑‍🔬 Unit Testing

- [x] I have written or updated unit tests to cover my changes
- Coverage: 100.0%

### 📓 Documentation Updated

No documentation changes required.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error responses when `id` or `code` is missing, returning standardized validation details instead of plain messages.
  * Added clearer 404 responses when a code system or code can’t be found, with more helpful titles and details.
  * Kept blank `version` values treated as “latest” while preserving successful lookup behavior.

* **Tests**
  * Added coverage for missing inputs, not-found cases, version handling, and successful code matches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->