### PR TITLE
LEGLINK-599: If CSV file contains duplicate codes w/ diff statuses, "last one wins".

### DIFF
--- a/DotNet/ServiceTests/UnitTests/Terminology/Services/CodeGroupCacheServiceTests.cs
+++ b/DotNet/ServiceTests/UnitTests/Terminology/Services/CodeGroupCacheServiceTests.cs
@@ -256,6 +256,52 @@ http://test.system,123,Test Display,Extra Value";
             Times.Once);
     }
 
+    [Fact]
+    public void ProcessValueSetCsv_WithDuplicateCode_UsesLastRecord()
+    {
+        var mockCache = new Mock<IMemoryCache>();
+        var mockConfig = new Mock<IOptions<TerminologyConfig>>();
+
+        mockConfig.Setup(x => x.Value).Returns(_config);
+
+        var mockService = new Mock<CodeGroupCacheService>(
+            _loggerMock.Object,
+            mockCache.Object,
+            mockConfig.Object)
+        {
+            CallBase = true
+        };
+
+        mockService
+            .Setup(x => x.SetCodeGroup(It.IsAny<CodeGroup>()))
+            .Verifiable();
+
+        var csvData = "system,code,display\r\n" +
+                     "http://test.system,123,Original Display\r\n" +
+                     "http://test.system,456,Another Display\r\n" +
+                     "http://test.system,123,Replacement Display";
+
+        using var reader = new StringReader(csvData);
+        using var csv = new CsvReader(reader, CultureInfo.InvariantCulture);
+
+        var codeGroup = new CodeGroup
+        {
+            Id = "test-id",
+            Type = CodeGroup.CodeGroupTypes.ValueSet,
+            Url = "http://test.valueset",
+            Version = "1.0"
+        };
+
+        mockService.Object.ProcessValueSetCsv(codeGroup, csv);
+
+        var codes = codeGroup.Codes["http://test.system"];
+        Assert.Equal(2, codes.Count);
+
+        var duplicateCode = Assert.Single(codes, code => code.Value == "123");
+        Assert.Equal("Replacement Display", duplicateCode.Display);
+        Assert.DoesNotContain(codes, code => code.Display == "Original Display");
+    }
+
     [Theory]
     [InlineData("code,display\r\n" +
                 "123,Test Display\r\n" +
@@ -315,6 +361,52 @@ http://test.system,123,Test Display,Extra Value";
             cg.Codes["http://test.codesystem"][1].Value == "456" &&
             cg.Codes["http://test.codesystem"][1].Display == "Another Display")),
             Times.Once);
+    }
+
+    [Fact]
+    public void ProcessCodeSystemCsv_WithDuplicateCode_UsesLastRecord()
+    {
+        var mockCache = new Mock<IMemoryCache>();
+        var mockConfig = new Mock<IOptions<TerminologyConfig>>();
+
+        mockConfig.Setup(x => x.Value).Returns(_config);
+
+        var mockService = new Mock<CodeGroupCacheService>(
+            _loggerMock.Object,
+            mockCache.Object,
+            mockConfig.Object)
+        {
+            CallBase = true
+        };
+
+        mockService
+            .Setup(x => x.SetCodeGroup(It.IsAny<CodeGroup>()))
+            .Verifiable();
+
+        var csvData = "code,display,status\r\n" +
+                      "123,Original Display,Inactive\r\n" +
+                      "456,Another Display,Active\r\n" +
+                      "123,Replacement Display,Active";
+
+        using var csv = CreateCsvReader(csvData);
+
+        var codeGroup = new CodeGroup
+        {
+            Id = "test-id",
+            Type = CodeGroup.CodeGroupTypes.CodeSystem,
+            Url = "http://test.codesystem",
+            Version = "1.0"
+        };
+
+        mockService.Object.ProcessCodeSystemCsv(codeGroup, csv);
+
+        var codes = codeGroup.Codes["http://test.codesystem"];
+        Assert.Equal(2, codes.Count);
+
+        var duplicateCode = Assert.IsType<CodeSystemCode>(Assert.Single(codes, code => code.Value == "123"));
+        Assert.Equal("Replacement Display", duplicateCode.Display);
+        Assert.Equal(CodeStatus.Active, duplicateCode.Status);
+        Assert.DoesNotContain(codes, code => code.Display == "Original Display");
     }
 
     [Fact]

--- a/DotNet/Terminology/Services/CodeGroupCacheService.cs
+++ b/DotNet/Terminology/Services/CodeGroupCacheService.cs
@@ -3,6 +3,7 @@ using System.Globalization;
 using CsvHelper;
 using CsvHelper.Configuration;
 using Hl7.Fhir.Model;
+using LantanaGroup.Link.Shared.Application.Services.Security;
 using LantanaGroup.Link.Terminology.Application.Models;
 using LantanaGroup.Link.Terminology.Application.Settings;
 using Microsoft.Extensions.Caching.Memory;
@@ -242,6 +243,12 @@ public class CodeGroupCacheService(
                 continue;
             }
 
+            if (systemCodes.Any(c => c.Value == code))
+            {
+                logger.LogWarning("Duplicate code {Code} detected for system {System} while loading value set {ValueSet}. Replacing the previous occurrence.", code.SanitizeForLog(), system.SanitizeForLog(), codeGroup.Id.SanitizeForLog());
+                systemCodes.RemoveAll(c => c.Value == code);
+            }
+
             systemCodes.Add(new Code
             {
                 Value = code,
@@ -281,6 +288,12 @@ public class CodeGroupCacheService(
 
             if (!codeGroup.Codes.ContainsKey(system))
                 codeGroup.Codes.Add(system, new List<Code>());
+
+            if (codeGroup.Codes[system].Any(c => c.Value == code))
+            {
+                logger.LogWarning("Duplicate code {Code} detected for code system {CodeSystem}. Replacing the previous occurrence.", code.SanitizeForLog(), codeGroup.Id.SanitizeForLog());
+                codeGroup.Codes[system].RemoveAll(c => c.Value == code);
+            }
 
             codeGroup.Codes[system].Add(new CodeSystemCode
             {


### PR DESCRIPTION
### 🛠️ Description of Changes

When importing CSV data in the Terminology service, ensure the last record wins when duplicate codes are encountered during CSV processing. CodeGroupCacheService now removes existing entries and logs a warning before adding a new Code/CodeSystemCode. Added unit tests (ProcessValueSetCsv_WithDuplicateCode_UsesLastRecord and ProcessCodeSystemCsv_WithDuplicateCode_UsesLastRecord) to verify duplicates are replaced and only the final record is retained.

### 🧪 Testing Performed

Executed test case 10357

### 🧑‍🔬 Unit Testing

- [x] I have written or updated unit tests to cover my changes
- Coverage: 100.0%

### 📓 Documentation Updated

N/A



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Duplicate codes in imported value sets and code systems are now handled consistently.
  * When the same code appears more than once, the latest row is kept, including updated display text and status where applicable.
  * Import results now avoid retaining earlier duplicate entries, reducing confusion in code lists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->