### PR TITLE
TECH_DEBT: Cache isSupported probes on remote terminology client

### DIFF
--- a/Java/validation/src/main/java/com/lantanagroup/link/validation/configs/MemoryCacheConfig.java
+++ b/Java/validation/src/main/java/com/lantanagroup/link/validation/configs/MemoryCacheConfig.java
@@ -27,7 +27,10 @@ public class MemoryCacheConfig {
     @ConditionalOnProperty(name = "cache.type", havingValue = "memory")
     public CacheManager caffeineCacheManager() {
         logger.info("Cache type set to 'memory'");
-        CaffeineCacheManager cacheManager = new CaffeineCacheManager("validateCodeCache");
+        CaffeineCacheManager cacheManager = new CaffeineCacheManager(
+                "validateCodeCache",
+                "isCodeSystemSupportedCache",
+                "isValueSetSupportedCache");
         cacheManager.setCaffeine(Caffeine.newBuilder()
                 .expireAfterWrite(Duration.ofSeconds(this.cacheConfig.getValidateCode().getTtl()))
                 .maximumSize(1000));

--- a/Java/validation/src/main/java/com/lantanagroup/link/validation/providers/RemoteTermServiceValidation.java
+++ b/Java/validation/src/main/java/com/lantanagroup/link/validation/providers/RemoteTermServiceValidation.java
@@ -279,8 +279,7 @@ public class RemoteTermServiceValidation extends BaseValidationSupport implement
             }
         }
 
-        IBaseResource codeSystem = this.fetchCodeSystem(theSystem, SummaryEnum.TRUE);
-        return codeSystem != null;
+        return validationCacheService.cachedIsCodeSystemSupported(this, theSystem);
     }
 
     public boolean isValueSetSupported(ValidationSupportContext theValidationSupportContext, String theValueSetUrl) {
@@ -294,8 +293,24 @@ public class RemoteTermServiceValidation extends BaseValidationSupport implement
             }
         }
 
-        IBaseResource valueSet = this.fetchValueSet(theValueSetUrl, SummaryEnum.TRUE);
-        return valueSet != null;
+        return validationCacheService.cachedIsValueSetSupported(this, theValueSetUrl);
+    }
+
+    /**
+     * Remote lookup for {@link #isCodeSystemSupported}, extracted so the result can be cached at the
+     * {@link ValidationCacheService} layer. Package-private so the cache service can invoke it via the
+     * delegate reference passed into the {@code @Cacheable} method.
+     */
+    boolean invokeIsCodeSystemSupported(String theSystem) {
+        return this.fetchCodeSystem(theSystem, SummaryEnum.TRUE) != null;
+    }
+
+    /**
+     * Remote lookup for {@link #isValueSetSupported}, extracted for the same reason as
+     * {@link #invokeIsCodeSystemSupported}.
+     */
+    boolean invokeIsValueSetSupported(String theValueSetUrl) {
+        return this.fetchValueSet(theValueSetUrl, SummaryEnum.TRUE) != null;
     }
 
     public TranslateConceptResults translateConcept(IValidationSupport.TranslateCodeRequest theRequest) {

--- a/Java/validation/src/main/java/com/lantanagroup/link/validation/providers/ValidationCacheService.java
+++ b/Java/validation/src/main/java/com/lantanagroup/link/validation/providers/ValidationCacheService.java
@@ -26,4 +26,24 @@ public class ValidationCacheService {
     ) {
         return delegate.invokeRemoteValidateCode(codeSystem, code, display, valueSetUrl, (IBaseResource) null);
     }
+
+    /**
+     * Cache wrapper for {@link RemoteTermServiceValidation#invokeIsCodeSystemSupported(String)}.
+     * HAPI's ValidationSupportChain probes {@code isCodeSystemSupported} per system per traversal,
+     * so an uncached implementation hits the remote TS on every coded element. Both {@code true}
+     * and {@code false} results are cached (unknown systems shouldn't be reprobed either).
+     */
+    @Cacheable(value = "isCodeSystemSupportedCache", key = "#codeSystem")
+    public boolean cachedIsCodeSystemSupported(RemoteTermServiceValidation delegate, String codeSystem) {
+        return delegate.invokeIsCodeSystemSupported(codeSystem);
+    }
+
+    /**
+     * Cache wrapper for {@link RemoteTermServiceValidation#invokeIsValueSetSupported(String)}.
+     * See {@link #cachedIsCodeSystemSupported} for rationale — identical caching model applies.
+     */
+    @Cacheable(value = "isValueSetSupportedCache", key = "#valueSetUrl")
+    public boolean cachedIsValueSetSupported(RemoteTermServiceValidation delegate, String valueSetUrl) {
+        return delegate.invokeIsValueSetSupported(valueSetUrl);
+    }
 }

