### PR TITLE
LEGLINK-564: Fix duplicate resources in ResourcesNormalized when using ABS resource cache

### DIFF
--- a/DotNet/Normalization/Listeners/ResourcesAcquiredListener.cs
+++ b/DotNet/Normalization/Listeners/ResourcesAcquiredListener.cs
@@ -210,10 +210,9 @@ public class ResourcesAcquiredListener : BackgroundService
                 }
                 else
                 {
+                    sequences.Sort((a, b) => a.Sequence.CompareTo(b.Sequence));
                     foreach (var resource in resources)
                     {
-                        sequences.Sort((a, b) => a.Sequence.CompareTo(b.Sequence));
-
                         foreach (var sequence in sequences)
                         {
                             var dbEntity = sequence.OperationResourceType.Operation;

--- a/DotNet/Normalization/Listeners/ResourcesAcquiredListener.cs
+++ b/DotNet/Normalization/Listeners/ResourcesAcquiredListener.cs
@@ -202,68 +202,68 @@ public class ResourcesAcquiredListener : BackgroundService
                     ResourceType = resourceType.ToString(),
                 }, cancellationToken: cancellationToken);
 
+                List<DomainResource> resources = resourceCache.Get(cacheKey);
+
                 if (sequences == null || sequences.Count == 0)
                 {
                     _logger.LogDebug("No operation sequences configured for {FacilityId}/{ResourceType}. Passing resource through without normalization.", result.Message.Key.FacilityId.SanitizeForLog(), resourceType.ToString().SanitizeForLog());
-                    resourceCache.Skipped(cacheKey, correlationId);
-                    continue;
                 }
-
-                List<DomainResource> resources = resourceCache.Get(cacheKey);
-
-                foreach (var resource in resources)
+                else
                 {
-                    sequences.Sort((a, b) => a.Sequence.CompareTo(b.Sequence));
-
-                    foreach (var sequence in sequences)
+                    foreach (var resource in resources)
                     {
-                        var dbEntity = sequence.OperationResourceType.Operation;
+                        sequences.Sort((a, b) => a.Sequence.CompareTo(b.Sequence));
 
-                        var operation = OperationHelper.GetOperation(dbEntity.OperationType, dbEntity.OperationJson);
-
-                        if (operation == null)
+                        foreach (var sequence in sequences)
                         {
-                            throw new TransientException("Operation Data Entity found, but the operation failed to deserialize");
-                        }
+                            var dbEntity = sequence.OperationResourceType.Operation;
 
-                        _logger.LogInformation("Normalizing {ResourceType}/{ResourceId} with {OperationType} operation ({OperationName})", resource.TypeName.SanitizeForLog(), resource.Id.SanitizeForLog(), operation.OperationType, operation.Name.SanitizeForLog());
+                            var operation = OperationHelper.GetOperation(dbEntity.OperationType, dbEntity.OperationJson);
 
-                        var operationResult = operation.OperationType switch
-                        {
-                            OperationType.CopyProperty => await _copyPropertyOperationService.ProcessOperationAsync((CopyPropertyOperation)operation, resource, cancellationToken),
-                            OperationType.CodeMap => await _codeMapOperationService.ProcessOperationAsync((CodeMapOperation)operation, resource, cancellationToken),
-                            OperationType.ConditionalTransform => await _conditionalTransformOperationService.ProcessOperationAsync((ConditionalTransformOperation)operation, resource, cancellationToken),
-                            OperationType.CopyLocation => await _copyLocationOperationService.ProcessOperationAsync((CopyLocationOperation)operation, resource, cancellationToken),
-                            OperationType.RemoveExtensions => await _removeExtensionsOperationService.ProcessOperationAsync((RemoveExtensionsOperation)operation, resource, cancellationToken),
-                            _ => null
-                        };
-
-                        if (operationResult != null && operationResult.SuccessCode != OperationStatus.Failure)
-                        {
-                            if (operationResult.SuccessCode == OperationStatus.Success)
+                            if (operation == null)
                             {
-                                _logger.LogInformation("Changed {ResourceType}/{ResourceId} as part of {OperationType} operation ({OperationName})", resource.TypeName.SanitizeForLog(), resource.Id.SanitizeForLog(), operation.OperationType, operation.Name.SanitizeForLog());
-                            }
-                            else if (operationResult.SuccessCode == OperationStatus.NoAction)
-                            {
-                                _logger.LogInformation("No changes made to {ResourceType}/{ResourceId} as part of {OperationType} operation ({OperationName})", resource.TypeName.SanitizeForLog(), resource.Id.SanitizeForLog(), operation.OperationType, operation.Name.SanitizeForLog());
+                                throw new TransientException("Operation Data Entity found, but the operation failed to deserialize");
                             }
 
-                            _metrics.IncrementResourceChangedCounter(new List<KeyValuePair<string, object?>>() {
-                                                new KeyValuePair<string, object?>(DiagnosticNames.FacilityId, result.Message.Key.FacilityId),
-                                                new KeyValuePair<string, object?>(DiagnosticNames.CorrelationId, correlationId),
-                                                new KeyValuePair<string, object?>(DiagnosticNames.PatientId, result.Message.Key.PatientId),
-                                                new KeyValuePair<string, object?>(DiagnosticNames.ResourceType, resource.TypeName),
-                                                new KeyValuePair<string, object?>(DiagnosticNames.OperationType, operation.OperationType.ToString())},
-                                                operationResult.SuccessCode == OperationStatus.Success);
-                        }
-                        else
-                        {
-                            _logger.LogWarning("Normalization Operation Failed ({FacilityId}, {CorrelationId}, {OperationType}): {ErrorMessage}", result.Message.Key.FacilityId.SanitizeForLog(), correlationId.SanitizeForLog(), operation.OperationType, operationResult?.ErrorMessage?.SanitizeForLog() ?? "No Operation Result Error result");
+                            _logger.LogInformation("Normalizing {ResourceType}/{ResourceId} with {OperationType} operation ({OperationName})", resource.TypeName.SanitizeForLog(), resource.Id.SanitizeForLog(), operation.OperationType, operation.Name.SanitizeForLog());
+
+                            var operationResult = operation.OperationType switch
+                            {
+                                OperationType.CopyProperty => await _copyPropertyOperationService.ProcessOperationAsync((CopyPropertyOperation)operation, resource, cancellationToken),
+                                OperationType.CodeMap => await _codeMapOperationService.ProcessOperationAsync((CodeMapOperation)operation, resource, cancellationToken),
+                                OperationType.ConditionalTransform => await _conditionalTransformOperationService.ProcessOperationAsync((ConditionalTransformOperation)operation, resource, cancellationToken),
+                                OperationType.CopyLocation => await _copyLocationOperationService.ProcessOperationAsync((CopyLocationOperation)operation, resource, cancellationToken),
+                                OperationType.RemoveExtensions => await _removeExtensionsOperationService.ProcessOperationAsync((RemoveExtensionsOperation)operation, resource, cancellationToken),
+                                _ => null
+                            };
+
+                            if (operationResult != null && operationResult.SuccessCode != OperationStatus.Failure)
+                            {
+                                if (operationResult.SuccessCode == OperationStatus.Success)
+                                {
+                                    _logger.LogInformation("Changed {ResourceType}/{ResourceId} as part of {OperationType} operation ({OperationName})", resource.TypeName.SanitizeForLog(), resource.Id.SanitizeForLog(), operation.OperationType, operation.Name.SanitizeForLog());
+                                }
+                                else if (operationResult.SuccessCode == OperationStatus.NoAction)
+                                {
+                                    _logger.LogInformation("No changes made to {ResourceType}/{ResourceId} as part of {OperationType} operation ({OperationName})", resource.TypeName.SanitizeForLog(), resource.Id.SanitizeForLog(), operation.OperationType, operation.Name.SanitizeForLog());
+                                }
+
+                                _metrics.IncrementResourceChangedCounter(new List<KeyValuePair<string, object?>>() {
+                                                    new KeyValuePair<string, object?>(DiagnosticNames.FacilityId, result.Message.Key.FacilityId),
+                                                    new KeyValuePair<string, object?>(DiagnosticNames.CorrelationId, correlationId),
+                                                    new KeyValuePair<string, object?>(DiagnosticNames.PatientId, result.Message.Key.PatientId),
+                                                    new KeyValuePair<string, object?>(DiagnosticNames.ResourceType, resource.TypeName),
+                                                    new KeyValuePair<string, object?>(DiagnosticNames.OperationType, operation.OperationType.ToString())},
+                                                    operationResult.SuccessCode == OperationStatus.Success);
+                            }
+                            else
+                            {
+                                _logger.LogWarning("Normalization Operation Failed ({FacilityId}, {CorrelationId}, {OperationType}): {ErrorMessage}", result.Message.Key.FacilityId.SanitizeForLog(), correlationId.SanitizeForLog(), operation.OperationType, operationResult?.ErrorMessage?.SanitizeForLog() ?? "No Operation Result Error result");
+                            }
                         }
                     }
                 }
-
+                
                 resourceCache.UpdateCorrelationCache(correlationId, resources, resourceType);
             }
 

