### PR TITLE
LEGLINK-562: Submission: Enable dQM specific submissions

### DIFF
--- a/DotNet/ServiceTests/UnitTests/Submission/BlobStorageServiceTests.cs
+++ b/DotNet/ServiceTests/UnitTests/Submission/BlobStorageServiceTests.cs
@@ -15,7 +15,7 @@ namespace UnitTests.Submission
         public void GetExternalBlobName_ReturnsExpectedPath(
             string? blobRoot, string reportName, string bundleName, bool flatten, string expected)
         {
-            var result = BlobStorageService.GetExternalBlobName(blobRoot, reportName, bundleName, flatten);
+            var result = BlobStorageService.GetExternalBlobName(blobRoot, null, reportName, bundleName, flatten);
 
             Assert.Equal(expected, result);
         }
@@ -23,7 +23,7 @@ namespace UnitTests.Submission
         [Fact]
         public void GetExternalBlobName_FlattenFalse_ProducesThreeSlashSegments()
         {
-            var result = BlobStorageService.GetExternalBlobName("root", "report", "bundle.ndjson", false);
+            var result = BlobStorageService.GetExternalBlobName("root", null, "report", "bundle.ndjson", false);
 
             Assert.Equal(3, result.Split('/').Length);
             Assert.EndsWith("/bundle.ndjson", result);
@@ -32,7 +32,7 @@ namespace UnitTests.Submission
         [Fact]
         public void GetExternalBlobName_FlattenTrue_ProducesTwoSlashSegments()
         {
-            var result = BlobStorageService.GetExternalBlobName("root", "report", "bundle.ndjson", true);
+            var result = BlobStorageService.GetExternalBlobName("root", null, "report", "bundle.ndjson", true);
 
             Assert.Equal(2, result.Split('/').Length);
             Assert.EndsWith("_bundle.ndjson", result);

--- a/DotNet/Submission/Application/Config/ExternalBlobStorageSettings.cs
+++ b/DotNet/Submission/Application/Config/ExternalBlobStorageSettings.cs
@@ -5,7 +5,8 @@
         public const string Key = "ExternalBlobStorage";
 
         public bool FlattenHierarchy { get; set; }
-
         public bool SuppressManifest { get; set; }
+        public bool UseMeasurePrefix { get; set; }
+        public Dictionary<string, string>? MeasurePrefixesByReportType { get; set; }
     }
 }

--- a/DotNet/Submission/Application/Interfaces/IStorageService.cs
+++ b/DotNet/Submission/Application/Interfaces/IStorageService.cs
@@ -10,6 +10,6 @@ namespace LantanaGroup.Link.Submission.Application.Interfaces
         Task<byte[]?> DownloadFromInternalAsync(SubmitPayloadValue value, CancellationToken cancellationToken = default);
         Task UploadToExternalAsync(SubmitPayloadKey key, SubmitPayloadValue value, byte[] content, CancellationToken cancellationToken = default);
         Task<IDictionary<string, byte[]>> DownloadFromInternalAsync(string payloadRootUri, CancellationToken cancellationToken = default);
-        Task<IDictionary<string, byte[]>> DownloadFromExternalAsync(string payloadRootUri, CancellationToken cancellationToken = default);
+        Task<IDictionary<string, byte[]>> DownloadFromExternalAsync(ICollection<string> reportTypes, string payloadRootUri, CancellationToken cancellationToken = default);
     }
 }

--- a/DotNet/Submission/Application/Services/BlobStorageService.cs
+++ b/DotNet/Submission/Application/Services/BlobStorageService.cs
@@ -29,14 +29,18 @@ namespace LantanaGroup.Link.Submission.Application.Services
             return new BlobContainerClient(settings.ConnectionString, settings.BlobContainerName);
         }
 
-        internal static string GetExternalBlobName(string? blobRoot, string reportName, string bundleName, bool flatten) =>
+        internal static string GetExternalBlobName(string? blobRoot, string? measurePrefix, string reportName, string bundleName, bool flatten) =>
             flatten
-                ? GetBlobName(blobRoot, $"{reportName}_{bundleName}")
-                : GetBlobName(blobRoot, reportName, bundleName);
+                ? GetBlobName(blobRoot, measurePrefix, $"{reportName}_{bundleName}")
+                : GetBlobName(blobRoot, measurePrefix, reportName, bundleName);
 
-        private static string GetBlobName(string? blobRoot, params string[] segments)
+        private static string GetBlobName(string? blobRoot, string? measurePrefix, params string[] segments)
         {
             IEnumerable<string> enumerable = segments;
+            if (!string.IsNullOrEmpty(measurePrefix))
+            {
+                enumerable = enumerable.Prepend(measurePrefix);
+            }
             if (!string.IsNullOrEmpty(blobRoot))
             {
                 enumerable = enumerable.Prepend(blobRoot);
@@ -56,7 +60,7 @@ namespace LantanaGroup.Link.Submission.Application.Services
             _externalContainerClient = GetContainerClient(_externalSettings);
         }
 
-        private string ChangeBlobRoot(string blobName)
+        private string ChangeBlobRoot(string? measurePrefix, string blobName)
         {
             if (_internalSettings.BlobRoot != null && blobName.StartsWith(_internalSettings.BlobRoot))
             {
@@ -70,7 +74,27 @@ namespace LantanaGroup.Link.Submission.Application.Services
                     blobName = $"{blobName[..index]}_{blobName[(index + 1)..]}";
                 }
             }
-            return GetBlobName(_externalSettings.BlobRoot, blobName);
+            return GetBlobName(_externalSettings.BlobRoot, measurePrefix, blobName);
+        }
+
+        private string? GetMeasurePrefix(ICollection<string> reportTypes)
+        {
+            if (!_externalSettings.UseMeasurePrefix)
+            {
+                return null;
+            }
+            if (_externalSettings.MeasurePrefixesByReportType == null)
+            {
+                return reportTypes.FirstOrDefault();
+            }
+            foreach (string reportType in reportTypes)
+            {
+                if (_externalSettings.MeasurePrefixesByReportType.TryGetValue(reportType, out string? measurePrefix))
+                {
+                    return measurePrefix;
+                }
+            }
+            return reportTypes.FirstOrDefault();
         }
 
         public bool HasInternalClient()
