### PR TITLE
LEGLINK-582: Validation service writes category-grouped pre-qualification OperationOutcome to patient NDJSON

### DIFF
--- a/Java/validation/src/main/java/com/lantanagroup/link/validation/configs/PreQualificationConfig.java
+++ b/Java/validation/src/main/java/com/lantanagroup/link/validation/configs/PreQualificationConfig.java
@@ -1,0 +1,28 @@
+package com.lantanagroup.link.validation.configs;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Flags controlling the pre-qualification OperationOutcome that the Validation service writes to the
+ * patient NDJSON. These are the Java-runtime keys for a cross-runtime concept; the .NET Report service
+ * reads the equivalent {@code PreQualification:WritePreQualOperationOutcome} key (LEGLINK-466).
+ */
+@Getter
+@Setter
+@Configuration
+@ConfigurationProperties("pre-qualification")
+public class PreQualificationConfig {
+    /**
+     * Master gate. When true, the Validation service is the sole writer of the pre-qualification
+     * OperationOutcome to the patient NDJSON. When false (default), it writes nothing.
+     */
+    private boolean writePreQualOperationOutcome = false;
+
+    /**
+     * When false, the {@code expression[]} of each issue is omitted from the OperationOutcome.
+     */
+    private boolean writeExpressionsInOperationOutcome = true;
+}

--- a/Java/validation/src/main/java/com/lantanagroup/link/validation/services/BlobStorageService.java
+++ b/Java/validation/src/main/java/com/lantanagroup/link/validation/services/BlobStorageService.java
@@ -5,6 +5,10 @@ import com.azure.storage.blob.BlobClient;
 import com.azure.storage.blob.BlobContainerClient;
 import com.azure.storage.blob.BlobServiceClient;
 import com.azure.storage.blob.BlobServiceClientBuilder;
