### PR TITLE
TECH_DEBT: Run every E2E validator before failing the run

### DIFF
--- a/DotNet/Automation.UI/Services/RunExecutor.cs
+++ b/DotNet/Automation.UI/Services/RunExecutor.cs
@@ -614,6 +614,14 @@ internal sealed class RunExecutor
 
             var validatorResults = new List<PipelineSummarySnapshotBuilder.ValidatorResultSnapshot>();
 
+            // Validator failures are collected rather than thrown immediately, and re-thrown together
+            // once every validator has run. Failing on the first one hid the evidence needed to
+            // localise a discrepancy: the ABS manifest validator runs first, so when it reported a
+            // missing resource the DataAcquisition and Normalization validators never executed, and
+            // there was no way to tell whether the resource had been lost upstream of the aggregation
+            // or by it. The layers are only diagnostic when read together.
+            var validatorFailures = new List<string>();
+
             async Task RunValidator(string name, Func<Task> action)
             {
                 try
@@ -641,8 +649,10 @@ internal sealed class RunExecutor
                         Outcome = "Failed",
                         IssueCount = issueCount
                     });
-                    // Re-throw so the run still fails as before.
-                    throw;
+
+                    // Collected, not thrown: the remaining validators still run, and the run fails
+                    // with all of their findings once they have.
+                    validatorFailures.Add($"{name}: {ex.Message}");
                 }
                 finally
                 {
@@ -786,6 +796,15 @@ internal sealed class RunExecutor
 
             await RunValidator("VALIDATION RESULTS (API)", () =>
                 validationResultsValidator.ValidateAllAsync(facilityId, reportId, expectedAllPatientIds, scenarioConfig.LokiScrapeWindow));
+
+            // Thrown before cleanup, matching the previous behaviour of leaving a failed run's data in
+            // place for inspection.
+            if (validatorFailures.Count > 0)
+            {
+                throw new InvalidOperationException(
+                    $"{validatorFailures.Count} validator(s) failed:{Environment.NewLine}" +
+                    string.Join(Environment.NewLine, validatorFailures.Select(failure => "  - " + failure)));
+            }
 
             await RunCleanupHelper.CleanupAfterRunAsync(
                 scenarioConfig,


### PR DESCRIPTION
### 🛠️ Description of Changes

Makes a failing E2E run report **all** validator findings instead of stopping at the first.

The scenario runner threw on the first validator failure. Because `REPORT INTERNAL ABS MANIFEST VALIDATION` runs first, a missing-resource report from it meant the Report, DataAcquisition, Normalization, Tenant and Validation-results validators never executed — so there was no way to tell whether a resource had been lost *upstream of* aggregation or *by* aggregation. The layers are only diagnostic when read together, and the first to fail is the least informative on its own.

- `RunValidator` records the failure and returns instead of re-throwing, so the remaining validators still run and still report into the dashboard snapshot.
- The run fails after the last validator with every collected failure listed.
- The throw happens before `RunCleanupHelper.CleanupAfterRunAsync`, preserving the existing behaviour of leaving a failed run's data in place for inspection.

No change to what any validator asserts, or to whether a run passes or fails — only to how much is known when it fails.

### 🧪 Testing Performed

Builds clean (`Automation.UI`, and the full solution).

**Motivating case:** an intermittent failure where the ABS manifest is short exactly one resource, always the last of its type — `Observation-030` of 30, `Observation-020` of 20. It is **not** caused by any particular change: the same commit was run twice and passed once, failed once (`76aa9939f`, runs 29959737422 and its re-run). Diagnosing it needs to know whether the missing resource reached the DataAcquisition and Normalization databases, and today that information is destroyed by the first-failure throw. With this change the next occurrence answers that question by itself.

Not verified against a live failing run — that requires reproducing an intermittent failure. The change is exercised by every E2E run, and a passing run is unaffected because no failures are collected.

### 🧑‍🔬 Unit Testing

- Coverage: 0.0%

- [ ] I have written or updated unit tests to cover my changes
- Justification: `RunExecutor` has no existing unit tests, and the affected code is a local function inside a single large orchestration method with heavy service dependencies (seven injected validators, snapshot store, Loki scraper, FHIR loader). Testing this behaviour would require extracting the validation section first — a refactor larger than the change itself, and one that would obscure it in review. Deliberately not bundled.

### 📓 Documentation Updated

None required — internal test-harness behaviour, no configuration keys, API surface or event contracts affected.

### 🔗 Related

Diagnostic groundwork for the intermittent last-resource loss described above; the bug itself is tracked separately.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Validation runs now complete all applicable checks, collecting every failure before reporting results.
  * Error messages include aggregated details from each failed validation, making issues easier to diagnose.
  * Failed-run data remains available for inspection after validation errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