--- a/DotNet/Shared/Application/Interfaces/IResourceCache.cs
+++ b/DotNet/Shared/Application/Interfaces/IResourceCache.cs
@@ -6,7 +6,6 @@ namespace LantanaGroup.Link.Shared.Application.Interfaces
     public interface IResourceCache
     {
         List<DomainResource> Get(string cacheKey);
-        void Skipped(string sourceCache, string correlationId);
         void Delete(List<string> cacheKeys);
         void UpdateCorrelationCache(string correlationId, List<DomainResource> resources, ResourceType resourceType);
         ResourceType GetResourceTypeByCacheKey(string cacheKey);

--- a/DotNet/Shared/Application/Services/ResourceCache/ABSResourceCache.cs
+++ b/DotNet/Shared/Application/Services/ResourceCache/ABSResourceCache.cs
@@ -172,34 +172,6 @@ namespace LantanaGroup.Link.Shared.Application.Services.ResourceCache
             return this;
         }
 
-        public void Skipped(string sourceCache, string destinationCache)
-        {
-            BlockBlobClient sourceBlobClient = _containerClient.GetBlockBlobClient(GetBlobKey(sourceCache));
-
-            if (!sourceBlobClient.Exists())
-            {
-                _logger.LogWarning("ABS blob not found for Skipped. SourceKey='{SourceKey}', BlobPath='{BlobPath}', Container='{Container}', DestinationKey='{DestinationKey}'",
-                    sourceCache, GetBlobKey(sourceCache), _settings.BlobContainerName, destinationCache);
-                return;
-            }
-
-            AppendBlobClient destinationBlobClient = _containerClient.GetAppendBlobClient(GetBlobKey(destinationCache));
-            destinationBlobClient.CreateIfNotExists();
-
-            try
-            {
-                using (Stream sourceStream = sourceBlobClient.OpenRead(true))
-                using (Stream destinationStream = destinationBlobClient.OpenWrite(false))
-                {
-                    sourceStream.CopyTo(destinationStream);
-                }
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError("Error when reading skipped ABS blob: Source Cache = {source}, Destination Cache = {destination}", sourceCache, destinationCache);
-            }
-        }
-
         public void Delete(List<string> cacheKeys)
         {
             foreach (var cacheKey in cacheKeys)

--- a/DotNet/Shared/Application/Services/ResourceCache/HybridResourceCache.cs
+++ b/DotNet/Shared/Application/Services/ResourceCache/HybridResourceCache.cs
@@ -55,13 +55,6 @@ namespace LantanaGroup.Link.Shared.Application.Services.ResourceCache
         }
 
         /// <inheritdoc/>
