### PR TITLE
LEGLINK-814: Duplicate CSV codes resolve last-one-wins at read time

### DIFF
--- a/DotNet/ServiceTests/UnitTests/Terminology/Controllers/ConfigControllerTests.cs
+++ b/DotNet/ServiceTests/UnitTests/Terminology/Controllers/ConfigControllerTests.cs
@@ -161,6 +161,28 @@ public class ConfigControllerTests
     }
 
     [Fact]
+    public void GetCodeSystemCode_DuplicateCode_ReturnsLastOccurrence()
+    {
+        // A CSV may list the same code twice with differing status (Active then Inactive).
+        // Last-one-wins (LEGLINK-599/814): the endpoint must return the last occurrence's status,
+        // agreeing with $validate-code rather than returning the first (Active) entry.
+        const string code = "ACCTRECEIVABLE";
+        var codeGroup = CodeSystemWithCodes(
+            new CodeSystemCode { Value = code, Display = "account receivable", Status = CodeStatus.Active },
+            new CodeSystemCode { Value = code, Display = "account receivable", Status = CodeStatus.Inactive });
+        _mockCacheService
+            .Setup(x => x.GetCodeGroupById(CodeGroup.CodeGroupTypes.CodeSystem, CodeSystemId, null))
+            .Returns(codeGroup);
+
+        var result = _controller.GetCodeSystemCode(CodeSystemId, code);
+
+        var ok = Assert.IsType<OkObjectResult>(result.Result);
+        var match = Assert.IsType<CodeSystemCode>(ok.Value);
+        Assert.Equal(code, match.Value);
+        Assert.Equal(CodeStatus.Inactive, match.Status);
+    }
+
+    [Fact]
     public void GetCodeSystemCode_Match_ReturnsOkWithCode()
     {
         var expected = new Code { Value = "12345", Display = "Matching code" };

--- a/DotNet/ServiceTests/UnitTests/Terminology/Services/FhirServiceTests.cs
+++ b/DotNet/ServiceTests/UnitTests/Terminology/Services/FhirServiceTests.cs
@@ -239,6 +239,59 @@ public class FhirServiceTests
     }
 
     [Fact]
