### PR TITLE
LEGLINK-649: Enable Http client retries when terminology server is down

### DIFF
--- a/Java/validation/src/main/java/com/lantanagroup/link/validation/configs/FhirConfig.java
+++ b/Java/validation/src/main/java/com/lantanagroup/link/validation/configs/FhirConfig.java
@@ -48,6 +48,9 @@ public class FhirConfig {
      */
     // Package-private for testing.
     static CloseableHttpClient buildHttpClient(int maxAttempts, long backoffMillis) {
+        if (backoffMillis < 0) {
+            throw new IllegalArgumentException("backoffMillis must be non-negative");
+        }
         PoolingHttpClientConnectionManager connectionManager =
                 new PoolingHttpClientConnectionManager(5000, TimeUnit.MILLISECONDS);
         connectionManager.setMaxTotal(IRestfulClientFactory.DEFAULT_POOL_MAX);

--- a/Java/validation/src/main/java/com/lantanagroup/link/validation/configs/FhirConfig.java
+++ b/Java/validation/src/main/java/com/lantanagroup/link/validation/configs/FhirConfig.java
@@ -1,13 +1,140 @@
 package com.lantanagroup.link.validation.configs;
 
 import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.rest.client.api.IRestfulClientFactory;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.HttpRequestRetryHandler;
+import org.apache.http.client.ServiceUnavailableRetryStrategy;
+import org.apache.http.client.config.RequestConfig;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
+import org.apache.http.protocol.HttpContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+import javax.net.ssl.SSLException;
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+
+
 @Configuration
 public class FhirConfig {
+    private static final Logger logger = LoggerFactory.getLogger(FhirConfig.class);
+
+    /**
+     * Shared {@link FhirContext} whose REST clients retry transient failures (connection errors,
+     * HTTP 429/5xx) so a brief terminology-service outage doesn't fail validation. 4xx responses
+     * are never retried; retrying is safe because these calls are read-only.
+     */
     @Bean
-    public FhirContext fhirContext() {
-        return FhirContext.forR4();
+    public FhirContext fhirContext(
+            @Value("${link.fhir-client-retry.max-attempts:5}") int maxAttempts,
+            @Value("${link.fhir-client-retry.backoff-millis:5000}") long backoffMillis) {
+        FhirContext fhirContext = FhirContext.forR4();
+        fhirContext.getRestfulClientFactory().setHttpClient(buildHttpClient(maxAttempts, backoffMillis));
+        logger.info("FHIR REST clients configured with transient-error retry: max {} attempts, {} ms backoff",
+                maxAttempts, backoffMillis);
+        return fhirContext;
+    }
+
+    /**
+     * Builds the HTTP client used by all HAPI REST clients, with HAPI's default pool/timeout
+     * settings (bypassed when a custom client is supplied) plus retry of transient HTTP responses
+     * and connection failures.
+     */
+    // Package-private for testing.
+    static CloseableHttpClient buildHttpClient(int maxAttempts, long backoffMillis) {
+        PoolingHttpClientConnectionManager connectionManager =
+                new PoolingHttpClientConnectionManager(5000, TimeUnit.MILLISECONDS);
+        connectionManager.setMaxTotal(IRestfulClientFactory.DEFAULT_POOL_MAX);
+        connectionManager.setDefaultMaxPerRoute(IRestfulClientFactory.DEFAULT_POOL_MAX_PER_ROUTE);
+
+        RequestConfig requestConfig = RequestConfig.custom()
+                .setConnectTimeout(IRestfulClientFactory.DEFAULT_CONNECT_TIMEOUT)
+                .setSocketTimeout(IRestfulClientFactory.DEFAULT_SOCKET_TIMEOUT)
+                .setConnectionRequestTimeout(IRestfulClientFactory.DEFAULT_CONNECTION_REQUEST_TIMEOUT)
+                .build();
+
+        return HttpClients.custom()
+                .setConnectionManager(connectionManager)
+                .setDefaultRequestConfig(requestConfig)
+                .setServiceUnavailableRetryStrategy(new TransientServerErrorRetryStrategy(maxAttempts, backoffMillis))
+                .setRetryHandler(new TransientConnectionFailureRetryHandler(maxAttempts, backoffMillis))
+                .disableCookieManagement()
+                .build();
+    }
+
+    /**
+     * Retries HTTP 429 and 5xx responses with fixed backoff; 2xx–4xx are never retried.
+     */
+    static class TransientServerErrorRetryStrategy implements ServiceUnavailableRetryStrategy {
+        private final int maxAttempts;
+        private final long backoffMillis;
+
+        TransientServerErrorRetryStrategy(int maxAttempts, long backoffMillis) {
+            this.maxAttempts = maxAttempts;
+            this.backoffMillis = backoffMillis;
+        }
+
+        @Override
+        public boolean retryRequest(HttpResponse response, int executionCount, HttpContext context) {
+            int status = response.getStatusLine().getStatusCode();
+            boolean transientFailure = status == 429 || status >= 500;
+            boolean retry = transientFailure && executionCount < maxAttempts;
+            if (retry) {
+                logger.warn("Transient HTTP {} from FHIR server; attempt {}/{}, retrying in {} ms",
+                        status, executionCount, maxAttempts, backoffMillis);
+            } else if (transientFailure) {
+                logger.warn("Transient HTTP {} from FHIR server; retries exhausted after {} attempts",
+                        status, executionCount);
+            }
+            return retry;
+        }
+
+        @Override
+        public long getRetryInterval() {
+            return backoffMillis;
+        }
+    }
+
+    /**
+     * Retries connection-level I/O failures (connection refused, timeouts, unknown host) with fixed
+     * backoff. Unknown host is included because a stopped container's DNS name stops resolving in
+     * Docker networks. SSL failures are not retried — they indicate configuration problems, not a
+     * transient outage.
+     */
+    static class TransientConnectionFailureRetryHandler implements HttpRequestRetryHandler {
+        private final int maxAttempts;
+        private final long backoffMillis;
+
+        TransientConnectionFailureRetryHandler(int maxAttempts, long backoffMillis) {
+            this.maxAttempts = maxAttempts;
+            this.backoffMillis = backoffMillis;
+        }
+
+        @Override
+        public boolean retryRequest(IOException exception, int executionCount, HttpContext context) {
+            if (exception instanceof SSLException) {
+                return false;
+            }
+            if (executionCount >= maxAttempts) {
+                logger.warn("Connection failure ({}) from FHIR server; retries exhausted after {} attempts",
+                        exception.toString(), executionCount);
+                return false;
+            }
+            logger.warn("Connection failure ({}) from FHIR server; attempt {}/{}, retrying in {} ms",
+                    exception.toString(), executionCount, maxAttempts, backoffMillis);
+            try {
+                Thread.sleep(backoffMillis);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                return false;
+            }
+            return true;
+        }
     }
 }

--- a/Java/validation/src/main/resources/application.yml
+++ b/Java/validation/src/main/resources/application.yml
@@ -110,6 +110,12 @@ authentication:
 link:
   info-route: /api/validation/info
   terminology-service-url: ''
+  # Retry for all HAPI FHIR REST clients (terminology validate-code/$lookup/etc.).
+  # Transient failures only: connection IOExceptions, HTTP 429, and 5xx (e.g. Envoy
+  # "503 no healthy upstream" during a terminology-service rollout). 4xx never retries.
+  fhir-client-retry:
+    max-attempts: 5
+    backoff-millis: 5000
   report:
     base-url: http://localhost:5110
     routes:

--- a/Java/validation/src/test/java/com/lantanagroup/link/validation/configs/FhirConfigTest.java
+++ b/Java/validation/src/test/java/com/lantanagroup/link/validation/configs/FhirConfigTest.java
@@ -1,0 +1,219 @@
+package com.lantanagroup.link.validation.configs;
+
+import com.sun.net.httpserver.HttpServer;
+import org.apache.http.HttpResponse;
+import org.apache.http.HttpVersion;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.message.BasicHttpResponse;
+import org.apache.http.util.EntityUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Verifies retry behavior of the HTTP client backing all HAPI REST clients: transient failures
+ * (connection errors, 429/5xx) are retried, 4xx responses fail fast.
+ */
+class FhirConfigTest {
+
+    // -------------------------------------------------------------------------
+    // TransientServerErrorRetryStrategy classification
+    // -------------------------------------------------------------------------
+
+    private static HttpResponse response(int status) {
+        return new BasicHttpResponse(HttpVersion.HTTP_1_1, status, null);
+    }
+
+    private static FhirConfig.TransientServerErrorRetryStrategy strategy(int maxAttempts) {
+        return new FhirConfig.TransientServerErrorRetryStrategy(maxAttempts, 250L);
+    }
+
+    @Test
+    void retryRequest_transientStatuses_retriedWhileAttemptsRemain() {
+        FhirConfig.TransientServerErrorRetryStrategy strategy = strategy(3);
+        for (int status : new int[]{429, 500, 502, 503, 504}) {
+            assertTrue(strategy.retryRequest(response(status), 1, null), "HTTP " + status + " should retry");
+            assertTrue(strategy.retryRequest(response(status), 2, null), "HTTP " + status + " should retry");
+        }
+    }
+
+    @Test
+    void retryRequest_transientStatus_notRetriedOnceAttemptsExhausted() {
+        FhirConfig.TransientServerErrorRetryStrategy strategy = strategy(3);
+        assertFalse(strategy.retryRequest(response(503), 3, null),
+                "no retry once executionCount reaches maxAttempts");
+    }
+
+    @Test
+    void retryRequest_nonTransientStatuses_neverRetried() {
+        FhirConfig.TransientServerErrorRetryStrategy strategy = strategy(3);
+        for (int status : new int[]{200, 201, 400, 401, 404, 422}) {
+            assertFalse(strategy.retryRequest(response(status), 1, null), "HTTP " + status + " should not retry");
+        }
+    }
+
+    @Test
+    void getRetryInterval_returnsConfiguredBackoff() {
+        assertEquals(250L, strategy(3).getRetryInterval());
+    }
+
+    // -------------------------------------------------------------------------
+    // End-to-end: the built client retries against a real HTTP server
+    // -------------------------------------------------------------------------
+
+    private HttpServer server;
+    private final AtomicInteger requestCount = new AtomicInteger();
+
+    @BeforeEach
+    void resetCount() {
+        requestCount.set(0);
+    }
+
+    @AfterEach
+    void stopServer() {
+        if (server != null) {
+            server.stop(0);
+            server = null;
+        }
+    }
+
+    /** Starts a local server that returns the given statuses in order (last one repeats). */
+    private String startServer(int... statuses) throws IOException {
+        server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        server.createContext("/", exchange -> {
+            int index = Math.min(requestCount.getAndIncrement(), statuses.length - 1);
+            byte[] body = "{}".getBytes(StandardCharsets.UTF_8);
+            exchange.getResponseHeaders().add("Content-Type", "application/json");
+            exchange.sendResponseHeaders(statuses[index], body.length);
+            try (OutputStream out = exchange.getResponseBody()) {
+                out.write(body);
+            }
+        });
+        server.start();
+        return "http://127.0.0.1:" + server.getAddress().getPort() + "/";
+    }
+
+    private static int executeGet(CloseableHttpClient client, String url) throws IOException {
+        try (CloseableHttpResponse response = client.execute(new HttpGet(url))) {
+            EntityUtils.consume(response.getEntity());
+            return response.getStatusLine().getStatusCode();
+        }
+    }
+
+    @Test
+    void builtClient_retries503ThenSucceeds() throws IOException {
+        String url = startServer(503, 503, 200);
+        try (CloseableHttpClient client = FhirConfig.buildHttpClient(3, 0L)) {
+            assertEquals(200, executeGet(client, url));
+        }
+        assertEquals(3, requestCount.get(), "two 503s should be retried, third attempt succeeds");
+    }
+
+    @Test
+    void builtClient_exhaustsRetriesAndReturnsLast503() throws IOException {
+        String url = startServer(503);
+        try (CloseableHttpClient client = FhirConfig.buildHttpClient(3, 0L)) {
+            assertEquals(503, executeGet(client, url));
+        }
+        assertEquals(3, requestCount.get(), "should stop after maxAttempts");
+    }
+
+    @Test
+    void builtClient_doesNotRetry4xx() throws IOException {
+        String url = startServer(400);
+        try (CloseableHttpClient client = FhirConfig.buildHttpClient(3, 0L)) {
+            assertEquals(400, executeGet(client, url));
+        }
+        assertEquals(1, requestCount.get(), "4xx must not be retried");
+    }
+
+    // -------------------------------------------------------------------------
+    // TransientConnectionFailureRetryHandler classification
+    // -------------------------------------------------------------------------
+
+    private static FhirConfig.TransientConnectionFailureRetryHandler connectionHandler(int maxAttempts) {
+        return new FhirConfig.TransientConnectionFailureRetryHandler(maxAttempts, 0L);
+    }
+
+    @Test
+    void connectionRetry_connectionRefusedAndTimeouts_retriedWhileAttemptsRemain() {
+        FhirConfig.TransientConnectionFailureRetryHandler handler = connectionHandler(3);
+        for (IOException exception : new IOException[]{
+                new java.net.ConnectException("Connection refused"),
+                new java.net.SocketTimeoutException("Read timed out"),
+                new org.apache.http.conn.ConnectTimeoutException("Connect timed out"),
+                // Unknown host is transient: a stopped container's name disappears from Docker DNS.
+                new java.net.UnknownHostException("terminology")}) {
+            assertTrue(handler.retryRequest(exception, 1, null), exception + " should retry");
+            assertTrue(handler.retryRequest(exception, 2, null), exception + " should retry");
+        }
+    }
+
+    @Test
+    void connectionRetry_notRetriedOnceAttemptsExhausted() {
+        FhirConfig.TransientConnectionFailureRetryHandler handler = connectionHandler(3);
+        assertFalse(handler.retryRequest(new java.net.ConnectException("Connection refused"), 3, null),
+                "no retry once executionCount reaches maxAttempts");
+    }
+
+    @Test
+    void connectionRetry_configurationFailures_neverRetried() {
+        FhirConfig.TransientConnectionFailureRetryHandler handler = connectionHandler(3);
+        assertFalse(handler.retryRequest(new javax.net.ssl.SSLException("handshake failure"), 1, null),
+                "SSL failures should not retry");
+    }
+
+    // -------------------------------------------------------------------------
+    // End-to-end: connection refused, then recovery
+    // -------------------------------------------------------------------------
+
+    @Test
+    void builtClient_retriesConnectionRefusedUntilServerComesBack() throws Exception {
+        // Reserve a port, then close the socket so connections are refused.
+        int port;
+        try (java.net.ServerSocket socket = new java.net.ServerSocket(0, 0, java.net.InetAddress.getByName("127.0.0.1"))) {
+            port = socket.getLocalPort();
+        }
+        String url = "http://127.0.0.1:" + port + "/";
+
+        // Bring the server up on that port after a delay, while the client is mid-retry.
+        Thread starter = new Thread(() -> {
+            try {
+                Thread.sleep(500);
+                server = HttpServer.create(new InetSocketAddress("127.0.0.1", port), 0);
+                server.createContext("/", exchange -> {
+                    requestCount.incrementAndGet();
+                    byte[] body = "{}".getBytes(StandardCharsets.UTF_8);
+                    exchange.sendResponseHeaders(200, body.length);
+                    try (OutputStream out = exchange.getResponseBody()) {
+                        out.write(body);
+                    }
+                });
+                server.start();
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        });
+        starter.start();
+
+        try (CloseableHttpClient client = FhirConfig.buildHttpClient(10, 250L)) {
+            assertEquals(200, executeGet(client, url),
+                    "connection-refused failures should be retried until the server is back");
+        } finally {
+            starter.join();
+        }
+        assertEquals(1, requestCount.get(), "exactly one request should reach the recovered server");
+    }
+}


### PR DESCRIPTION


### 🛠️ Description of Changes

Enable Http client retries when terminology server is temporarily down so that will not fail validation right away

### 🧪 Testing Performed

Tested locally

### 🧑‍🔬 Unit Testing

- [x ] I have written or updated unit tests to cover my changes
- Coverage: 83.9%

### 📓 Documentation Updated

Please update any relevant sections in the project documentation that were impacted by the changes in the PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * FHIR REST clients now automatically retry transient connection failures, HTTP 429 responses, and server errors.
  * Retry attempts and backoff intervals can be configured through application settings, with sensible defaults provided.
  * Non-transient client errors and SSL-related failures are not retried.

* **Bug Fixes**
  * Improved resilience when upstream FHIR services are temporarily unavailable or recovering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

