### PR TITLE
LEGLINK-548: Add Inpatient Pattern Configuration to UI

### DIFF
--- a/DotNet/Automation.Link/README.md
+++ b/DotNet/Automation.Link/README.md
@@ -283,3 +283,126 @@ Primary consumers:
   namespaces.
 - Strict prediction-vs-actual reconciliation is the default. The `Automation` README documents
   the prediction formula that drives these validators.
+
+---
+
+## 12. Inpatient Pattern feature (UI-driven cohort timing)
+
+`Automation.Link` now participates in a UI-driven inpatient-pattern workflow where each
+patient cohort carries explicit encounter timing intent relative to the report period.
+
+This replaced older hidden/default-only behavior and made cohort timing first-class in
+scenario authoring, orchestration, and strict prediction.
+
+### 12.1 What the feature is
+
+The feature allows each cohort to set a `ScheduledInpatientPattern` value that encodes
+admit/discharge timing relative to the report period:
+
+- admitted before / remains after,
+- admitted before / discharged during,
+- admitted during / remains after,
+- admitted during / discharged during,
+- admitted+discharged before,
+- admitted+discharged after.
+
+Patterns are authored in the scenario editor and persisted with the cohort definition.
+
+### 12.2 Why it matters for `Automation.Link`
+
+`Automation.Link` does not own the enum, but it is where orchestration + validators enforce
+pipeline truth. The inpatient pattern now affects:
+
+1. **Who should appear in report entries/submission**
+2. **Which census events are emitted in scheduled runs**
+3. **Which resources are predicted to land in ABS/report-resource stores**
+
+So this feature is tightly coupled to strict prediction-vs-actual validation behavior.
+
+### 12.3 Data flow (authoring -> execution -> validation)
+
+1. **Scenario authoring (Automation.UI)**
+   - Cohorts include explicit inpatient pattern.
+   - Cohorts also include concrete `CohortQualification` (`Qualifying` / `NonQualifying`).
+   - UI rules constrain incompatible combinations (e.g., non-qualifying cohorts cannot mark
+     measure eligibility as qualifying).
+
+2. **Run option resolution (Automation.UI)**
+   - Missing pattern defaults to `AdmittedBeforePeriodRemainsInpatientAfterPeriod`.
+   - Legacy scenarios are normalized so older persisted JSON still runs deterministically.
+
+3. **Generation (`Automation`)**
+   - Encounter windows are shaped from pattern + report period for all workflows
+     (scheduled and non-scheduled).
+
+4. **Execution (`Automation.Link` + Automation.UI host)**
+   - Scheduled workflows use pattern-derived census behavior to emit admit/discharge
+     snapshots and reconcile terminal submitted-patient sets.
+
+5. **Validation (`Automation.Link`)**
+   - Expected submitted/ABS sets now honor cohort qualification + pattern inclusion,
+     not measure flags alone.
+
+### 12.4 Scheduled vs non-scheduled behavior
+
+#### Scheduled / Regenerate
+
+- Patterns drive **live** census orchestration (`PatientListsAcquired` admit/discharge).
+- End-of-period acquisition behavior is pattern-sensitive (`remain inpatient` vs
+  `discharge during`).
+- Expected submitted sets are reconciled to terminal report truth before strict ABS checks.
+
+#### Adhoc / other non-scheduled
+
+- No live scheduled census event orchestration is required.
+- Pattern still drives generated encounter timing versus report period boundaries.
+- This keeps measure-eval and ABS expectations aligned with authored cohort intent.
+
+### 12.5 Prediction impact (strict validator mode)
+
+The strict validators compare `actual == expected`.
+
+With inpatient patterns enabled, expected counts/keys are gated by:
+
+- per-measure eligibility,
+- `CohortQualification`,
+- pattern inclusion semantics (`ExpectedInReport`).
+
+This prevents false expectations for cohorts that are intentionally outside report inclusion
+(for example, admitted/discharged fully before/after period).
+
+### 12.6 Acquisition simulation nuance
+
+`Automation` acquisition simulation supports a caller-controlled mode for encounter-anchored
+date override behavior. `Automation.Link` relies on this to keep prediction aligned by workflow:
+
+- **Scheduled / Regenerate**: encounter-anchored out-of-range override can be enabled to match
+  observed acquisition behavior.
+- **Non-scheduled**: strict date-bound simulation is preferred to avoid overprediction.
+
+This split is important for avoiding opposite failure shapes across test categories:
+
+- overprediction (`expected > actual`) in non-scheduled runs,
+- underprediction (`expected < actual`) in scheduled runs.
+
+### 12.7 Diagnostics and failure interpretation
+
+When inpatient-pattern mismatches exist, the first visible failure is usually
+`ReportAbsManifestValidator` with one of these shapes:
+
+- `expected=N, actual<N` and/or `missing expected resource <key>`
+- `expected=N, actual=M (ABS has M-N more than predicted)`
+
+Use the pipeline snapshot + run manifest to verify:
+
+- selected pattern per cohort,
+- terminal submitted patient set,
+- per-type expected-vs-actual deltas,
+- whether the run is scheduled/regenerate vs non-scheduled (different simulator mode).
+
+### 12.8 Operational notes
+
+- System scenarios are re-seeded on app startup; changing seeded inpatient patterns requires
+  restarting `Automation.UI` to refresh persisted system scenarios.
+- Unit tests should cover both seeded defaults and pattern-sensitive prediction behavior,
+  especially for multi-measure scenarios where one measure may be not-reportable per patient.

--- a/DotNet/Automation.UI/Controllers/ScenariosController.cs
+++ b/DotNet/Automation.UI/Controllers/ScenariosController.cs
@@ -1,4 +1,4 @@
-using Automation.UI.Models;
+﻿using Automation.UI.Models;
 using Automation.UI.Services.Persistence;
 using Hl7.Fhir.Model;
 using LantanaGroup.Automation;