+    public void ValidateCodeInValueSet_WithDuplicateCodeSystemEntries_RejoinsLastStatus()
+    {
+        // Arrange
+        // The CodeSystem lists the member code twice with differing status (Active then Inactive).
+        // The value-set rejoin must honor last-one-wins (LEGLINK-814) and report the code inactive.
+        var valueSetId = "test-vs-dup-rejoin";
+        var code = "ACCTRECEIVABLE";
+        var system = "http://test.system";
+        var display = "account receivable";
+
+        var valueSetGroup = new CodeGroup
+        {
+            Id = valueSetId,
+            Type = CodeGroup.CodeGroupTypes.ValueSet,
+            Codes = new Dictionary<string, List<Code>>
+            {
+                { system, new List<Code> { new() { Value = code, Display = display } } }
+            }
+        };
+        var codeSystemGroup = new CodeGroup
+        {
+            Url = system,
+            Type = CodeGroup.CodeGroupTypes.CodeSystem,
+            Codes = new Dictionary<string, List<Code>>
+            {
+                {
+                    system,
+                    new List<Code>
+                    {
+                        new CodeSystemCode { Value = code, Display = display, Status = CodeStatus.Active },
+                        new CodeSystemCode { Value = code, Display = display, Status = CodeStatus.Inactive }
+                    }
+                }
+            }
+        };
+
+        _mockCacheService
+            .Setup(x => x.GetCodeGroupById(CodeGroup.CodeGroupTypes.ValueSet, valueSetId, It.IsAny<string>()))
+            .Returns(valueSetGroup);
+        _mockCacheService
+            .Setup(x => x.GetCodeGroup(CodeGroup.CodeGroupTypes.CodeSystem, system, It.IsAny<string>()))
+            .Returns(codeSystemGroup);
+
+        // Act
+        var result = _service.ValidateCodeInValueSet(null, valueSetId, system, code, display, null);
+
+        // Assert
+        Assert.True(result.GetSingleValue<FhirBoolean>("result")?.Value);
+        var outcome = Assert.IsType<OperationOutcome>(result.Parameter.Single(p => p.Name == "issues").Resource);
+        Assert.Equal("Code is inactive.", Assert.Single(outcome.Issue).Details?.Text);
+    }
+
+    [Fact]
     public void ValidateCodeInValueSet_WithActiveMemberCode_ReturnsNoIssue()
     {
         // Arrange
@@ -1111,6 +1164,53 @@ public class FhirServiceTests
         Assert.Equal(_mockValueSets[0].Id, result.Entry[0].Resource.Id);
         Assert.Equal("ValueSet", result.Entry[1].Resource.TypeName);
         Assert.Equal(_mockValueSets[1].Id, result.Entry[1].Resource.Id);
+    }
+
+    #endregion
+
+    #region GetCodeSystems Tests
+
+    [Fact]
+    public void GetCodeSystems_WithDuplicateCode_EmitsSingleConceptWithLastDisplay()
+    {
+        // Arrange
+        // The CSV lists the same code twice; a non-summary read must emit it once, keeping the
+        // last occurrence's display (LEGLINK-814 dedup for $expand/read).
+        var codeSystemId = "v3-ActCode";
+        var url = "http://terminology.hl7.org/CodeSystem/v3-ActCode";
+        var code = "ACCTRECEIVABLE";
+
+        var mockCodeGroup = new CodeGroup
+        {
+            Id = codeSystemId,
+            Url = url,
+            Type = CodeGroup.CodeGroupTypes.CodeSystem,
+            Resource = new CodeSystem { Id = codeSystemId, Url = url },
+            Codes = new Dictionary<string, List<Code>>
+            {
+                {
+                    url,
+                    new List<Code>
+                    {
+                        new CodeSystemCode { Value = code, Display = "first display", Status = CodeStatus.Active },
+                        new CodeSystemCode { Value = code, Display = "last display", Status = CodeStatus.Inactive }
+                    }
+                }
+            }
+        };
+
+        _mockCacheService
+            .Setup(x => x.GetCodeGroup(CodeGroup.CodeGroupTypes.CodeSystem, url, It.IsAny<string>()))
+            .Returns(mockCodeGroup);
+
+        // Act (summary omitted -> concepts are materialized)
+        var result = _service.GetCodeSystems(url, null);
+
+        // Assert
+        var codeSystem = Assert.IsType<CodeSystem>(Assert.Single(result.Entry).Resource);
+        var concept = Assert.Single(codeSystem.Concept);
+        Assert.Equal(code, concept.Code);
+        Assert.Equal("last display", concept.Display);
     }
 
     #endregion

--- a/DotNet/Terminology/Controllers/ConfigController.cs
+++ b/DotNet/Terminology/Controllers/ConfigController.cs
@@ -87,9 +87,12 @@ public class ConfigController(ICodeGroupCacheService cacheService, ILogger<Confi
                 type: "https://tools.ietf.org/html/rfc9110#section-15.5.5");
         }
 
+        // A CSV may list the same code more than once with differing status; the last occurrence
+        // wins (LEGLINK-599/814). LastOrDefault mirrors FhirService.BuildMatchResult's last-match
+        // selection so this endpoint agrees with $validate-code.
         var match = codeGroup.Codes.Values
             .SelectMany(codes => codes)
