### PR TITLE
LEGLINK-601: Register in-memory terminology support as a fallback in validation

### DIFF
--- a/Java/validation/src/main/java/com/lantanagroup/link/validation/services/ValidationService.java
+++ b/Java/validation/src/main/java/com/lantanagroup/link/validation/services/ValidationService.java
@@ -60,13 +60,15 @@ public class ValidationService {
             validationSupportChain.addValidationSupport(remoteTerm);
             logger.info("Using Link terminology service at {}", terminologyServiceUrl);
         } else {
-            var commonCodeSystemsTerminologyService = new CommonCodeSystemsTerminologyService(fhirContext);
-            var inMemTerm = new InMemoryTerminologyServerValidationSupport(fhirContext);
-
-            validationSupportChain.addValidationSupport(commonCodeSystemsTerminologyService);
-            validationSupportChain.addValidationSupport(inMemTerm);
-            logger.info("Using in-memory terminology service");
+            logger.info("No remote terminology service configured; relying on in-memory terminology support");
         }
+
+        // Always register the in-memory terminology supports as a fallback. A remote terminology service
+        // only answers for the valuesets/code systems it owns; base-FHIR and package-owned valuesets (e.g.
+        // identifier-use, required code bindings) are validated in-process and have no validator otherwise.
+        // The chain consults the remote support first and falls through to these only when it declines.
+        validationSupportChain.addValidationSupport(new CommonCodeSystemsTerminologyService(fhirContext));
+        validationSupportChain.addValidationSupport(new InMemoryTerminologyServerValidationSupport(fhirContext));
     }
 
     public List<Result> validate(IBaseResource resource) {

--- a/Java/validation/src/main/java/com/lantanagroup/link/validation/services/ValidationService.java
+++ b/Java/validation/src/main/java/com/lantanagroup/link/validation/services/ValidationService.java
@@ -47,7 +47,8 @@ public class ValidationService {
         fhirValidator.setExecutorService(ForkJoinPool.commonPool());
     }
 
-    private static void loadTerminologyValidationSupport(FhirContext fhirContext, LinkConfig linkConfig, ValidationSupportChain validationSupportChain, ValidationCacheService validationCacheService) {
+    // Package-private for unit testing of the terminology support chain composition.
+    static void loadTerminologyValidationSupport(FhirContext fhirContext, LinkConfig linkConfig, ValidationSupportChain validationSupportChain, ValidationCacheService validationCacheService) {
         if (linkConfig.getFhirTerminologyServiceUrl() != null && !linkConfig.getFhirTerminologyServiceUrl().isEmpty()) {
             var remoteTerm = new RemoteTermServiceValidation(validationCacheService, fhirContext, linkConfig.getFhirTerminologyServiceUrl(), linkConfig.getWhiteListCodeSystemRegex(), linkConfig.getWhiteListValueSetRegex());
             validationSupportChain.addValidationSupport(remoteTerm);

--- a/Java/validation/src/test/java/com/lantanagroup/link/validation/services/ValidationServiceTest.java
+++ b/Java/validation/src/test/java/com/lantanagroup/link/validation/services/ValidationServiceTest.java
@@ -1,0 +1,97 @@
+package com.lantanagroup.link.validation.services;
+
+import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.context.support.DefaultProfileValidationSupport;
+import ca.uhn.fhir.context.support.IValidationSupport;
+import com.lantanagroup.link.validation.configs.LinkConfig;
+import com.lantanagroup.link.validation.providers.RemoteTermServiceValidation;
+import com.lantanagroup.link.validation.providers.ValidationCacheService;
+import org.hl7.fhir.common.hapi.validation.support.CommonCodeSystemsTerminologyService;
+import org.hl7.fhir.common.hapi.validation.support.InMemoryTerminologyServerValidationSupport;
+import org.hl7.fhir.common.hapi.validation.support.ValidationSupportChain;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Verifies that the terminology support chain always includes the in-memory fallback
+ * (CommonCodeSystems + InMemory) even when a remote terminology service is configured,
+ * and that the remote support is consulted before the in-memory fallback. See LEGLINK-601.
+ */
+class ValidationServiceTest {
+
+    private static final FhirContext FHIR_CONTEXT = FhirContext.forR4();
+
+    private static ValidationSupportChain newChain() {
+        return new ValidationSupportChain(new DefaultProfileValidationSupport(FHIR_CONTEXT));
+    }
+
+    private static LinkConfig config(String fhirTerminologyUrl, String linkTerminologyUrl) {
+        LinkConfig config = mock(LinkConfig.class);
+        when(config.getFhirTerminologyServiceUrl()).thenReturn(fhirTerminologyUrl);
+        when(config.getTerminologyServiceUrl()).thenReturn(linkTerminologyUrl);
+        when(config.getWhiteListCodeSystemRegex()).thenReturn(new ArrayList<>());
+        when(config.getWhiteListValueSetRegex()).thenReturn(new ArrayList<>());
+        return config;
+    }
+
+    private static int indexOfSupport(ValidationSupportChain chain, Class<?> type) {
+        List<IValidationSupport> supports = chain.getValidationSupports();
+        for (int i = 0; i < supports.size(); i++) {
+            if (type.isInstance(supports.get(i))) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    private static boolean hasSupport(ValidationSupportChain chain, Class<?> type) {
+        return indexOfSupport(chain, type) >= 0;
+    }
+
+    @Test
+    void linkTerminologyService_registersRemoteWithInMemoryFallbackAfterIt() {
+        ValidationSupportChain chain = newChain();
+
+        ValidationService.loadTerminologyValidationSupport(
+                FHIR_CONTEXT, config(null, "http://link-terminology:8076"), chain, mock(ValidationCacheService.class));
+
+        assertTrue(hasSupport(chain, RemoteTermServiceValidation.class), "remote support present");
+        assertTrue(hasSupport(chain, CommonCodeSystemsTerminologyService.class), "CommonCodeSystems fallback present");
+        assertTrue(hasSupport(chain, InMemoryTerminologyServerValidationSupport.class), "InMemory fallback present");
+        assertTrue(
+                indexOfSupport(chain, RemoteTermServiceValidation.class)
+                        < indexOfSupport(chain, InMemoryTerminologyServerValidationSupport.class),
+                "remote support must be consulted before the in-memory fallback");
+    }
+
+    @Test
+    void fhirTerminologyService_registersRemoteWithInMemoryFallback() {
+        ValidationSupportChain chain = newChain();
+
+        ValidationService.loadTerminologyValidationSupport(
+                FHIR_CONTEXT, config("http://fhir-terminology/fhir", null), chain, mock(ValidationCacheService.class));
+
+        assertTrue(hasSupport(chain, RemoteTermServiceValidation.class), "remote support present");
+        assertTrue(hasSupport(chain, CommonCodeSystemsTerminologyService.class), "CommonCodeSystems fallback present");
+        assertTrue(hasSupport(chain, InMemoryTerminologyServerValidationSupport.class), "InMemory fallback present");
+    }
+
+    @Test
+    void noRemoteTerminologyService_registersInMemoryWithoutRemote() {
+        ValidationSupportChain chain = newChain();
+
+        ValidationService.loadTerminologyValidationSupport(
+                FHIR_CONTEXT, config(null, null), chain, mock(ValidationCacheService.class));
+
+        assertFalse(hasSupport(chain, RemoteTermServiceValidation.class), "no remote support when none configured");
+        assertTrue(hasSupport(chain, CommonCodeSystemsTerminologyService.class), "CommonCodeSystems present");
+        assertTrue(hasSupport(chain, InMemoryTerminologyServerValidationSupport.class), "InMemory present");
+    }
+}


### PR DESCRIPTION
### 🛠️ Description of Changes

Pre-existing bug discovered during LEGLINK-580 end-to-end terminology testing.

`ValidationService.loadTerminologyValidationSupport` only registered the in-memory terminology supports (`CommonCodeSystemsTerminologyService` + `InMemoryTerminologyServerValidationSupport`) when **no** remote terminology service was configured. When a remote service is configured, HAPI still validates required base-FHIR code bindings (e.g. `identifier.use`) in-process; with no in-memory validator in the chain those codes had no validator and were reported as false "not found".

This change always registers the in-memory supports as a fallback. The remote support is consulted first (stays authoritative for the valuesets it owns); the chain falls through to in-memory only when the remote declines. `loadTerminologyValidationSupport` was made package-private so the chain composition can be unit-tested.

### 🧪 Testing Performed

- `ValidationServiceTest` (3 tests) asserts that with a remote service configured (fhir or link) the chain contains the remote support plus the CommonCodeSystems + InMemory fallback, that the remote support is ordered before the in-memory fallback, and that the no-remote path registers in-memory without a remote support.
- Verified locally: `identifier.use='usual'` and other base-FHIR bound codes stop reporting false "not found" once the fallback is in the chain, while remote-owned valuesets (US Core, NHSN, `cts.nlm` OIDs) remain validated by the remote service.

### 🧑‍🔬 Unit Testing

- [x] I have written or updated unit tests to cover my changes
- Coverage: 100.0%

### 📓 Documentation Updated

No new required config introduced. Optional: setting `whiteListValueSetRegex` / `whiteListCodeSystemRegex` to base-FHIR / `terminology.hl7.org` patterns avoids a remote round-trip for in-memory-owned valuesets.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Validation now always keeps built-in terminology support available as a fallback, even when a remote terminology service is configured.
  * When no remote terminology service is set, the app logs that it is relying on in-memory terminology support.
* **Tests**
  * Added coverage to verify terminology support is assembled in the expected order across remote and non-remote configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->