@@ -52,6 +52,18 @@ public class ScenariosController(
 
         if (model.ResourcesPerPatientMax < model.ResourcesPerPatientMin)
             model.ResourcesPerPatientMax = model.ResourcesPerPatientMin;
+
+        foreach (var cohort in model.PatientCohorts)
+        {
+            cohort.ScheduledInpatientPattern ??= ScheduledInpatientPattern.AdmittedBeforePeriodRemainsInpatientAfterPeriod;
+
+            var allNonQualifying = model.SelectedMeasures.Count > 0
+                && model.SelectedMeasures.All(m => cohort.GetEligibility(m) == MeasureEligibility.NonQualifying);
+
+            // Back-compat normalization for payloads that do not yet send cohortQualification.
+            if (allNonQualifying)
+                cohort.CohortQualification = MeasureEligibility.NonQualifying;
+        }
 
         // ----- Imported-patient validation (fail save on bad input) -----
         var importValidation = await ValidateImportedPatientsAsync(model, ct);

--- a/DotNet/Automation.UI/Controllers/ScenariosController.cs
+++ b/DotNet/Automation.UI/Controllers/ScenariosController.cs
@@ -50,11 +50,13 @@ public class ScenariosController(
         model.IsSystemScenario = false;
         model.UpdatedAt = DateTimeOffset.UtcNow;
 
-        if (model.ResourcesPerPatientMax < model.ResourcesPerPatientMin)
-            model.ResourcesPerPatientMax = model.ResourcesPerPatientMin;
-
         foreach (var cohort in model.PatientCohorts)
         {
+            if (cohort.ResourcesPerPatientMin < 1)
+                cohort.ResourcesPerPatientMin = 1;
+            if (cohort.ResourcesPerPatientMax < cohort.ResourcesPerPatientMin)
+                cohort.ResourcesPerPatientMax = cohort.ResourcesPerPatientMin;
+
             cohort.ScheduledInpatientPattern ??= ScheduledInpatientPattern.AdmittedBeforePeriodRemainsInpatientAfterPeriod;
 
             var allNonQualifying = model.SelectedMeasures.Count > 0
@@ -375,8 +377,6 @@ public class ScenariosController(
             SelectedMeasures = [.. source.SelectedMeasures],
             Seed = source.Seed,
             PatientCount = source.PatientCount,
-            ResourcesPerPatientMin = source.ResourcesPerPatientMin,
-            ResourcesPerPatientMax = source.ResourcesPerPatientMax,
             PatientCohorts = source.PatientCohorts
                 .Select(c => new PatientCohortDefinition
                 {

--- a/DotNet/Automation.UI/Controllers/ScenariosController.cs
+++ b/DotNet/Automation.UI/Controllers/ScenariosController.cs
@@ -381,10 +381,12 @@ public class ScenariosController(
                 .Select(c => new PatientCohortDefinition
                 {
                     PatientCount = c.PatientCount,
+                    CohortQualification = c.CohortQualification,
                     MeasureEligibilities = new(c.MeasureEligibilities),
                     EligibleClinicalScenarioIds = [.. c.EligibleClinicalScenarioIds],
                     ResourcesPerPatientMin = c.ResourcesPerPatientMin,
-                    ResourcesPerPatientMax = c.ResourcesPerPatientMax
+                    ResourcesPerPatientMax = c.ResourcesPerPatientMax,
+                    ScheduledInpatientPattern = c.ScheduledInpatientPattern
                 })
                 .ToList(),
             QueryPlanTemplateId = source.QueryPlanTemplateId,

--- a/DotNet/Automation.UI/Models/StartScenarioRequest.cs
+++ b/DotNet/Automation.UI/Models/StartScenarioRequest.cs
@@ -103,7 +103,6 @@ public class StartScenarioRequest : IValidatableObject
         ReportMethod = scenario.ReportMethod,
         Seed = scenario.Seed,
         PatientCount = scenario.PatientCount,
-        ResourcesPerPatient = scenario.ResourcesPerPatientMax,
         CleanupServiceData = scenario.CleanupServiceData,
         CleanupFhirData = scenario.CleanupFhirData,
         SelectedMeasures = scenario.SelectedMeasures,

--- a/DotNet/Automation.UI/README.md
+++ b/DotNet/Automation.UI/README.md
@@ -429,6 +429,7 @@ Legacy scenarios (saved before these fields were first-class) are normalized on 
 - missing `CohortQualification` is inferred from per-measure eligibility where possible.
 
 This keeps existing saved scenarios runnable while adopting the new model.
+
 ---
 
 ## 6. Dashboard and real-time updates

--- a/DotNet/Automation.UI/README.md
+++ b/DotNet/Automation.UI/README.md
@@ -287,7 +287,7 @@ A `TestScenarioDefinition` captures everything needed to run a test:
 | `Seed` | Deterministic generation seed. |
 | `PatientCount` | Computed from cohorts plus imported patients (read-only on the editor). |
 | `ResourcesPerPatientMin/Max` | Resource count range per patient. |
-| `PatientCohorts` | List of cohort definitions (count, eligibility, clinical profiles, resource range). |
+| `PatientCohorts` | List of cohort definitions (count, `CohortQualification`, per-measure eligibility, clinical profiles, resource range, inpatient pattern). |
 | `QueryPlanTemplateId` | Optional override for the FHIR query plan (null = system default). |
 | `CleanupServiceData` | Remove facility config and run artifacts after completion. |
 | `CleanupFhirData` | Expunge FHIR server data after completion. |
@@ -363,6 +363,72 @@ The editor enforces measure eligibility constraints in the UI:
   the generation layer).
 - The Hypoglycemic measure requires ACH Monthly to also be qualifying (dependency
   enforcement).
+
+### Inpatient Pattern (UI-driven encounter timing)
+
+Each cohort includes a `ScheduledInpatientPattern` that defines encounter timing relative to
+the report period. This is authored in the shared scenario editor modal and persisted with
+the cohort JSON.
+
+Supported values:
+
+- `AdmittedBeforePeriodRemainsInpatientAfterPeriod`
+- `AdmittedBeforePeriodDischargedDuringPeriod`
+- `AdmittedDuringPeriodRemainsInpatientAfterPeriod`
+- `AdmittedDuringPeriodDischargedDuringPeriod`
+- `AdmittedAndDischargedBeforePeriod`
+- `AdmittedAndDischargedAfterPeriod`
+
+The dropdown uses compact labels for readability and tooltip hints for the full wording.
+
+#### Cohort Outcome + Pattern compatibility
+
+The editor now treats cohort intent as explicit via `CohortQualification`:
+
+- `Qualifying`
+- `NonQualifying`
+
+Pattern options are filtered by that choice:
+
+- **Qualifying** cohorts can choose only patterns whose census behavior is
+  `ExpectedInReport=true`.
+- **Non-Qualifying** cohorts can choose only patterns whose census behavior is
+  `ExpectedInReport=false`.
+
+This prevents invalid UI combinations that previously caused prediction drift.
+
+#### Measure checkbox rules by Cohort Outcome
+
+The cohort measure-eligibility editor enforces hard constraints:
+
+- **Qualifying cohort**
+  - If one selected measure exists in the scenario, it cannot be unchecked.
+  - If multiple measures exist, at least one must remain checked.
+- **Non-Qualifying cohort**
+  - No measure checkboxes can be selected.
+
+These rules run on row add, measure toggle, cohort-outcome toggle, and global measure-list
+changes.
+
+#### Runtime impact
+
+The UI host passes inpatient pattern + cohort qualification through run resolution so the
+downstream generation/prediction model can align expectations with authored scenario intent:
+
+- Pattern shapes encounter timing for both scheduled and non-scheduled runs.
+- Scheduled/regenerate runs additionally use pattern-derived live census orchestration.
+- Expected submitted/ABS sets are gated by measure eligibility **and**
+  (`CohortQualification` + pattern inclusion semantics), reducing false validator failures.
+
+#### Backward compatibility
+
+Legacy scenarios (saved before these fields were first-class) are normalized on load/save:
+
+- missing pattern defaults to
+  `AdmittedBeforePeriodRemainsInpatientAfterPeriod`.
+- missing `CohortQualification` is inferred from per-measure eligibility where possible.
+
+This keeps existing saved scenarios runnable while adopting the new model.
 ---
 
 ## 6. Dashboard and real-time updates

--- a/DotNet/Automation.UI/Services/Persistence/MongoScenarioStore.cs
+++ b/DotNet/Automation.UI/Services/Persistence/MongoScenarioStore.cs
@@ -3,6 +3,7 @@ using MongoDB.Driver;
 using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace Automation.UI.Services.Persistence;
 
@@ -46,8 +47,18 @@ namespace Automation.UI.Services.Persistence;
 /// </summary>
 public sealed class MongoScenarioStore : IScenarioStore
 {
+    private static readonly JsonSerializerOptions CohortJsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true
+    };
+
     private readonly IMongoCollection<TestScenarioDocument> _scenarios;
     private readonly IMongoCollection<ImportedBundleDocument> _bundles;
+
+    static MongoScenarioStore()
+    {
+        CohortJsonOptions.Converters.Add(new JsonStringEnumConverter());
+    }
 
     public MongoScenarioStore(IMongoDatabase database)
     {
@@ -409,12 +420,12 @@ public sealed class MongoScenarioStore : IScenarioStore
         {
             using var doc = JsonDocument.Parse(json);
             if (doc.RootElement.ValueKind != JsonValueKind.Array)
-                return JsonSerializer.Deserialize<List<PatientCohortDefinition>>(json) ?? [];
+                return JsonSerializer.Deserialize<List<PatientCohortDefinition>>(json, CohortJsonOptions) ?? [];
 
             var cohorts = new List<PatientCohortDefinition>();
             foreach (var cohortElement in doc.RootElement.EnumerateArray())
             {
-                var cohort = JsonSerializer.Deserialize<PatientCohortDefinition>(cohortElement.GetRawText());
+                var cohort = JsonSerializer.Deserialize<PatientCohortDefinition>(cohortElement.GetRawText(), CohortJsonOptions);
                 if (cohort == null)
                     continue;
 

--- a/DotNet/Automation.UI/Services/Persistence/MongoScenarioStore.cs
+++ b/DotNet/Automation.UI/Services/Persistence/MongoScenarioStore.cs
@@ -1,4 +1,4 @@
-using System.Text.Json;
+ï»¿using System.Text.Json;
 using Automation.UI.Models;
 using LantanaGroup.Automation.Generation;
 using MongoDB.Driver;
@@ -144,7 +144,7 @@ public sealed class MongoScenarioStore : IScenarioStore
             }
 
             if (string.IsNullOrWhiteSpace(input.BundleJson))
-                continue; // ID-only entry mistakenly placed in the bundle list — nothing to externalize.
+                continue; // ID-only entry mistakenly placed in the bundle list â€” nothing to externalize.
 
             var hash = ComputeContentHash(input.BundleJson!);
             var byteCount = Encoding.UTF8.GetByteCount(input.BundleJson!);
@@ -386,7 +386,7 @@ public sealed class MongoScenarioStore : IScenarioStore
         foreach (var input in inputs)
         {
             if (!string.IsNullOrEmpty(input.BundleJson))
-                continue; // already inline (legacy doc) — leave as-is
+                continue; // already inline (legacy doc) â€” leave as-is
 
             var key = input.PatientId ?? string.Empty;
             if (refsByPatient.TryGetValue(key, out var queue) && queue.Count > 0)
@@ -408,7 +408,16 @@ public sealed class MongoScenarioStore : IScenarioStore
 
         try
         {
-            return JsonSerializer.Deserialize<List<PatientCohortDefinition>>(json) ?? [];
+            var cohorts = JsonSerializer.Deserialize<List<PatientCohortDefinition>>(json) ?? [];
+            foreach (var cohort in cohorts)
+            {
+                var allNonQualifying = cohort.MeasureEligibilities.Count > 0
+                    && cohort.MeasureEligibilities.Values.All(v => v == MeasureEligibility.NonQualifying);
+                if (allNonQualifying)
+                    cohort.CohortQualification = MeasureEligibility.NonQualifying;
+            }
+
+            return cohorts;
         }
         catch
         {

--- a/DotNet/Automation.UI/Services/Persistence/MongoScenarioStore.cs
+++ b/DotNet/Automation.UI/Services/Persistence/MongoScenarioStore.cs
@@ -1,9 +1,8 @@
-﻿using System.Text.Json;
-using Automation.UI.Models;
-using LantanaGroup.Automation.Generation;
+﻿using Automation.UI.Models;
 using MongoDB.Driver;
 using System.Security.Cryptography;
 using System.Text;
+using System.Text.Json;
 
 namespace Automation.UI.Services.Persistence;
 
@@ -408,13 +407,30 @@ public sealed class MongoScenarioStore : IScenarioStore
 
         try
         {
-            var cohorts = JsonSerializer.Deserialize<List<PatientCohortDefinition>>(json) ?? [];
-            foreach (var cohort in cohorts)
+            using var doc = JsonDocument.Parse(json);
+            if (doc.RootElement.ValueKind != JsonValueKind.Array)
+                return JsonSerializer.Deserialize<List<PatientCohortDefinition>>(json) ?? [];
+
+            var cohorts = new List<PatientCohortDefinition>();
+            foreach (var cohortElement in doc.RootElement.EnumerateArray())
             {
-                var allNonQualifying = cohort.MeasureEligibilities.Count > 0
-                    && cohort.MeasureEligibilities.Values.All(v => v == MeasureEligibility.NonQualifying);
-                if (allNonQualifying)
-                    cohort.CohortQualification = MeasureEligibility.NonQualifying;
+                var cohort = JsonSerializer.Deserialize<PatientCohortDefinition>(cohortElement.GetRawText());
+                if (cohort == null)
+                    continue;
+
+                var hasExplicitCohortQualification = cohortElement.ValueKind == JsonValueKind.Object
+                    && cohortElement.EnumerateObject().Any(p =>
+                        string.Equals(p.Name, nameof(PatientCohortDefinition.CohortQualification), StringComparison.OrdinalIgnoreCase));
+
+                if (!hasExplicitCohortQualification)
+                {
+                    var allNonQualifying = cohort.MeasureEligibilities.Count > 0
+                        && cohort.MeasureEligibilities.Values.All(v => v == MeasureEligibility.NonQualifying);
+                    if (allNonQualifying)
+                        cohort.CohortQualification = MeasureEligibility.NonQualifying;
+                }
+
+                cohorts.Add(cohort);
             }
 
             return cohorts;

--- a/DotNet/Automation.UI/Services/RunExecutor.cs
+++ b/DotNet/Automation.UI/Services/RunExecutor.cs
@@ -30,6 +30,8 @@ namespace Automation.UI.Services;
 /// </summary>
 internal sealed class RunExecutor
 {
+    private const ScheduledInpatientPattern DefaultScheduledInpatientPattern = ScheduledInpatientPattern.AdmittedBeforePeriodRemainsInpatientAfterPeriod;
+
     private readonly AutomationConfig _automationConfig;
     private readonly IServiceProvider _hostServices;
     private readonly ISnapshotStore _snapshotStore;
@@ -215,7 +217,10 @@ internal sealed class RunExecutor
                     {
                         QueryPlan = effectiveQueryPlan,
                         ClinicalPeriodStart = scenarioConfig.StartDate,
-                        ClinicalPeriodEnd = scenarioConfig.EndDate
+                        ClinicalPeriodEnd = scenarioConfig.EndDate,
+                        AllowEncounterAnchoredDateOverrideForOutOfRange =
+                            state.Options.ReportMethod == ReportMethod.ScheduledReport
+                            || state.Options.ReportMethod == ReportMethod.RegenerateReport
                     },
                     importedPatients: importedPatients.Count > 0 ? importedPatients : null);
 
@@ -226,7 +231,7 @@ internal sealed class RunExecutor
                 // Use the manifest's parallel PatientIds + Profiles arrays as the source of truth.
                 expectedSubmittedPatientIds = generationManifest.PatientIds
                     .Where((_, idx) => idx < generationManifest.Profiles.Count
-                                       && generationManifest.Profiles[idx].QualifiesForAny(selectedMeasures))
+                                       && generationManifest.Profiles[idx].IsExpectedToBeSubmitted(selectedMeasures))
                     .ToList();
 
                 if (state.Options.ReportMethod == ReportMethod.ScheduledReport)
@@ -668,20 +673,13 @@ internal sealed class RunExecutor
         for (var i = 0; i < count; i++)
         {
             var profile = profiles[i];
-            if (!profile.QualifiesForAny(selectedMeasures))
+            if (!profile.IsExpectedToBeSubmitted(selectedMeasures))
                 continue;
 
-            if (IsExpectedInScheduledReport(profile.ScheduledInpatientPattern))
-                expected.Add(patientIds[i]);
+            expected.Add(patientIds[i]);
         }
 
         return expected;
-    }
-
-    private static bool IsExpectedInScheduledReport(ScheduledInpatientPattern? pattern)
-    {
-        var effective = pattern ?? ScheduledInpatientPattern.AdmittedDuringPeriodDischargedDuringPeriod;
-        return effective.GetCensusBehavior().ExpectedInReport;
     }
 
     private static string ToZulu(DateTimeOffset value)
@@ -734,7 +732,7 @@ internal sealed class RunExecutor
         for (var i = 0; i < count; i++)
         {
             var pattern = profiles[i].ScheduledInpatientPattern
-                ?? ScheduledInpatientPattern.AdmittedDuringPeriodDischargedDuringPeriod;
+                ?? DefaultScheduledInpatientPattern;
             var behavior = pattern.GetCensusBehavior();
 
             // Patterns whose entire stay sits outside the report period emit no census events;

--- a/DotNet/Automation.UI/Services/RunExecutor.cs
+++ b/DotNet/Automation.UI/Services/RunExecutor.cs
@@ -85,9 +85,11 @@ internal sealed class RunExecutor
         {
             var scenarioConfig = ScenarioConfigBuilder.Build(state.Scenario, state.Options);
 
-            // For scheduled-report, compute the active window immediately so generation
+            var usesScheduledWorkflow = state.Options.ReportMethod is ReportMethod.ScheduledReport or ReportMethod.RegenerateReport;
+
+            // For scheduled-style runs, compute the active window immediately so generation
             // uses the correct clinical period boundaries (scenarioConfig.StartDate/EndDate).
-            if (state.Options.ReportMethod == ReportMethod.ScheduledReport)
+            if (usesScheduledWorkflow)
             {
                 // Use a clinically meaningful report window for generation so scheduled
                 // inpatient patterns produce rich in-period evidence (not minute-scale data).
@@ -313,7 +315,7 @@ internal sealed class RunExecutor
             // (a) attempt to read FHIR List resources that do not exist on the synthetic server
             // — surfacing spurious "configuration missing" errors — and (b) publish empty
             // snapshots that auto-discharge our still-admitted patients out of turn.
-            var enableBackgroundCensusJobs = state.Options.ReportMethod != ReportMethod.ScheduledReport;
+            var enableBackgroundCensusJobs = !usesScheduledWorkflow;
             await FacilitySetupHelper.EnsureCensusConfigAsync(
                 services.GetRequiredService<ICensusServiceClient>(),
                 output,
@@ -327,7 +329,7 @@ internal sealed class RunExecutor
 
             Frequency? scheduledRunFrequency = null;
             string reportId;
-            if (state.Options.ReportMethod == ReportMethod.ScheduledReport)
+            if (usesScheduledWorkflow)
             {
                 var scheduledWorkflowState = await ExecuteScheduledReportWorkflowAsync(
                     reportHelper,
@@ -376,7 +378,7 @@ internal sealed class RunExecutor
                     throw new InvalidOperationException($"Expected report with id {reportId} to be submitted but it was not.");
             }
 
-            if (state.Options.ReportMethod == ReportMethod.ScheduledReport)
+            if (usesScheduledWorkflow)
             {
                 // Scheduled runs can briefly report Submitted while entry-level state is still
                 // converging. Reconcile against terminal report truth (entries + submission
@@ -691,7 +693,7 @@ internal sealed class RunExecutor
     // Keep scheduled test runtimes bounded while still allowing long clinical windows.
     // Admin.BFF computes EndDate using current-time + delay, so this controls how long
     // the run waits for end-of-period execution.
-    private static readonly TimeSpan ScheduledRuntimeDelay = TimeSpan.FromMinutes(4);
+    private static readonly TimeSpan ScheduledRuntimeDelay = TimeSpan.FromMinutes(2);
 
     private static ScheduledReportWindow DeriveScheduledReportWindow(TestScenarioConfig scenarioConfig)
     {

--- a/DotNet/Automation.UI/Services/ScenarioSeedService.cs
+++ b/DotNet/Automation.UI/Services/ScenarioSeedService.cs
@@ -92,7 +92,8 @@ public sealed class ScenarioSeedService : IHostedService
                     MeasureEligibilities = new(DefaultQualifyingEligibilities),
                     EligibleClinicalScenarioIds = [..DefaultEligibleScenarioIds],
                     ResourcesPerPatientMin = 1000,
-                    ResourcesPerPatientMax = 1000
+                    ResourcesPerPatientMax = 1000,
+                    ScheduledInpatientPattern = ScheduledInpatientPattern.AdmittedBeforePeriodRemainsInpatientAfterPeriod
                 }
             ],
             CleanupServiceData = false,
@@ -120,7 +121,8 @@ public sealed class ScenarioSeedService : IHostedService
                     MeasureEligibilities = new(DefaultQualifyingEligibilities),
                     EligibleClinicalScenarioIds = [..DefaultEligibleScenarioIds],
                     ResourcesPerPatientMin = 15,
-                    ResourcesPerPatientMax = 15
+                    ResourcesPerPatientMax = 15,
+                    ScheduledInpatientPattern = ScheduledInpatientPattern.AdmittedBeforePeriodRemainsInpatientAfterPeriod
                 }
             ],
             CleanupServiceData = false,
@@ -148,7 +150,8 @@ public sealed class ScenarioSeedService : IHostedService
                     MeasureEligibilities = new(DefaultQualifyingEligibilities),
                     EligibleClinicalScenarioIds = [..DefaultEligibleScenarioIds],
                     ResourcesPerPatientMin = 25,
-                    ResourcesPerPatientMax = 50
+                    ResourcesPerPatientMax = 50,
+                    ScheduledInpatientPattern = ScheduledInpatientPattern.AdmittedBeforePeriodRemainsInpatientAfterPeriod
                 }
             ],
             CleanupServiceData = false,
@@ -176,7 +179,8 @@ public sealed class ScenarioSeedService : IHostedService
                     MeasureEligibilities = new(DefaultQualifyingEligibilities),
                     EligibleClinicalScenarioIds = [..DefaultEligibleScenarioIds],
                     ResourcesPerPatientMin = FhirBundleGenerator.DefaultResourcesPerPatient,
-                    ResourcesPerPatientMax = FhirBundleGenerator.DefaultResourcesPerPatient
+                    ResourcesPerPatientMax = FhirBundleGenerator.DefaultResourcesPerPatient,
+                    ScheduledInpatientPattern = ScheduledInpatientPattern.AdmittedBeforePeriodRemainsInpatientAfterPeriod
                 }
             ],
             CleanupServiceData = false,
@@ -204,7 +208,8 @@ public sealed class ScenarioSeedService : IHostedService
                     MeasureEligibilities = new(DefaultQualifyingEligibilities),
                     EligibleClinicalScenarioIds = [..DefaultEligibleScenarioIds],
                     ResourcesPerPatientMin = 5000,
-                    ResourcesPerPatientMax = 5000
+                    ResourcesPerPatientMax = 5000,
+                    ScheduledInpatientPattern = ScheduledInpatientPattern.AdmittedBeforePeriodRemainsInpatientAfterPeriod
                 },
                 new PatientCohortDefinition
                 {
@@ -212,7 +217,8 @@ public sealed class ScenarioSeedService : IHostedService
                     MeasureEligibilities = new(DefaultQualifyingEligibilities),
                     EligibleClinicalScenarioIds = [..DefaultEligibleScenarioIds],
                     ResourcesPerPatientMin = 25,
-                    ResourcesPerPatientMax = 50
+                    ResourcesPerPatientMax = 50,
+                    ScheduledInpatientPattern = ScheduledInpatientPattern.AdmittedBeforePeriodRemainsInpatientAfterPeriod
                 }
             ],
             CleanupServiceData = false,
@@ -316,7 +322,8 @@ public sealed class ScenarioSeedService : IHostedService
                     MeasureEligibilities = new(DefaultQualifyingEligibilities),
                     EligibleClinicalScenarioIds = [..DefaultEligibleScenarioIds],
                     ResourcesPerPatientMin = 100,
-                    ResourcesPerPatientMax = 100
+                    ResourcesPerPatientMax = 100,
+                    ScheduledInpatientPattern = ScheduledInpatientPattern.AdmittedBeforePeriodRemainsInpatientAfterPeriod
                 }
             ],
             CleanupServiceData = false,

--- a/DotNet/Automation.UI/Services/ScenarioSeedService.cs
+++ b/DotNet/Automation.UI/Services/ScenarioSeedService.cs
@@ -273,6 +273,7 @@ public sealed class ScenarioSeedService : IHostedService
                 new PatientCohortDefinition
                 {
                     PatientCount = 1,
+                    CohortQualification = MeasureEligibility.NonQualifying,
                     MeasureEligibilities = new(DefaultNonQualifyingEligibilities),
                     EligibleClinicalScenarioIds = [..DefaultNonQualifyingScenarioIds],
                     ResourcesPerPatientMin = 50,
@@ -282,6 +283,7 @@ public sealed class ScenarioSeedService : IHostedService
                 new PatientCohortDefinition
                 {
                     PatientCount = 1,
+                    CohortQualification = MeasureEligibility.NonQualifying,
                     MeasureEligibilities = new(DefaultNonQualifyingEligibilities),
                     EligibleClinicalScenarioIds = [..DefaultNonQualifyingScenarioIds],
                     ResourcesPerPatientMin = 50,
@@ -358,7 +360,8 @@ public sealed class ScenarioSeedService : IHostedService
                         ], MeasureEligibility.Qualifying)
                     ],
                     ResourcesPerPatientMin = 250,
-                    ResourcesPerPatientMax = 250
+                    ResourcesPerPatientMax = 250,
+                    ScheduledInpatientPattern = ScheduledInpatientPattern.AdmittedDuringPeriodDischargedDuringPeriod
                 },
                 // Cohort 2: qualifies for ACH only (inpatient, no Hypo med)
                 new PatientCohortDefinition
@@ -371,7 +374,8 @@ public sealed class ScenarioSeedService : IHostedService
                     },
                     EligibleClinicalScenarioIds = [..DefaultEligibleScenarioIds],
                     ResourcesPerPatientMin = 250,
-                    ResourcesPerPatientMax = 250
+                    ResourcesPerPatientMax = 250,
+                    ScheduledInpatientPattern = ScheduledInpatientPattern.AdmittedDuringPeriodDischargedDuringPeriod
                 }
             ],
             CleanupServiceData = false,

