### PR TITLE
LEGLINK-591: Add ProblemDetails and status code pages for Terminology

### DIFF
--- a/DotNet/ServiceTests/IntegrationTests/Terminology/TerminologyStatusCodePagesTests.cs
+++ b/DotNet/ServiceTests/IntegrationTests/Terminology/TerminologyStatusCodePagesTests.cs
@@ -1,0 +1,99 @@
+using LantanaGroup.Link.Terminology.Application.Extensions;
+using LantanaGroup.Link.Terminology.Application.Formatters;
+using LantanaGroup.Link.Terminology.Controllers;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using System.Net;
+using System.Text;
+using System.Text.Json.Nodes;
+using Xunit;
+using Task = System.Threading.Tasks.Task;
+
+namespace IntegrationTests.Terminology;
+
+[Trait("Category", "IntegrationTests")]
+public class TerminologyStatusCodePagesTests : IClassFixture<TerminologyStatusCodePagesFactory>
+{
+    private readonly TerminologyStatusCodePagesFactory _factory;
+
+    public TerminologyStatusCodePagesTests(TerminologyStatusCodePagesFactory factory)
+    {
+        _factory = factory;
+    }
+
+    [Fact]
+    public async Task UnknownTerminologyRoute_ReturnsNotFoundProblemDetailsWithTraceId()
+    {
+        var client = _factory.CreateClient();
+        using var content = new StringContent(
+            """
+            {
+              "resourceType": "Parameters",
+              "parameter": [{
+                "name": "url",
+                "valueUri": "http://terminology.hl7.org/CodeSystem/v3-ActCode"
+              }, {
+                "name": "code",
+                "valueCode": "WRKCOMP"
+              }]
+            }
+            """,
+            Encoding.UTF8,
+            "application/json");
+
+        var response = await client.PostAsync("/api/terminology/blah/CodeSystem/$validate-code", content);
+        var body = await response.Content.ReadAsStringAsync();
+        var problem = JsonNode.Parse(body)!.AsObject();
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+        Assert.Equal("https://tools.ietf.org/html/rfc9110#section-15.5.5", problem["type"]!.GetValue<string>());
+        Assert.Equal("Not Found", problem["title"]!.GetValue<string>());
+        Assert.Equal(StatusCodes.Status404NotFound, problem["status"]!.GetValue<int>());
+        Assert.False(string.IsNullOrWhiteSpace(problem["detail"]?.GetValue<string>()));
+        Assert.False(string.IsNullOrWhiteSpace(problem["traceId"]?.GetValue<string>()));
+    }
+}
+
+public sealed class TerminologyStatusCodePagesFactory : WebApplicationFactory<TerminologyStatusCodePagesFactory.ApiTestMarker>
+{
+    protected override IHost CreateHost(IHostBuilder builder)
+    {
+        builder.UseContentRoot(AppContext.BaseDirectory);
+        return base.CreateHost(builder);
+    }
+
+    protected override IHostBuilder CreateHostBuilder()
+    {
+        return Host.CreateDefaultBuilder()
+            .ConfigureWebHostDefaults(webBuilder =>
+            {
+                webBuilder
+                    .UseTestServer()
+                    .ConfigureServices((context, services) =>
+                    {
+                        services.AddTerminologyProblemDetails(context.HostingEnvironment);
+
+                        services
+                            .AddControllers(options =>
+                            {
+                                options.ModelBinderProviders.Insert(0, new FhirModelBinderProvider());
+                                options.OutputFormatters.Insert(0, new FhirOutputFormatter());
+                            })
+                            .AddApplicationPart(typeof(FhirController).Assembly);
+                    })
+                    .Configure(app =>
+                    {
+                        app.UseStatusCodePages();
+                        app.UseRouting();
+                        app.UseEndpoints(endpoints => endpoints.MapControllers());
+                    });
+            });
+    }
+
+    public sealed class ApiTestMarker { }
+}

