### PR TITLE
LEGLINK-600: Resolve versioned canonical URLs in terminology code-group lookup

### DIFF
--- a/DotNet/ServiceTests/UnitTests/Terminology/Services/CodeGroupCacheServiceTests.cs
+++ b/DotNet/ServiceTests/UnitTests/Terminology/Services/CodeGroupCacheServiceTests.cs
@@ -423,6 +423,40 @@ http://test.system,123,Test Display,Extra Value";
         Assert.Equal(CodeStatus.Inactive, ((CodeSystemCode)codes[1]).Status);
     }
 
+    [Theory]
+    [InlineData("http://test.codesystem")]        // no version
+    [InlineData("http://test.codesystem|1.0")]    // exact version suffix
+    [InlineData("http://test.codesystem|9.9")]    // unknown version -> falls back to latest loaded
+    public async Task GetCodeGroup_ResolvesCanonicalUrlWithVersionSuffix(string lookupUrl)
+    {
+        // HAPI sends versioned canonical URLs (e.g. ".../identifier-use|4.0.1"); the version
+        // suffix must not prevent the URL from resolving to the cached code group.
+        using var memoryCache = new MemoryCache(new MemoryCacheOptions());
+        var mockConfig = new Mock<IOptions<TerminologyConfig>>();
+        mockConfig.Setup(x => x.Value).Returns(_config);
+
+        var directoryFiles = new Dictionary<string, string[]>
+        {
+            ["/test/path/cs"] = new[] { "cs.json", "cs.csv" }
+        };
+        var fileContents = new Dictionary<string, string>
+        {
+            ["cs.json"] = "{ \"resourceType\": \"CodeSystem\", \"id\": \"test-cs\", " +
+                          "\"url\": \"http://test.codesystem\", \"version\": \"1.0\" }",
+            ["cs.csv"] = "code,display,status\r\n123,Test Display,Active\r\n"
+        };
+
+        var service = new TestableCodeGroupCacheService(
+            _loggerMock.Object, memoryCache, mockConfig.Object, directoryFiles, fileContents);
+        await service.LoadCache();
+
+        var codeGroup = service.GetCodeGroup(CodeGroup.CodeGroupTypes.CodeSystem, lookupUrl);
+
+        Assert.NotNull(codeGroup);
+        Assert.Equal("http://test.codesystem", codeGroup.Url);
+        Assert.Equal("1.0", codeGroup.Version);
+    }
+
     [Fact]
     public async Task LoadCache_BlankStatus_DefaultsToActive()
     {

--- a/DotNet/Terminology/Services/CodeGroupCacheService.cs
+++ b/DotNet/Terminology/Services/CodeGroupCacheService.cs
@@ -84,41 +84,36 @@ public class CodeGroupCacheService(
     /// <returns>The requested code group if it exists in the cache; otherwise, null.</returns>
     public CodeGroup? GetCodeGroup(CodeGroup.CodeGroupTypes type, string identifier, string? version = null)
     {
-        CacheKey? key = null;
-
-        if (version == null)
+        // A canonical URL may carry a version suffix, e.g. "http://example.org/ValueSet/x|4.0.1".
+        // Split it off so the URL matches the cached (unversioned) key, and treat the embedded
+        // version as the requested version when one was not supplied explicitly.
+        var pipeIndex = identifier.IndexOf('|');
+        if (pipeIndex >= 0)
         {
-            key = _cacheKeys
-                .Where(k => k.Type == type)
-                .Where(k => string.Equals(k.Url, identifier, StringComparison.CurrentCultureIgnoreCase))
-                .OrderByDescending(k => k.Version)
-                .FirstOrDefault();
-
-            if (key == null)
-            {
-                key = _cacheKeys
-                    .Where(k => k.Type == type)
-                    .Where(k => k.Identifiers.Any(i => string.Equals(i.Value, identifier, StringComparison.CurrentCultureIgnoreCase)))
-                    .OrderByDescending(k => k.Version)
-                    .FirstOrDefault();
-            }
+            version ??= identifier[(pipeIndex + 1)..];
+            identifier = identifier[..pipeIndex];
         }
-        else
-        {
 
-            var keys = _cacheKeys
-                .Where(k => k.Type == type)
-                .Where(k => string.Equals(k.Version, version, StringComparison.CurrentCultureIgnoreCase))
+        var byType = _cacheKeys.Where(k => k.Type == type).ToList();
+
+        // Prefer a match on Url; fall back to a match on a secondary identifier.
+        var candidates = byType
+            .Where(k => string.Equals(k.Url, identifier, StringComparison.CurrentCultureIgnoreCase))
+            .ToList();
+
+        if (candidates.Count == 0)
+        {
+            candidates = byType
+                .Where(k => k.Identifiers.Any(i => string.Equals(i.Value, identifier, StringComparison.CurrentCultureIgnoreCase)))
                 .ToList();
-
-            key = keys
-                .FirstOrDefault(k => string.Equals(k.Url, identifier, StringComparison.CurrentCultureIgnoreCase));
-
-            if (key == null)
-                key = keys.FirstOrDefault(k =>
-                    k.Identifiers.Any(i =>
-                        string.Equals(i.Value, identifier, StringComparison.CurrentCultureIgnoreCase)));
         }
+
+        // Prefer the requested version if it is loaded; otherwise fall back to the latest.
+        CacheKey? key = null;
+        if (version != null)
+            key = candidates.FirstOrDefault(k => string.Equals(k.Version, version, StringComparison.CurrentCultureIgnoreCase));
+
+        key ??= candidates.OrderByDescending(k => k.Version).FirstOrDefault();
 
         if (key == null)
             return null;


### PR DESCRIPTION
### 🛠️ Description of Changes

Pre-existing bug discovered during LEGLINK-580 end-to-end terminology testing.

HAPI requests valuesets/code systems by canonical URL with a version suffix (e.g. `http://hl7.org/fhir/ValueSet/identifier-use|4.0.1`). `CodeGroupCacheService.GetCodeGroup` matched identifiers with an exact string comparison, so any versioned URL failed to resolve and the code was reported as unknown — in practice nearly every coded element came back "not found" when Validation is wired to the terminology service.

This change strips the `|version` suffix, matches on the base URL (URL then Identifiers fallback), prefers the requested version, and falls back to the latest available.

### 🧪 Testing Performed

- Added `CodeGroupCacheServiceTests` cases: no version suffix, matching version, and non-matching version (latest fallback).
- Full Terminology unit suite green.

### 🧑‍🔬 Unit Testing

- [x] I have written or updated unit tests to cover my changes
- Coverage: 81.2%

### 📓 Documentation Updated

No documentation changes required — internal cache-lookup behavior; no API or config change.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved code group lookup to handle canonical URLs with or without a version suffix.
  * When a specific version is provided, the matching cached version is returned; otherwise, the latest available version is used.
  * Added coverage for lookups using no version, an exact version, and an unknown version fallback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->