--- a/DotNet/Automation.UI/Services/StartScenarioRequestResolver.cs
+++ b/DotNet/Automation.UI/Services/StartScenarioRequestResolver.cs
@@ -1,6 +1,5 @@
-﻿using System.Text.Json;
-using Automation.UI.Models;
-using LantanaGroup.Automation.Generation;
+﻿using Automation.UI.Models;
+using System.Text.Json;
 
 namespace Automation.UI.Services;
 
@@ -44,12 +43,14 @@ public static class StartScenarioRequestResolver
             ? request.PatientCohorts
             : ExtractCohortsFromJson(request.RunConfigurationJson, effectiveMeasures)
               ?? [
-                  PatientCohortDefinition.AllQualifying(
+                  BuildDefaultCohort(
                       effectiveMeasures,
                       request.PatientCount ?? defaults.PatientCount,
                       request.ResourcesPerPatient ?? defaults.ResourcesPerPatient,
                       request.ResourcesPerPatient ?? defaults.ResourcesPerPatient)
               ];
+
+        ApplyCohortDefaults(cohorts, effectiveMeasures);
 
         // Cohorts are the single source of truth for patient profiles; expand them.
         var profiles = PatientCohortDefinition.ExpandProfiles(cohorts, request.Seed ?? defaults.Seed);
@@ -88,6 +89,32 @@ public static class StartScenarioRequestResolver
             ReportPeriodStart = reportStart,
             ReportPeriodEnd = reportEnd
         };
+    }
+
+    private static PatientCohortDefinition BuildDefaultCohort(
+        IReadOnlyList<ProfiledMeasureType> measures,
+        int patientCount,
+        int resourcesMin,
+        int resourcesMax)
+    {
+        var cohort = PatientCohortDefinition.AllQualifying(measures, patientCount, resourcesMin, resourcesMax);
+        cohort.ScheduledInpatientPattern = ScheduledInpatientPattern.AdmittedBeforePeriodRemainsInpatientAfterPeriod;
+        return cohort;
+    }
+
+    private static void ApplyCohortDefaults(
+        IReadOnlyList<PatientCohortDefinition> cohorts,
+        IReadOnlyList<ProfiledMeasureType> selectedMeasures)
+    {
+        foreach (var cohort in cohorts)
+        {
+            cohort.ScheduledInpatientPattern ??= ScheduledInpatientPattern.AdmittedBeforePeriodRemainsInpatientAfterPeriod;
+
+            var allNonQualifying = selectedMeasures.Count > 0
+                && selectedMeasures.All(m => cohort.GetEligibility(m) == MeasureEligibility.NonQualifying);
+            if (allNonQualifying)
+                cohort.CohortQualification = MeasureEligibility.NonQualifying;
+        }
     }
 
     /// <summary>
@@ -256,9 +283,12 @@ public static class StartScenarioRequestResolver
                     }
                 }
 
+                var cohortQualification = InferCohortQualification(item, eligibilities, measures);
+
                 cohorts.Add(new PatientCohortDefinition
                 {
                     PatientCount = count,
+                    CohortQualification = cohortQualification,
                     MeasureEligibilities = eligibilities,
                     EligibleClinicalScenarioIds = scenarioIds,
                     ResourcesPerPatientMin = min,
@@ -273,7 +303,10 @@ public static class StartScenarioRequestResolver
         {
             return null;
         }
+
     }
+
+
 
     /// <summary>
     /// Extracts an imported-patient list (<c>importedPatientIds</c> or <c>importedPatientBundles</c>)
@@ -308,5 +341,32 @@ public static class StartScenarioRequestResolver
         {
             return null;
         }
+    }
+
+    private static MeasureEligibility InferCohortQualification(
+        JsonElement cohortElement,
+        IReadOnlyDictionary<ProfiledMeasureType, MeasureEligibility> eligibilities,
+        IReadOnlyList<ProfiledMeasureType> measures)
+    {
+        if (cohortElement.TryGetProperty("cohortQualification", out var cqEl))
+        {
+            if (cqEl.ValueKind == JsonValueKind.String
+                && Enum.TryParse<MeasureEligibility>(cqEl.GetString(), ignoreCase: true, out var parsed))
+            {
+                return parsed;
+            }
+
+            if (cqEl.ValueKind == JsonValueKind.Number)
+            {
+                var asInt = cqEl.GetInt32();
+                if (asInt == (int)MeasureEligibility.Qualifying) return MeasureEligibility.Qualifying;
+                if (asInt == (int)MeasureEligibility.NonQualifying) return MeasureEligibility.NonQualifying;
+            }
+        }
+
+        // Back-compat inference for scenarios saved before cohortQualification existed.
+        var allNonQualifying = measures.Count > 0
+            && measures.All(m => eligibilities.TryGetValue(m, out var e) && e == MeasureEligibility.NonQualifying);
+        return allNonQualifying ? MeasureEligibility.NonQualifying : MeasureEligibility.Qualifying;
     }
 }

--- a/DotNet/Automation.UI/Services/StartScenarioRequestResolver.cs
+++ b/DotNet/Automation.UI/Services/StartScenarioRequestResolver.cs
@@ -46,8 +46,8 @@ public static class StartScenarioRequestResolver
                   BuildDefaultCohort(
                       effectiveMeasures,
                       request.PatientCount ?? defaults.PatientCount,
-                      request.ResourcesPerPatient ?? defaults.ResourcesPerPatient,
-                      request.ResourcesPerPatient ?? defaults.ResourcesPerPatient)
+                      defaultResourcesMin: 250,
+                      defaultResourcesMax: 250)
               ];
 
         ApplyCohortDefaults(cohorts, effectiveMeasures);
@@ -70,7 +70,9 @@ public static class StartScenarioRequestResolver
         return defaults with
         {
             PatientCount = request.PatientCount ?? defaults.PatientCount,
-            ResourcesPerPatient = request.ResourcesPerPatient ?? defaults.ResourcesPerPatient,
+            // Legacy run-level ResourcesPerPatient is obsolete for cohort-based runs.
+            // Keep the field populated for back-compat telemetry/UI callers.
+            ResourcesPerPatient = cohorts.FirstOrDefault()?.ResourcesPerPatientMax ?? defaults.ResourcesPerPatient,
             Seed = request.Seed ?? defaults.Seed,
             PollingIntervalSeconds = 3,
             // Keep an explicit hard timeout for custom runs so scheduled workflows
@@ -94,10 +96,10 @@ public static class StartScenarioRequestResolver
     private static PatientCohortDefinition BuildDefaultCohort(
         IReadOnlyList<ProfiledMeasureType> measures,
         int patientCount,
-        int resourcesMin,
-        int resourcesMax)
+        int defaultResourcesMin,
+        int defaultResourcesMax)
     {
-        var cohort = PatientCohortDefinition.AllQualifying(measures, patientCount, resourcesMin, resourcesMax);
+        var cohort = PatientCohortDefinition.AllQualifying(measures, patientCount, defaultResourcesMin, defaultResourcesMax);
         cohort.ScheduledInpatientPattern = ScheduledInpatientPattern.AdmittedBeforePeriodRemainsInpatientAfterPeriod;
         return cohort;
     }

--- a/DotNet/Automation.UI/Views/Runs/Details.cshtml
+++ b/DotNet/Automation.UI/Views/Runs/Details.cshtml
@@ -565,6 +565,31 @@
             NhsnGlycemicControlHypoglycemicInitialPopulation: 'Hypoglycemic'
         };
 
+        const scheduledPatternShortNames = {
+            AdmittedBeforePeriodRemainsInpatientAfterPeriod: 'Before → Remains after',
+            AdmittedBeforePeriodDischargedDuringPeriod: 'Before → Discharged during',
+            AdmittedDuringPeriodRemainsInpatientAfterPeriod: 'During → Remains after',
+            AdmittedDuringPeriodDischargedDuringPeriod: 'During → Discharged during',
+            AdmittedAndDischargedBeforePeriod: 'Before → Before',
+            AdmittedAndDischargedAfterPeriod: 'After → After'
+        };
+        const defaultScheduledPattern = 'AdmittedBeforePeriodRemainsInpatientAfterPeriod';
+
+        function formatScheduledPattern(value) {
+            if (value === null || value === undefined || value === '')
+                return escapeHtml(scheduledPatternShortNames[defaultScheduledPattern]);
+            const key = String(value).trim();
+            if (!key) return escapeHtml(scheduledPatternShortNames[defaultScheduledPattern]);
+            if (scheduledPatternShortNames[key]) return escapeHtml(scheduledPatternShortNames[key]);
+            if (/^\d+$/.test(key)) {
+                const index = Number.parseInt(key, 10);
+                const keys = Object.keys(scheduledPatternShortNames);
+                if (index >= 0 && index < keys.length)
+                    return escapeHtml(scheduledPatternShortNames[keys[index]]);
+            }
+            return escapeHtml(toLabel(key));
+        }
+
         function renderConfigProperties(rawJson) {
             const container = document.getElementById('runConfigProps');
             if (!container) return;
@@ -692,11 +717,12 @@
                     }).join('');
                     const min = c?.resourcesPerPatientMin ?? '-';
                     const max = c?.resourcesPerPatientMax ?? '-';
-                    return `<tr><td class="fw-semibold">${idx + 1}</td><td>${c?.patientCount ?? '-'}</td><td>${escapeHtml(String(min))}\u2013${escapeHtml(String(max))}</td>${eligCells}</tr>`;
+                    const inpatientPattern = formatScheduledPattern(c?.scheduledInpatientPattern);
+                    return `<tr><td class="fw-semibold">${idx + 1}</td><td>${c?.patientCount ?? '-'}</td><td>${escapeHtml(String(min))}\u2013${escapeHtml(String(max))}</td><td>${inpatientPattern}</td>${eligCells}</tr>`;
                 }).join('');
 
                 cohortBody.innerHTML =
-                    `<table class="au-cohort-summary-table"><thead><tr><th>#</th><th>Patients</th><th>Resources</th>${measureCols}</tr></thead><tbody>${rows}</tbody></table>`;
+                    `<table class="au-cohort-summary-table"><thead><tr><th>#</th><th>Patients</th><th>Resources</th><th>Inpatient Pattern</th>${measureCols}</tr></thead><tbody>${rows}</tbody></table>`;
                 cohortCard.style.display = '';
             }
         }

--- a/DotNet/Automation.UI/Views/Runs/Index.cshtml
+++ b/DotNet/Automation.UI/Views/Runs/Index.cshtml
@@ -124,7 +124,6 @@
                         <input type="hidden" name="ReportMethod" id="qlReportMethod" value="Adhoc" />
                         <input type="hidden" name="Seed" id="qlSeed" value="20260329" />
                         <input type="hidden" name="PatientCount" id="qlPatientCount" value="10" />
-                        <input type="hidden" name="ResourcesPerPatient" id="qlResourcesPerPatient" value="250" />
                         <input type="hidden" name="CleanupFhirData" id="qlCleanupFhirData" value="true" />
                         <input type="hidden" name="CleanupServiceData" id="qlCleanupServiceData" value="false" />
                         <input type="hidden" name="QueryPlanTemplateId" id="qlQueryPlanTemplateId" value="" />

--- a/DotNet/Automation.UI/Views/Runs/Manifest.cshtml
+++ b/DotNet/Automation.UI/Views/Runs/Manifest.cshtml
@@ -135,6 +135,7 @@
     'use strict';
 
     const runId = '@runId';
+    const runConfigurationJson = @Html.Raw(System.Text.Json.JsonSerializer.Serialize(run.RunConfigurationJson ?? string.Empty));
     const manifestDataUrl = '@Url.Action("ManifestData", "Runs")';
     const absDataUrl = '@Url.Action("AbsUploadData", "Runs")';
     const isComplete = @(isComplete ? "true" : "false");
@@ -144,6 +145,16 @@
         NhsnAcuteCareHospitalDailyInitialPopulation: 'ACH Daily',
         NhsnGlycemicControlHypoglycemicInitialPopulation: 'Hypoglycemic'
     };
+
+    const scheduledPatternShortNames = {
+        AdmittedBeforePeriodRemainsInpatientAfterPeriod: 'Before → Remains after',
+        AdmittedBeforePeriodDischargedDuringPeriod: 'Before → Discharged during',
+        AdmittedDuringPeriodRemainsInpatientAfterPeriod: 'During → Remains after',
+        AdmittedDuringPeriodDischargedDuringPeriod: 'During → Discharged during',
+        AdmittedAndDischargedBeforePeriod: 'Before → Before',
+        AdmittedAndDischargedAfterPeriod: 'After → After'
+    };
+    const defaultScheduledPattern = 'AdmittedBeforePeriodRemainsInpatientAfterPeriod';
 
     const chartColors = [
         '#4da3ff','#28a745','#ffc107','#dc3545','#6f42c1','#20c997','#fd7e14',
@@ -157,6 +168,21 @@
         return d.innerHTML;
     }
 
+    function formatScheduledPattern(value) {
+        if (value === null || value === undefined || value === '')
+            return escapeHtml(scheduledPatternShortNames[defaultScheduledPattern]);
+        const key = String(value).trim();
+        if (!key) return escapeHtml(scheduledPatternShortNames[defaultScheduledPattern]);
+        if (scheduledPatternShortNames[key]) return escapeHtml(scheduledPatternShortNames[key]);
+        if (/^\d+$/.test(key)) {
+            const index = Number.parseInt(key, 10);
+            const keys = Object.keys(scheduledPatternShortNames);
+            if (index >= 0 && index < keys.length)
+                return escapeHtml(scheduledPatternShortNames[keys[index]]);
+        }
+        return escapeHtml(key.replace(/([a-z])([A-Z])/g, '$1 $2'));
+    }
+
     function renderBadgeSet(items) {
         if (!items?.length) return '<span class="text-muted small">None</span>';
         return '<div class="d-flex flex-wrap gap-1">' +
@@ -166,6 +192,7 @@
 
     // ─── Fetch & Render ────────────────────────────────────────────
     let manifestData = null;
+    let fallbackInpatientPatternByPatient = null;
 
     fetch(`${manifestDataUrl}?id=${runId}`)
         .then(r => r.ok && r.status !== 204 ? r.json() : null)
@@ -302,6 +329,8 @@
             return;
         }
 
