### PR TITLE
LEGLINK-618: Reduce PR noise and 'Skip Test' noise in TestAutomation Slack Channel

### DIFF
--- a/Tests/AutomationUI.Pipeline/azure-pipelines.yml
+++ b/Tests/AutomationUI.Pipeline/azure-pipelines.yml
@@ -10,11 +10,7 @@
 #  restructuring the pipeline -- just fill in their base URL below.
 # =========================================
 
-trigger:
-  branches:
-    include:
-      - main
-      - feature/*
+trigger: none
 
 pr: none
 
@@ -503,7 +499,7 @@ stages:
           # -------------------------------------------------------------
           - task: AzureCLI@2
             displayName: "Fetch Slack webhook from Azure App Configuration"
-            condition: always()
+            condition: and(always(), ne(variables.SKIP_RUN, 'true'))
             inputs:
               azureSubscription: "$(AZURE_SERVICE_CONNECTION)"
               scriptType: "pscore"
@@ -529,7 +525,7 @@ stages:
           # -------------------------------------------------------------
           - task: PowerShell@2
             displayName: "Send result to Slack"
-            condition: always()
+            condition: and(always(), ne(variables.SKIP_RUN, 'true'))
             env:
               RUN_STATUS: $(RUN_STATUS)
               RUN_ERROR: $(RUN_ERROR)


### PR DESCRIPTION
### 🛠️ Description of Changes

The Automated Smoke Test that is meant to run only on deployments to Test is creating noise on other occasions that read as failures when they are really just a ‘Skip’ scenario.

Tighten the pipeline so that it does not:

Produce a message to the TestAutomation Slack channel on ‘Skips’

Appear as a PR Test/Check failure on PRs.

### 🧪 Testing Performed

Please describe the testing that was performed on the changes included in this PR.

### 🧑‍🔬 Unit Testing

- [ ] I have written or updated unit tests to cover my changes
- Coverage: 0.0%

### 📓 Documentation Updated

Please update any relevant sections in the project documentation that were impacted by the changes in the PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated pipeline automation to stop running on branch-based CI triggers.
  * Slack notification steps now run only when the pipeline is not intentionally skipped.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