@@ -116,6 +140,7 @@ namespace LantanaGroup.Link.Submission.Application.Services
             {
                 throw new InvalidOperationException("Not configured for external blob storage.");
             }
+            string? measurePrefix = GetMeasurePrefix(value.ReportTypes);
             string blobName;
             if (string.IsNullOrEmpty(value.PayloadUri))
             {
@@ -126,12 +151,12 @@ namespace LantanaGroup.Link.Submission.Application.Services
                     PayloadType.ReportSchedule => "manifest.ndjson",
                     _ => $"{Guid.NewGuid()}.ndjson"
                 };
-                blobName = GetExternalBlobName(_externalSettings.BlobRoot, reportName, bundleName, _externalSettings.FlattenHierarchy);
+                blobName = GetExternalBlobName(_externalSettings.BlobRoot, measurePrefix, reportName, bundleName, _externalSettings.FlattenHierarchy);
             }
             else
             {
                 BlobUriBuilder uriBuilder = new(new Uri(value.PayloadUri));
-                blobName = ChangeBlobRoot(uriBuilder.BlobName);
+                blobName = ChangeBlobRoot(measurePrefix, uriBuilder.BlobName);
             }
             _logger.LogDebug("Uploading: {}", blobName);
             BlockBlobClient blobClient = _externalContainerClient.GetBlockBlobClient(blobName);
@@ -174,14 +199,15 @@ namespace LantanaGroup.Link.Submission.Application.Services
             return DownloadAsync(_internalContainerClient, prefix, cancellationToken);
         }
 
-        public Task<IDictionary<string, byte[]>> DownloadFromExternalAsync(string payloadRootUri, CancellationToken cancellationToken = default)
+        public Task<IDictionary<string, byte[]>> DownloadFromExternalAsync(ICollection<string> reportTypes, string payloadRootUri, CancellationToken cancellationToken = default)
         {
             if (!HasExternalClient())
             {
                 throw new InvalidOperationException("Not configured for external blob storage.");
             }
+            string? measurePrefix = GetMeasurePrefix(reportTypes);
             BlobUriBuilder uriBuilder = new(new Uri(payloadRootUri));
-            string prefix = ChangeBlobRoot(uriBuilder.BlobName);
+            string prefix = ChangeBlobRoot(measurePrefix, uriBuilder.BlobName);
             return DownloadAsync(_externalContainerClient, prefix, cancellationToken);
         }
     }

--- a/DotNet/Submission/Controllers/SubmissionController.cs
+++ b/DotNet/Submission/Controllers/SubmissionController.cs
@@ -93,8 +93,21 @@ public class SubmissionController(
             throw new Exception("Missing 'payloadRootUri' in the response.");
         }
 
+        var reportTypes = new List<string>();
+        if (jsonResponse.RootElement.TryGetProperty("reportTypes", out var reportTypesElement))
+        {
+            foreach (JsonElement reportTypeElement in reportTypesElement.EnumerateArray())
+            {
+                string? reportType = reportTypeElement.GetString();
+                if (reportType != null)
+                {
+                    reportTypes.Add(reportType);
+                }
+            }
+        }
+
         IDictionary<string, byte[]> files = external
-            ? await blobStorageService.DownloadFromExternalAsync(payloadRootUri.GetString())
+            ? await blobStorageService.DownloadFromExternalAsync(reportTypes, payloadRootUri.GetString())
             : await blobStorageService.DownloadFromInternalAsync(payloadRootUri.GetString());
 
         var compressedData = this.CompressFiles(files);

--- a/app-config.yaml
+++ b/app-config.yaml
@@ -313,6 +313,12 @@ services:
     - key: "ExternalBlobStorage:SuppressManifest"
       description: "Whether to suppress submission of manifest bundles."
       required: false
+    - key: "ExternalBlobStorage:UseMeasurePrefix"
+      description: "Whether to use a measure prefix (i.e., dQM-specific directory following the blob root) for external blobs."
+      required: false
+    - key: "ExternalBlobStorage:MeasurePrefixesByReportType"
+      description: "Mapping of report types to measure prefixes."
+      required: false
   Tenant:
     - key: "FacilityIdSettings:NumericOnlyFacilityId"
       description: "Boolean flag to restrict facility IDs to numeric values only."


### PR DESCRIPTION
### 🛠️ Description of Changes

Add support for a "measure prefix" (i.e., dQM-specific directory following the blob root) for external blobs.

### 🧪 Testing Performed

Tested locally.

### 🧑‍🔬 Unit Testing

- [X] I have written or updated unit tests to cover my changes
- Coverage: 11.1%

### 📓 Documentation Updated

Updated `app-config.yaml`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional measure-prefix support for organizing external storage blobs.
  * Added report-type-specific measure-prefix configuration.
  * External report downloads now use report types to locate the correct stored files.
* **Bug Fixes**
  * Improved external blob path generation for uploads and downloads while preserving existing report archive behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