-            .FirstOrDefault(c => string.Equals(c.Value, cleanCode, StringComparison.Ordinal));
+            .LastOrDefault(c => string.Equals(c.Value, cleanCode, StringComparison.Ordinal));
 
         if (match == null)
         {

--- a/DotNet/Terminology/Services/FhirService.cs
+++ b/DotNet/Terminology/Services/FhirService.cs
@@ -216,7 +216,13 @@ public class FhirService(ICodeGroupCacheService cacheService, ILogger<FhirServic
                 {
                     logger.LogDebug("Search performed without summary mode for code system {Url}", url.SanitizeAndRemove());
 
-                    foreach (var codeGroupCode in codeGroup.Codes[codeGroup.Codes.Keys.First()])
+                    // A CSV may list the same code more than once; emit each code once, keeping the
+                    // last occurrence's display so the read agrees with last-one-wins (LEGLINK-814).
+                    var lastByValue = codeGroup.Codes[codeGroup.Codes.Keys.First()]
+                        .GroupBy(c => c.Value)
+                        .Select(g => g.Last());
+
+                    foreach (var codeGroupCode in lastByValue)
                     {
                         clone.Concept.Add(new CodeSystem.ConceptDefinitionComponent()
                         {
@@ -631,10 +637,12 @@ public class FhirService(ICodeGroupCacheService cacheService, ILogger<FhirServic
         }
 
         var codeSystemGroup = cacheService.GetCodeGroup(CodeGroup.CodeGroupTypes.CodeSystem, system);
+        // When the CodeSystem lists the code more than once with differing status, the last
+        // occurrence wins (LEGLINK-599/814), matching BuildMatchResult's last-match selection.
         var match = codeSystemGroup?.Codes.Values
             .SelectMany(codes => codes)
             .OfType<CodeSystemCode>()
-            .FirstOrDefault(c => c.Value == codeObject.Value);
+            .LastOrDefault(c => c.Value == codeObject.Value);
 
         return match == null || match.Status == CodeStatus.Active;
     }


### PR DESCRIPTION
### 🛠️ Description of Changes

Fixes **LEGLINK-814** — a regression of LEGLINK-599. When a terminology CSV lists the same code twice with differing status (e.g. `ACCTRECEIVABLE` in `v3-ActCode` as Active then Inactive), the platform must treat the **last** occurrence as authoritative ("last one wins").

LEGLINK-633 deliberately moved dedup from load time to **read time** (keep duplicates in the list, select the last match at query time) for performance. `FhirService.BuildMatchResult` did this correctly, but three read paths still selected the *first* match — so a code marked active-then-inactive was reported active, and the cached-code GET endpoint disagreed with `$validate-code` on the same code.

This PR corrects all three read paths (no load-time dedup is re-added, preserving the LEGLINK-633 performance design):

- **`ConfigController.GetCodeSystemCode`** — the cached-code GET endpoint (`config/code-systems/{id}/codes/{code}`, the exact ticket repro) now selects the last occurrence (`LastOrDefault`), agreeing with `$validate-code`.
- **`FhirService.ResolveIsActive`** — the value-set-member → CodeSystem status rejoin now selects the last CodeSystem occurrence, so `ValueSet/$validate-code` reports inactive for a last-inactive duplicate. *(Covers the "apply to valueset imports" requirement.)*
- **`FhirService.GetCodeSystems`** — a non-summary CodeSystem read/`$expand` now collapses duplicate codes to a single concept carrying the last-occurrence display.

### 🧪 Testing Performed

- `dotnet test DotNet/ServiceTests/ServiceTests.csproj --filter FullyQualifiedName~Terminology` → **56 passed, 0 failed**, including 3 new regression tests.
- Manual parity against the ticket (CSV with `ACCTRECEIVABLE` Active-then-Inactive, cache reloaded):
  - `GET .../config/code-systems/v3-ActCode/codes/ACCTRECEIVABLE` → `status: "Inactive"`.
  - `POST .../fhir/CodeSystem/$validate-code` (url=v3-ActCode, code=ACCTRECEIVABLE) → `result: true` + warning "Code is inactive." (now consistent with the GET).
  - `POST .../fhir/ValueSet/$validate-code` for a value set containing that code → inactive warning.

### 🧑‍🔬 Unit Testing

- [x] I have written or updated unit tests to cover my changes
- Coverage: 100.0%
  - `ConfigControllerTests.GetCodeSystemCode_DuplicateCode_ReturnsLastOccurrence`
  - `FhirServiceTests.ValidateCodeInValueSet_WithDuplicateCodeSystemEntries_RejoinsLastStatus`
  - `FhirServiceTests.GetCodeSystems_WithDuplicateCode_EmitsSingleConceptWithLastDisplay`

### 📓 Documentation Updated

No documentation changes required — no new config keys, Kafka topics, or API surface changes (behavior fix only).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved terminology lookups when duplicate codes are present.
  - Duplicate code entries now consistently use the last listed status, ensuring accurate active/inactive results.
  - Removed repeated codes from generated code system results.
  - When duplicates have different display names, the most recently listed display value is retained.
  - Code validation and terminology responses now apply consistent duplicate-handling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