+        fallbackInpatientPatternByPatient = buildFallbackInpatientPatternMap(m);
+
         // Bar chart: total resources per patient (top 50)
         const patientTotals = patients.map(([pid, counts]) => ({
             pid,
@@ -353,14 +382,18 @@
         }
 
         // Compact table view for many patients
-        let html = '<table class="au-table table table-sm small mb-0"><thead><tr><th>Patient</th><th class="text-end">Total</th><th>Resource Types</th></tr></thead><tbody>';
+        let html = '<table class="au-table table table-sm small mb-0"><thead><tr><th>Patient</th><th>Inpatient Pattern</th><th class="text-end">Total</th><th>Resource Types</th></tr></thead><tbody>';
         patients.forEach(([pid, counts]) => {
             const total = Object.values(counts).reduce((s, c) => s + c, 0);
+            const inpatientPattern = manifestData?.patientInpatientPatterns?.[pid]
+                || fallbackInpatientPatternByPatient?.[pid]
+                || defaultScheduledPattern;
             const types = Object.entries(counts).sort(([,a],[,b]) => b - a)
                 .map(([t, c]) => `<span class="badge me-1 mb-1" style="background:#e8f4ff;color:var(--au-dark);border:1px solid #c5ddf5;font-weight:500;" data-bs-toggle="tooltip" title="${c} ${t}">${escapeHtml(t)}: ${c}</span>`)
                 .join('');
             html += `<tr>
                 <td><code>${escapeHtml(pid)}</code></td>
+                <td>${formatScheduledPattern(inpatientPattern)}</td>
                 <td class="text-end fw-semibold">${total.toLocaleString()}</td>
                 <td style="max-width:500px;">${types}</td>
             </tr>`;
@@ -369,6 +402,47 @@
         container.innerHTML = html;
         // Re-init tooltips for new elements
         container.querySelectorAll('[data-bs-toggle="tooltip"]').forEach(el => new bootstrap.Tooltip(el));
+    }
+
+    function normalizePatternForDisplay(value) {
+        if (value === null || value === undefined || value === '') return defaultScheduledPattern;
+        const key = String(value).trim();
+        if (!key) return defaultScheduledPattern;
+        if (scheduledPatternShortNames[key]) return key;
+        if (/^\d+$/.test(key)) {
+            const index = Number.parseInt(key, 10);
+            const keys = Object.keys(scheduledPatternShortNames);
+            if (index >= 0 && index < keys.length) return keys[index];
+        }
+        return key;
+    }
+
+    function buildFallbackInpatientPatternMap(m) {
+        const map = {};
+        if (!m?.patientIds?.length) return map;
+
+        try {
+            const cfg = runConfigurationJson ? JSON.parse(runConfigurationJson) : null;
+            const cohorts = Array.isArray(cfg?.patientCohorts) ? cfg.patientCohorts : [];
+            if (!cohorts.length) return map;
+
+            const expandedPatterns = [];
+            cohorts.forEach(c => {
+                const count = Number.parseInt(String(c?.patientCount ?? 0), 10);
+                const safeCount = Number.isFinite(count) && count > 0 ? count : 0;
+                const pattern = normalizePatternForDisplay(c?.scheduledInpatientPattern);
+                for (let i = 0; i < safeCount; i++) expandedPatterns.push(pattern);
+            });
+
+            const max = Math.min(m.patientIds.length, expandedPatterns.length);
+            for (let i = 0; i < max; i++) {
+                map[m.patientIds[i]] = expandedPatterns[i];
+            }
+        } catch {
+            // Ignore parse failures; caller will use manifest map/default fallback.
+        }
+
+        return map;
     }
 
     // ─── COMPARISON TAB ────────────────────────────────────────────

--- a/DotNet/Automation.UI/Views/Scenarios/Index.cshtml
+++ b/DotNet/Automation.UI/Views/Scenarios/Index.cshtml
@@ -32,12 +32,17 @@
                 <tbody>
                     @foreach (var s in Model)
                     {
-                        var resourceRange = s.ResourcesPerPatientMin == s.ResourcesPerPatientMax
-                            ? s.ResourcesPerPatientMin.ToString()
-                            : $"{s.ResourcesPerPatientMin}\u2013{s.ResourcesPerPatientMax}";
                         var patientCount = s.PatientCohorts.Count > 0
                             ? s.PatientCohorts.Sum(c => c.PatientCount)
                             : s.PatientCount;
+                        var resourceRange = s.PatientCohorts.Count > 0
+                            ? string.Join(", ",
+                                s.PatientCohorts
+                                    .Select(c => c.ResourcesPerPatientMin == c.ResourcesPerPatientMax
+                                        ? c.ResourcesPerPatientMin.ToString()
+                                        : $"{c.ResourcesPerPatientMin}\u2013{c.ResourcesPerPatientMax}")
+                                    .Distinct())
+                            : "-";
 
                         <tr data-id="@s.Id">
                             <td>

--- a/DotNet/Automation.UI/Views/Shared/_ScenarioEditorModal.cshtml
+++ b/DotNet/Automation.UI/Views/Shared/_ScenarioEditorModal.cshtml
@@ -13,12 +13,24 @@
 @{
     var queryPlanTemplates = (List<QueryPlanTemplate>?)ViewBag.QueryPlanTemplates ?? [];
     var clinicalScenarios = ClinicalScenarioInfo.GetAll(Enum.GetValues<ProfiledMeasureType>().ToList());
+    var scheduledPatternOptions = Enum.GetValues<ScheduledInpatientPattern>()
+        .Select(p =>
+        {
+            return new
+            {
+                Value = p.ToString(),
+                Label = p.GetUiShortLabel(),
+                Hint = p.GetUiHint(),
+                ExpectedInReport = p.GetCensusBehavior().ExpectedInReport
+            };
+        })
+        .ToList();
 }
 
 @* ========== Scenario Editor Modal ========== *@
 <div id="scenarioModal" style="display:none;position:fixed;inset:0;z-index:1055;overflow-y:auto;">
     <div style="min-height:100%;display:flex;align-items:center;justify-content:center;padding:2rem;">
-        <div style="background:#fff;border-radius:var(--au-radius);box-shadow:0 8px 40px rgba(0,0,0,.3);width:100%;max-width:960px;display:flex;flex-direction:column;max-height:90vh;">
+        <div class="au-scenario-modal-dialog" style="background:#fff;border-radius:var(--au-radius);box-shadow:0 8px 40px rgba(0,0,0,.3);width:100%;display:flex;flex-direction:column;max-height:90vh;">
             <div style="background:var(--au-dark);color:#fff;padding:.75rem 1rem;border-radius:var(--au-radius) var(--au-radius) 0 0;flex-shrink:0;" class="d-flex justify-content-between align-items-center">
                 <h5 class="mb-0" id="modalTitle"><i class="bi bi-pencil-square me-2"></i>Scenario</h5>
                 <div class="d-flex gap-2 align-items-center">
@@ -108,20 +120,24 @@
                             <div class="au-cohort-card mt-1">
                                 <div class="card-body">
                                     <span class="fw-semibold"><i class="bi bi-people-fill me-1"></i>Cohorts</span>
-                                    <table class="table table-sm table-bordered au-table mb-2 mt-2" id="cohortTable">
-                                        <thead>
-                                            <tr>
-                                                <th style="width:40px">#</th>
-                                                <th style="width:100px">Patients</th>
-                                                <th>Measure Eligibility</th>
-                                                <th style="width:90px">Res Min</th>
-                                                <th style="width:90px">Res Max</th>
-                                                <th>Clinical Profiles</th>
-                                                <th style="width:40px"></th>
-                                            </tr>
-                                        </thead>
-                                        <tbody id="cohortRows"></tbody>
-                                    </table>
+                                    <div class="table-responsive au-table-wrap mt-2 mb-2">
+                                        <table class="table table-sm table-bordered au-table au-cohort-table mb-0" id="cohortTable">
+                                            <thead>
+                                                <tr>
+                                                    <th style="width:40px">#</th>
+                                                    <th style="width:100px">Patients</th>
+                                                    <th style="width:140px">Cohort Outcome</th>
+                                                    <th>Measure Eligibility</th>
+                                                    <th style="width:90px">Res Min</th>
+                                                    <th style="width:90px">Res Max</th>
+                                                    <th>Clinical Profiles</th>
+                                                    <th class="cohort-pattern-col" style="min-width:240px">Inpatient Pattern</th>
+                                                    <th style="width:40px"></th>
+                                                </tr>
+                                            </thead>
+                                            <tbody id="cohortRows"></tbody>
+                                        </table>
+                                    </div>
                                     <div class="d-flex gap-2" id="cohortActions">
                                         <button type="button" class="btn btn-sm btn-outline-success" id="addQualifyingCohort">+ Qualifying</button>
                                         <button type="button" class="btn btn-sm btn-outline-warning" id="addNonQualifyingCohort">+ Non-Qualifying</button>
@@ -138,20 +154,22 @@
                                     <div class="small text-muted mb-2">
                                         Supplements the random/cohort generation above. ID-based patients are fetched from the configured FHIR server at run time and are <em>not</em> expunged on cleanup. Bundle uploads are uploaded to the FHIR server during the run and <em>are</em> expunged on cleanup.
                                     </div>
-                                    <table class="table table-sm table-bordered au-table mb-2" id="importedTable">
-                                        <thead>
-                                            <tr>
-                                                <th style="width:40px">#</th>
-                                                <th style="width:90px">Source</th>
-                                                <th>Patient ID / File</th>
-                                                <th>Measure Eligibility</th>
-                                                <th style="width:170px">Encounter Dates</th>
-                                                <th style="width:90px">Detected</th>
-                                                <th style="width:40px"></th>
-                                            </tr>
-                                        </thead>
-                                        <tbody id="importedRows"></tbody>
-                                    </table>
+                                    <div class="table-responsive au-table-wrap mb-2">
+                                        <table class="table table-sm table-bordered au-table au-imported-table mb-0" id="importedTable">
+                                            <thead>
+                                                <tr>
+                                                    <th style="width:40px">#</th>
+                                                    <th style="width:90px">Source</th>
+                                                    <th>Patient ID / File</th>
+                                                    <th>Measure Eligibility</th>
+                                                    <th style="width:170px">Encounter Dates</th>
+                                                    <th style="width:90px">Detected</th>
+                                                    <th style="width:40px"></th>
+                                                </tr>
+                                            </thead>
+                                            <tbody id="importedRows"></tbody>
+                                        </table>
+                                    </div>
                                     <div class="d-flex gap-2 align-items-center flex-wrap" id="importedActions">
                                         <div class="input-group input-group-sm" style="width:auto;">
                                             <span class="input-group-text">Patient ID</span>
@@ -182,6 +200,10 @@
                         new System.Text.Json.JsonSerializerOptions { PropertyNamingPolicy = System.Text.Json.JsonNamingPolicy.CamelCase }));
 
         var QUALIFYING = 'Qualifying', NON_QUALIFYING = 'NonQualifying';
+        var scheduledPatternOptions = @Html.Raw(System.Text.Json.JsonSerializer.Serialize(
+                        scheduledPatternOptions,
+                        new System.Text.Json.JsonSerializerOptions { PropertyNamingPolicy = System.Text.Json.JsonNamingPolicy.CamelCase }));
+        var DEFAULT_SCHEDULED_PATTERN = scheduledPatternOptions[0].value;
         var modal = document.getElementById('scenarioModal');
         var backdrop = document.getElementById('scenarioModalBackdrop');
         var modalTitle = document.getElementById('modalTitle');
@@ -308,6 +330,84 @@
             return clinicalScenarioCatalog.filter(function (sc) { return cohortMatchesScenario(sc, n); }).map(function (sc) { return sid(sc.scenarioId); });
         }
 
+        function normalizeScheduledPattern(value) {
+            var raw = String(value || '').trim();
+            if (!raw) return DEFAULT_SCHEDULED_PATTERN;
+            var direct = scheduledPatternOptions.find(function (o) { return o.value === raw; });
+            if (direct) return direct.value;
+
+            var lowered = raw.toLowerCase();
+            var byCaseInsensitiveName = scheduledPatternOptions.find(function (o) { return o.value.toLowerCase() === lowered; });
+            if (byCaseInsensitiveName) return byCaseInsensitiveName.value;
+
+            var numeric = parseInt(raw, 10);
+            if (!isNaN(numeric) && numeric >= 0 && numeric < scheduledPatternOptions.length)
+                return scheduledPatternOptions[numeric].value;
+
+            return DEFAULT_SCHEDULED_PATTERN;
+        }
+
+        function normalizeCohortQualification(value) {
+            var raw = String(value || '').trim();
+            if (!raw) return QUALIFYING;
+            var lowered = raw.toLowerCase();
+            if (lowered === 'nonqualifying' || lowered === 'non_qualifying' || lowered === 'non-qualifying' || lowered === '1')
+                return NON_QUALIFYING;
+            return QUALIFYING;
+        }
+
+        function inferCohortQualification(elig) {
+            var n = normElig(elig);
+            var measures = selectedMeasureTypes();
+            var allNonQualifying = measures.length > 0 && measures.every(function (m) { return n[m] === NON_QUALIFYING; });
+            return allNonQualifying ? NON_QUALIFYING : QUALIFYING;
+        }
+
+        function allowedScheduledPatternsForQualification(qualification) {
+            var normalized = normalizeCohortQualification(qualification);
+            return scheduledPatternOptions.filter(function (o) {
+                return normalized === QUALIFYING ? !!o.expectedInReport : !o.expectedInReport;
+            });
+        }
+
+        function buildScheduledPatternEditor(pattern, qualification) {
+            var allowed = allowedScheduledPatternsForQualification(qualification);
+            var normalized = normalizeScheduledPattern(pattern);
+            var selected = allowed.some(function (o) { return o.value === normalized; })
+                ? normalized
+                : (allowed[0] ? allowed[0].value : DEFAULT_SCHEDULED_PATTERN);
+            var options = allowed.map(function (o) {
+                return '<option value="' + o.value + '" title="' + escAttr(o.hint || o.label) + '" ' + (o.value === selected ? 'selected' : '') + '>' + esc(o.label) + '</option>';
+            }).join('');
+            return '<select class="form-select form-select-sm cohort-scheduled-pattern">' + options + '</select>';
+        }
+
+        function buildCohortQualificationEditor(value) {
+            var selected = normalizeCohortQualification(value);
+            return '<select class="form-select form-select-sm cohort-qualification">' +
+                '<option value="' + QUALIFYING + '" ' + (selected === QUALIFYING ? 'selected' : '') + '>Qualifying</option>' +
+                '<option value="' + NON_QUALIFYING + '" ' + (selected === NON_QUALIFYING ? 'selected' : '') + '>Non-Qualifying</option>' +
+                '</select>';
+        }
+
+        function readCohortQualification(row) {
+            var select = row.querySelector('.cohort-qualification');
+            return normalizeCohortQualification(select ? select.value : QUALIFYING);
+        }
+
+        function syncScheduledPatternEditorForRow(row) {
+            var cell = row.querySelector('.cohort-pattern-cell');
+            if (!cell) return;
+            var qualification = readCohortQualification(row);
+            var current = row.querySelector('.cohort-scheduled-pattern');
+            cell.innerHTML = buildScheduledPatternEditor(current ? current.value : DEFAULT_SCHEDULED_PATTERN, qualification);
+        }
+
+        function syncPatternColumns() {
+            document.querySelectorAll('.cohort-pattern-col').forEach(function (el) { el.style.display = ''; });
+            cohortRows.querySelectorAll('.cohort-pattern-cell').forEach(function (el) { el.style.display = ''; });
+        }
+
         // ---- Cohort row builders ----
         function buildEligEditor(elig) {
             var sel = selectedMeasureTypes();
@@ -328,21 +428,35 @@
             return '<div class="dropdown cohort-scenarios-dropdown"><button type="button" class="btn btn-sm btn-outline-secondary dropdown-toggle w-100 text-start cohort-scenarios-toggle" data-bs-toggle="dropdown" data-bs-auto-close="outside">All</button><div class="dropdown-menu p-2 w-100" style="max-height:200px;overflow:auto;">' + opts + '</div></div>';
         }
 
-        function addCohortRow(count, elig, scenarios, rMin, rMax) {
+        function addCohortRow(count, elig, scenarios, rMin, rMax, scheduledPattern, cohortQualification) {
             var idx = cohortRows.children.length, ne = normElig(elig);
             var sel = (scenarios && scenarios.length > 0) ? scenarios : eligIds(ne);
+            var normalizedQualification = normalizeCohortQualification(cohortQualification || inferCohortQualification(ne));
+            var effectivePattern = normalizeScheduledPattern(scheduledPattern);
             var tr = document.createElement('tr');
             tr.innerHTML = '<td class="text-center align-middle">' + (idx + 1) + '</td>' +
                 '<td><input type="number" class="form-control form-control-sm cohort-count" min="1" value="' + (count || 1) + '" /></td>' +
+                '<td>' + buildCohortQualificationEditor(normalizedQualification) + '</td>' +
                 '<td><div class="cohort-measure-editor">' + buildEligEditor(ne) + '</div></td>' +
                 '<td><input type="number" class="form-control form-control-sm cohort-min" min="1" value="' + (rMin || 50) + '" /></td>' +
                 '<td><input type="number" class="form-control form-control-sm cohort-max" min="1" value="' + (rMax || rMin || 100) + '" /></td>' +
                 '<td>' + buildScenarioSelect(sel) + '</td>' +
+                '<td class="cohort-pattern-cell">' + buildScheduledPatternEditor(effectivePattern, normalizedQualification) + '</td>' +
                 '<td class="text-center align-middle"><button type="button" class="btn btn-sm btn-outline-danger btn-remove-cohort">&times;</button></td>';
             cohortRows.appendChild(tr);
-            enforceDeps(tr); applyFilter(tr, readElig(tr)); updateSummary(tr); reindex(); syncCount();
+            enforceCohortMeasureRules(tr);
+            enforceDeps(tr);
+            enforceCohortMeasureRules(tr);
+            applyFilter(tr, readElig(tr));
+            updateSummary(tr);
+            reindex();
+            syncCount();
+            syncPatternColumns();
         }
-        function addDefault(count, isQ, rMin, rMax) { addCohortRow(count, defaultElig(!!isQ), null, rMin, rMax); }
+        function addDefault(count, isQ, rMin, rMax) {
+            var qualification = isQ ? QUALIFYING : NON_QUALIFYING;
+            addCohortRow(count, defaultElig(!!isQ), null, rMin, rMax, DEFAULT_SCHEDULED_PATTERN, qualification);
+        }
 
         function readElig(row) {
             var v = {}; row.querySelectorAll('.cohort-measure-eligibility').forEach(function (cb) { v[cb.getAttribute('data-measure')] = cb.checked ? QUALIFYING : NON_QUALIFYING; });
@@ -356,9 +470,38 @@
             if (ch === 'NhsnAcuteCareHospitalMonthlyInitialPopulation' && !ach.checked && hypo.checked) { hypo.checked = false; return; }
             if (hypo.checked && !ach.checked) ach.checked = true;
         }
+        function enforceCohortMeasureRules(row, changedMeasure) {
+            var qualification = readCohortQualification(row);
+            var boxes = Array.prototype.slice.call(row.querySelectorAll('.cohort-measure-eligibility'));
+            if (!boxes.length) return;
+
+            if (qualification === NON_QUALIFYING) {
+                boxes.forEach(function (cb) { cb.checked = false; cb.disabled = true; });
+                return;
+            }
+
+            boxes.forEach(function (cb) { cb.disabled = false; });
+
+            if (boxes.length === 1) {
+                boxes[0].checked = true;
+                boxes[0].disabled = true;
+                return;
+            }
+
+            var checked = boxes.filter(function (cb) { return cb.checked; });
+            if (!checked.length) {
+                var fallback = changedMeasure
+                    ? row.querySelector('.cohort-measure-eligibility[data-measure="' + changedMeasure + '"]')
+                    : null;
+                (fallback || boxes[0]).checked = true;
+            }
+        }
         function rerenderEditor(row) {
             var ed = row.querySelector('.cohort-measure-editor'); if (!ed) return;
-            ed.innerHTML = buildEligEditor(readElig(row)); enforceDeps(row); applyFilter(row, readElig(row));
+            ed.innerHTML = buildEligEditor(readElig(row));
+            enforceCohortMeasureRules(row);
+            enforceDeps(row);
+            applyFilter(row, readElig(row));
         }
         function applyFilter(row, elig) {
             var allowed = new Set(eligIds(elig)), dd = row.querySelector('.cohort-scenarios-dropdown');
@@ -389,11 +532,15 @@
                 var min = parseInt(row.querySelector('.cohort-min').value || '50', 10);
                 var max = parseInt(row.querySelector('.cohort-max').value || String(min), 10);
                 if (max < min) { max = min; row.querySelector('.cohort-max').value = String(max); }
+                var patternSelect = row.querySelector('.cohort-scheduled-pattern');
+                var qualification = readCohortQualification(row);
                 return {
                     patientCount: parseInt(row.querySelector('.cohort-count').value || '0', 10),
+                    cohortQualification: qualification,
                     measureEligibilities: readElig(row),
                     eligibleClinicalScenarioIds: Array.prototype.map.call(row.querySelectorAll('.cohort-scenario-option:checked:not(:disabled)'), function (cb) { return sid(cb.value); }).filter(Boolean),
-                    resourcesPerPatientMin: min, resourcesPerPatientMax: max
+                    resourcesPerPatientMin: min, resourcesPerPatientMax: max,
+                    scheduledInpatientPattern: normalizeScheduledPattern(patternSelect ? patternSelect.value : DEFAULT_SCHEDULED_PATTERN)
                 };
             }).filter(function (c) { return c.patientCount > 0; });
         }
