### PR TITLE
LEGLINK-616: Add support/handling for PatientAggregator:IncludeOrganizationResource

### DIFF
--- a/DotNet/Automation.UI/Services/RunExecutor.cs
+++ b/DotNet/Automation.UI/Services/RunExecutor.cs
@@ -36,6 +36,7 @@ internal sealed class RunExecutor
     private readonly RunSnapshotOrchestrator _orchestrator;
     private readonly QueryPlanTemplateResolver _queryPlanResolver;
     private readonly bool _suppressExternalManifest;
+    private readonly bool _includePatientAggregatorOrganizationResource;
     private readonly ILogger _logger;
 
     public RunExecutor(
@@ -53,6 +54,7 @@ internal sealed class RunExecutor
         _orchestrator = orchestrator;
         _queryPlanResolver = queryPlanResolver;
         _suppressExternalManifest = configuration.GetValue<bool>("ExternalBlobStorage:SuppressManifest");
+        _includePatientAggregatorOrganizationResource = configuration.GetValue<bool>("PatientAggregator:IncludeOrganizationResource");
         _logger = logger;
     }
 
@@ -274,6 +276,7 @@ internal sealed class RunExecutor
                 generationManifest.AcquiredResourceTypes = QueryPlanDefaults.GetAcquiredResourceTypes(effectiveQueryPlan);
                 generationManifest.ParameterQueryResourceTypes = QueryPlanDefaults.GetParameterQueryResourceTypes(effectiveQueryPlan);
                 generationManifest.CqlReferencedResourceTypes = CqlResourceTypeExtractor.ExtractForMeasures(state.Options.SelectedMeasures);
+                generationManifest.IncludePatientAggregatorOrganizationResource = _includePatientAggregatorOrganizationResource;
 
                 // Persist a lightweight manifest snapshot for the UI.
                 await _snapshotStore.SetDomainAsync(state.RunId, "generationManifest", generationManifest.ToSnapshot(), cancellationToken);

--- a/DotNet/Automation.UI/appsettings.Docker.json
+++ b/DotNet/Automation.UI/appsettings.Docker.json
@@ -10,6 +10,9 @@
     "ServiceConfigName": "AutomationUI",
     "ProductVersion": "dev"
   },
+  "PatientAggregator": {
+    "IncludeOrganizationResource": true
+  },
   "Authentication": {
     "UseBearerForServiceCalls": false,
     "EnableAnonymousAccess": true

--- a/DotNet/Automation/Generation/GenerationManifest.cs
+++ b/DotNet/Automation/Generation/GenerationManifest.cs
@@ -103,6 +103,16 @@ public sealed class GenerationManifest
         = new Dictionary<string, int>(StringComparer.Ordinal);
 
     /// <summary>
+    /// When true, predict one additional <c>Organization</c> resource per submitted patient
+    /// artifact in ABS to account for Report's <c>PatientAggregator:IncludeOrganizationResource</c>
+    /// behavior.
+    ///
+    /// This is count-level only: the organization ID is assigned by downstream services and
+    /// is not represented in key-level expectations.
+    /// </summary>
+    public bool IncludePatientAggregatorOrganizationResource { get; set; }
+
+    /// <summary>
     /// Optional explicit ABS scope: when populated, only these patients are expected
     /// to produce patient-{id}.ndjson artifacts.
     ///
@@ -325,6 +335,13 @@ public sealed class GenerationManifest
             && ooCount > 0)
         {
             counts["OperationOutcome"] = ooCount;
+        }
+
+        if (IncludePatientAggregatorOrganizationResource)
+        {
+            counts["Organization"] = counts.TryGetValue("Organization", out var orgCount)
+                ? orgCount + 1
+                : 1;
         }
     }
 

--- a/DotNet/Report/Properties/launchSettings.json
+++ b/DotNet/Report/Properties/launchSettings.json
@@ -13,6 +13,7 @@
       "launchBrowser": false,
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Docker",
+        "PatientAggregator__IncludeOrganizationResource": "true",
         "ConnectionStrings__DatabaseConnection": "Server=tcp:localhost,1433;Initial Catalog=link-report;Persist Security Info=False;User ID=sa;Password=${LINK_DB_PASS};MultipleActiveResultSets=False;Encrypt=True;TrustServerCertificate=True;Connection Timeout=30;",
         "KafkaConnection__BootstrapServers__0": "localhost:9094",
         "InternalBlobStorage__ConnectionString": "",

--- a/DotNet/Report/appsettings.Docker.json
+++ b/DotNet/Report/appsettings.Docker.json
@@ -47,6 +47,9 @@
     },
     "CensusServiceUrl": "http://census:8064"
   },
+  "PatientAggregator": {
+    "IncludeOrganizationResource": true
+  },
   "Telemetry": {
     "EnableTelemetry": true,
     "EnableTracing": true,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -691,6 +691,7 @@ services:
     container_name: link-automation-ui
     environment:
       ASPNETCORE_ENVIRONMENT: Docker
+      PatientAggregator__IncludeOrganizationResource: true
     volumes:
       - automation_ui_keys:/keys/dataprotection
     ports:
@@ -825,6 +826,7 @@ services:
     container_name: link-report
     environment:
       ASPNETCORE_ENVIRONMENT: Docker
+      PatientAggregator__IncludeOrganizationResource: true
       KafkaConnection__SaslUsername: ${KAFKA_SASL_CLIENT_USER}
       KafkaConnection__SaslPassword: ${KAFKA_SASL_CLIENT_PASSWORD}
       InternalBlobStorage__ConnectionString: ${AZURITE_CONNECTION_STRING}


### PR DESCRIPTION
### 🛠️ Description of Changes

LEGLINK-616: Add support/handling for PatientAggregator:IncludeOrganizationResource

### 🧪 Testing Performed

Included the setting as set to true in docker environments and local runs. Tested locally with the setting enabled, tests passed.

### 🧑‍🔬 Unit Testing

- [ ] I have written or updated unit tests to cover my changes
- Coverage: 

### 📓 Documentation Updated

Please update any relevant sections in the project documentation that were impacted by the changes in the PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for including organization resource data in patient aggregation flows.
  * Enabled the new setting in Docker and runtime profiles for the affected services.

* **Bug Fixes**
  * Updated generation expectations so resource counts align with the new organization resource behavior.



<!-- end of auto-generated comment: release notes by coderabbit.ai -->