--- a/DotNet/Terminology/Application/Extensions/TerminologyProblemDetailsExtensions.cs
+++ b/DotNet/Terminology/Application/Extensions/TerminologyProblemDetailsExtensions.cs
@@ -1,0 +1,55 @@
+using LantanaGroup.Link.Terminology.Application.Settings;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using System.Diagnostics;
+using System.Net;
+
+namespace LantanaGroup.Link.Terminology.Application.Extensions;
+
+internal static class TerminologyProblemDetailsExtensions
+{
+    internal static IServiceCollection AddTerminologyProblemDetails(
+        this IServiceCollection services,
+        IWebHostEnvironment environment,
+        bool includeExceptionDetails = false)
+    {
+        services.AddProblemDetails(options =>
+        {
+            options.CustomizeProblemDetails = ctx =>
+            {
+                var statusCode = ctx.ProblemDetails.Status ?? ctx.HttpContext.Response.StatusCode;
+
+                if (statusCode == (int)HttpStatusCode.InternalServerError)
+                {
+                    ctx.ProblemDetails.Detail =
+                        "An error occurred in our API. Please use the trace id when requesting assistance.";
+                }
+                else if (string.IsNullOrWhiteSpace(ctx.ProblemDetails.Detail))
+                {
+                    ctx.ProblemDetails.Detail = statusCode == (int)HttpStatusCode.NotFound
+                        ? "The requested terminology endpoint was not found."
+                        : "The request could not be completed. Please use the trace id when requesting assistance.";
+                }
+
+                if (!ctx.ProblemDetails.Extensions.ContainsKey("traceId"))
+                {
+                    var traceId = Activity.Current?.Id ?? ctx.HttpContext.TraceIdentifier;
+                    ctx.ProblemDetails.Extensions.Add(new KeyValuePair<string, object?>("traceId", traceId));
+                }
+
+                if (environment.IsDevelopment() || includeExceptionDetails)
+                {
+                    ctx.ProblemDetails.Extensions.Add("API", TerminologyConstants.ServiceName);
+                }
+                else
+                {
+                    ctx.ProblemDetails.Extensions.Remove("exception");
+                }
+            };
+        });
+
+        return services;
+    }
+}

--- a/DotNet/Terminology/Program.cs
+++ b/DotNet/Terminology/Program.cs
@@ -3,6 +3,7 @@ using LantanaGroup.Link.Shared.Application.Extensions;
 using LantanaGroup.Link.Shared.Application.Extensions.Security;
 using LantanaGroup.Link.Shared.Application.Middleware;
 using LantanaGroup.Link.Shared.Application.Models.Configs;
+using LantanaGroup.Link.Terminology.Application.Extensions;
 using LantanaGroup.Link.Terminology.Application.Formatters;
 using LantanaGroup.Link.Terminology.Application.Settings;
 using LantanaGroup.Link.Terminology.Services;
@@ -51,6 +52,10 @@ static void RegisterServices(WebApplicationBuilder builder)
         options.ModelBinderProviders.Insert(0, new FhirModelBinderProvider());
         options.OutputFormatters.Insert(0, new FhirOutputFormatter());
     });
+
+    builder.Services.AddTerminologyProblemDetails(
+        builder.Environment,
+        builder.Configuration.GetValue<bool>("ProblemDetails:IncludeExceptionDetails"));
 
     builder.Services.AddHealthChecks();
 
@@ -155,6 +160,17 @@ static void SetupMiddleware(WebApplication app)
     {
         ResponseWriter = UIResponseWriter.WriteHealthCheckUIResponse
     });
+
+    app.UseStatusCodePages();
+
+    if (app.Environment.IsDevelopment())
+    {
+        app.UseDeveloperExceptionPage();
+    }
+    else
+    {
+        app.UseExceptionHandler();
+    }
 
     app.UseRouting();
     app.UseCors(CorsSettings.DefaultCorsPolicyName);


### PR DESCRIPTION
### 🛠️ Description of Changes

Introduce centralized ProblemDetails handling for the Terminology service and wire up status code pages and exception handling.

- Add TerminologyProblemDetailsExtensions to customize ProblemDetails (adds traceId, friendly details, optional exception info and API name in dev).
- Register AddTerminologyProblemDetails in Program.cs (reads IncludeExceptionDetails from config), enable UseStatusCodePages and environment-specific exception handling.
- Add integration test TerminologyStatusCodePagesTests to verify NotFound returns RFC ProblemDetails with traceId.

Improves error transparency and diagnostics for the Terminology API.

### 🧪 Testing Performed

Test case 14634

### 🧑‍🔬 Unit Testing

- [x] I have written or updated unit tests to cover my changes
- Coverage: 74.4%

### 📓 Documentation Updated

N/A