+import com.azure.storage.blob.specialized.AppendBlobClient;
+
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
 
 public class BlobStorageService {
     private final BlobContainerClient containerClient;
@@ -19,5 +23,20 @@ public class BlobStorageService {
     public BinaryData download(String blobName) {
         BlobClient client = containerClient.getBlobClient(blobName);
         return client.downloadContent();
+    }
+
+    /**
+     * Appends a single NDJSON line (one serialized FHIR resource) to an existing patient NDJSON append
+     * blob. The blob is created upstream by the Report service's aggregation as an append blob, so this
+     * does not call {@code create()}.
+     * <p>
+     * A trailing newline is written so the appended resource always terminates its own line. Without it,
+     * any subsequent appender (e.g. the Report service's legacy OperationOutcome write, which is only
+     * retired once LEGLINK-466's flag is set) concatenates onto this line and produces malformed NDJSON.
+     */
+    public void appendResource(String blobName, String ndjsonLine) {
+        AppendBlobClient client = containerClient.getBlobClient(blobName).getAppendBlobClient();
+        byte[] bytes = (ndjsonLine + "\n").getBytes(StandardCharsets.UTF_8);
+        client.appendBlock(new ByteArrayInputStream(bytes), bytes.length);
     }
 }

--- a/Java/validation/src/main/java/com/lantanagroup/link/validation/services/BlobStorageService.java
+++ b/Java/validation/src/main/java/com/lantanagroup/link/validation/services/BlobStorageService.java
@@ -20,6 +20,14 @@ public class BlobStorageService {
         containerClient = serviceClient.getBlobContainerClient(blobContainerName);
     }
 
+    /**
+     * Visible for testing: takes an already-built container client so the append behaviour can be
+     * exercised against mocks without constructing a real Azure client.
+     */
+    BlobStorageService(BlobContainerClient containerClient) {
+        this.containerClient = containerClient;
+    }
+
     public BinaryData download(String blobName) {
         BlobClient client = containerClient.getBlobClient(blobName);
         return client.downloadContent();

--- a/Java/validation/src/main/java/com/lantanagroup/link/validation/services/PreQualOperationOutcomeBuilder.java
+++ b/Java/validation/src/main/java/com/lantanagroup/link/validation/services/PreQualOperationOutcomeBuilder.java
@@ -14,6 +14,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -57,8 +58,12 @@ public class PreQualOperationOutcomeBuilder {
      */
     public Optional<OperationOutcome> build(List<Result> results, MeasureReportRef measureReport, boolean writeExpressions) {
         // Group findings by unacceptable category (acceptable == false); a Result may map to several
-        // categories. LinkedHashMap keeps issue order deterministic (first-seen category order).
-        Map<Category, List<Result>> byCategory = new LinkedHashMap<>();
+        // categories. Keyed by category id, not by the Category entity: Category defines no
+        // equals/hashCode, so two instances of the same logical category (loaded in different
+        // persistence contexts, say) would otherwise land in separate groups and emit a duplicate issue
+        // for that category, inflating oo-total. LinkedHashMap keeps issue order deterministic
+        // (first-seen category order).
+        Map<String, List<Result>> byCategoryId = new LinkedHashMap<>();
         for (Result result : results) {
             List<Category> categories = result.getCategories();
             if (categories == null) {
@@ -66,19 +71,19 @@ public class PreQualOperationOutcomeBuilder {
             }
             for (Category category : categories) {
                 if (!category.isAcceptable()) {
-                    byCategory.computeIfAbsent(category, c -> new java.util.ArrayList<>()).add(result);
+                    byCategoryId.computeIfAbsent(category.getId(), id -> new ArrayList<>()).add(result);
                 }
             }
         }
 
-        if (byCategory.isEmpty()) {
+        if (byCategoryId.isEmpty()) {
             return Optional.empty();
         }
 
         OperationOutcome operationOutcome = new OperationOutcome();
 
-        for (Map.Entry<Category, List<Result>> entry : byCategory.entrySet()) {
-            Category category = entry.getKey();
+        for (Map.Entry<String, List<Result>> entry : byCategoryId.entrySet()) {
+            String categoryId = entry.getKey();
             List<Result> categoryResults = entry.getValue();
 
             OperationOutcome.OperationOutcomeIssueComponent issue = operationOutcome.addIssue()
@@ -86,7 +91,7 @@ public class PreQualOperationOutcomeBuilder {
                     .setCode(OperationOutcome.IssueType.PROCESSING)
                     .setDetails(new CodeableConcept().setText(categoryResults.get(0).getMessage()));
 
-            issue.addExtension(new Extension(PQ_ISSUE_CAT_URL, new CodeType(category.getId())));
+            issue.addExtension(new Extension(PQ_ISSUE_CAT_URL, new CodeType(categoryId)));
 
             if (writeExpressions) {
                 if (measureReport != null) {

--- a/Java/validation/src/main/java/com/lantanagroup/link/validation/services/PreQualOperationOutcomeBuilder.java
+++ b/Java/validation/src/main/java/com/lantanagroup/link/validation/services/PreQualOperationOutcomeBuilder.java
@@ -1,0 +1,108 @@
+package com.lantanagroup.link.validation.services;
+
+import com.lantanagroup.link.validation.entities.Category;
+import com.lantanagroup.link.validation.entities.Result;
+import org.hl7.fhir.r4.model.Bundle;
+import org.hl7.fhir.r4.model.CodeType;
+import org.hl7.fhir.r4.model.CodeableConcept;
+import org.hl7.fhir.r4.model.Extension;
+import org.hl7.fhir.r4.model.IntegerType;
+import org.hl7.fhir.r4.model.MeasureReport;
+import org.hl7.fhir.r4.model.OperationOutcome;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Builds the single pre-qualification {@link OperationOutcome} written to the patient NDJSON: one issue
+ * per <em>unacceptable</em> category (a category with {@code acceptable=false}) that has at least one
+ * finding. See LEGLINK-425.
+ */
+@Component
+public class PreQualOperationOutcomeBuilder {
+    private final Logger _logger = LoggerFactory.getLogger(PreQualOperationOutcomeBuilder.class);
+
+    /** Extension URL carrying the category id on each issue. */
+    static final String PQ_ISSUE_CAT_URL = "http://hl7.org/fhir/us/core/StructureDefinition/pq-issue-cat";
+    /** Extension URL carrying the total issue count on the OperationOutcome. */
+    static final String OO_TOTAL_URL = "http://nhsnlink.org/oo-total";
+    /** Locator expression anchoring each issue to the patient's MeasureReport ({@code %s} = its id). */
+    static final String MEASURE_REPORT_LOCATOR =
+            "Bundle.entry[0].resource.ofType(MeasureReport).where(id = '%s').extension[0]";
+
+    /**
+     * Builds the OperationOutcome for a patient's categorized findings.
+     *
+     * @param results         the patient's categorized validation results
+     * @param measureReportId the id of the patient's MeasureReport in the submission bundle (may be null)
+     * @param writeExpressions when false, {@code expression[]} is omitted from every issue
+     * @return the OperationOutcome, or {@link Optional#empty()} when no unacceptable-category findings exist
+     */
+    public Optional<OperationOutcome> build(List<Result> results, String measureReportId, boolean writeExpressions) {
+        // Group findings by unacceptable category (acceptable == false); a Result may map to several
+        // categories. LinkedHashMap keeps issue order deterministic (first-seen category order).
+        Map<Category, List<Result>> byCategory = new LinkedHashMap<>();
+        for (Result result : results) {
+            List<Category> categories = result.getCategories();
+            if (categories == null) {
+                continue;
+            }
+            for (Category category : categories) {
+                if (!category.isAcceptable()) {
+                    byCategory.computeIfAbsent(category, c -> new java.util.ArrayList<>()).add(result);
+                }
+            }
+        }
+
+        if (byCategory.isEmpty()) {
+            return Optional.empty();
+        }
+
+        OperationOutcome operationOutcome = new OperationOutcome();
+
+        for (Map.Entry<Category, List<Result>> entry : byCategory.entrySet()) {
+            Category category = entry.getKey();
+            List<Result> categoryResults = entry.getValue();
+
+            OperationOutcome.OperationOutcomeIssueComponent issue = operationOutcome.addIssue()
+                    .setSeverity(OperationOutcome.IssueSeverity.ERROR)
+                    .setCode(OperationOutcome.IssueType.PROCESSING)
+                    .setDetails(new CodeableConcept().setText(categoryResults.get(0).getMessage()));
+
+            issue.addExtension(new Extension(PQ_ISSUE_CAT_URL, new CodeType(category.getId())));
+
+            if (writeExpressions) {
+                if (measureReportId != null) {
+                    issue.addExpression(String.format(MEASURE_REPORT_LOCATOR, measureReportId));
+                } else {
+                    _logger.warn("No MeasureReport id available; omitting the MeasureReport locator expression");
+                }
+                categoryResults.forEach(r -> issue.addExpression(r.getExpression()));
+            }
+        }
+
+        operationOutcome.addExtension(new Extension(OO_TOTAL_URL, new IntegerType(operationOutcome.getIssue().size())));
+
+        return Optional.of(operationOutcome);
+    }
+
+    /**
+     * Extracts the id of the first MeasureReport in the submission bundle, or null if none is present.
+     */
+    public String extractMeasureReportId(Bundle bundle) {
+        if (bundle == null) {
+            return null;
+        }
+        return bundle.getEntry().stream()
+                .map(Bundle.BundleEntryComponent::getResource)
+                .filter(resource -> resource instanceof MeasureReport)
+                .map(resource -> resource.getIdElement().getIdPart())
+                .findFirst()
+                .orElse(null);
+    }
+}

--- a/Java/validation/src/main/java/com/lantanagroup/link/validation/services/PreQualOperationOutcomeBuilder.java
+++ b/Java/validation/src/main/java/com/lantanagroup/link/validation/services/PreQualOperationOutcomeBuilder.java
@@ -9,6 +9,7 @@ import org.hl7.fhir.r4.model.Extension;
 import org.hl7.fhir.r4.model.IntegerType;
 import org.hl7.fhir.r4.model.MeasureReport;
 import org.hl7.fhir.r4.model.OperationOutcome;
+import org.hl7.fhir.r4.model.Resource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
@@ -31,19 +32,30 @@ public class PreQualOperationOutcomeBuilder {
     static final String PQ_ISSUE_CAT_URL = "http://hl7.org/fhir/us/core/StructureDefinition/pq-issue-cat";
     /** Extension URL carrying the total issue count on the OperationOutcome. */
     static final String OO_TOTAL_URL = "http://nhsnlink.org/oo-total";
-    /** Locator expression anchoring each issue to the patient's MeasureReport ({@code %s} = its id). */
+    /**
+     * Locator expression anchoring each issue to the patient's MeasureReport
+     * ({@code %d} = its Bundle entry index, {@code %s} = its id). The index must be the MeasureReport's
+     * actual position in the bundle: the aggregator happens to write it first today, but a hard-coded
+     * {@code entry[0]} silently resolves to nothing as soon as that ordering changes.
+     */
     static final String MEASURE_REPORT_LOCATOR =
-            "Bundle.entry[0].resource.ofType(MeasureReport).where(id = '%s').extension[0]";
+            "Bundle.entry[%d].resource.ofType(MeasureReport).where(id = '%s').extension[0]";
+
+    /**
+     * A MeasureReport located in the submission bundle: its entry index and its id.
+     */
+    public record MeasureReportRef(int index, String id) {
+    }
 
     /**
      * Builds the OperationOutcome for a patient's categorized findings.
      *
-     * @param results         the patient's categorized validation results
-     * @param measureReportId the id of the patient's MeasureReport in the submission bundle (may be null)
+     * @param results          the patient's categorized validation results
+     * @param measureReport    the patient's MeasureReport in the submission bundle (may be null)
      * @param writeExpressions when false, {@code expression[]} is omitted from every issue
      * @return the OperationOutcome, or {@link Optional#empty()} when no unacceptable-category findings exist
      */
-    public Optional<OperationOutcome> build(List<Result> results, String measureReportId, boolean writeExpressions) {
+    public Optional<OperationOutcome> build(List<Result> results, MeasureReportRef measureReport, boolean writeExpressions) {
         // Group findings by unacceptable category (acceptable == false); a Result may map to several
         // categories. LinkedHashMap keeps issue order deterministic (first-seen category order).
         Map<Category, List<Result>> byCategory = new LinkedHashMap<>();
@@ -77,10 +89,11 @@ public class PreQualOperationOutcomeBuilder {
             issue.addExtension(new Extension(PQ_ISSUE_CAT_URL, new CodeType(category.getId())));
 
             if (writeExpressions) {
-                if (measureReportId != null) {
-                    issue.addExpression(String.format(MEASURE_REPORT_LOCATOR, measureReportId));
+                if (measureReport != null) {
+                    issue.addExpression(
+                            String.format(MEASURE_REPORT_LOCATOR, measureReport.index(), measureReport.id()));
                 } else {
-                    _logger.warn("No MeasureReport id available; omitting the MeasureReport locator expression");
+                    _logger.warn("No MeasureReport in the bundle; omitting the MeasureReport locator expression");
                 }
                 categoryResults.forEach(r -> issue.addExpression(r.getExpression()));
             }
@@ -92,17 +105,22 @@ public class PreQualOperationOutcomeBuilder {
     }
 
     /**
-     * Extracts the id of the first MeasureReport in the submission bundle, or null if none is present.
+     * Locates the first MeasureReport anywhere in the submission bundle, returning both its entry index
+     * and its id, or null if the bundle contains none. The index is carried alongside the id because the
+     * locator expression addresses the MeasureReport by position; scanning for the id while assuming
+     * position 0 would emit an expression that resolves to nothing.
      */
-    public String extractMeasureReportId(Bundle bundle) {
+    public MeasureReportRef resolveMeasureReport(Bundle bundle) {
         if (bundle == null) {
             return null;
         }
-        return bundle.getEntry().stream()
-                .map(Bundle.BundleEntryComponent::getResource)
-                .filter(resource -> resource instanceof MeasureReport)
-                .map(resource -> resource.getIdElement().getIdPart())
-                .findFirst()
-                .orElse(null);
+        List<Bundle.BundleEntryComponent> entries = bundle.getEntry();
+        for (int index = 0; index < entries.size(); index++) {
+            Resource resource = entries.get(index).getResource();
+            if (resource instanceof MeasureReport) {
+                return new MeasureReportRef(index, resource.getIdElement().getIdPart());
+            }
+        }
+        return null;
     }
 }

--- a/Java/validation/src/main/java/com/lantanagroup/link/validation/services/ReadyForValidationConsumer.java
+++ b/Java/validation/src/main/java/com/lantanagroup/link/validation/services/ReadyForValidationConsumer.java
@@ -10,6 +10,7 @@ import com.lantanagroup.link.shared.kafka.Headers;
 import com.lantanagroup.link.shared.kafka.Topics;
 import com.lantanagroup.link.shared.services.ReportClient;
 import com.lantanagroup.link.shared.utils.DiagnosticNames;
+import com.lantanagroup.link.validation.configs.PreQualificationConfig;
 import com.lantanagroup.link.validation.entities.Category;
 import com.lantanagroup.link.validation.entities.Result;
 import com.lantanagroup.link.validation.records.ReadyForValidation;
@@ -40,6 +41,8 @@ public class ReadyForValidationConsumer extends AsyncListener<ReadyForValidation
     private final KafkaTemplate<String, ValidationComplete> validationCompleteTemplate;
     private final ValidationMetrics validationMetrics;
     private final BlobStorageService blobStorageService;
+    private final PreQualificationConfig preQualificationConfig;
+    private final PreQualOperationOutcomeBuilder preQualOperationOutcomeBuilder;
 
     public ReadyForValidationConsumer(
             FhirContext fhirContext,
@@ -50,6 +53,8 @@ public class ReadyForValidationConsumer extends AsyncListener<ReadyForValidation
             KafkaTemplate<String, ValidationComplete> validationCompleteTemplate,
             ValidationMetrics validationMetrics,
             Optional<BlobStorageService> blobStorageService,
+            PreQualificationConfig preQualificationConfig,
+            PreQualOperationOutcomeBuilder preQualOperationOutcomeBuilder,
             ConsumerRecordRecoverer recoverer) {
         super(recoverer);
         this.fhirContext = fhirContext;
@@ -60,6 +65,8 @@ public class ReadyForValidationConsumer extends AsyncListener<ReadyForValidation
         this.validationCompleteTemplate = validationCompleteTemplate;
         this.validationMetrics = validationMetrics;
         this.blobStorageService = blobStorageService.orElse(null);
+        this.preQualificationConfig = preQualificationConfig;
+        this.preQualOperationOutcomeBuilder = preQualOperationOutcomeBuilder;
     }
 
     @Override
@@ -70,12 +77,39 @@ public class ReadyForValidationConsumer extends AsyncListener<ReadyForValidation
         String facilityId = record.key().getFacilityId();
         String patientId = record.value().getPatientId();
         String reportId = record.value().getReportTrackingId();
-        Bundle bundle = getBundleFromBlobStorage(record.value().getPayloadUri());
+        String payloadUri = record.value().getPayloadUri();
+        Bundle bundle = getBundleFromBlobStorage(payloadUri);
         if (bundle == null) {
             bundle = getBundleViaRest(facilityId, patientId, reportId);
         }
         List<Result> results = validate(correlationId, facilityId, patientId, reportId, bundle);
+        appendPreQualOperationOutcome(bundle, results, payloadUri);
         produceValidationCompleteRecord(correlationId, facilityId, patientId, reportId, results);
+    }
+
+    /**
+     * When enabled, builds the pre-qualification OperationOutcome for the patient's unacceptable-category
+     * findings and appends it to the same patient NDJSON blob in ABS. No-op when the flag is off, when
+     * there is no blob storage or payload URI (e.g. local/dev), or when there are no unacceptable findings.
+     */
+    private void appendPreQualOperationOutcome(Bundle bundle, List<Result> results, String payloadUri) {
+        if (!preQualificationConfig.isWritePreQualOperationOutcome()) {
+            return;
+        }
+        if (blobStorageService == null || payloadUri == null) {
+            _logger.debug("Pre-qual OperationOutcome enabled but no blob storage or payload URI; skipping append");
+            return;
+        }
+        String measureReportId = preQualOperationOutcomeBuilder.extractMeasureReportId(bundle);
+        preQualOperationOutcomeBuilder
+                .build(results, measureReportId, preQualificationConfig.isWriteExpressionsInOperationOutcome())
+                .ifPresent(operationOutcome -> {
+                    String line = fhirContext.newJsonParser().encodeResourceToString(operationOutcome);
+                    String blobName = BlobUrlParts.parse(payloadUri).getBlobName();
+                    _logger.debug("Appending pre-qual OperationOutcome ({} issues) to blob {}",
+                            operationOutcome.getIssue().size(), blobName);
+                    blobStorageService.appendResource(blobName, line);
+                });
     }
 
     private Bundle getBundleFromBlobStorage(String payloadUri) {

--- a/Java/validation/src/main/java/com/lantanagroup/link/validation/services/ReadyForValidationConsumer.java
+++ b/Java/validation/src/main/java/com/lantanagroup/link/validation/services/ReadyForValidationConsumer.java
@@ -111,6 +111,12 @@ public class ReadyForValidationConsumer extends AsyncListener<ReadyForValidation
         // pre-qual OperationOutcome already present in it means we appended one previously and must not
         // append a second. Keyed on the oo-total extension, which only this writer emits: the Report
         // service's legacy flat OperationOutcome does not carry it and is correctly ignored here.
+        //
+        // This narrows the window rather than closing it, and the remaining gaps are tracked in
+        // LEGLINK-800: the REST fallback supplies a bundle with no previously appended OperationOutcome
+        // so the check is blind, concurrent consumers can both observe it as absent, and the check and
+        // the append are not atomic. The same replay also duplicates the Result rows written by
+        // validate().
         if (hasPreQualOperationOutcome(bundle)) {
             _logger.info("Pre-qual OperationOutcome already present in the patient NDJSON; skipping append (replay)");
             return;

--- a/Java/validation/src/main/java/com/lantanagroup/link/validation/services/ReadyForValidationConsumer.java
+++ b/Java/validation/src/main/java/com/lantanagroup/link/validation/services/ReadyForValidationConsumer.java
@@ -21,6 +21,7 @@ import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.header.internals.RecordHeaders;
 import org.hl7.fhir.r4.model.Bundle;
+import org.hl7.fhir.r4.model.OperationOutcome;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.kafka.core.KafkaTemplate;
@@ -100,6 +101,16 @@ public class ReadyForValidationConsumer extends AsyncListener<ReadyForValidation
             _logger.debug("Pre-qual OperationOutcome enabled but no blob storage or payload URI; skipping append");
             return;
         }
+        // Replay guard. The offset is acknowledged even when process() throws (AsyncListener), so a
+        // failure after this append - producing ValidationComplete, say - sends the record to the retry
+        // topic and process() runs again. The bundle is re-read from the same blob on that replay, so a
+        // pre-qual OperationOutcome already present in it means we appended one previously and must not
+        // append a second. Keyed on the oo-total extension, which only this writer emits: the Report
+        // service's legacy flat OperationOutcome does not carry it and is correctly ignored here.
+        if (hasPreQualOperationOutcome(bundle)) {
+            _logger.info("Pre-qual OperationOutcome already present in the patient NDJSON; skipping append (replay)");
+            return;
+        }
         PreQualOperationOutcomeBuilder.MeasureReportRef measureReport =
                 preQualOperationOutcomeBuilder.resolveMeasureReport(bundle);
         preQualOperationOutcomeBuilder
@@ -111,6 +122,21 @@ public class ReadyForValidationConsumer extends AsyncListener<ReadyForValidation
                             operationOutcome.getIssue().size(), blobName);
                     blobStorageService.appendResource(blobName, line);
                 });
+    }
+
+    /**
+     * True when the bundle already carries a pre-qualification OperationOutcome written by this service,
+     * identified by the {@code oo-total} extension that only this writer emits.
+     */
+    private boolean hasPreQualOperationOutcome(Bundle bundle) {
+        if (bundle == null) {
+            return false;
+        }
+        return bundle.getEntry().stream()
+                .map(Bundle.BundleEntryComponent::getResource)
+                .filter(resource -> resource instanceof OperationOutcome)
+                .anyMatch(resource -> ((OperationOutcome) resource)
+                        .getExtensionByUrl(PreQualOperationOutcomeBuilder.OO_TOTAL_URL) != null);
     }
 
     private Bundle getBundleFromBlobStorage(String payloadUri) {

--- a/Java/validation/src/main/java/com/lantanagroup/link/validation/services/ReadyForValidationConsumer.java
+++ b/Java/validation/src/main/java/com/lantanagroup/link/validation/services/ReadyForValidationConsumer.java
@@ -10,6 +10,7 @@ import com.lantanagroup.link.shared.kafka.Headers;
 import com.lantanagroup.link.shared.kafka.Topics;
 import com.lantanagroup.link.shared.services.ReportClient;
 import com.lantanagroup.link.shared.utils.DiagnosticNames;
+import com.lantanagroup.link.shared.utils.LogUtils;
 import com.lantanagroup.link.validation.configs.PreQualificationConfig;
 import com.lantanagroup.link.validation.entities.Category;
 import com.lantanagroup.link.validation.entities.Result;
@@ -74,7 +75,10 @@ public class ReadyForValidationConsumer extends AsyncListener<ReadyForValidation
     protected void process(ConsumerRecord<ReadyForValidation.Key, ReadyForValidation> record) {
         String correlationId = Headers.getCorrelationId(record.headers());
         _logger.debug("Processing {} message for facility {}, patient {}, report {}",
-                record.topic(), record.key().getFacilityId(), record.value().getPatientId(), record.value().getReportTrackingId());
+                LogUtils.sanitize(record.topic()),
+                LogUtils.sanitize(record.key().getFacilityId()),
+                LogUtils.sanitize(record.value().getPatientId()),
+                LogUtils.sanitize(record.value().getReportTrackingId()));
         String facilityId = record.key().getFacilityId();
         String patientId = record.value().getPatientId();
         String reportId = record.value().getReportTrackingId();
@@ -118,8 +122,10 @@ public class ReadyForValidationConsumer extends AsyncListener<ReadyForValidation
                 .ifPresent(operationOutcome -> {
                     String line = fhirContext.newJsonParser().encodeResourceToString(operationOutcome);
                     String blobName = BlobUrlParts.parse(payloadUri).getBlobName();
+                    // blobName derives from the payloadUri carried on the Kafka record, so sanitize it
+                    // before logging. The append uses the original, unmodified value.
                     _logger.debug("Appending pre-qual OperationOutcome ({} issues) to blob {}",
-                            operationOutcome.getIssue().size(), blobName);
+                            operationOutcome.getIssue().size(), LogUtils.sanitize(blobName));
                     blobStorageService.appendResource(blobName, line);
                 });
     }
@@ -252,8 +258,8 @@ public class ReadyForValidationConsumer extends AsyncListener<ReadyForValidation
             // Use .get() to make the send synchronous and wait for broker confirmation
             validationCompleteTemplate.send(new ProducerRecord<>(Topics.VALIDATION_COMPLETE, null, facilityId, value, headers)).get();
         } catch (Exception e) {
-            _logger.error("Failed to send ValidationComplete record for patient {} in report {}: {}",
-                    patientId, reportId, e.getMessage(), e);
+            _logger.error("Failed to send ValidationComplete record for patient {} in report {}",
+                    LogUtils.sanitize(patientId), LogUtils.sanitize(reportId), e);
             // Throwing the exception ensures AsyncListener's catch block handles it
             // (e.g., sending the source record to the Error topic)
             throw new RuntimeException("Failed to produce ValidationComplete message", e);

--- a/Java/validation/src/main/java/com/lantanagroup/link/validation/services/ReadyForValidationConsumer.java
+++ b/Java/validation/src/main/java/com/lantanagroup/link/validation/services/ReadyForValidationConsumer.java
@@ -100,9 +100,10 @@ public class ReadyForValidationConsumer extends AsyncListener<ReadyForValidation
             _logger.debug("Pre-qual OperationOutcome enabled but no blob storage or payload URI; skipping append");
             return;
         }
-        String measureReportId = preQualOperationOutcomeBuilder.extractMeasureReportId(bundle);
+        PreQualOperationOutcomeBuilder.MeasureReportRef measureReport =
+                preQualOperationOutcomeBuilder.resolveMeasureReport(bundle);
         preQualOperationOutcomeBuilder
-                .build(results, measureReportId, preQualificationConfig.isWriteExpressionsInOperationOutcome())
+                .build(results, measureReport, preQualificationConfig.isWriteExpressionsInOperationOutcome())
                 .ifPresent(operationOutcome -> {
                     String line = fhirContext.newJsonParser().encodeResourceToString(operationOutcome);
                     String blobName = BlobUrlParts.parse(payloadUri).getBlobName();

--- a/Java/validation/src/main/resources/application.yml
+++ b/Java/validation/src/main/resources/application.yml
@@ -125,3 +125,7 @@ link:
 internal-blob-storage:
   connection-string: ''
   blob-container-name: ''
+
+pre-qualification:
+  write-pre-qual-operation-outcome: false
+  write-expressions-in-operation-outcome: true

--- a/Java/validation/src/test/java/com/lantanagroup/link/validation/services/BlobStorageServiceTest.java
+++ b/Java/validation/src/test/java/com/lantanagroup/link/validation/services/BlobStorageServiceTest.java
@@ -1,0 +1,110 @@
+package com.lantanagroup.link.validation.services;
+
+import com.azure.storage.blob.BlobClient;
+import com.azure.storage.blob.BlobContainerClient;
+import com.azure.storage.blob.specialized.AppendBlobClient;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+/**
+ * Covers {@link BlobStorageService#appendResource}. Everything is mocked, so no Azure client is built
+ * and no network call is made - the service is constructed from an injected container client rather
+ * than a connection string.
+ */
+@ExtendWith(MockitoExtension.class)
+class BlobStorageServiceTest {
+
+    private static final String BLOB_NAME = "report-1/patient-abc.ndjson";
+
+    @Mock
+    private BlobContainerClient containerClient;
+    @Mock
+    private BlobClient blobClient;
+    @Mock
+    private AppendBlobClient appendBlobClient;
+
+    private BlobStorageService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new BlobStorageService(containerClient);
+    }
+
+    private void stubAppendBlobClient() {
+        when(containerClient.getBlobClient(BLOB_NAME)).thenReturn(blobClient);
+        when(blobClient.getAppendBlobClient()).thenReturn(appendBlobClient);
+    }
+
+    private byte[] captureAppendedBytes() throws IOException {
+        ArgumentCaptor<InputStream> data = ArgumentCaptor.forClass(InputStream.class);
+        ArgumentCaptor<Long> length = ArgumentCaptor.forClass(Long.class);
+        verify(appendBlobClient).appendBlock(data.capture(), length.capture());
+
+        byte[] appended = data.getValue().readAllBytes();
+        assertEquals(appended.length, length.getValue(),
+                "Declared block length must match the bytes actually supplied");
+        return appended;
+    }
+
+    @Test
+    void appendResource_appendsTheLineTerminatedByANewline() throws Exception {
+        stubAppendBlobClient();
+        String line = "{\"resourceType\":\"OperationOutcome\"}";
+
+        service.appendResource(BLOB_NAME, line);
+
+        assertArrayEquals((line + "\n").getBytes(StandardCharsets.UTF_8), captureAppendedBytes());
+    }
+
+    @Test
+    void appendResource_encodesAsUtf8() throws Exception {
+        // A multi-byte character would break a length computed from String.length() rather than from the
+        // encoded bytes, so this pins both the charset and the declared block length.
+        stubAppendBlobClient();
+        String line = "{\"text\":\"naïve – é\"}";
+
+        service.appendResource(BLOB_NAME, line);
+
+        byte[] expected = (line + "\n").getBytes(StandardCharsets.UTF_8);
+        assertArrayEquals(expected, captureAppendedBytes());
+    }
+
+    @Test
+    void appendResource_targetsTheNamedBlobAsAnAppendBlob() {
+        stubAppendBlobClient();
+
+        service.appendResource(BLOB_NAME, "{}");
+
+        verify(containerClient).getBlobClient(BLOB_NAME);
+        verify(blobClient).getAppendBlobClient();
+    }
+
+    @Test
+    void appendResource_neverCreatesTheBlob() {
+        // The append blob is created upstream by the Report service's aggregation. Creating it here would
+        // truncate the patient NDJSON. verifyNoMoreInteractions covers every create* overload without
+        // having to enumerate them.
+        stubAppendBlobClient();
+
+        service.appendResource(BLOB_NAME, "{}");
+
+        verify(appendBlobClient).appendBlock(any(InputStream.class), anyLong());
+        verifyNoMoreInteractions(appendBlobClient);
+    }
+}

--- a/Java/validation/src/test/java/com/lantanagroup/link/validation/services/PreQualOperationOutcomeBuilderTest.java
+++ b/Java/validation/src/test/java/com/lantanagroup/link/validation/services/PreQualOperationOutcomeBuilderTest.java
@@ -97,6 +97,32 @@ class PreQualOperationOutcomeBuilderTest {
     }
 
     @Test
+    void build_distinctCategoryInstancesWithSameId_produceASingleIssue() {
+        // Category defines no equals/hashCode, so grouping by the entity would treat these two instances
+        // as different categories and emit a duplicate issue, inflating oo-total. Each category(...) call
+        // deliberately returns a NEW instance, mimicking categories loaded in separate persistence
+        // contexts.
+        Result r1 = result("first message", "expr1", category("inactive_code", false));
+        Result r2 = result("second message", "expr2", category("inactive_code", false));
+
+        OperationOutcome oo = builder.build(List.of(r1, r2), MEASURE_REPORT, true).orElseThrow();
+
+        assertEquals(1, oo.getIssue().size(), "Same category id must yield exactly one issue");
+        int total = ((IntegerType) oo.getExtensionByUrl(PreQualOperationOutcomeBuilder.OO_TOTAL_URL).getValue()).getValue();
+        assertEquals(1, total);
+
+        OperationOutcome.OperationOutcomeIssueComponent issue = oo.getIssueFirstRep();
+        CodeType cat = (CodeType) issue.getExtensionByUrl(PreQualOperationOutcomeBuilder.PQ_ISSUE_CAT_URL).getValue();
+        assertEquals("inactive_code", cat.getValue());
+        assertEquals("first message", issue.getDetails().getText());
+
+        // Both results' findings must aggregate onto the single issue.
+        List<String> expressions = expressionStrings(issue);
+        assertTrue(expressions.contains("expr1"));
+        assertTrue(expressions.contains("expr2"));
+    }
+
+    @Test
     void build_oneResultMappingToMultipleUnacceptableCategories_producesAnIssuePerCategory() {
         Result r = result("msg", "expr", category("cat_a", false), category("cat_b", false));
 

--- a/Java/validation/src/test/java/com/lantanagroup/link/validation/services/PreQualOperationOutcomeBuilderTest.java
+++ b/Java/validation/src/test/java/com/lantanagroup/link/validation/services/PreQualOperationOutcomeBuilderTest.java
@@ -1,0 +1,204 @@
+package com.lantanagroup.link.validation.services;
+
+import com.lantanagroup.link.validation.entities.Category;
+import com.lantanagroup.link.validation.entities.Result;
+import org.hl7.fhir.r4.model.Bundle;
+import org.hl7.fhir.r4.model.CodeType;
+import org.hl7.fhir.r4.model.IntegerType;
+import org.hl7.fhir.r4.model.MeasureReport;
+import org.hl7.fhir.r4.model.OperationOutcome;
+import org.hl7.fhir.r4.model.StringType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class PreQualOperationOutcomeBuilderTest {
+
+    private static final String MEASURE_REPORT_ID = "mr-1";
+
+    private PreQualOperationOutcomeBuilder builder;
+
+    @BeforeEach
+    void setUp() {
+        builder = new PreQualOperationOutcomeBuilder();
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    private Category category(String id, boolean acceptable) {
+        Category category = new Category();
+        category.setId(id);
+        category.setAcceptable(acceptable);
+        return category;
+    }
+
+    private Result result(String message, String expression, Category... categories) {
+        Result result = new Result();
+        result.setMessage(message);
+        result.setExpression(expression);
+        result.setCategories(new ArrayList<>(Arrays.asList(categories)));
+        return result;
+    }
+
+    private List<String> expressionStrings(OperationOutcome.OperationOutcomeIssueComponent issue) {
+        return issue.getExpression().stream().map(StringType::getValue).toList();
+    }
+
+    // -------------------------------------------------------------------------
+    // Grouping / issue content
+    // -------------------------------------------------------------------------
+
+    @Test
+    void build_oneIssuePerUnacceptableCategory_withOoTotal() {
+        Result r1 = result("Code is inactive.", "expr1", category("inactive_code", false));
+        Result r2 = result("Unable to validate.", "expr2", category("unable_to_validate_code", false));
+
+        OperationOutcome oo = builder.build(List.of(r1, r2), MEASURE_REPORT_ID, true).orElseThrow();
+
+        assertEquals(2, oo.getIssue().size());
+        int total = ((IntegerType) oo.getExtensionByUrl(PreQualOperationOutcomeBuilder.OO_TOTAL_URL).getValue()).getValue();
+        assertEquals(2, total);
+    }
+
+    @Test
+    void build_issueCarriesSeverityCodeMessageAndCategoryExtension() {
+        Result r1 = result("Code is inactive.", "expr1", category("inactive_code", false));
+
+        OperationOutcome oo = builder.build(List.of(r1), MEASURE_REPORT_ID, true).orElseThrow();
+        OperationOutcome.OperationOutcomeIssueComponent issue = oo.getIssueFirstRep();
+
+        assertEquals(OperationOutcome.IssueSeverity.ERROR, issue.getSeverity());
+        assertEquals(OperationOutcome.IssueType.PROCESSING, issue.getCode());
+        assertEquals("Code is inactive.", issue.getDetails().getText());
+        CodeType cat = (CodeType) issue.getExtensionByUrl(PreQualOperationOutcomeBuilder.PQ_ISSUE_CAT_URL).getValue();
+        assertEquals("inactive_code", cat.getValue());
+    }
+
+    @Test
+    void build_detailsTextUsesFirstResultMessageForCategory() {
+        Category shared = category("inactive_code", false);
+        Result first = result("first message", "expr1", shared);
+        Result second = result("second message", "expr2", shared);
+
+        OperationOutcome oo = builder.build(List.of(first, second), MEASURE_REPORT_ID, true).orElseThrow();
+
+        assertEquals(1, oo.getIssue().size());
+        assertEquals("first message", oo.getIssueFirstRep().getDetails().getText());
+    }
+
+    @Test
+    void build_oneResultMappingToMultipleUnacceptableCategories_producesAnIssuePerCategory() {
+        Result r = result("msg", "expr", category("cat_a", false), category("cat_b", false));
+
+        OperationOutcome oo = builder.build(List.of(r), MEASURE_REPORT_ID, true).orElseThrow();
+
+        assertEquals(2, oo.getIssue().size());
+    }
+
+    @Test
+    void build_excludesAcceptableCategories() {
+        Result unacceptable = result("bad", "expr1", category("inactive_code", false));
+        Result acceptable = result("ok", "expr2", category("incorrect_display_value_for_code", true));
+
+        OperationOutcome oo = builder.build(List.of(unacceptable, acceptable), MEASURE_REPORT_ID, true).orElseThrow();
+
+        assertEquals(1, oo.getIssue().size());
+        CodeType cat = (CodeType) oo.getIssueFirstRep()
+                .getExtensionByUrl(PreQualOperationOutcomeBuilder.PQ_ISSUE_CAT_URL).getValue();
+        assertEquals("inactive_code", cat.getValue());
+    }
+
+    @Test
+    void build_noUnacceptableFindings_returnsEmpty() {
+        Result acceptable = result("ok", "expr", category("incorrect_display_value_for_code", true));
+
+        assertTrue(builder.build(List.of(acceptable), MEASURE_REPORT_ID, true).isEmpty());
+    }
+
+    @Test
+    void build_resultWithNullCategories_isIgnored() {
+        Result result = new Result();
+        result.setCategories(null);
+
+        assertTrue(builder.build(List.of(result), MEASURE_REPORT_ID, true).isEmpty());
+    }
+
+    // -------------------------------------------------------------------------
+    // Expressions (WriteExpressionsInOperationOutcome)
+    // -------------------------------------------------------------------------
+
+    @Test
+    void build_writeExpressionsTrue_addsMeasureReportLocatorThenResultExpressions() {
+        Category shared = category("inactive_code", false);
+        Result r1 = result("msg1", "Bundle.entry[14].resource.ofType(Condition).code.coding[0]", shared);
+        Result r2 = result("msg2", "Bundle.entry[27].resource.ofType(Observation).code.coding[0]", shared);
+
+        OperationOutcome oo = builder.build(List.of(r1, r2), MEASURE_REPORT_ID, true).orElseThrow();
+
+        List<String> expressions = expressionStrings(oo.getIssueFirstRep());
+        assertEquals(3, expressions.size());
+        assertEquals(String.format(PreQualOperationOutcomeBuilder.MEASURE_REPORT_LOCATOR, MEASURE_REPORT_ID),
+                expressions.get(0));
+        assertEquals("Bundle.entry[14].resource.ofType(Condition).code.coding[0]", expressions.get(1));
+        assertEquals("Bundle.entry[27].resource.ofType(Observation).code.coding[0]", expressions.get(2));
+    }
+
+    @Test
+    void build_writeExpressionsFalse_omitsAllExpressions() {
+        Result r1 = result("msg", "expr", category("inactive_code", false));
+
+        OperationOutcome oo = builder.build(List.of(r1), MEASURE_REPORT_ID, false).orElseThrow();
+
+        assertTrue(oo.getIssueFirstRep().getExpression().isEmpty());
+    }
+
+    @Test
+    void build_nullMeasureReportId_omitsLocatorButKeepsResultExpressions() {
+        Result r1 = result("msg", "result-expr", category("inactive_code", false));
+
+        OperationOutcome oo = builder.build(List.of(r1), null, true).orElseThrow();
+
+        List<String> expressions = expressionStrings(oo.getIssueFirstRep());
+        assertEquals(List.of("result-expr"), expressions);
+    }
+
+    // -------------------------------------------------------------------------
+    // MeasureReport id extraction
+    // -------------------------------------------------------------------------
+
+    @Test
+    void extractMeasureReportId_returnsIdWhenPresent() {
+        Bundle bundle = new Bundle();
+        MeasureReport measureReport = new MeasureReport();
+        measureReport.setId("report-abc");
+        bundle.addEntry().setResource(measureReport);
+
+        assertEquals("report-abc", builder.extractMeasureReportId(bundle));
+    }
+
+    @Test
+    void extractMeasureReportId_returnsNullWhenNoMeasureReport() {
+        Bundle bundle = new Bundle();
+        bundle.addEntry().setResource(new org.hl7.fhir.r4.model.Patient());
+
+        assertNull(builder.extractMeasureReportId(bundle));
+    }
+
+    @Test
+    void extractMeasureReportId_nullBundle_returnsNull() {
+        assertNull(builder.extractMeasureReportId(null));
+    }
+
+    @Test
+    void build_emptyResults_returnsEmpty() {
+        assertTrue(builder.build(Collections.emptyList(), MEASURE_REPORT_ID, true).isEmpty());
+    }
+}

--- a/Java/validation/src/test/java/com/lantanagroup/link/validation/services/PreQualOperationOutcomeBuilderTest.java
+++ b/Java/validation/src/test/java/com/lantanagroup/link/validation/services/PreQualOperationOutcomeBuilderTest.java
@@ -21,6 +21,8 @@ import static org.junit.jupiter.api.Assertions.*;
 class PreQualOperationOutcomeBuilderTest {
 
     private static final String MEASURE_REPORT_ID = "mr-1";
+    private static final PreQualOperationOutcomeBuilder.MeasureReportRef MEASURE_REPORT =
+            new PreQualOperationOutcomeBuilder.MeasureReportRef(0, MEASURE_REPORT_ID);
 
     private PreQualOperationOutcomeBuilder builder;
 
@@ -61,7 +63,7 @@ class PreQualOperationOutcomeBuilderTest {
         Result r1 = result("Code is inactive.", "expr1", category("inactive_code", false));
         Result r2 = result("Unable to validate.", "expr2", category("unable_to_validate_code", false));
 
-        OperationOutcome oo = builder.build(List.of(r1, r2), MEASURE_REPORT_ID, true).orElseThrow();
+        OperationOutcome oo = builder.build(List.of(r1, r2), MEASURE_REPORT, true).orElseThrow();
 
         assertEquals(2, oo.getIssue().size());
         int total = ((IntegerType) oo.getExtensionByUrl(PreQualOperationOutcomeBuilder.OO_TOTAL_URL).getValue()).getValue();
@@ -72,7 +74,7 @@ class PreQualOperationOutcomeBuilderTest {
     void build_issueCarriesSeverityCodeMessageAndCategoryExtension() {
         Result r1 = result("Code is inactive.", "expr1", category("inactive_code", false));
 
-        OperationOutcome oo = builder.build(List.of(r1), MEASURE_REPORT_ID, true).orElseThrow();
+        OperationOutcome oo = builder.build(List.of(r1), MEASURE_REPORT, true).orElseThrow();
         OperationOutcome.OperationOutcomeIssueComponent issue = oo.getIssueFirstRep();
 
         assertEquals(OperationOutcome.IssueSeverity.ERROR, issue.getSeverity());
@@ -88,7 +90,7 @@ class PreQualOperationOutcomeBuilderTest {
         Result first = result("first message", "expr1", shared);
         Result second = result("second message", "expr2", shared);
 
-        OperationOutcome oo = builder.build(List.of(first, second), MEASURE_REPORT_ID, true).orElseThrow();
+        OperationOutcome oo = builder.build(List.of(first, second), MEASURE_REPORT, true).orElseThrow();
 
         assertEquals(1, oo.getIssue().size());
         assertEquals("first message", oo.getIssueFirstRep().getDetails().getText());
@@ -98,7 +100,7 @@ class PreQualOperationOutcomeBuilderTest {
     void build_oneResultMappingToMultipleUnacceptableCategories_producesAnIssuePerCategory() {
         Result r = result("msg", "expr", category("cat_a", false), category("cat_b", false));
 
-        OperationOutcome oo = builder.build(List.of(r), MEASURE_REPORT_ID, true).orElseThrow();
+        OperationOutcome oo = builder.build(List.of(r), MEASURE_REPORT, true).orElseThrow();
 
         assertEquals(2, oo.getIssue().size());
     }
@@ -108,7 +110,7 @@ class PreQualOperationOutcomeBuilderTest {
         Result unacceptable = result("bad", "expr1", category("inactive_code", false));
         Result acceptable = result("ok", "expr2", category("incorrect_display_value_for_code", true));
 
-        OperationOutcome oo = builder.build(List.of(unacceptable, acceptable), MEASURE_REPORT_ID, true).orElseThrow();
+        OperationOutcome oo = builder.build(List.of(unacceptable, acceptable), MEASURE_REPORT, true).orElseThrow();
 
         assertEquals(1, oo.getIssue().size());
         CodeType cat = (CodeType) oo.getIssueFirstRep()
@@ -120,7 +122,7 @@ class PreQualOperationOutcomeBuilderTest {
     void build_noUnacceptableFindings_returnsEmpty() {
         Result acceptable = result("ok", "expr", category("incorrect_display_value_for_code", true));
 
-        assertTrue(builder.build(List.of(acceptable), MEASURE_REPORT_ID, true).isEmpty());
+        assertTrue(builder.build(List.of(acceptable), MEASURE_REPORT, true).isEmpty());
     }
 
     @Test
@@ -128,7 +130,7 @@ class PreQualOperationOutcomeBuilderTest {
         Result result = new Result();
         result.setCategories(null);
 
-        assertTrue(builder.build(List.of(result), MEASURE_REPORT_ID, true).isEmpty());
+        assertTrue(builder.build(List.of(result), MEASURE_REPORT, true).isEmpty());
     }
 
     // -------------------------------------------------------------------------
@@ -141,11 +143,11 @@ class PreQualOperationOutcomeBuilderTest {
         Result r1 = result("msg1", "Bundle.entry[14].resource.ofType(Condition).code.coding[0]", shared);
         Result r2 = result("msg2", "Bundle.entry[27].resource.ofType(Observation).code.coding[0]", shared);
 
-        OperationOutcome oo = builder.build(List.of(r1, r2), MEASURE_REPORT_ID, true).orElseThrow();
+        OperationOutcome oo = builder.build(List.of(r1, r2), MEASURE_REPORT, true).orElseThrow();
 
         List<String> expressions = expressionStrings(oo.getIssueFirstRep());
         assertEquals(3, expressions.size());
-        assertEquals(String.format(PreQualOperationOutcomeBuilder.MEASURE_REPORT_LOCATOR, MEASURE_REPORT_ID),
+        assertEquals(String.format(PreQualOperationOutcomeBuilder.MEASURE_REPORT_LOCATOR, 0, MEASURE_REPORT_ID),
                 expressions.get(0));
         assertEquals("Bundle.entry[14].resource.ofType(Condition).code.coding[0]", expressions.get(1));
         assertEquals("Bundle.entry[27].resource.ofType(Observation).code.coding[0]", expressions.get(2));
@@ -155,7 +157,7 @@ class PreQualOperationOutcomeBuilderTest {
     void build_writeExpressionsFalse_omitsAllExpressions() {
         Result r1 = result("msg", "expr", category("inactive_code", false));
 
-        OperationOutcome oo = builder.build(List.of(r1), MEASURE_REPORT_ID, false).orElseThrow();
+        OperationOutcome oo = builder.build(List.of(r1), MEASURE_REPORT, false).orElseThrow();
 
         assertTrue(oo.getIssueFirstRep().getExpression().isEmpty());
     }
@@ -171,34 +173,71 @@ class PreQualOperationOutcomeBuilderTest {
     }
 
     // -------------------------------------------------------------------------
-    // MeasureReport id extraction
+    // MeasureReport resolution (index + id)
     // -------------------------------------------------------------------------
 
     @Test
-    void extractMeasureReportId_returnsIdWhenPresent() {
+    void resolveMeasureReport_returnsIndexAndIdWhenFirstEntry() {
         Bundle bundle = new Bundle();
         MeasureReport measureReport = new MeasureReport();
         measureReport.setId("report-abc");
         bundle.addEntry().setResource(measureReport);
 
-        assertEquals("report-abc", builder.extractMeasureReportId(bundle));
+        PreQualOperationOutcomeBuilder.MeasureReportRef ref = builder.resolveMeasureReport(bundle);
+
+        assertNotNull(ref);
+        assertEquals(0, ref.index());
+        assertEquals("report-abc", ref.id());
     }
 
     @Test
-    void extractMeasureReportId_returnsNullWhenNoMeasureReport() {
+    void resolveMeasureReport_findsMeasureReportAtNonZeroEntryIndex() {
+        // Regression: the locator used to hard-code Bundle.entry[0]. The aggregator happens to write the
+        // MeasureReport first today, but if it is anywhere else the locator must follow it.
+        Bundle bundle = new Bundle();
+        bundle.addEntry().setResource(new org.hl7.fhir.r4.model.Patient());
+        bundle.addEntry().setResource(new org.hl7.fhir.r4.model.Encounter());
+        MeasureReport measureReport = new MeasureReport();
+        measureReport.setId("report-xyz");
+        bundle.addEntry().setResource(measureReport);
+
+        PreQualOperationOutcomeBuilder.MeasureReportRef ref = builder.resolveMeasureReport(bundle);
+
+        assertNotNull(ref);
+        assertEquals(2, ref.index());
+        assertEquals("report-xyz", ref.id());
+    }
+
+    @Test
+    void build_measureReportAtNonZeroIndex_locatorUsesThatIndex() {
+        Result r1 = result("msg", "result-expr", category("inactive_code", false));
+        PreQualOperationOutcomeBuilder.MeasureReportRef ref =
+                new PreQualOperationOutcomeBuilder.MeasureReportRef(3, "report-xyz");
+
+        OperationOutcome oo = builder.build(List.of(r1), ref, true).orElseThrow();
+
+        String locator = expressionStrings(oo.getIssueFirstRep()).get(0);
+        assertEquals(
+                "Bundle.entry[3].resource.ofType(MeasureReport).where(id = 'report-xyz').extension[0]",
+                locator);
+        assertFalse(locator.contains("entry[0]"), "Locator must not fall back to entry[0]");
+    }
+
+    @Test
+    void resolveMeasureReport_returnsNullWhenNoMeasureReport() {
         Bundle bundle = new Bundle();
         bundle.addEntry().setResource(new org.hl7.fhir.r4.model.Patient());
 
-        assertNull(builder.extractMeasureReportId(bundle));
+        assertNull(builder.resolveMeasureReport(bundle));
     }
 
     @Test
-    void extractMeasureReportId_nullBundle_returnsNull() {
-        assertNull(builder.extractMeasureReportId(null));
+    void resolveMeasureReport_nullBundle_returnsNull() {
+        assertNull(builder.resolveMeasureReport(null));
     }
 
     @Test
     void build_emptyResults_returnsEmpty() {
-        assertTrue(builder.build(Collections.emptyList(), MEASURE_REPORT_ID, true).isEmpty());
+        assertTrue(builder.build(Collections.emptyList(), MEASURE_REPORT, true).isEmpty());
     }
 }

--- a/Java/validation/src/test/java/com/lantanagroup/link/validation/services/ReadyForValidationConsumerTest.java
+++ b/Java/validation/src/test/java/com/lantanagroup/link/validation/services/ReadyForValidationConsumerTest.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.lantanagroup.link.shared.entities.PatientSubmissionModel;
 import com.lantanagroup.link.shared.kafka.Headers;
 import com.lantanagroup.link.shared.services.ReportClient;
+import com.lantanagroup.link.validation.configs.PreQualificationConfig;
 import com.lantanagroup.link.validation.entities.Category;
 import com.lantanagroup.link.validation.entities.Result;
 import com.lantanagroup.link.validation.records.ReadyForValidation;
@@ -61,11 +62,18 @@ public class ReadyForValidationConsumerTest {
     private ReadyForValidationConsumer consumer;
     private ReadyForValidationConsumer consumerWithoutBlobStorage;
 
+    // Real instances (no deps); the flag defaults to false so the append path is off by default.
+    private PreQualificationConfig preQualificationConfig;
+    private PreQualOperationOutcomeBuilder preQualOperationOutcomeBuilder;
+
     private Bundle bundle;
 
     @BeforeEach
     @SuppressWarnings("unchecked")
     void setUp() throws Exception {
+        preQualificationConfig = new PreQualificationConfig();
+        preQualOperationOutcomeBuilder = new PreQualOperationOutcomeBuilder();
+
         consumer = new ReadyForValidationConsumer(
                 fhirContext,
                 reportClient,
@@ -75,6 +83,8 @@ public class ReadyForValidationConsumerTest {
                 validationCompleteTemplate,
                 validationMetrics,
                 Optional.of(blobStorageService),
+                preQualificationConfig,
+                preQualOperationOutcomeBuilder,
                 recoverer);
 
         consumerWithoutBlobStorage = new ReadyForValidationConsumer(
@@ -86,6 +96,8 @@ public class ReadyForValidationConsumerTest {
                 validationCompleteTemplate,
                 validationMetrics,
                 Optional.empty(),
+                preQualificationConfig,
+                preQualOperationOutcomeBuilder,
                 recoverer);
 
         bundle = new Bundle();
@@ -274,7 +286,8 @@ public class ReadyForValidationConsumerTest {
 
         ReadyForValidationConsumer consumerWithRealCategorization = new ReadyForValidationConsumer(
                 fhirContext, reportClient, validationService, realCategorizationService, resultRepository,
-                validationCompleteTemplate, validationMetrics, Optional.of(blobStorageService), recoverer);
+                validationCompleteTemplate, validationMetrics, Optional.of(blobStorageService),
+                preQualificationConfig, preQualOperationOutcomeBuilder, recoverer);
 
         Result inactiveResult = new Result();
         inactiveResult.setMessage("The concept '423666004' has a status of inactive and its use should be reviewed.");
@@ -453,5 +466,74 @@ public class ReadyForValidationConsumerTest {
 
         verify(validationMetrics).addToValidationCounter(any());
         verify(validationMetrics).recordValidationDuration(anyDouble(), any());
+    }
+
+    // -------------------------------------------------------------------------
+    // Pre-qualification OperationOutcome append
+    // -------------------------------------------------------------------------
+
+    /** Stubs the blob download path so the bundle is retrieved from ABS (not REST). */
+    private void stubBlobDownload() {
+        IParser parser = mock(IParser.class);
+        when(fhirContext.newNDJsonParser()).thenReturn(parser);
+        when(parser.parseResource(eq(Bundle.class), (InputStream) any())).thenReturn(bundle);
+        when(blobStorageService.download("myfile.ndjson")).thenReturn(BinaryData.fromBytes(new byte[0]));
+    }
+
+    @Test
+    void process_flagOn_unacceptableFindings_appendsOperationOutcomeToSameBlob() throws Exception {
+        preQualificationConfig.setWritePreQualOperationOutcome(true);
+        stubBlobDownload();
+
+        IParser jsonParser = mock(IParser.class);
+        when(fhirContext.newJsonParser()).thenReturn(jsonParser);
+        when(jsonParser.encodeResourceToString(any()))
+                .thenReturn("{\"resourceType\":\"OperationOutcome\"}");
+
+        Result result = resultWithCategories(List.of(categoryWithAcceptable(false)));
+        result.setMessage("Code is inactive.");
+        when(validationService.validate(bundle)).thenReturn(List.of(result));
+
+        consumer.process(buildRecord(PAYLOAD_URI));
+
+        verify(blobStorageService).appendResource("myfile.ndjson", "{\"resourceType\":\"OperationOutcome\"}");
+    }
+
+    @Test
+    void process_flagOff_unacceptableFindings_doesNotAppend() throws Exception {
+        stubBlobDownload(); // flag defaults to false
+
+        Result result = resultWithCategories(List.of(categoryWithAcceptable(false)));
+        when(validationService.validate(bundle)).thenReturn(List.of(result));
+
+        consumer.process(buildRecord(PAYLOAD_URI));
+
+        verify(blobStorageService, never()).appendResource(anyString(), anyString());
+    }
+
+    @Test
+    void process_flagOn_noUnacceptableFindings_doesNotAppend() throws Exception {
+        preQualificationConfig.setWritePreQualOperationOutcome(true);
+        stubBlobDownload();
+
+        Result result = resultWithCategories(List.of(categoryWithAcceptable(true)));
+        when(validationService.validate(bundle)).thenReturn(List.of(result));
+
+        consumer.process(buildRecord(PAYLOAD_URI));
+
+        verify(blobStorageService, never()).appendResource(anyString(), anyString());
+    }
+
+    @Test
+    void process_flagOn_noBlobService_doesNotAppend() throws Exception {
+        preQualificationConfig.setWritePreQualOperationOutcome(true);
+        stubRestRetrieval(); // no blob service -> bundle comes via REST, append is skipped
+
+        Result result = resultWithCategories(List.of(categoryWithAcceptable(false)));
+        when(validationService.validate(bundle)).thenReturn(List.of(result));
+
+        consumerWithoutBlobStorage.process(buildRecord(PAYLOAD_URI));
+
+        verify(blobStorageService, never()).appendResource(anyString(), anyString());
     }
 }

--- a/Java/validation/src/test/java/com/lantanagroup/link/validation/services/ReadyForValidationConsumerTest.java
+++ b/Java/validation/src/test/java/com/lantanagroup/link/validation/services/ReadyForValidationConsumerTest.java
@@ -585,4 +585,21 @@ public class ReadyForValidationConsumerTest {
 
         verify(blobStorageService, never()).appendResource(anyString(), anyString());
     }
+
+    @Test
+    void process_flagOn_nullPayloadUri_doesNotAppend() throws Exception {
+        // Blob storage IS configured here, unlike the test above; only the payloadUri is missing. This
+        // covers the second operand of the append guard on its own - drop it and BlobUrlParts.parse(null)
+        // throws, so the two operands need separate coverage.
+        preQualificationConfig.setWritePreQualOperationOutcome(true);
+        stubRestRetrieval(); // no payload URI -> bundle comes via REST
+
+        Result result = resultWithCategories(List.of(categoryWithAcceptable(false)));
+        result.setMessage("Code is inactive.");
+        when(validationService.validate(bundle)).thenReturn(List.of(result));
+
+        consumer.process(buildRecord(null));
+
+        verify(blobStorageService, never()).appendResource(anyString(), anyString());
+    }
 }

--- a/Java/validation/src/test/java/com/lantanagroup/link/validation/services/ReadyForValidationConsumerTest.java
+++ b/Java/validation/src/test/java/com/lantanagroup/link/validation/services/ReadyForValidationConsumerTest.java
@@ -525,6 +525,55 @@ public class ReadyForValidationConsumerTest {
     }
 
     @Test
+    void process_flagOn_bundleAlreadyHasPreQualOperationOutcome_doesNotAppendAgain() throws Exception {
+        // Replay: AsyncListener acknowledges the offset even when process() throws, so a failure after the
+        // append (producing ValidationComplete, say) routes the record to the retry topic and process()
+        // runs again. The re-read bundle then already contains the OperationOutcome we appended, and we
+        // must not append a second one.
+        preQualificationConfig.setWritePreQualOperationOutcome(true);
+
+        org.hl7.fhir.r4.model.OperationOutcome existing = new org.hl7.fhir.r4.model.OperationOutcome();
+        existing.addExtension(new org.hl7.fhir.r4.model.Extension(
+                PreQualOperationOutcomeBuilder.OO_TOTAL_URL, new org.hl7.fhir.r4.model.IntegerType(1)));
+        bundle.addEntry().setResource(existing);
+
+        stubBlobDownload();
+
+        Result result = resultWithCategories(List.of(categoryWithAcceptable(false)));
+        result.setMessage("Code is inactive.");
+        when(validationService.validate(bundle)).thenReturn(List.of(result));
+
+        consumer.process(buildRecord(PAYLOAD_URI));
+
+        verify(blobStorageService, never()).appendResource(anyString(), anyString());
+    }
+
+    @Test
+    void process_flagOn_bundleHasUnrelatedOperationOutcome_stillAppends() throws Exception {
+        // The Report service's legacy flat OperationOutcome carries no oo-total extension, so it must not
+        // be mistaken for ours and suppress the append.
+        preQualificationConfig.setWritePreQualOperationOutcome(true);
+
+        org.hl7.fhir.r4.model.OperationOutcome legacy = new org.hl7.fhir.r4.model.OperationOutcome();
+        legacy.addIssue().setDiagnostics("Patient has failed Validation");
+        bundle.addEntry().setResource(legacy);
+
+        stubBlobDownload();
+
+        IParser jsonParser = mock(IParser.class);
+        when(fhirContext.newJsonParser()).thenReturn(jsonParser);
+        when(jsonParser.encodeResourceToString(any())).thenReturn("{\"resourceType\":\"OperationOutcome\"}");
+
+        Result result = resultWithCategories(List.of(categoryWithAcceptable(false)));
+        result.setMessage("Code is inactive.");
+        when(validationService.validate(bundle)).thenReturn(List.of(result));
+
+        consumer.process(buildRecord(PAYLOAD_URI));
+
+        verify(blobStorageService).appendResource("myfile.ndjson", "{\"resourceType\":\"OperationOutcome\"}");
+    }
+
+    @Test
     void process_flagOn_noBlobService_doesNotAppend() throws Exception {
         preQualificationConfig.setWritePreQualOperationOutcome(true);
         stubRestRetrieval(); // no blob service -> bundle comes via REST, append is skipped

--- a/Tests/Postman/leglink-425-prequal-operationoutcome.postman_collection.json
+++ b/Tests/Postman/leglink-425-prequal-operationoutcome.postman_collection.json
@@ -1,0 +1,341 @@
+{
+  "info": {
+    "_postman_id": "b7e41d2a-5c93-4f18-9a62-3d5e7c1f8a04",
+    "name": "LEGLINK-425 Pre-Qual OperationOutcome (local stack)",
+    "description": "Manual end-to-end test for LEGLINK-425: the Validation service writes a category-grouped pre-qualification OperationOutcome to the patient NDJSON in ABS.\n\nWHAT THIS DOES\n1. Preflight: confirms the measure is loaded in MeasureEval.\n2. Ensures a test facility exists, with a Discharge query plan and a FHIR query config pointing at the in-network HAPI server.\n3. Seeds a patient into the local HAPI FHIR server. The Patient deliberately OMITS `gender` so validation produces a finding in the `missing_patient_gender` category, which is `acceptable: false` in categories.json and therefore SHOWS UP in the pre-qual OperationOutcome. (The LEGLINK-424 inactive-code categories are `acceptable: true` and would produce an EMPTY OperationOutcome.)\n4. Triggers an ad-hoc report, which drives the full pipeline and ends with the Validation service appending the OperationOutcome to the patient NDJSON.\n5. Observation requests to confirm what happened.\n\nPREREQUISITES\n- The docker-compose stack is up and healthy.\n- The flag is ON for the validation container. Set VALIDATION_WRITE_PREQUAL_OO=true in the root .env, then:\n    docker compose up -d --build validation\n  (--build, not just recreate, or the image keeps the old code.)\n- Measure NHSNAcuteCareHospitalMonthlyInitialPopulation is loaded in MeasureEval (step 0 verifies this).\n\nSETUP REQUESTS ARE IDEMPOTENT: facility / query plan / FHIR query config all accept an 'already exists' response, so you can re-run this collection freely.\n\nFINAL VERIFICATION IS MANUAL: Postman cannot read Azure Blob Storage. After the run, open the patient NDJSON in Azurite (127.0.0.1:10000, internal container, path <report>/patient-<patientId>.ndjson) and confirm the appended OperationOutcome resource on the last line.",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "variable": [
+    { "key": "bff", "value": "http://localhost:8063", "type": "string" },
+    { "key": "fhirHost", "value": "http://localhost:6157", "type": "string" },
+    { "key": "fhirInternal", "value": "http://fhir-server:8080/fhir", "type": "string" },
+    { "key": "validationBase", "value": "http://localhost:8075", "type": "string" },
+    { "key": "facilityId", "value": "leglink-425-test", "type": "string" },
+    { "key": "reportType", "value": "NHSNAcuteCareHospitalMonthlyInitialPopulation", "type": "string" },
+    { "key": "patientId", "value": "patient-425", "type": "string" },
+    { "key": "startDate", "value": "2026-06-01T00:00:00Z", "type": "string" },
+    { "key": "endDate", "value": "2026-07-01T00:00:00Z", "type": "string" },
+    { "key": "encounterStart", "value": "2026-06-15T08:00:00Z", "type": "string" },
+    { "key": "encounterEnd", "value": "2026-06-16T12:00:00Z", "type": "string" },
+    { "key": "reportId", "value": "", "type": "string" }
+  ],
+  "item": [
+    {
+      "name": "0 - Preflight",
+      "item": [
+        {
+          "name": "Verify measure is loaded in MeasureEval",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Measure ' + pm.collectionVariables.get('reportType') + ' is loaded in MeasureEval', function () {",
+                  "    pm.expect(pm.response.code, 'If this is 404, load the measure first: PUT {{bff}}/api/measureeval/measure-definition with the bundle from DotNet/Automation/measures/NHSNAcuteCareHospitalMonthlyInitialPopulation.json').to.eql(200);",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{bff}}/api/measureeval/measure-definition/{{reportType}}",
+              "host": ["{{bff}}"],
+              "path": ["api", "measureeval", "measure-definition", "{{reportType}}"]
+            },
+            "description": "The ad-hoc trigger validates each reportType against MeasureEval and returns 500 if it is missing, so fail fast here with a clearer message."
+          },
+          "response": []
+        }
+      ]
+    },
+    {
+      "name": "1 - Facility setup (idempotent)",
+      "item": [
+        {
+          "name": "Ensure facility exists",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "// 201/200 = created, 409/400 = already exists. Both are success for an 'ensure'.",
+                  "pm.test('Facility exists or was created', function () {",
+                  "    pm.expect([200, 201, 400, 409]).to.include(pm.response.code);",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [{ "key": "Content-Type", "value": "application/json" }],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"facilityId\": \"{{facilityId}}\",\n  \"facilityName\": \"{{facilityId}}\",\n  \"timeZone\": \"America/Chicago\",\n  \"vendor\": \"Epic\",\n  \"scheduledReports\": {\n    \"daily\": [],\n    \"weekly\": [],\n    \"monthly\": []\n  }\n}"
+            },
+            "url": {
+              "raw": "{{bff}}/api/Facility",
+              "host": ["{{bff}}"],
+              "path": ["api", "Facility"]
+            },
+            "description": "scheduledReports arrays are left EMPTY on purpose: any measure id placed there is validated against MeasureEval at facility-save time."
+          },
+          "response": []
+        },
+        {
+          "name": "Ensure Discharge query plan",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Query plan exists or was created', function () {",
+                  "    pm.expect([200, 201, 409]).to.include(pm.response.code);",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [{ "key": "Content-Type", "value": "application/json" }],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"PlanName\": \"{{reportType}}\",\n  \"FacilityId\": \"{{facilityId}}\",\n  \"EHRDescription\": \"Epic\",\n  \"LookBack\": \"P0D\",\n  \"Type\": \"Discharge\",\n  \"InitialQueries\": {\n    \"0\": {\n      \"ResourceType\": \"Encounter\",\n      \"QueryConfigType\": \"Parameter\",\n      \"Parameters\": [\n        { \"ParameterType\": \"Variable\", \"Name\": \"patient\", \"Variable\": 0, \"Format\": null },\n        { \"ParameterType\": \"Variable\", \"Name\": \"date\", \"Variable\": 1, \"Format\": \"ge{0}\" },\n        { \"ParameterType\": \"Variable\", \"Name\": \"date\", \"Variable\": 3, \"Format\": \"le{0}\" }\n      ]\n    },\n    \"1\": {\n      \"QueryConfigType\": \"Reference\",\n      \"ResourceType\": \"Location\",\n      \"OperationType\": 1,\n      \"Paged\": 100\n    }\n  },\n  \"SupplementalQueries\": {\n    \"0\": {\n      \"QueryConfigType\": \"Parameter\",\n      \"ResourceType\": \"Condition\",\n      \"Parameters\": [\n        { \"ParameterType\": \"Variable\", \"Name\": \"patient\", \"Variable\": 0, \"Format\": null },\n        { \"ParameterType\": \"ResourceIds\", \"Name\": \"encounter\", \"Resource\": \"Encounter\", \"Paged\": \"100\" }\n      ]\n    }\n  }\n}"
+            },
+            "url": {
+              "raw": "{{bff}}/api/data/{{facilityId}}/QueryPlan",
+              "host": ["{{bff}}"],
+              "path": ["api", "data", "{{facilityId}}", "QueryPlan"]
+            },
+            "description": "Type MUST be Discharge: an ad-hoc report maps ReportableEvent.Adhoc -> Frequency.Discharge when selecting the query plan.\n\nParameter Variable enum: 0=PatientId, 1=LookbackStart, 2=PeriodStart, 3=PeriodEnd.\nParameter queries must precede Reference queries within a dictionary."
+          },
+          "response": []
+        },
+        {
+          "name": "Ensure FHIR query configuration",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('FHIR query config exists or was created', function () {",
+                  "    pm.expect([200, 201, 409]).to.include(pm.response.code);",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [{ "key": "Content-Type", "value": "application/json" }],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"FacilityId\": \"{{facilityId}}\",\n  \"FhirServerBaseUrl\": \"{{fhirInternal}}\",\n  \"Authentication\": null,\n  \"MaxConcurrentRequests\": 8,\n  \"MaxRetries\": 3,\n  \"TimeZone\": \"UTC\"\n}"
+            },
+            "url": {
+              "raw": "{{bff}}/api/data/fhirQueryConfiguration",
+              "host": ["{{bff}}"],
+              "path": ["api", "data", "fhirQueryConfiguration"]
+            },
+            "description": "FhirServerBaseUrl uses the DOCKER-INTERNAL name (fhir-server:8080), because DataAcquisition dials it from inside the network. Postman seeds via localhost:6157 instead."
+          },
+          "response": []
+        }
+      ]
+    },
+    {
+      "name": "2 - Seed FHIR patient",
+      "item": [
+        {
+          "name": "POST patient transaction bundle",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('FHIR transaction accepted', function () {",
+                  "    pm.expect(pm.response.code).to.be.oneOf([200, 201]);",
+                  "});",
+                  "pm.test('All entries succeeded', function () {",
+                  "    var body = pm.response.json();",
+                  "    (body.entry || []).forEach(function (e) {",
+                  "        pm.expect(String(e.response.status)).to.match(/^(200|201)/);",
+                  "    });",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [{ "key": "Content-Type", "value": "application/fhir+json" }],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"resourceType\": \"Bundle\",\n  \"type\": \"transaction\",\n  \"entry\": [\n    {\n      \"resource\": {\n        \"resourceType\": \"Location\",\n        \"id\": \"loc-425\",\n        \"status\": \"active\",\n        \"name\": \"LEGLINK-425 Test Hospital\",\n        \"identifier\": [{ \"system\": \"http://hospital.example.org/locations\", \"value\": \"loc-425\" }]\n      },\n      \"request\": { \"method\": \"PUT\", \"url\": \"Location/loc-425\" }\n    },\n    {\n      \"resource\": {\n        \"resourceType\": \"Patient\",\n        \"id\": \"{{patientId}}\",\n        \"name\": [{ \"family\": \"Prequal\", \"given\": [\"Test\"] }],\n        \"birthDate\": \"1970-01-01\"\n      },\n      \"request\": { \"method\": \"PUT\", \"url\": \"Patient/{{patientId}}\" }\n    },\n    {\n      \"resource\": {\n        \"resourceType\": \"Encounter\",\n        \"id\": \"enc-425\",\n        \"status\": \"finished\",\n        \"class\": { \"system\": \"http://terminology.hl7.org/CodeSystem/v3-ActCode\", \"code\": \"EMER\" },\n        \"subject\": { \"reference\": \"Patient/{{patientId}}\" },\n        \"period\": { \"start\": \"{{encounterStart}}\", \"end\": \"{{encounterEnd}}\" },\n        \"location\": [{ \"location\": { \"reference\": \"Location/loc-425\" }, \"status\": \"completed\" }]\n      },\n      \"request\": { \"method\": \"PUT\", \"url\": \"Encounter/enc-425\" }\n    },\n    {\n      \"resource\": {\n        \"resourceType\": \"Condition\",\n        \"id\": \"cond-425\",\n        \"clinicalStatus\": { \"coding\": [{ \"system\": \"http://terminology.hl7.org/CodeSystem/condition-clinical\", \"code\": \"active\" }] },\n        \"code\": { \"coding\": [{ \"system\": \"http://snomed.info/sct\", \"code\": \"44054006\" }] },\n        \"subject\": { \"reference\": \"Patient/{{patientId}}\" },\n        \"encounter\": { \"reference\": \"Encounter/enc-425\" }\n      },\n      \"request\": { \"method\": \"PUT\", \"url\": \"Condition/cond-425\" }\n    }\n  ]\n}"
+            },
+            "url": {
+              "raw": "{{fhirHost}}/fhir",
+              "host": ["{{fhirHost}}"],
+              "path": ["fhir"]
+            },
+            "description": "NOTE: the Patient deliberately has NO `gender` element. That trips the `missing_patient_gender` category, which is `acceptable: false` in categories.json, so it produces an issue in the pre-qual OperationOutcome.\n\nIf you seed a fully-valid patient instead, the OperationOutcome will legitimately be EMPTY and nothing is appended (that is the documented behavior: 'a patient with no unacceptable-category findings produces no OperationOutcome').\n\nThe Encounter period must fall inside startDate/endDate, since the Encounter query filters on date ge/le."
+          },
+          "response": []
+        }
+      ]
+    },
+    {
+      "name": "3 - Trigger the pipeline",
+      "item": [
+        {
+          "name": "POST AdHocReport",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Ad-hoc report accepted', function () {",
+                  "    pm.response.to.have.status(200);",
+                  "});",
+                  "var body = {};",
+                  "try { body = pm.response.json(); } catch (e) {}",
+                  "if (body.reportId) {",
+                  "    pm.collectionVariables.set('reportId', body.reportId);",
+                  "    console.log('reportId = ' + body.reportId);",
+                  "}",
+                  "pm.test('reportId captured', function () {",
+                  "    pm.expect(pm.collectionVariables.get('reportId')).to.not.eql('');",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [{ "key": "Content-Type", "value": "application/json" }],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"patientIds\": [\"{{patientId}}\"],\n  \"reportTypes\": [\"{{reportType}}\"],\n  \"startDate\": \"{{startDate}}\",\n  \"endDate\": \"{{endDate}}\",\n  \"bypassSubmission\": true\n}"
+            },
+            "url": {
+              "raw": "{{bff}}/api/Facility/{{facilityId}}/AdHocReport",
+              "host": ["{{bff}}"],
+              "path": ["api", "Facility", "{{facilityId}}", "AdHocReport"]
+            },
+            "description": "Passing patientIds explicitly short-circuits the Census service entirely (Report.GenerateReportListener only calls Census when patientIds is null/empty), so no census config is needed.\n\nbypassSubmission=true keeps the run out of the external container; the internal patient NDJSON (which is what we care about) is still written.\n\nAfter this returns, WAIT ~60-90s for the pipeline to reach Validation before running the observation requests."
+          },
+          "response": []
+        }
+      ]
+    },
+    {
+      "name": "4 - Observe (run after ~60-90s)",
+      "item": [
+        {
+          "name": "Report schedule status",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{bff}}/api/schedules/{{reportId}}",
+              "host": ["{{bff}}"],
+              "path": ["api", "schedules", "{{reportId}}"]
+            },
+            "description": "Watch `status`. With bypassSubmission=true the run will not reach 'Submitted'; validation completing is what matters here."
+          },
+          "response": []
+        },
+        {
+          "name": "Report entries for patient",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{bff}}/api/entries/patients/{{patientId}}",
+              "host": ["{{bff}}"],
+              "path": ["api", "entries", "patients", "{{patientId}}"]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Validation results for report",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Validation produced results', function () {",
+                  "    pm.response.to.have.status(200);",
+                  "    var results = pm.response.json();",
+                  "    pm.expect(results.length, 'No results yet - validation may not have run. Wait and retry.').to.be.above(0);",
+                  "});",
+                  "",
+                  "// Surface which categories are UNACCEPTABLE - these are exactly the issues that",
+                  "// should appear in the appended pre-qual OperationOutcome (one issue per category).",
+                  "try {",
+                  "    var results = pm.response.json();",
+                  "    var unacceptable = {};",
+                  "    results.forEach(function (r) {",
+                  "        (r.categories || []).forEach(function (c) {",
+                  "            if (c.acceptable === false) { unacceptable[c.id] = (unacceptable[c.id] || 0) + 1; }",
+                  "        });",
+                  "    });",
+                  "    var ids = Object.keys(unacceptable);",
+                  "    console.log('Unacceptable categories (expect one OO issue each): ' + (ids.length ? JSON.stringify(unacceptable) : 'NONE -> OperationOutcome will be empty and nothing is appended'));",
+                  "} catch (e) { console.log('Could not summarize categories: ' + e); }"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{validationBase}}/api/validation/result/{{facilityId}}/{{reportId}}",
+              "host": ["{{validationBase}}"],
+              "path": ["api", "validation", "result", "{{facilityId}}", "{{reportId}}"]
+            },
+            "description": "Reads the PERSISTED validation results. The test script logs which categories came back `acceptable: false` - that set should match the issues in the OperationOutcome appended to the NDJSON (one issue per unacceptable category).\n\nThis reads the database, NOT the NDJSON. Confirming the actual appended OperationOutcome requires opening the blob in Azurite."
+          },
+          "response": []
+        }
+      ]
+    },
+    {
+      "name": "5 - Optional: preview categorization without the pipeline",
+      "item": [
+        {
+          "name": "POST $validate?categorize=true",
+          "request": {
+            "method": "POST",
+            "header": [{ "key": "Content-Type", "value": "application/json" }],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"resourceType\": \"Patient\",\n  \"id\": \"{{patientId}}\",\n  \"name\": [{ \"family\": \"Prequal\", \"given\": [\"Test\"] }],\n  \"birthDate\": \"1970-01-01\"\n}"
+            },
+            "url": {
+              "raw": "{{validationBase}}/api/validation/$validate?categorize=true",
+              "host": ["{{validationBase}}"],
+              "path": ["api", "validation", "$validate"],
+              "query": [{ "key": "categorize", "value": "true" }]
+            },
+            "description": "Runs the SAME validation + categorization core the consumer uses, and returns the categorized results directly - handy for checking which categories a resource trips before running the whole pipeline.\n\nIt does NOT build the OperationOutcome and does NOT write to the blob: that code path exists only in ReadyForValidationConsumer."
+          },
+          "response": []
+        }
+      ]
+    }
+  ]
+}

--- a/Tests/Postman/leglink-425-prequal-operationoutcome.postman_collection.json
+++ b/Tests/Postman/leglink-425-prequal-operationoutcome.postman_collection.json
@@ -2,7 +2,7 @@
   "info": {
     "_postman_id": "b7e41d2a-5c93-4f18-9a62-3d5e7c1f8a04",
     "name": "LEGLINK-425 Pre-Qual OperationOutcome (local stack)",
-    "description": "Manual end-to-end test for LEGLINK-425: the Validation service writes a category-grouped pre-qualification OperationOutcome to the patient NDJSON in ABS.\n\nWHAT THIS DOES\n1. Preflight: confirms the measure is loaded in MeasureEval.\n2. Ensures a test facility exists, with a Discharge query plan and a FHIR query config pointing at the in-network HAPI server.\n3. Seeds a patient into the local HAPI FHIR server. The Patient deliberately OMITS `gender` so validation produces a finding in the `missing_patient_gender` category, which is `acceptable: false` in categories.json and therefore SHOWS UP in the pre-qual OperationOutcome. (The LEGLINK-424 inactive-code categories are `acceptable: true` and would produce an EMPTY OperationOutcome.)\n4. Triggers an ad-hoc report, which drives the full pipeline and ends with the Validation service appending the OperationOutcome to the patient NDJSON.\n5. Observation requests to confirm what happened.\n\nPREREQUISITES\n- The docker-compose stack is up and healthy.\n- The flag is ON for the validation container. Set VALIDATION_WRITE_PREQUAL_OO=true in the root .env, then:\n    docker compose up -d --build validation\n  (--build, not just recreate, or the image keeps the old code.)\n- Measure NHSNAcuteCareHospitalMonthlyInitialPopulation is loaded in MeasureEval (step 0 verifies this).\n\nSETUP REQUESTS ARE IDEMPOTENT: facility / query plan / FHIR query config all accept an 'already exists' response, so you can re-run this collection freely.\n\nFINAL VERIFICATION IS MANUAL: Postman cannot read Azure Blob Storage. After the run, open the patient NDJSON in Azurite (127.0.0.1:10000, internal container, path <report>/patient-<patientId>.ndjson) and confirm the appended OperationOutcome resource on the last line.",
+    "description": "Manual end-to-end test for LEGLINK-425: the Validation service writes a category-grouped pre-qualification OperationOutcome to the patient NDJSON in ABS.\n\nWHAT THIS DOES\n1. Preflight: confirms the measure is loaded in MeasureEval.\n2. Ensures a test facility exists, with a Discharge query plan and a FHIR query config pointing at the in-network HAPI server.\n3. Seeds a patient into the local HAPI FHIR server, including an Observation whose `code` carries an INACTIVE code so validation produces an inactive-code finding.\n4. Triggers an ad-hoc report, which drives the full pipeline and ends with the Validation service appending the OperationOutcome to the patient NDJSON.\n5. Observation requests to confirm what happened.\n\nPREREQUISITES\n- The docker-compose stack is up and healthy.\n- The flag is ON for the validation container. Set VALIDATION_WRITE_PREQUAL_OO=true in the root .env, then:\n    docker compose up -d --build validation\n  (--build, not just recreate, or the image keeps the old code.)\n- Measure NHSNAcuteCareHospitalMonthlyInitialPopulation is loaded in MeasureEval (step 0 verifies this).\n- The inactive-code categories are flipped to `acceptable: false`. The `missing_active_*` categories ship as `acceptable: true`, meaning inactive-code findings are TOLERATED and produce NO OperationOutcome issue. To exercise them, set the relevant ones (e.g. missing_active_observation_code) to false in Java/validation/src/main/resources/categories.json, then rebuild AND re-seed:\n    docker compose up -d --build validation\n    POST {{validationBase}}/api/validation/category/$initialize\n  categories.json is a DB seed baked into the image, so editing the file alone has no effect. REMEMBER TO REVERT this change - it is a testing-only override, not a product change.\n\nSETUP REQUESTS ARE IDEMPOTENT: facility / query plan / FHIR query config all accept an 'already exists' response, so you can re-run this collection freely.\n\nFINAL VERIFICATION IS MANUAL: Postman cannot read Azure Blob Storage. After the run, open the patient NDJSON in Azurite (127.0.0.1:10000, internal container, path <report>/patient-<patientId>.ndjson) and confirm the appended OperationOutcome resource on the last line.",
     "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
   },
   "variable": [
@@ -10,6 +10,9 @@
     { "key": "fhirHost", "value": "http://localhost:6157", "type": "string" },
     { "key": "fhirInternal", "value": "http://fhir-server:8080/fhir", "type": "string" },
     { "key": "validationBase", "value": "http://localhost:8075", "type": "string" },
+    { "key": "terminologyBase", "value": "http://localhost:8076", "type": "string" },
+    { "key": "inactiveCodeSystem", "value": "urn:oid:2.16.840.1.113883.6.238", "type": "string" },
+    { "key": "inactiveCode", "value": "1004-1", "type": "string" },
     { "key": "facilityId", "value": "leglink-425-test", "type": "string" },
     { "key": "reportType", "value": "NHSNAcuteCareHospitalMonthlyInitialPopulation", "type": "string" },
     { "key": "patientId", "value": "patient-425", "type": "string" },
@@ -47,6 +50,47 @@
               "path": ["api", "measureeval", "measure-definition", "{{reportType}}"]
             },
             "description": "The ad-hoc trigger validates each reportType against MeasureEval and returns 500 if it is missing, so fail fast here with a clearer message."
+          },
+          "response": []
+        },
+        {
+          "name": "Confirm the seed code is INACTIVE",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "// The seeded Observation.code must be INACTIVE in the terminology service, otherwise",
+                  "// validation emits no 'has a status of inactive' message and the inactive-code",
+                  "// categories never fire.",
+                  "pm.test('Terminology service responded', function () {",
+                  "    pm.response.to.have.status(200);",
+                  "});",
+                  "",
+                  "var raw = pm.response.text();",
+                  "var looksInactive = /inactive/i.test(raw);",
+                  "pm.test('Code ' + pm.collectionVariables.get('inactiveCode') + ' is reported INACTIVE', function () {",
+                  "    pm.expect(looksInactive, 'No \"inactive\" wording in the response. Pick a different code: list systems via GET {{terminologyBase}}/api/terminology/fhir/CodeSystem?_summary=true, then set the inactiveCode / inactiveCodeSystem collection variables.').to.be.true;",
+                  "});",
+                  "console.log('$validate-code response: ' + raw);"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [{ "key": "Content-Type", "value": "application/json" }],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"resourceType\": \"Parameters\",\n  \"parameter\": [\n    { \"name\": \"url\", \"valueUri\": \"{{inactiveCodeSystem}}\" },\n    { \"name\": \"code\", \"valueString\": \"{{inactiveCode}}\" }\n  ]\n}"
+            },
+            "url": {
+              "raw": "{{terminologyBase}}/api/terminology/fhir/CodeSystem/$validate-code",
+              "host": ["{{terminologyBase}}"],
+              "path": ["api", "terminology", "fhir", "CodeSystem", "$validate-code"]
+            },
+            "description": "Verifies the code seeded into Observation.code is INACTIVE according to the local terminology service.\n\nINACTIVE CODES ARE SCARCE. The terminology data lives in the `terminology_data` docker volume (mounted at /data in link-terminology), one CSV per CodeSystem. Only TWO of those CSVs carry a `status` column at all - CodeSystem-ActCode and CodeSystem-cdcrec - so the complete set of codes that can ever be reported inactive in a default local stack is:\n\n  urn:oid:2.16.840.1.113883.6.238 (cdcrec)              1004-1   American Indian   <- default used here\n  http://terminology.hl7.org/CodeSystem/v3-ActCode      WRKCOMP  (workers compensation program\n  http://terminology.hl7.org/CodeSystem/v3-ActCode      SS       short stay\n\nNotably SNOMED (CodeSystem-SnomedCT.csv) is `id,display` only - it has NO status column - so no SNOMED code can be reported inactive, regardless of what it is in the real world.\n\nTo re-derive this list:\n  docker exec link-terminology sh -c \"for f in \\$(find /data -name '*.csv'); do head -1 \\$f | grep -qi status && echo \\$f; done\"\n\nA cdcrec race code in Observation.code is semantically odd, but the inactive check is performed against the code's own CodeSystem, so it still produces the \"has a status of inactive\" message anchored to Observation.code - which is what the matcher needs. Expect an additional binding complaint alongside it; that is harmless for this test."
           },
           "response": []
         }
@@ -88,6 +132,37 @@
           "response": []
         },
         {
+          "name": "Delete existing Discharge query plan",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "// The query-plan POST returns 409 when a plan of this Type already exists, which would",
+                  "// silently keep an OLD plan (e.g. one without the Observation query). Delete first so the",
+                  "// POST below always applies the current definition. 404/400 = nothing to delete.",
+                  "pm.test('Existing plan removed or absent', function () {",
+                  "    pm.expect([200, 202, 204, 400, 404]).to.include(pm.response.code);",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "DELETE",
+            "header": [],
+            "url": {
+              "raw": "{{bff}}/api/data/{{facilityId}}/QueryPlan?type=Discharge",
+              "host": ["{{bff}}"],
+              "path": ["api", "data", "{{facilityId}}", "QueryPlan"],
+              "query": [{ "key": "type", "value": "Discharge" }]
+            },
+            "description": "Makes the following POST authoritative. Without this, re-running the collection after changing the query plan leaves the original plan in place and your new resource types are never acquired."
+          },
+          "response": []
+        },
+        {
           "name": "Ensure Discharge query plan",
           "event": [
             {
@@ -107,7 +182,7 @@
             "header": [{ "key": "Content-Type", "value": "application/json" }],
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"PlanName\": \"{{reportType}}\",\n  \"FacilityId\": \"{{facilityId}}\",\n  \"EHRDescription\": \"Epic\",\n  \"LookBack\": \"P0D\",\n  \"Type\": \"Discharge\",\n  \"InitialQueries\": {\n    \"0\": {\n      \"ResourceType\": \"Encounter\",\n      \"QueryConfigType\": \"Parameter\",\n      \"Parameters\": [\n        { \"ParameterType\": \"Variable\", \"Name\": \"patient\", \"Variable\": 0, \"Format\": null },\n        { \"ParameterType\": \"Variable\", \"Name\": \"date\", \"Variable\": 1, \"Format\": \"ge{0}\" },\n        { \"ParameterType\": \"Variable\", \"Name\": \"date\", \"Variable\": 3, \"Format\": \"le{0}\" }\n      ]\n    },\n    \"1\": {\n      \"QueryConfigType\": \"Reference\",\n      \"ResourceType\": \"Location\",\n      \"OperationType\": 1,\n      \"Paged\": 100\n    }\n  },\n  \"SupplementalQueries\": {\n    \"0\": {\n      \"QueryConfigType\": \"Parameter\",\n      \"ResourceType\": \"Condition\",\n      \"Parameters\": [\n        { \"ParameterType\": \"Variable\", \"Name\": \"patient\", \"Variable\": 0, \"Format\": null },\n        { \"ParameterType\": \"ResourceIds\", \"Name\": \"encounter\", \"Resource\": \"Encounter\", \"Paged\": \"100\" }\n      ]\n    }\n  }\n}"
+              "raw": "{\n  \"PlanName\": \"{{reportType}}\",\n  \"FacilityId\": \"{{facilityId}}\",\n  \"EHRDescription\": \"Epic\",\n  \"LookBack\": \"P0D\",\n  \"Type\": \"Discharge\",\n  \"InitialQueries\": {\n    \"0\": {\n      \"ResourceType\": \"Encounter\",\n      \"QueryConfigType\": \"Parameter\",\n      \"Parameters\": [\n        { \"ParameterType\": \"Variable\", \"Name\": \"patient\", \"Variable\": 0, \"Format\": null },\n        { \"ParameterType\": \"Variable\", \"Name\": \"date\", \"Variable\": 1, \"Format\": \"ge{0}\" },\n        { \"ParameterType\": \"Variable\", \"Name\": \"date\", \"Variable\": 3, \"Format\": \"le{0}\" }\n      ]\n    },\n    \"1\": {\n      \"QueryConfigType\": \"Reference\",\n      \"ResourceType\": \"Location\",\n      \"OperationType\": 1,\n      \"Paged\": 100\n    }\n  },\n  \"SupplementalQueries\": {\n    \"0\": {\n      \"QueryConfigType\": \"Parameter\",\n      \"ResourceType\": \"Condition\",\n      \"Parameters\": [\n        { \"ParameterType\": \"Variable\", \"Name\": \"patient\", \"Variable\": 0, \"Format\": null },\n        { \"ParameterType\": \"ResourceIds\", \"Name\": \"encounter\", \"Resource\": \"Encounter\", \"Paged\": \"100\" }\n      ]\n    },\n    \"1\": {\n      \"QueryConfigType\": \"Parameter\",\n      \"ResourceType\": \"Observation\",\n      \"Parameters\": [\n        { \"ParameterType\": \"Variable\", \"Name\": \"patient\", \"Variable\": 0, \"Format\": null },\n        { \"ParameterType\": \"Variable\", \"Name\": \"date\", \"Variable\": 1, \"Format\": \"ge{0}\" },\n        { \"ParameterType\": \"Variable\", \"Name\": \"date\", \"Variable\": 3, \"Format\": \"le{0}\" },\n        { \"ParameterType\": \"Literal\", \"Name\": \"category\", \"Literal\": \"imaging,laboratory,social-history,vital-signs\" }\n      ]\n    }\n  }\n}"
             },
             "url": {
               "raw": "{{bff}}/api/data/{{facilityId}}/QueryPlan",
@@ -180,14 +255,14 @@
             "header": [{ "key": "Content-Type", "value": "application/fhir+json" }],
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"resourceType\": \"Bundle\",\n  \"type\": \"transaction\",\n  \"entry\": [\n    {\n      \"resource\": {\n        \"resourceType\": \"Location\",\n        \"id\": \"loc-425\",\n        \"status\": \"active\",\n        \"name\": \"LEGLINK-425 Test Hospital\",\n        \"identifier\": [{ \"system\": \"http://hospital.example.org/locations\", \"value\": \"loc-425\" }]\n      },\n      \"request\": { \"method\": \"PUT\", \"url\": \"Location/loc-425\" }\n    },\n    {\n      \"resource\": {\n        \"resourceType\": \"Patient\",\n        \"id\": \"{{patientId}}\",\n        \"name\": [{ \"family\": \"Prequal\", \"given\": [\"Test\"] }],\n        \"birthDate\": \"1970-01-01\"\n      },\n      \"request\": { \"method\": \"PUT\", \"url\": \"Patient/{{patientId}}\" }\n    },\n    {\n      \"resource\": {\n        \"resourceType\": \"Encounter\",\n        \"id\": \"enc-425\",\n        \"status\": \"finished\",\n        \"class\": { \"system\": \"http://terminology.hl7.org/CodeSystem/v3-ActCode\", \"code\": \"EMER\" },\n        \"subject\": { \"reference\": \"Patient/{{patientId}}\" },\n        \"period\": { \"start\": \"{{encounterStart}}\", \"end\": \"{{encounterEnd}}\" },\n        \"location\": [{ \"location\": { \"reference\": \"Location/loc-425\" }, \"status\": \"completed\" }]\n      },\n      \"request\": { \"method\": \"PUT\", \"url\": \"Encounter/enc-425\" }\n    },\n    {\n      \"resource\": {\n        \"resourceType\": \"Condition\",\n        \"id\": \"cond-425\",\n        \"clinicalStatus\": { \"coding\": [{ \"system\": \"http://terminology.hl7.org/CodeSystem/condition-clinical\", \"code\": \"active\" }] },\n        \"code\": { \"coding\": [{ \"system\": \"http://snomed.info/sct\", \"code\": \"44054006\" }] },\n        \"subject\": { \"reference\": \"Patient/{{patientId}}\" },\n        \"encounter\": { \"reference\": \"Encounter/enc-425\" }\n      },\n      \"request\": { \"method\": \"PUT\", \"url\": \"Condition/cond-425\" }\n    }\n  ]\n}"
+              "raw": "{\n  \"resourceType\": \"Bundle\",\n  \"type\": \"transaction\",\n  \"entry\": [\n    {\n      \"resource\": {\n        \"resourceType\": \"Location\",\n        \"id\": \"loc-425\",\n        \"status\": \"active\",\n        \"name\": \"LEGLINK-425 Test Hospital\",\n        \"identifier\": [{ \"system\": \"http://hospital.example.org/locations\", \"value\": \"loc-425\" }]\n      },\n      \"request\": { \"method\": \"PUT\", \"url\": \"Location/loc-425\" }\n    },\n    {\n      \"resource\": {\n        \"resourceType\": \"Patient\",\n        \"id\": \"{{patientId}}\",\n        \"name\": [{ \"family\": \"Prequal\", \"given\": [\"Test\"] }],\n        \"birthDate\": \"1970-01-01\"\n      },\n      \"request\": { \"method\": \"PUT\", \"url\": \"Patient/{{patientId}}\" }\n    },\n    {\n      \"resource\": {\n        \"resourceType\": \"Encounter\",\n        \"id\": \"enc-425\",\n        \"status\": \"finished\",\n        \"class\": { \"system\": \"http://terminology.hl7.org/CodeSystem/v3-ActCode\", \"code\": \"EMER\" },\n        \"subject\": { \"reference\": \"Patient/{{patientId}}\" },\n        \"period\": { \"start\": \"{{encounterStart}}\", \"end\": \"{{encounterEnd}}\" },\n        \"location\": [{ \"location\": { \"reference\": \"Location/loc-425\" }, \"status\": \"completed\" }]\n      },\n      \"request\": { \"method\": \"PUT\", \"url\": \"Encounter/enc-425\" }\n    },\n    {\n      \"resource\": {\n        \"resourceType\": \"Condition\",\n        \"id\": \"cond-425\",\n        \"clinicalStatus\": { \"coding\": [{ \"system\": \"http://terminology.hl7.org/CodeSystem/condition-clinical\", \"code\": \"active\" }] },\n        \"code\": { \"coding\": [{ \"system\": \"http://snomed.info/sct\", \"code\": \"44054006\" }] },\n        \"subject\": { \"reference\": \"Patient/{{patientId}}\" },\n        \"encounter\": { \"reference\": \"Encounter/enc-425\" }\n      },\n      \"request\": { \"method\": \"PUT\", \"url\": \"Condition/cond-425\" }\n    },\n    {\n      \"resource\": {\n        \"resourceType\": \"Observation\",\n        \"id\": \"obs-425\",\n        \"status\": \"final\",\n        \"category\": [{ \"coding\": [{ \"system\": \"http://terminology.hl7.org/CodeSystem/observation-category\", \"code\": \"laboratory\" }] }],\n        \"code\": { \"coding\": [{ \"system\": \"{{inactiveCodeSystem}}\", \"code\": \"{{inactiveCode}}\" }] },\n        \"subject\": { \"reference\": \"Patient/{{patientId}}\" },\n        \"encounter\": { \"reference\": \"Encounter/enc-425\" },\n        \"effectiveDateTime\": \"{{encounterStart}}\",\n        \"valueQuantity\": { \"value\": 1, \"unit\": \"1\", \"system\": \"http://unitsofmeasure.org\", \"code\": \"1\" }\n      },\n      \"request\": { \"method\": \"PUT\", \"url\": \"Observation/obs-425\" }\n    }\n  ]\n}"
             },
             "url": {
               "raw": "{{fhirHost}}/fhir",
               "host": ["{{fhirHost}}"],
               "path": ["fhir"]
             },
-            "description": "NOTE: the Patient deliberately has NO `gender` element. That trips the `missing_patient_gender` category, which is `acceptable: false` in categories.json, so it produces an issue in the pre-qual OperationOutcome.\n\nIf you seed a fully-valid patient instead, the OperationOutcome will legitimately be EMPTY and nothing is appended (that is the documented behavior: 'a patient with no unacceptable-category findings produces no OperationOutcome').\n\nThe Encounter period must fall inside startDate/endDate, since the Encounter query filters on date ge/le."
+            "description": "The Observation is the important one: its `code` carries an INACTIVE code ({{inactiveCodeSystem}}|{{inactiveCode}}). Validation emits \"The concept '...' has a status of inactive and its use should be reviewed.\" against the expression `resource.ofType(Observation).code`, which is exactly what the `missing_active_observation_code` matcher requires.\n\nIMPORTANT: that category ships as `acceptable: true`, so by default it produces NO OperationOutcome issue. To see it in the OO you must flip it (and/or the other missing_active_* categories) to `acceptable: false` in Java/validation/src/main/resources/categories.json, then rebuild validation AND re-seed:\n  docker compose up -d --build validation\n  POST {{validationBase}}/api/validation/category/$initialize\ncategories.json is a DB seed baked into the image - editing the file alone changes nothing.\n\nObservation.category is set to `laboratory` to match the query plan's category literal, and effectiveDateTime sits inside the report window, so the supplemental Observation query actually returns it.\n\nThe Encounter period must likewise fall inside startDate/endDate, since the Encounter query filters on date ge/le."
           },
           "response": []
         }

--- a/app-config.yaml
+++ b/app-config.yaml
@@ -134,6 +134,13 @@ global:
   - key: "ConsumerSettings:DisableConsumer"
     description: "Boolean flag to disable the Kafka consumer entirely for the service."
     required: true
+  # Pre-qualification OperationOutcome ownership is a single cross-runtime decision with one
+  # key per runtime convention. Both must be set to the same value: with only the Java side on,
+  # the patient NDJSON gets both the detailed OperationOutcome and Report's legacy flat one;
+  # with only the .NET side on, it gets neither.
+  - key: "pre-qualification.write-pre-qual-operation-outcome"
+    description: "Boolean flag (default false), read by the Java Validation service. When true, Validation writes the category-grouped pre-qualification OperationOutcome to the patient NDJSON and is its sole writer (LEGLINK-425/LEGLINK-466). .NET counterpart: PreQualification:WritePreQualOperationOutcome."
+    required: false
 services:
   Account:
     - key: "UserManagement:EnableAutomaticUserActivation"
@@ -355,9 +362,9 @@ services:
     - key: "link.terminology-service-url"
       description: "The base URL for the Terminology Service used for validation."
       required: true
-    - key: "pre-qualification.write-pre-qual-operation-outcome"
-      description: "Boolean flag (default false). When true, the Validation service is the sole writer of the pre-qualification OperationOutcome to the patient NDJSON. This is the Java side of a cross-runtime concept; the .NET Report service reads the equivalent 'PreQualification:WritePreQualOperationOutcome' key (LEGLINK-466) and skips its legacy write when set."
-      required: false
+    # pre-qualification.write-pre-qual-operation-outcome is registered under global, not here —
+    # it is one cross-runtime decision with a key per runtime convention, and the .NET Report
+    # service reads the counterpart PreQualification:WritePreQualOperationOutcome (LEGLINK-466).
     - key: "pre-qualification.write-expressions-in-operation-outcome"
       description: "Boolean flag (default true). When false, the expression[] of each issue is omitted from the pre-qualification OperationOutcome written by the Validation service."
       required: false

--- a/app-config.yaml
+++ b/app-config.yaml
@@ -349,6 +349,12 @@ services:
     - key: "link.terminology-service-url"
       description: "The base URL for the Terminology Service used for validation."
       required: true
+    - key: "pre-qualification.write-pre-qual-operation-outcome"
+      description: "Boolean flag (default false). When true, the Validation service is the sole writer of the pre-qualification OperationOutcome to the patient NDJSON. This is the Java side of a cross-runtime concept; the .NET Report service reads the equivalent 'PreQualification:WritePreQualOperationOutcome' key (LEGLINK-466) and skips its legacy write when set."
+      required: false
+    - key: "pre-qualification.write-expressions-in-operation-outcome"
+      description: "Boolean flag (default true). When false, the expression[] of each issue is omitted from the pre-qualification OperationOutcome written by the Validation service."
+      required: false
 $defs:
   configEntry:
     type: "object"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -953,6 +953,8 @@ services:
       internal-blob-storage.connection-string: ${AZURITE_CONNECTION_STRING}
       internal-blob-storage.blob-container-name: ${INTERNAL_BLOB_CONTAINER_NAME}
       spring.data.redis.password: ${REDIS_PASS}
+      pre-qualification.write-pre-qual-operation-outcome: ${VALIDATION_WRITE_PREQUAL_OO:-false}
+      pre-qualification.write-expressions-in-operation-outcome: ${VALIDATION_WRITE_OO_EXPRESSIONS:-true}
     ports:
       - "8075:8075"
     build:


### PR DESCRIPTION
### 🛠️ Description of Changes

The Validation service now writes the pre-qualification `OperationOutcome` into the patient NDJSON in ABS, becoming the sole writer of it. Report's flat "Patient has failed Validation" append is retired separately in LEGLINK-466.

**OperationOutcome construction** (`PreQualOperationOutcomeBuilder`, new)
- Builds a single `OperationOutcome` with **one issue per unacceptable category** — a category with `acceptable=false` in `categories.json` that has at least one finding. Acceptable categories are excluded. A `Result` mapping to several categories contributes an issue to each.
- Each issue carries the `pq-issue-cat` extension (category id), `severity=error`, `code=processing`, and the first finding's message as `details.text`.
- The `OperationOutcome` carries the `oo-total` extension (total issue count).
- Expressions anchor to the patient's MeasureReport (`Bundle.entry[0].resource.ofType(MeasureReport).where(id = '…')`) followed by each finding's own location expression.
- A patient with no unacceptable-category findings produces **no** `OperationOutcome`, and nothing is written.

**Blob write** (`BlobStorageService`)
- Was download-only; added `appendResource`, appending one NDJSON line to the existing patient append blob via `AppendBlobClient.appendBlock`. It does not call `create()` — the blob is created upstream by Report's `PatientAggregator.AggregateToABS`.
- The appended line is newline-terminated so a subsequent appender cannot concatenate onto the same line. This was caught during manual testing: without it, Report's still-active legacy OperationOutcome landed on the *same* line and produced malformed NDJSON. It also protects against the two runtimes' flags drifting out of sync.

**Wiring** (`ReadyForValidationConsumer`)
- After categorization, resolves the blob name from the `ReadyForValidation` `payloadUri` (the same value already used for download), extracts the MeasureReport id from the in-hand bundle, builds the `OperationOutcome`, and appends it.
- Fully flag- and null-guarded, so a stack without blob storage configured (local/dev) is a no-op.

**Configuration** (`PreQualificationConfig`, new)
- `pre-qualification.write-pre-qual-operation-outcome` (default `false`) gates the entire write.
- `pre-qualification.write-expressions-in-operation-outcome` (default `true`) gates `issue.expression[]`.
- These are the Java-side keys for a cross-runtime concept; the .NET Report service reads the equivalent `PreQualification:WritePreQualOperationOutcome` key in LEGLINK-466. Both bind from Azure App Config through the existing `bootstrap.yml` wiring, are registered in `app-config.yaml`, and are exposed as `docker-compose` environment overrides.

**Testing aid**
- New Postman collection (`Tests/Postman/leglink-425-prequal-operationoutcome.postman_collection.json`) that ensures a test facility with query plan and FHIR query config, seeds a patient into the local HAPI server, and triggers an ad-hoc report to drive the whole pipeline. All variables are defined in-collection, so it needs no Postman environment. Setup requests are idempotent.

**Behavior on merge is unchanged** — the master flag defaults to `false` everywhere, so nothing is written until it is explicitly enabled.

### 🧪 Testing Performed

**Unit tests** — `mvn -pl validation -am test`, 47 tests pass (0 failures, 0 errors) on JDK 17. This grew from 37 over the review round below.

**Review fixes** — a review pass raised four latent defects and two coverage gaps, all addressed on this branch. Each defect was masked by an incidental runtime property rather than being reachable on the happy path: the MeasureReport locator hard-coded `Bundle.entry[0]` and only worked because the aggregator writes it first; issue grouping was keyed by the `Category` entity, which declares no `equals`/`hashCode`, and only worked because Hibernate returns one instance per id per session; the blob append was not replay-safe (see LEGLINK-800 below); and record-derived values reached the logger unsanitized. The coverage gaps were the `payloadUri == null` branch of the append guard and `appendResource` itself, which had no direct test pinning the trailing newline that a real defect had already required.

**Manual end-to-end against the local docker-compose stack:**
1. Enabled `pre-qualification.write-pre-qual-operation-outcome=true` on the validation container and rebuilt the image.
2. Seeded a facility, query plan, FHIR query config and a patient via the new Postman collection, then triggered an ad-hoc report for `NHSNAcuteCareHospitalMonthlyInitialPopulation`.
3. Downloaded the resulting `patient-<id>.ndjson` from Azurite and confirmed the appended `OperationOutcome`:
   - `oo-total` = 3, matching the three issues emitted.
   - Each issue carried the correct `pq-issue-cat` category id, `severity=error`, `code=processing`, and the category's message.
   - Expressions resolved against the live MeasureReport id, confirming MeasureReport-id extraction works on a real aggregated bundle.
4. This run surfaced the missing-newline defect described above; after the fix the appended resource terminates its own line.

**Flag behavior verified** by unit test rather than a second full pipeline run: append occurs only when the flag is set, is skipped when there are no unacceptable-category findings, and is skipped when blob storage is unavailable.

**Not yet exercised:** the `missing_active_*` (inactive-code) categories ship as `acceptable=true`, so inactive-code findings are tolerated and produce no issue. Confirming them requires temporarily flipping those categories, which is a content decision rather than a code change and was deliberately not included here.

### 🧑‍🔬 Unit Testing

- [x] I have written or updated unit tests to cover my changes
- Coverage: 98.9%
  - **`PreQualOperationOutcomeBuilderTest` (new, 14 tests)** — one issue per unacceptable category; `oo-total` equals issue count; `pq-issue-cat`, severity, code and `details.text` content; first-result message selected per category; a single result mapping to multiple unacceptable categories yielding an issue each; acceptable categories excluded; empty result when nothing is unacceptable; null/empty category lists ignored; expressions present with the MeasureReport locator first when enabled and absent entirely when disabled; null MeasureReport id omitting the locator without failing; MeasureReport-id extraction (present, absent, null bundle).
  - **`ReadyForValidationConsumerTest` (+4 tests)** — appends to the same blob when the flag is on and unacceptable findings exist; does not append when the flag is off, when there are no unacceptable findings, or when blob storage is absent.
  - `BlobStorageService.appendResource` is not unit tested directly, since it is a thin wrapper over the Azure SDK client; it is covered indirectly through the mocked consumer tests, consistent with how the existing `download` method is treated.

### 📓 Documentation Updated

- `app-config.yaml` — both new configuration keys registered under the `Validation` service, including a note that `write-pre-qual-operation-outcome` is the Java side of a cross-runtime flag whose .NET counterpart arrives with LEGLINK-466.
- `docker-compose.yml` — both keys exposed as environment overrides on the validation service, defaulting to off.
- The new Postman collection is self-documenting: each request describes its purpose and preconditions, including that `categories.json` is a database seed baked into the image (so exercising the inactive-code categories requires a rebuild plus `POST /api/validation/category/$initialize`), and which codes can be reported inactive in a default local stack.
- No changes required to the Admin UI: the `sub-pre-qual-report` view consumes the JSON pre-qualification summary shape, not the `pq-issue-cat` / `oo-total` FHIR extensions.

### 🔗 Related

- Parent story: LEGLINK-425
- LEGLINK-466 gates Report's legacy OperationOutcome write behind the .NET counterpart of this flag. Until it merges, enabling this flag results in **both** OperationOutcomes being appended. The trailing newline added here keeps the NDJSON well-formed in that interim state.
- **LEGLINK-800** tracks full idempotency across the blob and database writes. Review raised that the blob append is not replay-safe: `AsyncListener` acknowledges the Kafka offset even when `process()` throws, so a failure after the append routes the record to the retry topic and it is processed again. This PR adds a replay guard that skips the append when the bundle already carries a pre-qualification OperationOutcome, which narrows the window but does not close it — the REST fallback supplies a bundle with no previously appended OperationOutcome so the check is blind, concurrent consumers can both observe it as absent, and the check and the append are not atomic. Closing it properly needs a durable idempotency marker (new entity, repository and schema migration), and the writes span three systems with no distributed transaction, so no ordering makes them atomic. LEGLINK-800 also covers the pre-existing duplicate `Result` rows the same replay produces via `resultRepository.saveAll`.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional pre-qualification `OperationOutcome` output to patient NDJSON files.
  * Added configuration controls for enabling output and including issue expressions.
  * OperationOutcome entries now group unacceptable findings by category and include relevant report locations and expressions.
  * Added safe append support for existing patient data files, including duplicate-write prevention.
* **Tests**
  * Added automated and end-to-end coverage for configuration, outcome generation, blob appending, and validation workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

