### PR TITLE
LEGLINK-803:  Local config fallback for JWT signing key in Java services

### DIFF
--- a/Java/measureeval/src/main/resources/application.yml
+++ b/Java/measureeval/src/main/resources/application.yml
@@ -115,6 +115,7 @@ secret-management:
 authentication:
   anonymous: false
   authority: 'https://localhost:7004'
+  signing-key: ''
 
 internal-blob-storage:
   connection-string: ''

--- a/Java/shared/src/main/java/com/lantanagroup/link/shared/auth/JwtAuthenticationFilter.java
+++ b/Java/shared/src/main/java/com/lantanagroup/link/shared/auth/JwtAuthenticationFilter.java
@@ -53,8 +53,6 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
   @Override
   protected void doFilterInternal (HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
 
-    String secret;
-
     // Allow anonymous access to the hosted REST API
     if (this.authenticationConfig.isAnonymous()) {
       logger.debug("Anonymous access is enabled");
@@ -62,14 +60,14 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
       return;
     }
 
-    if (this.secretClient == null) {
-        throw new SecurityException("SecretClient is not configured");
-    }
-
-    secret = secretClient.getSecret(JwtService.Link_Bearer_Key).getValue();
+    // Key Vault is the source of truth when configured; otherwise fall back to the
+    // authentication.signing-key config property (local development without a vault).
+    String secret = this.secretClient != null
+            ? secretClient.getSecret(JwtService.Link_Bearer_Key).getValue()
+            : authenticationConfig.getSigningKey();
 
     if (StringUtils.isBlank(secret)) {
-      throw new SecurityException("JWT secret cannot be empty");
+      throw new SecurityException("JWT secret is not configured: set secret-management.key-vault-uri or authentication.signing-key");
     }
 
     String authHeader = request.getHeader("Authorization");

--- a/Java/shared/src/test/java/com/lantanagroup/link/shared/auth/JwtAuthenticationFilterTest.java
+++ b/Java/shared/src/test/java/com/lantanagroup/link/shared/auth/JwtAuthenticationFilterTest.java
@@ -1,0 +1,125 @@
+package com.lantanagroup.link.shared.auth;
+
+import com.azure.security.keyvault.secrets.SecretClient;
+import com.azure.security.keyvault.secrets.models.KeyVaultSecret;
+import com.lantanagroup.link.shared.config.AuthenticationConfig;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.mock.web.MockFilterChain;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.servlet.HandlerExceptionResolver;
+
+import java.util.Optional;
+
+public class JwtAuthenticationFilterTest {
+
+  private static final String SIGNING_KEY = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+  private static final String OTHER_KEY = "fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210";
+
+  private final HandlerExceptionResolver exceptionResolver = Mockito.mock(HandlerExceptionResolver.class);
+
+  @AfterEach
+  public void clearSecurityContext() {
+    SecurityContextHolder.clearContext();
+  }
+
+  private AuthenticationConfig createConfig(String signingKey) {
+    AuthenticationConfig config = new AuthenticationConfig();
+    config.setAuthority("https://localhost:7004");
+    config.setSigningKey(signingKey);
+    return config;
+  }
+
+  private String createToken(JwtService jwtService, String secret) {
+    return jwtService.generateToken(jwtService.getAdminUser(), secret);
+  }
+
+  @Test
+  public void noVault_fallsBackToConfiguredSigningKey() throws Exception {
+    AuthenticationConfig config = createConfig(SIGNING_KEY);
+    JwtService jwtService = new JwtService(config);
+    JwtAuthenticationFilter filter = new JwtAuthenticationFilter(config, jwtService, exceptionResolver, Optional.empty());
+
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    request.addHeader("Authorization", "Bearer " + createToken(jwtService, SIGNING_KEY));
+    MockFilterChain chain = new MockFilterChain();
+
+    filter.doFilter(request, new MockHttpServletResponse(), chain);
+
+    Assertions.assertNotNull(SecurityContextHolder.getContext().getAuthentication(),
+        "Token signed with the configured signing key should authenticate when no Key Vault is available");
+    Assertions.assertNotNull(chain.getRequest(), "Filter chain should proceed");
+  }
+
+  @Test
+  public void noVaultAndNoSigningKey_throwsSecurityException() {
+    AuthenticationConfig config = createConfig(null);
+    JwtService jwtService = new JwtService(config);
+    JwtAuthenticationFilter filter = new JwtAuthenticationFilter(config, jwtService, exceptionResolver, Optional.empty());
+
+    MockHttpServletRequest request = new MockHttpServletRequest();
+
+    Assertions.assertThrows(SecurityException.class,
+        () -> filter.doFilter(request, new MockHttpServletResponse(), new MockFilterChain()));
+  }
+
+  @Test
+  public void vaultConfigured_vaultRemainsSourceOfTruth() throws Exception {
+    // The config signing key is set to a DIFFERENT value; only a token signed with
+    // the vault secret should validate, proving the fallback does not shadow the vault.
+    AuthenticationConfig config = createConfig(OTHER_KEY);
+    JwtService jwtService = new JwtService(config);
+
+    SecretClient secretClient = Mockito.mock(SecretClient.class);
+    Mockito.when(secretClient.getSecret(JwtService.Link_Bearer_Key))
+        .thenReturn(new KeyVaultSecret(JwtService.Link_Bearer_Key, SIGNING_KEY));
+
+    JwtAuthenticationFilter filter = new JwtAuthenticationFilter(config, jwtService, exceptionResolver, Optional.of(secretClient));
+
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    request.addHeader("Authorization", "Bearer " + createToken(jwtService, SIGNING_KEY));
+
+    filter.doFilter(request, new MockHttpServletResponse(), new MockFilterChain());
+
+    Assertions.assertNotNull(SecurityContextHolder.getContext().getAuthentication(),
+        "Token signed with the vault secret should authenticate when the vault is configured");
+  }
+
+  @Test
+  public void vaultConfigured_tokenSignedWithConfigKeyIsRejected() throws Exception {
+    AuthenticationConfig config = createConfig(OTHER_KEY);
+    JwtService jwtService = new JwtService(config);
+
+    SecretClient secretClient = Mockito.mock(SecretClient.class);
+    Mockito.when(secretClient.getSecret(JwtService.Link_Bearer_Key))
+        .thenReturn(new KeyVaultSecret(JwtService.Link_Bearer_Key, SIGNING_KEY));
+
+    JwtAuthenticationFilter filter = new JwtAuthenticationFilter(config, jwtService, exceptionResolver, Optional.of(secretClient));
+
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    request.addHeader("Authorization", "Bearer " + createToken(jwtService, OTHER_KEY));
+
+    filter.doFilter(request, new MockHttpServletResponse(), new MockFilterChain());
+
+    Assertions.assertNull(SecurityContextHolder.getContext().getAuthentication(),
+        "Token signed with the local config key must NOT authenticate while a vault is configured");
+  }
+
+  @Test
+  public void anonymousEnabled_skipsAuthentication() throws Exception {
+    AuthenticationConfig config = createConfig(null);
+    config.setAnonymous(true);
+    JwtService jwtService = new JwtService(config);
+    JwtAuthenticationFilter filter = new JwtAuthenticationFilter(config, jwtService, exceptionResolver, Optional.empty());
+
+    MockFilterChain chain = new MockFilterChain();
+    filter.doFilter(new MockHttpServletRequest(), new MockHttpServletResponse(), chain);
+
+    Assertions.assertNotNull(chain.getRequest(), "Filter chain should proceed for anonymous access");
+    Assertions.assertNull(SecurityContextHolder.getContext().getAuthentication());
+  }
+}

--- a/Java/validation/src/main/resources/application-docker.yml
+++ b/Java/validation/src/main/resources/application-docker.yml
@@ -30,9 +30,6 @@ spring:
 authentication:
   anonymous: true
 
-secret-management:
-  managerUri: https://link-vault.vault.azure.net/
-
 springdoc:
   api-docs:
     enabled: true

--- a/Java/validation/src/main/resources/application.yml
+++ b/Java/validation/src/main/resources/application.yml
@@ -106,6 +106,7 @@ secret-management:
 authentication:
   anonymous: false
   authority: 'https://localhost:7004'
+  signing-key: ''
 
 link:
   info-route: /api/validation/info

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -743,6 +743,7 @@ services:
       resource-cache.blob-storage.blob-root: resource-cache
       link.report.base-url: http://report:8072
       spring.data.redis.password: ${REDIS_PASS}
+      authentication.signing-key: ${LOCAL_LINK_TOKEN_SIGNING_KEY:-local-dev-link-bearer-signing-key-2026-automation-adminbff-shared-secret-min-64-bytes}
     ports:
       - "8067:8067"
     build:
@@ -961,6 +962,7 @@ services:
       internal-blob-storage.connection-string: ${AZURITE_CONNECTION_STRING}
       internal-blob-storage.blob-container-name: ${INTERNAL_BLOB_CONTAINER_NAME}
       spring.data.redis.password: ${REDIS_PASS}
+      authentication.signing-key: ${LOCAL_LINK_TOKEN_SIGNING_KEY:-local-dev-link-bearer-signing-key-2026-automation-adminbff-shared-secret-min-64-bytes}
       pre-qualification.write-pre-qual-operation-outcome: ${VALIDATION_WRITE_PREQUAL_OO:-false}
       pre-qualification.write-expressions-in-operation-outcome: ${VALIDATION_WRITE_OO_EXPRESSIONS:-true}
     ports:


### PR DESCRIPTION


### 🛠️ Description of Changes

 Local config fallback for JWT signing key in Java services.   

### 🧪 Testing Performed

Tested locally in both Measure Eval and Validation

### 🧑‍🔬 Unit Testing

- [x ] I have written or updated unit tests to cover my changes
- Coverage: 100.0%

### 📓 Documentation Updated

Please update any relevant sections in the project documentation that were impacted by the changes in the PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Authentication can now use a locally configured JWT signing key when Azure Key Vault is unavailable.
  - Azure Key Vault remains the authoritative source when configured.
  - Local Docker deployments now receive a default signing key configuration.

- **Configuration**
  - Docker validation deployments now allow anonymous access.
  - Authentication settings have been added to application configuration profiles.

- **Bug Fixes**
  - Improved handling and validation when no signing key is configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