@@ -403,7 +550,21 @@
         document.getElementById('addNonQualifyingCohort').addEventListener('click', function () { addDefault(10, false, 50, 100); });
         cohortRows.addEventListener('click', function (e) { if (e.target.closest('.btn-remove-cohort')) { e.target.closest('tr').remove(); reindex(); syncCount(); } });
         cohortRows.addEventListener('change', function (e) {
-            if (e.target.classList.contains('cohort-measure-eligibility')) { var r = e.target.closest('tr'); enforceDeps(r, e.target.getAttribute('data-measure')); applyFilter(r, readElig(r)); }
+            if (e.target.classList.contains('cohort-measure-eligibility')) {
+                var r1 = e.target.closest('tr');
+                enforceCohortMeasureRules(r1, e.target.getAttribute('data-measure'));
+                enforceDeps(r1, e.target.getAttribute('data-measure'));
+                enforceCohortMeasureRules(r1, e.target.getAttribute('data-measure'));
+                applyFilter(r1, readElig(r1));
+            }
+            if (e.target.classList.contains('cohort-qualification')) {
+                var r2 = e.target.closest('tr');
+                enforceCohortMeasureRules(r2);
+                enforceDeps(r2);
+                enforceCohortMeasureRules(r2);
+                applyFilter(r2, readElig(r2));
+                syncScheduledPatternEditorForRow(r2);
+            }
             if (e.target.classList.contains('cohort-scenario-option')) updateSummary(e.target.closest('tr'));
             if (e.target.classList.contains('cohort-count')) syncCount();
         });
@@ -411,6 +572,7 @@
         document.querySelectorAll('.measure-checkbox').forEach(function (cb) {
             cb.addEventListener('change', function () { Array.prototype.forEach.call(cohortRows.children, function (r) { rerenderEditor(r); }); });
         });
+        document.getElementById('ReportMethod').addEventListener('change', syncPatternColumns);
 
         // ---- Imported Patients ----
         var importedRows = document.getElementById('importedRows');
@@ -741,10 +903,20 @@
             (data.selectedMeasures || []).forEach(function (m) { var cb = document.getElementById(mMap[String(m)]); if (cb) cb.checked = true; });
             cohortRows.innerHTML = '';
             if (data.patientCohorts && data.patientCohorts.length > 0) {
-                data.patientCohorts.forEach(function (c) { addCohortRow(c.patientCount, c.measureEligibilities || defaultElig(true), c.eligibleClinicalScenarioIds || [], c.resourcesPerPatientMin || data.resourcesPerPatientMin || 50, c.resourcesPerPatientMax || data.resourcesPerPatientMax || 100); });
+                data.patientCohorts.forEach(function (c) {
+                    addCohortRow(
+                        c.patientCount,
+                        c.measureEligibilities || defaultElig(true),
+                        c.eligibleClinicalScenarioIds || [],
+                        c.resourcesPerPatientMin || data.resourcesPerPatientMin || 50,
+                        c.resourcesPerPatientMax || data.resourcesPerPatientMax || 100,
+                        c.scheduledInpatientPattern || DEFAULT_SCHEDULED_PATTERN,
+                        c.cohortQualification || inferCohortQualification(c.measureEligibilities));
+                });
             } else {
                 addDefault(data.patientCount || 10, true, data.resourcesPerPatientMin || 50, data.resourcesPerPatientMax || 100);
             }