--- a/Java/validation/src/test/java/com/lantanagroup/link/validation/providers/RemoteTermServiceValidationTest.java
+++ b/Java/validation/src/test/java/com/lantanagroup/link/validation/providers/RemoteTermServiceValidationTest.java
@@ -22,9 +22,11 @@ import org.mockito.ArgumentCaptor;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doReturn;
@@ -32,6 +34,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 /**
@@ -307,5 +310,75 @@ class RemoteTermServiceValidationTest {
                 result.getMessage());
         // The inline path targets the ValueSet resource, not CodeSystem.
         verify(operation).onType("ValueSet");
+    }
+
+    // ---------- isCodeSystemSupported / isValueSetSupported delegation to cache ----------
+    // These methods are hit per-system per-chain-traversal by HAPI's ValidationSupportChain, so the
+    // remote lookup has to go through ValidationCacheService. The tests below verify the delegation
+    // and confirm the fast pre-cache checks (null input, whitelist regex) short-circuit before the
+    // cache is consulted at all.
+
+    @Test
+    void isCodeSystemSupported_delegatesToCacheService() {
+        ValidationCacheService cacheService = mock(ValidationCacheService.class);
+        RemoteTermServiceValidation subject = new RemoteTermServiceValidation(
+                cacheService, fhirContext, "http://tx.example.org/fhir", List.of(), List.of());
+        when(cacheService.cachedIsCodeSystemSupported(subject, CODE_SYSTEM_URL)).thenReturn(true);
+
+        assertTrue(subject.isCodeSystemSupported(null, CODE_SYSTEM_URL));
+        verify(cacheService).cachedIsCodeSystemSupported(subject, CODE_SYSTEM_URL);
+    }
+
+    @Test
+    void isCodeSystemSupported_nullSystem_returnsFalseWithoutTouchingCache() {
+        ValidationCacheService cacheService = mock(ValidationCacheService.class);
+        RemoteTermServiceValidation subject = new RemoteTermServiceValidation(
+                cacheService, fhirContext, "http://tx.example.org/fhir", List.of(), List.of());
+
+        assertFalse(subject.isCodeSystemSupported(null, null));
+        verifyNoInteractions(cacheService);
+    }
+
+    @Test
+    void isCodeSystemSupported_matchesWhitelist_returnsFalseWithoutTouchingCache() {
+        ValidationCacheService cacheService = mock(ValidationCacheService.class);
+        RemoteTermServiceValidation subject = new RemoteTermServiceValidation(
+                cacheService, fhirContext, "http://tx.example.org/fhir",
+                List.of("^http://open\\.epic\\.com/.*"), List.of());
+
+        assertFalse(subject.isCodeSystemSupported(null, "http://open.epic.com/FHIR/foo"));
+        verifyNoInteractions(cacheService);
+    }
+
+    @Test
+    void isValueSetSupported_delegatesToCacheService() {
+        ValidationCacheService cacheService = mock(ValidationCacheService.class);
+        RemoteTermServiceValidation subject = new RemoteTermServiceValidation(
+                cacheService, fhirContext, "http://tx.example.org/fhir", List.of(), List.of());
+        when(cacheService.cachedIsValueSetSupported(subject, VALUE_SET_URL)).thenReturn(true);
+
+        assertTrue(subject.isValueSetSupported(null, VALUE_SET_URL));
+        verify(cacheService).cachedIsValueSetSupported(subject, VALUE_SET_URL);
+    }
+
+    @Test
+    void isValueSetSupported_nullUrl_returnsFalseWithoutTouchingCache() {
+        ValidationCacheService cacheService = mock(ValidationCacheService.class);
+        RemoteTermServiceValidation subject = new RemoteTermServiceValidation(
+                cacheService, fhirContext, "http://tx.example.org/fhir", List.of(), List.of());
+
+        assertFalse(subject.isValueSetSupported(null, null));
+        verifyNoInteractions(cacheService);
+    }
+
+    @Test
+    void isValueSetSupported_matchesWhitelist_returnsFalseWithoutTouchingCache() {
+        ValidationCacheService cacheService = mock(ValidationCacheService.class);
+        RemoteTermServiceValidation subject = new RemoteTermServiceValidation(
+                cacheService, fhirContext, "http://tx.example.org/fhir",
+                List.of(), List.of("^http://example\\.org/ValueSet/.*"));
+
+        assertFalse(subject.isValueSetSupported(null, "http://example.org/ValueSet/vs"));
+        verifyNoInteractions(cacheService);
     }
 }


### PR DESCRIPTION
### 🛠️ Description of Changes

Eliminates the largest per-bundle latency contributor identified in the remote-terminology cost analysis: RemoteTermServiceValidation.isCodeSystemSupported / isValueSetSupported were making full HTTP round-trips to the terminology server on every chain-traversal probe. HAPI's ValidationSupportChain calls these methods per code system per traversal, so a bundle referencing 20 code systems triggered 20+ uncached round-trips just to answer "who owns this system?" before any actual code validation happened.

#### What ships

- Two new `@Cacheable` methods on ValidationCacheService:
  - cachedIsCodeSystemSupported(delegate, codeSystem) - cache region isCodeSystemSupportedCache, keyed on the URL
  - cachedIsValueSetSupported(delegate, valueSetUrl) - cache region isValueSetSupportedCache, keyed on the URL
  - Both cache true and false results - unknown systems shouldn't be re-probed either.
- RemoteTermServiceValidation refactor:
  - The public isCodeSystemSupported(...) / isValueSetSupported(...) methods now do the fast static checks (null input, whitelist regex) and delegate the remote lookup through the cache service.
  - Remote lookups extracted into package-private invokeIsCodeSystemSupported(String) / invokeIsValueSetSupported(String) - this is what the cache service calls back into on cache miss.
  - Static short-circuits happen before the cache is consulted; no point caching regex answers.
- MemoryCacheConfig: two new cache regions added to the CaffeineCacheManager constructor. Shares TTL, max size, and other config with the existing validateCodeCache via the Caffeine builder.
- Redis: no config changes needed. RedisCacheManager auto-creates cache regions on first use with the shared cacheDefaults(...), so the new caches inherit the existing TTL, Jackson serializer, and disableCachingNullValues settings. Primitive boolean returns can't be null, so the disableCachingNullValues interaction is safe.
- Six new tests in RemoteTermServiceValidationTest.java:
  - delegation to cache service for both isCodeSystemSupported and isValueSetSupported
  - null-input short-circuit (verifies cache is not touched)
  - whitelist regex short-circuit (verifies cache is not touched)
  - Follows the existing validateCodeInValueSet_withCanonicalUrl_delegatesToRemoteViaCache pattern.

#### Expected impact

Per-bundle latency should drop noticeably on the warm-cache path, particularly for the unknown/unresolved code system families where the same handful of URLs are probed over and over. Concrete expectations:

- link.validation.validate.duration histogram - meaningful reduction at p50 and p95 for bundles referencing repeat code systems.
- Remote TS call volume for search().forResource("CodeSystem").where(url=...) and the equivalent ValueSet search — drops proportional to how quickly the cache warms.
- No effect on cold-start latency for the first bundle after deploy (cache fills gradually).

Applies to both remote configurations

ValidationService builds RemoteTermServiceValidation for two configurations:

- linkConfig.getFhirTerminologyServiceUrl() (raw FHIR TS)
- linkConfig.getTerminologyServiceUrl() (Link .NET terminology service)

Both benefit from this cache. Pure in-memory fallback (CommonCodeSystemsTerminologyService + InMemoryTerminologyServerValidationSupport) is unaffected - those classes are local map lookups, and caching them would add cost, not remove it.

### 🧪 Testing Performed

#### Test plan

- [x] CI Java unit tests pass (adds six tests, existing tests still green)
- [x] Production sources compile cleanly (verified locally with javac against the resolved Maven classpath — local Maven compile is blocked by unrelated Lombok annotation-processor issues on this dev env)
- [ ] After deploy, confirm link.validation.validate.duration p95 drops on the first steady-state hour of traffic
- [ ] Sanity check that no new terminology-related errors appear in logs (the cache is behavior-preserving for known-good codes; only latency changes)
- [ ] Verify Redis is populating the new cache regions if cache.type=redis (should see isCodeSystemSupportedCache::<url> and isValueSetSupportedCache::<url> keys after a bundle 

### 🧑‍🔬 Unit Testing

- [x] I have written or updated unit tests to cover my changes
- Coverage: 28.6%

### 📓 Documentation Updated

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Added caching for code system and value set support checks.
  * Repeated validation requests can now return cached results, including unsupported-resource results, reducing unnecessary remote lookups.

* **Bug Fixes**
  * Improved handling of null or invalid inputs by avoiding remote checks when they cannot produce valid results.

* **Tests**
  * Added coverage for cached delegation, short-circuit behavior, and supported/unsupported resource checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