-        public void Skipped(string sourceCache, string correlationId)
-        {
-            var cache = ResolveFromKey(sourceCache);
-            cache.Skipped(sourceCache, correlationId);
-        }
-
-        /// <inheritdoc/>
         public ResourceType GetResourceTypeByCacheKey(string cacheKey)
         {
             var cache = ResolveFromKey(cacheKey);

--- a/DotNet/Shared/Application/Services/ResourceCache/RedisResourceCache.cs
+++ b/DotNet/Shared/Application/Services/ResourceCache/RedisResourceCache.cs
@@ -86,13 +86,6 @@ namespace LantanaGroup.Link.Shared.Application.Services.ResourceCache
             _db.HashSet(correlationId, correlationHash.ToArray());
         }
 
-        public void Skipped(string sourceCache, string correlationId)
-        {
-            var hashEntries = _db.HashGetAll(sourceCache);
-
-            _db.HashSet(correlationId, hashEntries);
-        }
-
         public ResourceCacheType GetCacheTypeForCorrelationId(string correlationId)
         {
             return ResourceCacheType.Redis;


### PR DESCRIPTION
### 🛠️ Description of Changes

Remove the Skipped cache API and its implementations (ABS, Redis, Hybrid) and update ResourcesAcquiredListener accordingly. ResourcesAcquiredListener now fetches resources earlier, no longer calls Skipped when no sequences are configured, and consolidates/cleans up the normalization flow with improved logging, metrics and error handling.

### 🧪 Testing Performed

Ran test patient that previously failed and observed it completing successfully. Also ran large automated reports to ensure performance wasn't impacted.

### 🧑‍🔬 Unit Testing

- [ ] I have written or updated unit tests to cover my changes
- Coverage: 70.0%

### 📓 Documentation Updated

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved processing for resources without configured normalization operations, allowing them to continue through the workflow instead of being marked as skipped.
  - Improved resource cache selection and handling across supported storage types.
  - Removed legacy skipped-resource copying behavior to prevent unnecessary cache operations.
- **Reliability**
  - Resource and correlation information is now maintained more consistently during processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