+            syncPatternColumns();
             // Imported patients
             importedRows.innerHTML = '';
             (data.importedPatientIds || []).forEach(function (p) {

--- a/DotNet/Automation.UI/Views/Shared/_ScenarioEditorModal.cshtml
+++ b/DotNet/Automation.UI/Views/Shared/_ScenarioEditorModal.cshtml
@@ -845,8 +845,6 @@
         // ---- Collect form into JSON payload ----
         function collectModel() {
             var cohorts = getCohorts();
-            var mins = cohorts.map(function (c) { return c.resourcesPerPatientMin || 50; });
-            var maxes = cohorts.map(function (c) { return c.resourcesPerPatientMax || 100; });
             var imported = getImportedPatients();
             var importedIds = imported.filter(function (p) { return p.source === 'ExistingId'; });
             var importedBundles = imported.filter(function (p) { return p.source === 'Bundle'; });
@@ -862,8 +860,6 @@
                 // patientCount as a fallback cohort-generation target when no cohorts are
                 // configured; including imported patients here would inflate that fallback.
                 patientCount: cohorts.reduce(function (s, c) { return s + (c.patientCount || 0); }, 0),
-                resourcesPerPatientMin: mins.length > 0 ? Math.min.apply(null, mins) : 50,
-                resourcesPerPatientMax: maxes.length > 0 ? Math.max.apply(null, maxes) : 100,
                 patientCohorts: cohorts,
                 cleanupServiceData: document.getElementById('CleanupServiceData').checked,
                 cleanupFhirData: document.getElementById('CleanupFhirData').checked,

--- a/DotNet/Automation.UI/wwwroot/css/site.css
+++ b/DotNet/Automation.UI/wwwroot/css/site.css
@@ -173,6 +173,27 @@ body { margin-bottom: 60px; background: var(--au-bg); color: #222; }
 }
 .au-cohort-card .card-body { padding: .75rem 1rem; }
 
+.au-table-wrap {
+  width: 100%;
+  max-width: 100%;
+  overflow-x: auto;
+}
+
+.au-cohort-table {
+  min-width: 1080px;
+}
+
+.au-imported-table {
+  min-width: 860px;
+}
+
+.au-cohort-table td .form-control,
+.au-cohort-table td .form-select,
+.au-imported-table td .form-control,
+.au-imported-table td .form-select {
+  max-width: 100%;
+}
+
 /* ===================================================================
    Scenario header bar (inside the form)
    =================================================================== */
@@ -182,6 +203,10 @@ body { margin-bottom: 60px; background: var(--au-bg); color: #222; }
   border-radius: var(--au-radius);
   padding: .75rem 1rem;
   margin-bottom: 1rem;
+}
+
+.au-scenario-modal-dialog {
+  max-width: min(96vw, 1360px);
 }
 
 /* ===================================================================
@@ -277,6 +302,7 @@ body { margin-bottom: 60px; background: var(--au-bg); color: #222; }
   .au-card .card-body { padding: .75rem; }
   .au-table { font-size: .8rem; }
   .au-summary-item { font-size: .8rem; }
+  .au-scenario-modal-dialog { max-width: 96vw; }
 }
 
 /* ===================================================================

--- a/DotNet/Automation/Generation/FhirGenerationPipeline.cs
+++ b/DotNet/Automation/Generation/FhirGenerationPipeline.cs
@@ -59,6 +59,13 @@ public static class FhirGenerationPipeline
         public required QueryPlanInput QueryPlan { get; init; }
         public string? ClinicalPeriodStart { get; init; }
         public string? ClinicalPeriodEnd { get; init; }
+
+        /// <summary>
+        /// When true, the simulator may use encounter-anchored fallback for date-mismatch
+        /// cases (resource has a recognized date, but falls outside strict ge/le bounds).
+        /// Scheduled workflows rely on this to mirror downstream acquisition behavior.
+        /// </summary>
+        public bool AllowEncounterAnchoredDateOverrideForOutOfRange { get; init; }
     }
 
     /// <summary>
@@ -346,7 +353,8 @@ public static class FhirGenerationPipeline
                 acquisitionSimulation.QueryPlan,
                 acquisitionSimulation.ClinicalPeriodStart,
                 acquisitionSimulation.ClinicalPeriodEnd,
-                output);
+                output,
+                acquisitionSimulation.AllowEncounterAnchoredDateOverrideForOutOfRange);
             manifestBuilder.SetSimulatedAcquiredKeys(patientId, acquiredKeys);
             // patientSimEntries (JsonElement clones) are now eligible for GC
         }
@@ -484,7 +492,8 @@ public static class FhirGenerationPipeline
                 acquisitionSimulation.QueryPlan,
                 acquisitionSimulation.ClinicalPeriodStart,
                 acquisitionSimulation.ClinicalPeriodEnd,
-                output);
+                output,
+                acquisitionSimulation.AllowEncounterAnchoredDateOverrideForOutOfRange);
             manifestBuilder.SetSimulatedAcquiredKeys(patientId, acquiredKeys);
         }
 

--- a/DotNet/Automation/Generation/FhirGenerationPipeline.cs
+++ b/DotNet/Automation/Generation/FhirGenerationPipeline.cs
@@ -143,9 +143,13 @@ public static class FhirGenerationPipeline
         var qualifyingAllCount = profiles.Count(p => p.QualifiesForAll(measures));
         var nonQualifyingAllCount = profiles.Count(p => p.QualifiesForNone(measures));
         var mixedEligibilityCount = profiles.Count - qualifyingAllCount - nonQualifyingAllCount;
+        var profileResourceOverrides = profiles.Count(p => p.ResourcesPerPatient.HasValue);
+        var resourceShape = profileResourceOverrides > 0
+            ? $"run default ~{totalResourcesPerPatient} resources (per-profile overrides: {profileResourceOverrides})"
+            : $"~{totalResourcesPerPatient} resources each";
         output.WriteLine($"[Pipeline] Generating {profiles.Count} profiled patients ({qualifyingAllCount} qualifying-all, " +
                          $"{nonQualifyingAllCount} non-qualifying-all, {mixedEligibilityCount} mixed) " +
-                         $"with ~{totalResourcesPerPatient} resources each, runId='{effectiveRunId}'" +
+                         $"with {resourceShape}, runId='{effectiveRunId}'" +
                          (generationSeed.HasValue ? $", seed={generationSeed.Value}" : string.Empty) + "...");
 
         // ------------------------------------------------------------------
@@ -287,9 +291,13 @@ public static class FhirGenerationPipeline
         var patientSeed = baseSeed + (profile.SeedOffset ?? patientIndex);
         var patientId = ids.PatientId(patientIndex);
 
+        // Respect per-profile resources override when present (e.g., cohort min/max expansion).
+        // Falls back to run-level default for profiles that do not specify a concrete target.
+        var effectiveResourcesPerPatient = profile.ResourcesPerPatient ?? totalResourcesPerPatient;
+
         // Generate entries using the same per-patient logic shared with FhirBundleGenerator.
         var entries = GeneratePatientEntries(
-            profile, patientIndex, baseSeed, totalResourcesPerPatient,
+            profile, patientIndex, baseSeed, effectiveResourcesPerPatient,
             sharedPractitionerIds, sharedMedicationIds, measures,
             generationClinicalPeriodStart, generationClinicalPeriodEnd, config, ids);
 

--- a/DotNet/Automation/Generation/GenerationManifest.cs
+++ b/DotNet/Automation/Generation/GenerationManifest.cs
@@ -459,6 +459,7 @@ public sealed class GenerationManifest
     public GenerationManifestSnapshot ToSnapshot()
     {
         var eligibility = new Dictionary<string, List<string>>();
+        var inpatientPatterns = new Dictionary<string, string>(StringComparer.Ordinal);
         for (var i = 0; i < PatientIds.Count && i < Profiles.Count; i++)
         {
             var qualifying = new List<string>();
@@ -468,6 +469,10 @@ public sealed class GenerationManifest
                     qualifying.Add(measure.ToString());
             }
             eligibility[PatientIds[i]] = qualifying;
+
+            var pattern = Profiles[i].ScheduledInpatientPattern
+                ?? ScheduledInpatientPattern.AdmittedBeforePeriodRemainsInpatientAfterPeriod;
+            inpatientPatterns[PatientIds[i]] = pattern.ToString();
         }
 
         // Build predicted ABS counts per patient (generated ? acquired ? CQL-referenced)
@@ -503,6 +508,7 @@ public sealed class GenerationManifest
                 .Where(kv => !string.IsNullOrEmpty(kv.Key))
                 .ToDictionary(kv => kv.Key, kv => new Dictionary<string, int>(kv.Value)),
             PatientEligibility = eligibility,
+            PatientInpatientPatterns = inpatientPatterns,
             ExpectedAbsCountsByPatient = expectedAbsByPatient,
             ExpectedAbsTotalCountsByType = expectedAbsTotals
         };

--- a/DotNet/Automation/Generation/GenerationManifest.cs
+++ b/DotNet/Automation/Generation/GenerationManifest.cs
@@ -350,6 +350,8 @@ public sealed class GenerationManifest
         var idx = PatientIds.ToList().IndexOf(patientId);
         if (idx < 0 || idx >= Profiles.Count) return 0;
         var profile = Profiles[idx];
+        if (!profile.IsExpectedInReportByCohortAndPattern())
+            return 0;
         return SelectedMeasures.Count(m => profile.QualifiesFor(m));
     }
 
@@ -357,7 +359,7 @@ public sealed class GenerationManifest
     {
         var idx = PatientIds.ToList().IndexOf(patientId);
         if (idx < 0 || idx >= Profiles.Count) return false;
-        return Profiles[idx].QualifiesForAny(SelectedMeasures);
+        return Profiles[idx].IsExpectedToBeSubmitted(SelectedMeasures);
     }
 
     private bool ShouldExpectAbsForPatient(string patientId)
@@ -390,9 +392,10 @@ public sealed class GenerationManifest
     public int QualifyingPatientCount(string measureId)
     {
         var idx = IndexOfMeasure(measureId);
-        if (idx < 0 || idx >= SelectedMeasures.Count) return Profiles.Count; // fallback: assume all qualify
+        if (idx < 0 || idx >= SelectedMeasures.Count)
+            return Profiles.Count(p => p.IsExpectedInReportByCohortAndPattern());
         var measureType = SelectedMeasures[idx];
-        return Profiles.Count(p => p.QualifiesFor(measureType));
+        return Profiles.Count(p => p.IsExpectedInReportByCohortAndPattern() && p.QualifiesFor(measureType));
     }
 
     private static string GetResourceTypeFromKey(string key)
@@ -416,7 +419,7 @@ public sealed class GenerationManifest
         var result = new List<string>();
         for (var i = 0; i < PatientIds.Count && i < Profiles.Count; i++)
         {
-            if (Profiles[i].QualifiesForAny(SelectedMeasures))
+            if (Profiles[i].IsExpectedToBeSubmitted(SelectedMeasures))
                 result.Add(PatientIds[i]);
         }
         return result;

--- a/DotNet/Automation/Generation/GenerationManifestSnapshot.cs
+++ b/DotNet/Automation/Generation/GenerationManifestSnapshot.cs
@@ -41,6 +41,10 @@ public sealed class GenerationManifestSnapshot
     public IReadOnlyDictionary<string, List<string>> PatientEligibility { get; init; }
         = new Dictionary<string, List<string>>();
 
+    /// <summary>Per-patient scheduled inpatient pattern (enum name) used during generation.</summary>
+    public IReadOnlyDictionary<string, string> PatientInpatientPatterns { get; init; }
+        = new Dictionary<string, string>();
+
     /// <summary>
     /// Per-patient predicted ABS resource counts (generated ∩ query-plan-acquired ∩ CQL-referenced).
     /// This is the "our prediction" side of the Generated vs ABS comparison.

--- a/DotNet/Automation/Generation/PatientCohortDefinition.cs
+++ b/DotNet/Automation/Generation/PatientCohortDefinition.cs
@@ -15,6 +15,13 @@ public class PatientCohortDefinition
     public int PatientCount { get; set; }
 
     /// <summary>
+    /// Concrete cohort-level expected qualification outcome used by prediction logic.
+    /// This allows scenarios to explicitly mark a cohort as qualifying vs non-qualifying
+    /// independent of per-measure checkbox drift in UI editing.
+    /// </summary>
+    public MeasureEligibility CohortQualification { get; set; } = MeasureEligibility.Qualifying;
+
+    /// <summary>
     /// Optional scheduled-report inpatient behavior for patients in this cohort.
     /// When set, scheduled-report automation uses this to decide admit/discharge timing.
     /// </summary>
@@ -75,7 +82,11 @@ public class PatientCohortDefinition
                 var resources = min == max ? min : min + ((seed + seedCursor) % (max - min + 1));
                 result.Add(new PatientProfile(
                     new Dictionary<ProfiledMeasureType, MeasureEligibility>(cohort.MeasureEligibilities),
-                    seedOffset, scenarioId, resources, cohort.ScheduledInpatientPattern));
+                    seedOffset,
+                    scenarioId,
+                    resources,
+                    cohort.ScheduledInpatientPattern,
+                    cohort.CohortQualification));
                 seedCursor++;
             }
         }
@@ -95,6 +106,7 @@ public class PatientCohortDefinition
         return new PatientCohortDefinition
         {
             PatientCount = patientCount,
+            CohortQualification = MeasureEligibility.Qualifying,
             MeasureEligibilities = measures.ToDictionary(m => m, _ => MeasureEligibility.Qualifying),
             ResourcesPerPatientMin = resourcesMin,
             ResourcesPerPatientMax = resourcesMax
@@ -113,6 +125,7 @@ public class PatientCohortDefinition
         return new PatientCohortDefinition
         {
             PatientCount = patientCount,
+            CohortQualification = MeasureEligibility.NonQualifying,
             MeasureEligibilities = measures.ToDictionary(m => m, _ => MeasureEligibility.NonQualifying),
             ResourcesPerPatientMin = resourcesMin,
             ResourcesPerPatientMax = resourcesMax

--- a/DotNet/Automation/Generation/PatientCohortDefinition.cs
+++ b/DotNet/Automation/Generation/PatientCohortDefinition.cs
@@ -65,6 +65,7 @@ public class PatientCohortDefinition
     {
         var result = new List<PatientProfile>();
         var seedCursor = 0;
+        var cohortIndex = 0;
 
         foreach (var cohort in cohorts)
         {
@@ -79,7 +80,7 @@ public class PatientCohortDefinition
             {
                 var seedOffset = seedCursor;
                 var scenarioId = scenarios[seedCursor % scenarios.Count];
-                var resources = min == max ? min : min + ((seed + seedCursor) % (max - min + 1));
+                var resources = ComputeResourceTarget(seed, cohortIndex, i, min, max);
                 result.Add(new PatientProfile(
                     new Dictionary<ProfiledMeasureType, MeasureEligibility>(cohort.MeasureEligibilities),
                     seedOffset,
@@ -89,9 +90,29 @@ public class PatientCohortDefinition
                     cohort.CohortQualification));
                 seedCursor++;
             }
+
+            cohortIndex++;
         }
 
         return result;
+    }
+
+    private static int ComputeResourceTarget(int seed, int cohortIndex, int patientIndexInCohort, int min, int max)
+    {
+        if (max <= min)
+            return min;
+
+        var span = max - min + 1;
+
+        // Deterministic per-patient selection based on (seed, cohort #, patient #).
+        // Cantor pairing gives each (cohort,patient) tuple a stable unique ordinal so
+        // adjacent patients and same patient-number across cohorts distribute independently.
+        long sum = cohortIndex + patientIndexInCohort;
+        long pairedOrdinal = (sum * (sum + 1) / 2) + patientIndexInCohort;
+        long raw = seed + pairedOrdinal;
+        var offset = (int)((raw % span + span) % span);
+
+        return min + offset;
     }
 
     /// <summary>

--- a/DotNet/Automation/Generation/PatientProfile.cs
+++ b/DotNet/Automation/Generation/PatientProfile.cs
@@ -26,7 +26,8 @@ public record PatientProfile(
     int? SeedOffset = null,
     string? ClinicalScenarioId = null,
     int? ResourcesPerPatient = null,
-    ScheduledInpatientPattern? ScheduledInpatientPattern = null)
+    ScheduledInpatientPattern? ScheduledInpatientPattern = null,
+    MeasureEligibility CohortQualification = MeasureEligibility.Qualifying)
 {
     /// <summary>
     /// Returns true when this profile qualifies for the given measure.
@@ -70,6 +71,26 @@ public record PatientProfile(
         => measures.All(m => !QualifiesFor(m));
 
     /// <summary>
+    /// Returns true when this patient is expected to be report-eligible from cohort-level
+    /// designation and inpatient-pattern inclusion rules.
+    /// </summary>
+    public bool IsExpectedInReportByCohortAndPattern()
+    {
+        if (CohortQualification == MeasureEligibility.NonQualifying)
+            return false;
+
+        var pattern = ScheduledInpatientPattern
+            ?? global::LantanaGroup.Automation.Generation.ScheduledInpatientPattern.AdmittedBeforePeriodRemainsInpatientAfterPeriod;
+        return pattern.GetCensusBehavior().ExpectedInReport;
+    }
+
+    /// <summary>
+    /// Returns true when this patient should be predicted as submitted for selected measures.
+    /// </summary>
+    public bool IsExpectedToBeSubmitted(IReadOnlyList<ProfiledMeasureType> measures)
+        => IsExpectedInReportByCohortAndPattern() && QualifiesForAny(measures);
+
+    /// <summary>
     /// Builds a map of pipeline measure ID → number of qualifying patients from
     /// concrete cohort/profile data. This allows validators to know the expected
     /// shape of pipeline output without interrogating the pipeline's own data.
@@ -90,7 +111,7 @@ public record PatientProfile(
         for (var i = 0; i < measureIds.Count && i < selectedMeasures.Count; i++)
         {
             var measureType = selectedMeasures[i];
-            var count = profiles.Count(p => p.QualifiesFor(measureType));
+            var count = profiles.Count(p => p.IsExpectedInReportByCohortAndPattern() && p.QualifiesFor(measureType));
             result[measureIds[i]] = count;
         }
 

--- a/DotNet/Automation/Generation/QueryPlanAcquisitionSimulator.cs
+++ b/DotNet/Automation/Generation/QueryPlanAcquisitionSimulator.cs
@@ -42,7 +42,8 @@ public static class QueryPlanAcquisitionSimulator
         QueryPlanInput queryPlan,
         string? clinicalPeriodStart = null,
         string? clinicalPeriodEnd = null,
-        IAutomationOutput? output = null)
+        IAutomationOutput? output = null,
+        bool allowEncounterAnchoredDateOverrideForOutOfRange = true)
     {
         var hasStart = DateTimeOffset.TryParse(clinicalPeriodStart, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal, out var start);
         var hasEnd = DateTimeOffset.TryParse(clinicalPeriodEnd, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal, out var end);
@@ -97,7 +98,15 @@ public static class QueryPlanAcquisitionSimulator
 
                 foreach (var resource in candidates)
                 {
-                    if (!MatchesParameterQuery(resource, query, hasStart ? start : null, hasEnd ? end : null, acquiredByType, warnedKeys, output))
+                    if (!MatchesParameterQuery(
+                            resource,
+                            query,
+                            hasStart ? start : null,
+                            hasEnd ? end : null,
+                            acquiredByType,
+                            warnedKeys,
+                            output,
+                            allowEncounterAnchoredDateOverrideForOutOfRange))
                         continue;
 
                     acquired.Add(resource.Key);
@@ -134,7 +143,8 @@ public static class QueryPlanAcquisitionSimulator
         DateTimeOffset? periodEnd,
         Dictionary<string, HashSet<string>> acquiredByType,
         HashSet<string> warnedKeys,
-        IAutomationOutput? output)
+        IAutomationOutput? output,
+        bool allowEncounterAnchoredDateOverrideForOutOfRange)
     {
         foreach (var p in query.Parameters)
         {
@@ -216,8 +226,11 @@ public static class QueryPlanAcquisitionSimulator
 
                     if (!matchedAny)
                     {
-                        if (HasEncounterAnchoredDateOverride(resource, acquiredByType))
+                        if (allowEncounterAnchoredDateOverrideForOutOfRange
+                            && HasEncounterAnchoredDateOverride(resource, acquiredByType))
+                        {
                             continue;
+                        }
 
                         return false;
                     }
@@ -254,7 +267,8 @@ public static class QueryPlanAcquisitionSimulator
 
                 if (isGe && resourceEnd < bound.Value)
                 {
-                    if (string.Equals(p.Name, "date", StringComparison.OrdinalIgnoreCase)
+                    if (allowEncounterAnchoredDateOverrideForOutOfRange
+                        && string.Equals(p.Name, "date", StringComparison.OrdinalIgnoreCase)
                         && HasEncounterAnchoredDateOverride(resource, acquiredByType))
                     {
                         continue;
@@ -265,7 +279,8 @@ public static class QueryPlanAcquisitionSimulator
 
                 if (isLe && resourceStart > bound.Value)
                 {
-                    if (string.Equals(p.Name, "date", StringComparison.OrdinalIgnoreCase)
+                    if (allowEncounterAnchoredDateOverrideForOutOfRange
+                        && string.Equals(p.Name, "date", StringComparison.OrdinalIgnoreCase)
                         && HasEncounterAnchoredDateOverride(resource, acquiredByType))
                     {
                         continue;
@@ -281,10 +296,12 @@ public static class QueryPlanAcquisitionSimulator
 
     /// <summary>
     /// Some DA query paths are encounter-anchored and can include resources linked to an
-    /// already-acquired encounter even when date predicate semantics differ from our strict
-    /// local interpretation (effective/issued boundary nuances). This targeted override is
-    /// restricted to date-filtered Observation/DiagnosticReport/Procedure resources and only
-    /// when their Encounter reference resolves to an acquired Encounter id.
+    /// already-acquired encounter. The simulator always uses this as a fallback when a
+    /// resource doesn't expose a recognizable date field, and can optionally apply it to
+    /// out-of-range recognized-date cases when enabled by the caller.
+    ///
+    /// This override is restricted to date-filtered Observation/DiagnosticReport/Procedure
+    /// resources and only when their Encounter reference resolves to an acquired Encounter id.
     /// </summary>
     private static bool HasEncounterAnchoredDateOverride(
         GeneratedResource resource,

--- a/DotNet/Automation/Generation/ScheduledInpatientPattern.cs
+++ b/DotNet/Automation/Generation/ScheduledInpatientPattern.cs
@@ -1,16 +1,29 @@
 ﻿namespace LantanaGroup.Automation.Generation;
 
+using System.ComponentModel;
+
 /// <summary>
 /// Defines when a patient's inpatient stay starts/ends relative to the scheduled report period.
 /// Used by scheduled-report automation to emit the right admit/discharge events.
 /// </summary>
 public enum ScheduledInpatientPattern
 {
+    [Description("Admitted before, remains")]
     AdmittedBeforePeriodRemainsInpatientAfterPeriod,
+
+    [Description("Admitted before, discharged during")]
     AdmittedBeforePeriodDischargedDuringPeriod,
+
+    [Description("Admitted during, remains")]
     AdmittedDuringPeriodRemainsInpatientAfterPeriod,
+
+    [Description("Admitted during, discharged during")]
     AdmittedDuringPeriodDischargedDuringPeriod,
+
+    [Description("Admitted & discharged before period")]
     AdmittedAndDischargedBeforePeriod,
+
+    [Description("Admitted & discharged after period")]
     AdmittedAndDischargedAfterPeriod
 }
 
@@ -53,6 +66,40 @@ public readonly record struct ScheduledPatternCensusBehavior(
 /// </summary>
 public static class ScheduledInpatientPatternExtensions
 {
+    /// <summary>
+    /// Compact UI label suitable for dropdown display.
+    /// </summary>
+    public static string GetUiShortLabel(this ScheduledInpatientPattern pattern) => pattern switch
+    {
+        ScheduledInpatientPattern.AdmittedBeforePeriodRemainsInpatientAfterPeriod => "Before -> Remains after",
+        ScheduledInpatientPattern.AdmittedBeforePeriodDischargedDuringPeriod => "Before -> Discharged during",
+        ScheduledInpatientPattern.AdmittedDuringPeriodRemainsInpatientAfterPeriod => "During -> Remains after",
+        ScheduledInpatientPattern.AdmittedDuringPeriodDischargedDuringPeriod => "During -> Discharged during",
+        ScheduledInpatientPattern.AdmittedAndDischargedBeforePeriod => "Before -> Before",
+        ScheduledInpatientPattern.AdmittedAndDischargedAfterPeriod => "After -> After",
+        _ => pattern.ToString()
+    };
+
+    /// <summary>
+    /// Full explanatory text for tooltips/help text.
+    /// </summary>
+    public static string GetUiHint(this ScheduledInpatientPattern pattern) => pattern switch
+    {
+        ScheduledInpatientPattern.AdmittedBeforePeriodRemainsInpatientAfterPeriod
+            => "Admitted before report period; remains inpatient after report period.",
+        ScheduledInpatientPattern.AdmittedBeforePeriodDischargedDuringPeriod
+            => "Admitted before report period; discharged during report period.",
+        ScheduledInpatientPattern.AdmittedDuringPeriodRemainsInpatientAfterPeriod
+            => "Admitted during report period; remains inpatient after report period.",
+        ScheduledInpatientPattern.AdmittedDuringPeriodDischargedDuringPeriod
+            => "Admitted and discharged during report period.",
+        ScheduledInpatientPattern.AdmittedAndDischargedBeforePeriod
+            => "Admitted and discharged before report period.",
+        ScheduledInpatientPattern.AdmittedAndDischargedAfterPeriod
+            => "Admitted and discharged after report period.",
+        _ => pattern.ToString()
+    };
+
     /// <summary>
     /// Returns the census-event behavior required to exercise the given pattern.
     /// </summary>

--- a/DotNet/Automation/README.md
+++ b/DotNet/Automation/README.md
@@ -323,18 +323,37 @@ before saving the scenario.
 Compact cohort inputs defining a group of patients:
 
 - `PatientCount` -- how many patients to generate.
+- `CohortQualification` -- explicit cohort intent (`Qualifying` / `NonQualifying`) used by
+  prediction gating, independent of per-measure map drift.
 - `MeasureEligibilities` -- per-measure `Qualifying` / `NonQualifying` map.
+- `ScheduledInpatientPattern` -- encounter admit/discharge timing relative to the report
+  period.
 - `EligibleClinicalScenarioIds` -- which clinical scenarios to draw from (empty = all).
 - `ResourcesPerPatientMin` / `ResourcesPerPatientMax` -- resource count range.
+
+`ScheduledInpatientPattern` values:
+
+- `AdmittedBeforePeriodRemainsInpatientAfterPeriod`
+- `AdmittedBeforePeriodDischargedDuringPeriod`
+- `AdmittedDuringPeriodRemainsInpatientAfterPeriod`
+- `AdmittedDuringPeriodDischargedDuringPeriod`
+- `AdmittedAndDischargedBeforePeriod`
+- `AdmittedAndDischargedAfterPeriod`
 
 ### 7.2 `PatientProfile`
 
 Expanded per-patient configuration produced by `PatientCohortDefinition.ExpandProfiles()`:
 
 - Per-measure eligibility map.
+- `CohortQualification` propagated from the source cohort.
+- `ScheduledInpatientPattern` propagated from the source cohort.
 - Seed offset for deterministic generation.
 - Clinical scenario assignment (round-robin from eligible scenarios).
 - Resource count (randomized within the cohort's min/max range).
+
+`PatientProfile` exposes prediction helpers that combine measure eligibility with cohort-level
+intent and pattern inclusion semantics, so hosts can compute expected submitted/ABS sets
+without re-implementing rule logic.
 
 ### 7.3 Expansion flow
 
@@ -392,6 +411,8 @@ For each patient the predicted set of resources is computed in layers:
 base        = simulated-acquired keys (fallback: generated keys) filtered by
               IsExpectedInAbs(resourceType)
 base        = base minus CqlFilteredResourceKeysByPatient[patientId]
+base        = empty when patient is excluded by cohort qualification/pattern inclusion
+              semantics
 base        = base plus Patient/{patientId}   when the patient qualifies for any measure
               (MeasureEval's CQL engine loads Patient implicitly)
 

--- a/DotNet/Automation/README.md
+++ b/DotNet/Automation/README.md
@@ -126,6 +126,10 @@ logic in a streaming pipeline that:
    patient IDs are appended to `MarkPreExistingPatient` when sourced by ID, so cleanup
    skips expunging them.
 
+Inpatient-pattern shaping is applied in this pipeline for both scheduled and non-scheduled
+workflows whenever the profile carries `ScheduledInpatientPattern` and a clinical period is
+provided. This keeps generation and prediction aligned with scenario-authored timing intent.
+
 The pipeline accepts an optional `runId` parameter; when omitted a fresh short GUID is
 generated so concurrent invocations remain isolated. Provide a stable `runId` only when
 reproducing a specific run for debugging.
@@ -368,6 +372,25 @@ PatientCohortDefinition[]
 When `EligibleClinicalScenarioIds` is empty, expansion falls back to all clinical scenarios
 from `FhirGenerationCodes.ClinicalScenarios`.
 
+### 7.4 Inpatient pattern semantics in generation/prediction
+
+`ScheduledInpatientPattern` influences two independent but coordinated behaviors:
+
+1. **Encounter window derivation** -- controls admit/discharge placement relative to the
+   report period (`before`, `during`, `after`).
+2. **Prediction inclusion semantics** -- each pattern maps to `ExpectedInReport` via
+   `ScheduledInpatientPatternExtensions.GetCensusBehavior()`.
+
+Prediction helpers (`PatientProfile.IsExpectedInReportByCohortAndPattern()` and
+`IsExpectedToBeSubmitted(...)`) combine:
+
+- per-measure eligibility,
+- `CohortQualification`,
+- pattern `ExpectedInReport`.
+
+This prevents expected-output inflation for cohorts intentionally configured as
+non-reportable by timing or cohort qualification.
+
 ---
 
 ## 8. Predictive expectation model
@@ -522,7 +545,8 @@ matter of implementing `ICqlFilterProfile` (which exposes `TargetResourceType`,
   acquire for each patient. The single-patient entrypoint
   `SimulateAcquiredKeysForPatient` accepts the patient's pre-parsed entries plus the
   shared infrastructure entries, the query plan, and an optional clinical period
-  (`clinicalPeriodStart` / `clinicalPeriodEnd`):
+  (`clinicalPeriodStart` / `clinicalPeriodEnd`), plus an optional
+  `allowEncounterAnchoredDateOverrideForOutOfRange` mode switch:
   - When the query plan declares a `date=ge...` or `date=le...` parameter, the simulator
     extracts the candidate resource's date range (instant fields collapse to start == end)
     and applies FHIR overlap semantics: `ge S` requires `resource.End >= S`, `le E`
@@ -532,6 +556,10 @@ matter of implementing `ICqlFilterProfile` (which exposes `TargetResourceType`,
     set and a one-time-per-resource warning is emitted via the optional `IAutomationOutput`
     sink. This keeps prediction honest for unfamiliar imported FHIR shapes; extending
     `TryGetResourceDateRange` is the way to model new shapes.
+  - **Encounter-anchored out-of-range override (optional)** -- callers can opt-in to keep
+    encounter-linked Observation/DiagnosticReport/Procedure resources when strict date-bound
+    matching would otherwise exclude them. Hosts typically enable this for scheduled/regenerate
+    workflows and keep strict mode for non-scheduled runs.
 - `CqlResourceTypeExtractor` -- extracts CQL-retrieved resource types from measure bundles.
   Reachability roots include both population criteria expressions and `supplementalData`
   criteria expressions (SDE roots).

--- a/DotNet/ServiceTests/UnitTests/Automation/GenerationManifestExpectedAbsTests.cs
+++ b/DotNet/ServiceTests/UnitTests/Automation/GenerationManifestExpectedAbsTests.cs
@@ -166,4 +166,51 @@ public class GenerationManifestExpectedAbsTests
 
         keys.Should().BeEquivalentTo(["Patient/p-q", "Encounter/Esim"]);
     }
+
+    [Fact]
+    public void Pattern_excluded_patient_is_not_predicted_in_abs_even_if_measure_qualifying()
+    {
+        var manifest = new GenerationManifest
+        {
+            PatientIds = ["p-pattern-out"],
+            Profiles =
+            [
+                new PatientProfile(
+                    new Dictionary<ProfiledMeasureType, MeasureEligibility> { [Ach] = MeasureEligibility.Qualifying },
+                    ScheduledInpatientPattern: ScheduledInpatientPattern.AdmittedAndDischargedAfterPeriod)
+            ],
+            SelectedMeasures = [Ach],
+            ResourceKeysByPatient = new Dictionary<string, HashSet<string>>(StringComparer.Ordinal)
+            {
+                ["p-pattern-out"] = new(StringComparer.OrdinalIgnoreCase) { "Encounter/E1", "Condition/C1" }
+            }
+        };
+
+        manifest.GetExpectedAbsKeysForPatient("p-pattern-out").Should().BeEmpty();
+        manifest.ExpectedSubmittedPatientIds().Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Cohort_non_qualifying_designation_excludes_patient_from_predictions()
+    {
+        var manifest = new GenerationManifest
+        {
+            PatientIds = ["p-cohort-nq"],
+            Profiles =
+            [
+                new PatientProfile(
+                    new Dictionary<ProfiledMeasureType, MeasureEligibility> { [Ach] = MeasureEligibility.Qualifying },
+                    CohortQualification: MeasureEligibility.NonQualifying)
+            ],
+            SelectedMeasures = [Ach],
+            ResourceKeysByPatient = new Dictionary<string, HashSet<string>>(StringComparer.Ordinal)
+            {
+                ["p-cohort-nq"] = new(StringComparer.OrdinalIgnoreCase) { "Encounter/E2", "Condition/C2" }
+            }
+        };
+
+        manifest.GetExpectedAbsKeysForPatient("p-cohort-nq").Should().BeEmpty();
+        manifest.ExpectedSubmittedPatientIds().Should().BeEmpty();
+        manifest.QualifyingPatientCount("any").Should().Be(0);
+    }
 }

--- a/DotNet/ServiceTests/UnitTests/Automation/PatientCohortDefinitionTests.cs
+++ b/DotNet/ServiceTests/UnitTests/Automation/PatientCohortDefinitionTests.cs
@@ -1,0 +1,57 @@
+﻿using LantanaGroup.Automation.Generation;
+
+namespace UnitTests.Automation;
+
+[Trait("Category", "UnitTests")]
+public class PatientCohortDefinitionTests
+{
+    [Fact]
+    public void ExpandProfiles_uses_seed_plus_cohort_and_patient_index_for_resource_targets()
+    {
+        var measures = new[] { ProfiledMeasureType.NhsnAcuteCareHospitalMonthlyInitialPopulation };
+
+        var cohorts = new List<PatientCohortDefinition>
+        {
+            new()
+            {
+                PatientCount = 2,
+                MeasureEligibilities = measures.ToDictionary(m => m, _ => MeasureEligibility.Qualifying),
+                ResourcesPerPatientMin = 50,
+                ResourcesPerPatientMax = 100
+            },
+            new()
+            {
+                PatientCount = 1,
+                MeasureEligibilities = measures.ToDictionary(m => m, _ => MeasureEligibility.Qualifying),
+                ResourcesPerPatientMin = 50,
+                ResourcesPerPatientMax = 100
+            }
+        };
+
+        var profiles = PatientCohortDefinition.ExpandProfiles(cohorts, seed: 20260326);
+
+        Assert.Equal(3, profiles.Count);
+
+        var cohort1Patient1 = profiles[0].ResourcesPerPatient;
+        var cohort1Patient2 = profiles[1].ResourcesPerPatient;
+        var cohort2Patient1 = profiles[2].ResourcesPerPatient;
+
+        Assert.NotNull(cohort1Patient1);
+        Assert.NotNull(cohort1Patient2);
+        Assert.NotNull(cohort2Patient1);
+
+        Assert.NotEqual(cohort1Patient1, cohort1Patient2);
+        Assert.NotEqual(cohort1Patient1, cohort2Patient1);
+        Assert.NotEqual(cohort1Patient2, cohort2Patient1);
+
+        Assert.InRange(cohort1Patient1!.Value, 50, 100);
+        Assert.InRange(cohort1Patient2!.Value, 50, 100);
+        Assert.InRange(cohort2Patient1!.Value, 50, 100);
+
+        // Deterministic for same inputs.
+        var secondPass = PatientCohortDefinition.ExpandProfiles(cohorts, seed: 20260326);
+        Assert.Equal(
+            profiles.Select(p => p.ResourcesPerPatient).ToArray(),
+            secondPass.Select(p => p.ResourcesPerPatient).ToArray());
+    }
+}

--- a/DotNet/ServiceTests/UnitTests/AutomationUI/MongoScenarioStoreTests.cs
+++ b/DotNet/ServiceTests/UnitTests/AutomationUI/MongoScenarioStoreTests.cs
@@ -1,0 +1,40 @@
+﻿using Automation.UI.Services.Persistence;
+using FluentAssertions;
+using LantanaGroup.Automation.Generation;
+using System.Reflection;
+
+namespace UnitTests.AutomationUI;
+
+[Trait("Category", "UnitTests")]
+public class MongoScenarioStoreTests
+{
+    [Fact]
+    public void DeserializeCohorts_preserves_explicit_qualifying_when_all_measures_are_non_qualifying()
+    {
+        var json = """
+            [
+              {
+                "PatientCount": 1,
+                "CohortQualification": "Qualifying",
+                "MeasureEligibilities": {
+                  "NhsnAcuteCareHospitalMonthlyInitialPopulation": "NonQualifying"
+                },
+                "ResourcesPerPatientMin": 50,
+                "ResourcesPerPatientMax": 50
+              }
+            ]
+            """;
+
+        var method = typeof(MongoScenarioStore)
+            .GetMethod("DeserializeCohorts", BindingFlags.Static | BindingFlags.NonPublic);
+
+        method.Should().NotBeNull();
+
+        var cohorts = (List<PatientCohortDefinition>)method!.Invoke(null, new object?[] { json })!;
+
+        cohorts.Should().ContainSingle();
+        cohorts[0].CohortQualification.Should().Be(MeasureEligibility.Qualifying);
+        cohorts[0].GetEligibility(ProfiledMeasureType.NhsnAcuteCareHospitalMonthlyInitialPopulation)
+            .Should().Be(MeasureEligibility.NonQualifying);
+    }
+}

--- a/DotNet/ServiceTests/UnitTests/AutomationUI/ScenarioSeedServiceTests.cs
+++ b/DotNet/ServiceTests/UnitTests/AutomationUI/ScenarioSeedServiceTests.cs
@@ -1,0 +1,55 @@
+﻿using Automation.UI.Models;
+using Automation.UI.Services;
+using Automation.UI.Services.Persistence;
+using FluentAssertions;
+using LantanaGroup.Automation.Generation;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace UnitTests.AutomationUI;
+
+[Trait("Category", "UnitTests")]
+public class ScenarioSeedServiceTests
+{
+    private static readonly Guid MultiMeasureScenarioId = new("00000000-0000-0000-0000-000000000006");
+
+    [Fact]
+    public async global::System.Threading.Tasks.Task Multi_measure_seeded_scenario_sets_inpatient_pattern_for_each_cohort()
+    {
+        var store = new InMemoryScenarioStore();
+        var sut = new ScenarioSeedService(store, NullLogger<ScenarioSeedService>.Instance);
+
+        await sut.StartAsync(CancellationToken.None);
+
+        var scenario = await store.GetByIdAsync(MultiMeasureScenarioId, CancellationToken.None);
+        scenario.Should().NotBeNull();
+        scenario!.PatientCohorts.Should().HaveCount(2);
+        scenario.PatientCohorts.Should().OnlyContain(c =>
+            c.ScheduledInpatientPattern == ScheduledInpatientPattern.AdmittedDuringPeriodDischargedDuringPeriod);
+    }
+
+    private sealed class InMemoryScenarioStore : IScenarioStore
+    {
+        private readonly Dictionary<Guid, TestScenarioDefinition> _items = new();
+
+        public global::System.Threading.Tasks.Task<List<TestScenarioDefinition>> GetAllAsync(CancellationToken ct = default)
+            => global::System.Threading.Tasks.Task.FromResult(_items.Values.ToList());
+
+        public global::System.Threading.Tasks.Task<TestScenarioDefinition?> GetByIdAsync(Guid id, CancellationToken ct = default)
+        {
+            _items.TryGetValue(id, out var scenario);
+            return global::System.Threading.Tasks.Task.FromResult<TestScenarioDefinition?>(scenario);
+        }
+
+        public global::System.Threading.Tasks.Task UpsertAsync(TestScenarioDefinition scenario, CancellationToken ct = default)
+        {
+            _items[scenario.Id] = scenario;
+            return global::System.Threading.Tasks.Task.CompletedTask;
+        }
+
+        public global::System.Threading.Tasks.Task DeleteAsync(Guid id, CancellationToken ct = default)
+        {
+            _items.Remove(id);
+            return global::System.Threading.Tasks.Task.CompletedTask;
+        }
+    }
+}

--- a/DotNet/ServiceTests/UnitTests/AutomationUI/StartScenarioRequestResolverTests.cs
+++ b/DotNet/ServiceTests/UnitTests/AutomationUI/StartScenarioRequestResolverTests.cs
@@ -107,6 +107,102 @@ public class StartScenarioRequestResolverTests
         options.PatientProfiles.Should().HaveCount(5);
     }
 
+    [Fact]
+    public void Scheduled_report_defaults_missing_cohort_inpatient_pattern_to_first_pattern()
+    {
+        var json = """
+            {
+                "patientCohorts": [
+                    {
+                        "patientCount": 2,
+                        "resourcesPerPatientMin": 50,
+                        "resourcesPerPatientMax": 75,
+                        "measureEligibilities": {
+                            "NhsnAcuteCareHospitalMonthlyInitialPopulation": "Qualifying"
+                        }
+                    }
+                ]
+            }
+            """;
+
+        var options = StartScenarioRequestResolver.Resolve(new StartScenarioRequest
+        {
+            Scenario = AutomationScenarioKind.Custom,
+            ReportMethod = ReportMethod.ScheduledReport,
+            RunConfigurationJson = json,
+        });
+
+        options.PatientCohorts.Should().ContainSingle();
+        options.PatientCohorts[0].ScheduledInpatientPattern
+            .Should().Be(ScheduledInpatientPattern.AdmittedBeforePeriodRemainsInpatientAfterPeriod);
+
+        options.PatientProfiles.Should().HaveCount(2);
+        options.PatientProfiles.Should().OnlyContain(p =>
+            p.ScheduledInpatientPattern == ScheduledInpatientPattern.AdmittedBeforePeriodRemainsInpatientAfterPeriod);
+    }
+
+    [Fact]
+    public void Adhoc_report_also_defaults_missing_cohort_inpatient_pattern_to_first_pattern()
+    {
+        var json = """
+            {
+                "patientCohorts": [
+                    {
+                        "patientCount": 1,
+                        "resourcesPerPatientMin": 50,
+                        "resourcesPerPatientMax": 75,
+                        "measureEligibilities": {
+                            "NhsnAcuteCareHospitalMonthlyInitialPopulation": "Qualifying"
+                        }
+                    }
+                ]
+            }
+            """;
+
+        var options = StartScenarioRequestResolver.Resolve(new StartScenarioRequest
+        {
+            Scenario = AutomationScenarioKind.Custom,
+            ReportMethod = ReportMethod.Adhoc,
+            RunConfigurationJson = json,
+        });
+
+        options.PatientCohorts.Should().ContainSingle();
+        options.PatientCohorts[0].ScheduledInpatientPattern
+            .Should().Be(ScheduledInpatientPattern.AdmittedBeforePeriodRemainsInpatientAfterPeriod);
+        options.PatientProfiles.Should().ContainSingle();
+        options.PatientProfiles[0].ScheduledInpatientPattern
+            .Should().Be(ScheduledInpatientPattern.AdmittedBeforePeriodRemainsInpatientAfterPeriod);
+    }
+
+    [Fact]
+    public void Cohort_qualification_is_extracted_and_propagated_to_profiles()
+    {
+        var json = """
+            {
+                "patientCohorts": [
+                    {
+                        "patientCount": 1,
+                        "cohortQualification": "NonQualifying",
+                        "measureEligibilities": {
+                            "NhsnAcuteCareHospitalMonthlyInitialPopulation": "Qualifying"
+                        }
+                    }
+                ]
+            }
+            """;
+
+        var options = StartScenarioRequestResolver.Resolve(new StartScenarioRequest
+        {
+            Scenario = AutomationScenarioKind.Custom,
+            RunConfigurationJson = json,
+        });
+
+        options.PatientCohorts.Should().ContainSingle();
+        options.PatientCohorts[0].CohortQualification.Should().Be(MeasureEligibility.NonQualifying);
+        options.PatientProfiles.Should().ContainSingle();
+        options.PatientProfiles[0].CohortQualification.Should().Be(MeasureEligibility.NonQualifying);
+    }
+
     // ---------- Custom scenario: JSON fallback when typed properties are missing ----------
 
     [Fact]

--- a/DotNet/ServiceTests/UnitTests/AutomationUI/StartScenarioRequestResolverTests.cs
+++ b/DotNet/ServiceTests/UnitTests/AutomationUI/StartScenarioRequestResolverTests.cs
@@ -62,7 +62,6 @@ public class StartScenarioRequestResolverTests
         {
             Scenario = AutomationScenarioKind.Custom,
             PatientCount = 7,
-            ResourcesPerPatient = 42,
             Seed = 12345,
             CleanupServiceData = true,
             CleanupFhirData = false,
@@ -74,7 +73,7 @@ public class StartScenarioRequestResolverTests
         var options = StartScenarioRequestResolver.Resolve(request);
 
         options.PatientCount.Should().Be(7);
-        options.ResourcesPerPatient.Should().Be(42);
+        options.ResourcesPerPatient.Should().Be(250);
         options.Seed.Should().Be(12345);
         options.CleanupServiceData.Should().BeTrue();
         options.CleanupFhirData.Should().BeFalse();
@@ -102,6 +101,8 @@ public class StartScenarioRequestResolverTests
         cohort.PatientCount.Should().Be(5);
         cohort.GetEligibility(ProfiledMeasureType.NhsnAcuteCareHospitalMonthlyInitialPopulation)
             .Should().Be(MeasureEligibility.Qualifying);
+        cohort.ResourcesPerPatientMin.Should().Be(250);
+        cohort.ResourcesPerPatientMax.Should().Be(250);
 
         // Synthesized cohort should expand to PatientCount profiles.
         options.PatientProfiles.Should().HaveCount(5);


### PR DESCRIPTION
### 🛠️ Description of Changes

This PR delivers the `LEGLINK-548` UI-driven inpatient pattern enhancements across Automation UI and generation/runtime behavior.

Compared to `dev`, this branch adds support for explicitly modeling scheduled inpatient timing per cohort, aligns expected submission logic with cohort-level qualification, and updates scenario persistence/seed behavior for backward compatibility.

## What changed

### 1) Cohort model + generation behavior
- Added/expanded scheduled inpatient pattern support in generation domain:
  - `ScheduledInpatientPattern` now includes UI labels/hints and centralized census behavior mapping (`ExpectedInReport`, admit/discharge behavior).
- `PatientCohortDefinition` now carries:
  - `CohortQualification`
  - `ScheduledInpatientPattern`
- Cohort expansion (`ExpandProfiles`) now propagates both values into `PatientProfile`.
- `PatientProfile` expected-submission logic now uses cohort qualification + scheduled pattern inclusion rules (`IsExpectedInReportByCohortAndPattern`, `IsExpectedToBeSubmitted`).
- `FhirGenerationPipeline` encounter-date derivation now respects scheduled inpatient pattern windows when report period bounds are present.

### 2) Runtime/orchestration alignment
- `RunExecutor` expected submitted patient computation now relies on profile-based expected-submission logic to stay aligned with cohort + pattern semantics.
- Scheduled workflow orchestration now consumes pattern behavior (`GetCensusBehavior`) so census admit/discharge events and submission expectations come from the same source of truth.

### 3) Automation UI (scenario editor)
- `_ScenarioEditorModal.cshtml` enhancements:
  - Added **Cohort Outcome** control (Qualifying / Non-Qualifying).
  - Added **Inpatient Pattern** selection per cohort.
  - Pattern options are constrained by cohort outcome (in-report vs out-of-report patterns).
  - Added normalization/inference helpers for legacy values and case/numeric variants.
- `site.css` updated to support new cohort editor UI/table layout.

### 4) Request resolution, persistence, and back-compat
- `StartScenarioRequestResolver`:
  - Applies defaults for missing cohort inpatient pattern.
  - Extracts/parses `cohortQualification` from saved JSON (string + numeric support).
  - Infers non-qualifying cohort state from measure eligibilities for legacy payloads.
- `ScenariosController.SaveInline`:
  - Normalizes missing inpatient pattern and legacy cohort qualification before persistence.
- `MongoScenarioStore` deserialization:
  - Backfills non-qualifying cohort qualification when all measure eligibilities are non-qualifying.
- `ScenarioSeedService`:
  - Updated seeded multi-measure scenario cohorts to include explicit scheduled inpatient patterns.

### 5) Tests and docs
- Added unit tests in `ScenarioSeedServiceTests` for seeded cohort pattern behavior.
- Expanded `StartScenarioRequestResolverTests` to cover:
  - default patterning,
  - cohort qualification extraction/propagation,
  - legacy and mixed payload handling.
- Updated Automation READMEs (`Automation`, `Automation.UI`, `Automation.Link`) to document new cohort/pattern behavior.
- Updated expected ABS manifest unit test coverage (`GenerationManifestExpectedAbsTests`).

## File-level impact
- **19 files changed**
- **~907 insertions / ~80 deletions**

## Risk / compatibility notes
- Includes explicit back-compat handling for older scenario JSON documents lacking `cohortQualification` and/or `scheduledInpatientPattern`.
- Behavior is intended to be additive and normalization-focused for existing saved scenarios.

## Validation
- Added/updated unit tests for resolver and seed-service behavior.
- No database schema migration introduced.

## Checklist
- [x] Feature behavior implemented end-to-end (UI → resolver/persistence → generation/orchestration)
- [x] Legacy scenario payloads handled with normalization/inference
- [x] Unit tests added/updated for key behavior paths
- [x] Documentation updated

### 🧪 Testing Performed

Local manual testing, some implicit testing performed on PR build runs.

### 🧑‍🔬 Unit Testing

- [ ] I have written or updated unit tests to cover my changes
- Coverage: 50.7%

### 📓 Documentation Updated

Please update any relevant sections in the project documentation that were impacted by the changes in the PR.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Added UI-driven inpatient timing patterns and per-cohort qualification, editable in the scenario editor and displayed in run details and patient/manifest breakdowns.
  - Added an “Inpatient Pattern” column to scenario and patient views, including user-friendly labels/tooltips.

- **Bug Fixes**
  - Improved expected patient/report predictions and strict validation by honoring cohort qualification and inpatient patterns.
  - Enhanced defaults and backward compatibility for scenarios missing the new fields.

- **Documentation**
  - Expanded guidance on inpatient patterns, validation behavior, and troubleshooting.

- **Tests**
  - Added regression tests covering prediction gating and deterministic cohort expansion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



