### PR TITLE
LEGLINK-634: Fix reading/writing from/to Redis when Redis is slow or unavailable

### DIFF
--- a/Java/validation/src/main/java/com/lantanagroup/link/validation/configs/CacheErrorHandlingConfig.java
+++ b/Java/validation/src/main/java/com/lantanagroup/link/validation/configs/CacheErrorHandlingConfig.java
@@ -1,0 +1,48 @@
+package com.lantanagroup.link.validation.configs;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.cache.Cache;
+import org.springframework.cache.annotation.CachingConfigurer;
+import org.springframework.cache.interceptor.CacheErrorHandler;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Cache errors (e.g. a Redis timeout) are logged and treated as cache misses instead of failing
+ * validation. A failed GET falls back to calling the terminology service; a failed PUT skips
+ * caching the result. By default Spring rethrows cache errors, which dead-letters an
+ * otherwise-valid ReadyForValidation message. With this handler, a Redis outage will be an
+ * uncached validation.
+ */
+@Configuration
+public class CacheErrorHandlingConfig implements CachingConfigurer {
+    private static final Logger logger = LoggerFactory.getLogger(CacheErrorHandlingConfig.class);
+
+    // Replaces Spring's default SimpleCacheErrorHandler, which rethrows cache errors, with one that
+    // logs and swallows them.
+    @Override
+    public CacheErrorHandler errorHandler() {
+        return new CacheErrorHandler() {
+            @Override
+            public void handleCacheGetError(RuntimeException exception, Cache cache, Object key) {
+                logger.warn("Cache '{}' GET failed; calling the terminology service directly: {}",
+                        cache.getName(), exception.getMessage());
+            }
+
+            @Override
+            public void handleCachePutError(RuntimeException exception, Cache cache, Object key, Object value) {
+                logger.warn("Cache '{}' PUT failed: {}", cache.getName(), exception.getMessage());
+            }
+
+            @Override
+            public void handleCacheEvictError(RuntimeException exception, Cache cache, Object key) {
+                logger.warn("Cache '{}' EVICT failed: {}", cache.getName(), exception.getMessage());
+            }
+
+            @Override
+            public void handleCacheClearError(RuntimeException exception, Cache cache) {
+                logger.warn("Cache '{}' CLEAR failed: {}", cache.getName(), exception.getMessage());
+            }
+        };
+    }
+}

--- a/Java/validation/src/test/java/com/lantanagroup/link/validation/configs/CacheErrorHandlingConfigTest.java
+++ b/Java/validation/src/test/java/com/lantanagroup/link/validation/configs/CacheErrorHandlingConfigTest.java
@@ -1,0 +1,70 @@
+package com.lantanagroup.link.validation.configs;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.cache.Cache;
+import org.springframework.cache.interceptor.CacheErrorHandler;
+import org.springframework.dao.QueryTimeoutException;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Verifies that cache-backend failures are swallowed rather than rethrown, so a Redis
+ * timeout becomes a cache miss instead of dead-lettering the ReadyForValidation
+ * message. See LEGLINK-634.
+ */
+class CacheErrorHandlingConfigTest {
+
+    // The exact failure observed in the ReadyForValidation-Error dead-letter messages.
+    private static final QueryTimeoutException REDIS_TIMEOUT =
+            new QueryTimeoutException("Redis command timed out");
+
+    private CacheErrorHandler handler;
+    private Cache cache;
+
+    @BeforeEach
+    void setUp() {
+        handler = new CacheErrorHandlingConfig().errorHandler();
+        cache = mock(Cache.class);
+        when(cache.getName()).thenReturn("validateCodeCache");
+    }
+
+    @Test
+    void errorHandler_isProvided() {
+        assertNotNull(handler, "config must supply a CacheErrorHandler (replacing SimpleCacheErrorHandler)");
+    }
+
+    @Test
+    void handleCacheGetError_swallowsBackendFailure() {
+        // Swallowing lets the caching interceptor treat the failure as a miss and invoke the
+        // underlying method; rethrowing here is what dead-lettered valid messages.
+        assertDoesNotThrow(() -> handler.handleCacheGetError(REDIS_TIMEOUT, cache, "some-key"));
+    }
+
+    @Test
+    void handleCachePutError_swallowsBackendFailure() {
+        assertDoesNotThrow(() -> handler.handleCachePutError(REDIS_TIMEOUT, cache, "some-key", "some-value"));
+    }
+
+    @Test
+    void handleCacheEvictError_swallowsBackendFailure() {
+        assertDoesNotThrow(() -> handler.handleCacheEvictError(REDIS_TIMEOUT, cache, "some-key"));
+    }
+
+    @Test
+    void handleCacheClearError_swallowsBackendFailure() {
+        assertDoesNotThrow(() -> handler.handleCacheClearError(REDIS_TIMEOUT, cache));
+    }
+
+    @Test
+    void handlers_swallowArbitraryRuntimeExceptions() {
+        // Not just timeouts: connection failures and any other backend RuntimeException must also
+        // be non-fatal (e.g. RedisConnectionFailureException when Redis is down entirely).
+        RuntimeException connectionFailure = new RuntimeException("Unable to connect to Redis");
+        assertDoesNotThrow(() -> handler.handleCacheGetError(connectionFailure, cache, "k"));
+        assertDoesNotThrow(() -> handler.handleCachePutError(connectionFailure, cache, "k", "v"));
+    }
+}


### PR DESCRIPTION
### 🛠️ Description of Changes

Fix Validation  service when reading from Redis when Redis is slow or unavailable

### 🧪 Testing Performed

Tested locally

### 🧑‍🔬 Unit Testing

- [ x] I have written or updated unit tests to cover my changes
- Coverage: 100.0%

### 📓 Documentation Updated

Please update any relevant sections in the project documentation that were impacted by the changes in the PR.

