### PR TITLE
LEGLINK-639: Terminology reads value-set membership status

### DIFF
--- a/DotNet/ServiceTests/UnitTests/Terminology/Services/CodeGroupCacheServiceTests.cs
+++ b/DotNet/ServiceTests/UnitTests/Terminology/Services/CodeGroupCacheServiceTests.cs
@@ -183,8 +183,9 @@ public class CodeGroupCacheServiceTests
             Version = "1.0"
         };
 
-        var csvContent = @"system,code,display,extra
-http://test.system,123,Test Display,Extra Value";
+        // Four columns (system,code,display,status) is now valid; five columns is not.
+        var csvContent = @"system,code,display,status,extra
+http://test.system,123,Test Display,Active,Extra Value";
 
         using var reader = new StringReader(csvContent);
         using var csv = new CsvReader(reader, CultureInfo.InvariantCulture);
@@ -193,7 +194,7 @@ http://test.system,123,Test Display,Extra Value";
         var ex = Assert.Throws<InvalidOperationException>(() =>
             mockService.Object.ProcessValueSetCsv(codeGroup, csv));
 
-        Assert.Contains("ValueSet CSV must have exactly 3 columns", ex.Message);
+        Assert.Contains("ValueSet CSV must have", ex.Message);
     }
 
     [Fact]
@@ -221,8 +222,9 @@ http://test.system,123,Test Display,Extra Value";
                      "http://test.system,123,Test Display\r\n" +
                      "http://test.system,456,Another Display";
 
-        using var reader = new StringReader(csvData);
-        using var csv = new CsvReader(reader, CultureInfo.InvariantCulture);
+        // Use the same reader configuration LoadCache builds (MissingFieldFound tolerated), since a
+        // 3-column value set has no field at the optional status index.
+        using var csv = CreateCsvReader(csvData);
 
         var codeGroup = new CodeGroup
         {
@@ -576,6 +578,162 @@ http://test.system,123,Test Display,Extra Value";
         Assert.Equal(CodeStatus.Active, ((CodeSystemCode)codes[0]).Status);
         Assert.Equal(CodeStatus.Inactive, ((CodeSystemCode)codes[1]).Status);
         Assert.Equal(CodeStatus.Inactive, ((CodeSystemCode)codes[2]).Status);
+    }
+
+    [Fact]
+    public async Task LoadCache_ValueSetWithStatusColumn_LoadsValueSetCodeWithStatus()
+    {
+        // A four-column value set file (system,code,display,status) carries its own membership
+        // status, which is loaded as a ValueSetCode and is authoritative over the code system.
+        using var memoryCache = new MemoryCache(new MemoryCacheOptions());
+        var mockConfig = new Mock<IOptions<TerminologyConfig>>();
+        mockConfig.Setup(x => x.Value).Returns(_config);
+
+        var directoryFiles = new Dictionary<string, string[]>
+        {
+            ["/test/path/vs"] = new[] { "vs.json", "vs.csv" }
+        };
+        var fileContents = new Dictionary<string, string>
+        {
+            ["vs.json"] = "{ \"resourceType\": \"ValueSet\", \"id\": \"test-vs\", " +
+                          "\"url\": \"http://test.valueset\", \"version\": \"1.0\" }",
+            ["vs.csv"] = "system,code,display,status\r\n" +
+                         "http://test.system,123,Test Display,Active\r\n" +
+                         "http://test.system,456,Another Display,Inactive\r\n"
+        };
+
+        var service = new TestableCodeGroupCacheService(
+            _loggerMock.Object, memoryCache, mockConfig.Object, directoryFiles, fileContents);
+
+        // Act
+        await service.LoadCache();
+
+        // Assert - members are ValueSetCode instances carrying the file's membership status.
+        var codeGroup = service.GetCodeGroup(
+            CodeGroup.CodeGroupTypes.ValueSet, "http://test.valueset");
+
+        Assert.NotNull(codeGroup);
+        Assert.Equal("test-vs", codeGroup.Id);
+        var codes = codeGroup.Codes["http://test.system"];
+        Assert.Equal(2, codes.Count);
+        Assert.Equal(CodeStatus.Active, ((ValueSetCode)codes[0]).Status);
+        Assert.Equal(CodeStatus.Inactive, ((ValueSetCode)codes[1]).Status);
+    }
+
+    [Fact]
+    public async Task LoadCache_ValueSetBlankStatus_DefaultsToActive()
+    {
+        using var memoryCache = new MemoryCache(new MemoryCacheOptions());
+        var mockConfig = new Mock<IOptions<TerminologyConfig>>();
+        mockConfig.Setup(x => x.Value).Returns(_config);
+
+        var directoryFiles = new Dictionary<string, string[]>
+        {
+            ["/test/path/vs"] = new[] { "vs.json", "vs.csv" }
+        };
+        var fileContents = new Dictionary<string, string>
+        {
+            ["vs.json"] = "{ \"resourceType\": \"ValueSet\", \"id\": \"test-vs\", " +
+                          "\"url\": \"http://test.valueset\", \"version\": \"1.0\" }",
+            // Second row has a blank status column, which should default to Active.
+            ["vs.csv"] = "system,code,display,status\r\n" +
+                         "http://test.system,123,Test Display,Inactive\r\n" +
+                         "http://test.system,456,Another Display,\r\n"
+        };
+
+        var service = new TestableCodeGroupCacheService(
+            _loggerMock.Object, memoryCache, mockConfig.Object, directoryFiles, fileContents);
+
+        // Act
+        await service.LoadCache();
+
+        // Assert - the blank-status member is loaded as an Active ValueSetCode.
+        var codeGroup = service.GetCodeGroup(
+            CodeGroup.CodeGroupTypes.ValueSet, "http://test.valueset");
+
+        Assert.NotNull(codeGroup);
+        var codes = codeGroup.Codes["http://test.system"];
+        Assert.Equal(2, codes.Count);
+        Assert.Equal("456", codes[1].Value);
+        Assert.Equal(CodeStatus.Active, ((ValueSetCode)codes[1]).Status);
+    }
+
+    [Fact]
+    public async Task LoadCache_ValueSetNoStatusColumn_LoadsPlainCode()
+    {
+        // A three-column value set file has no membership status, so its members are plain Code
+        // instances (not ValueSetCode) and fall back to the code system status when validated.
+        using var memoryCache = new MemoryCache(new MemoryCacheOptions());
+        var mockConfig = new Mock<IOptions<TerminologyConfig>>();
+        mockConfig.Setup(x => x.Value).Returns(_config);
+
+        var directoryFiles = new Dictionary<string, string[]>
+        {
+            ["/test/path/vs"] = new[] { "vs.json", "vs.csv" }
+        };
+        var fileContents = new Dictionary<string, string>
+        {
+            ["vs.json"] = "{ \"resourceType\": \"ValueSet\", \"id\": \"test-vs\", " +
+                          "\"url\": \"http://test.valueset\", \"version\": \"1.0\" }",
+            ["vs.csv"] = "system,code,display\r\n" +
+                         "http://test.system,123,Test Display\r\n" +
+                         "http://test.system,456,Another Display\r\n"
+        };
+
+        var service = new TestableCodeGroupCacheService(
+            _loggerMock.Object, memoryCache, mockConfig.Object, directoryFiles, fileContents);
+
+        // Act
+        await service.LoadCache();
+
+        // Assert - members are plain Code (no membership status), not ValueSetCode.
+        var codeGroup = service.GetCodeGroup(
+            CodeGroup.CodeGroupTypes.ValueSet, "http://test.valueset");
+
+        Assert.NotNull(codeGroup);
+        var codes = codeGroup.Codes["http://test.system"];
+        Assert.Equal(2, codes.Count);
+        Assert.All(codes, code => Assert.Equal(
+            typeof(LantanaGroup.Link.Terminology.Application.Models.Code), code.GetType()));
+    }
+
+    [Fact]
+    public async Task LoadCache_ValueSetMixedCaseStatus_ParsesCaseInsensitively()
+    {
+        using var memoryCache = new MemoryCache(new MemoryCacheOptions());
+        var mockConfig = new Mock<IOptions<TerminologyConfig>>();
+        mockConfig.Setup(x => x.Value).Returns(_config);
+
+        var directoryFiles = new Dictionary<string, string[]>
+        {
+            ["/test/path/vs"] = new[] { "vs.json", "vs.csv" }
+        };
+        var fileContents = new Dictionary<string, string>
+        {
+            ["vs.json"] = "{ \"resourceType\": \"ValueSet\", \"id\": \"test-vs\", " +
+                          "\"url\": \"http://test.valueset\", \"version\": \"1.0\" }",
+            ["vs.csv"] = "system,code,display,status\r\n" +
+                         "http://test.system,123,Test Display,active\r\n" +
+                         "http://test.system,456,Another Display,INACTIVE\r\n" +
+                         "http://test.system,789,Third Display,Inactive\r\n"
+        };
+
+        var service = new TestableCodeGroupCacheService(
+            _loggerMock.Object, memoryCache, mockConfig.Object, directoryFiles, fileContents);
+
+        // Act
+        await service.LoadCache();
+
+        // Assert - lowercase/uppercase/mixed-case status all load and normalize correctly.
+        var codeGroup = service.GetCodeGroup(
+            CodeGroup.CodeGroupTypes.ValueSet, "http://test.valueset");
+
+        Assert.NotNull(codeGroup);
+        var codes = codeGroup.Codes["http://test.system"];
+        Assert.Equal(3, codes.Count);
+        Assert.Equal(CodeStatus.Active, ((ValueSetCode)codes[0]).Status);
+        Assert.Equal(CodeStatus.Inactive, ((ValueSetCode)codes[1]).Status);
+        Assert.Equal(CodeStatus.Inactive, ((ValueSetCode)codes[2]).Status);
     }
 
     // Loads two versions of the same code group into a real cache. Defaults to "4.0.9" and

--- a/DotNet/ServiceTests/UnitTests/Terminology/Services/FhirServiceTests.cs
+++ b/DotNet/ServiceTests/UnitTests/Terminology/Services/FhirServiceTests.cs
@@ -461,6 +461,99 @@ public class FhirServiceTests
     }
 
     [Fact]
+    public void ValidateCodeInValueSet_ValueSetCodeInactive_OverridesActiveCodeSystem_ReturnsInactiveIssue()
+    {
+        // Arrange - the member carries its own inactive membership status (a 4-column value set file).
+        // Even though the CodeSystem marks the code Active, the value set membership status wins.
+        var valueSetId = "test-vs-member-inactive";
+        var code = "member-inactive-code";
+        var system = "http://test.system";
+        var display = "Member Inactive Code";
+
+        var valueSetGroup = new CodeGroup
+        {
+            Id = valueSetId,
+            Type = CodeGroup.CodeGroupTypes.ValueSet,
+            Codes = new Dictionary<string, List<Code>>
+            {
+                { system, new List<Code> { new ValueSetCode { Value = code, Display = display, Status = CodeStatus.Inactive } } }
+            }
+        };
+        // CodeSystem says Active; it must NOT be consulted because the membership status is authoritative.
+        var codeSystemGroup = new CodeGroup
+        {
+            Url = system,
+            Type = CodeGroup.CodeGroupTypes.CodeSystem,
+            Codes = new Dictionary<string, List<Code>>
+            {
+                { system, new List<Code> { new CodeSystemCode { Value = code, Display = display, Status = CodeStatus.Active } } }
+            }
+        };
+
+        _mockCacheService
+            .Setup(x => x.GetCodeGroupById(CodeGroup.CodeGroupTypes.ValueSet, valueSetId, It.IsAny<string>()))
+            .Returns(valueSetGroup);
+        _mockCacheService
+            .Setup(x => x.GetCodeGroup(CodeGroup.CodeGroupTypes.CodeSystem, system, It.IsAny<string>()))
+            .Returns(codeSystemGroup);
+
+        // Act
+        var result = _service.ValidateCodeInValueSet(null, valueSetId, system, code, display, null);
+
+        // Assert - membership status makes it inactive despite the active CodeSystem.
+        Assert.True(result.GetSingleValue<FhirBoolean>("result")?.Value);
+        var issuesParameter = result.Parameter.FirstOrDefault(p => p.Name == "issues");
+        Assert.NotNull(issuesParameter);
+        var outcome = Assert.IsType<OperationOutcome>(issuesParameter.Resource);
+        Assert.Equal("Code is inactive.", Assert.Single(outcome.Issue).Details?.Text);
+    }
+
+    [Fact]
+    public void ValidateCodeInValueSet_ValueSetCodeActive_OverridesInactiveCodeSystem_ReturnsNoIssue()
+    {
+        // Arrange - the member carries its own active membership status; the CodeSystem is not consulted,
+        // so an inactive CodeSystem status does not make an active value set member inactive.
+        var valueSetId = "test-vs-member-active";
+        var code = "member-active-code";
+        var system = "http://test.system";
+        var display = "Member Active Code";
+
+        var valueSetGroup = new CodeGroup
+        {
+            Id = valueSetId,
+            Type = CodeGroup.CodeGroupTypes.ValueSet,
+            Codes = new Dictionary<string, List<Code>>
+            {
+                { system, new List<Code> { new ValueSetCode { Value = code, Display = display, Status = CodeStatus.Active } } }
+            }
+        };
+        // CodeSystem says Inactive; it must NOT be consulted because the membership status is authoritative.
+        var codeSystemGroup = new CodeGroup
+        {
+            Url = system,
+            Type = CodeGroup.CodeGroupTypes.CodeSystem,
+            Codes = new Dictionary<string, List<Code>>
+            {
+                { system, new List<Code> { new CodeSystemCode { Value = code, Display = display, Status = CodeStatus.Inactive } } }
+            }
+        };
+
+        _mockCacheService
+            .Setup(x => x.GetCodeGroupById(CodeGroup.CodeGroupTypes.ValueSet, valueSetId, It.IsAny<string>()))
+            .Returns(valueSetGroup);
+        _mockCacheService
+            .Setup(x => x.GetCodeGroup(CodeGroup.CodeGroupTypes.CodeSystem, system, It.IsAny<string>()))
+            .Returns(codeSystemGroup);
+
+        // Act
+        var result = _service.ValidateCodeInValueSet(null, valueSetId, system, code, display, null);
+
+        // Assert - active membership status means no inactive issue, despite the inactive CodeSystem.
+        Assert.True(result.GetSingleValue<FhirBoolean>("result")?.Value);
+        Assert.Null(result.Parameter.FirstOrDefault(p => p.Name == "issues"));
+    }
+
+    [Fact]
     public void ValidateCodeInValueSet_WithInvalidCode_ReturnsFalse()
     {
         // Arrange

--- a/DotNet/Terminology/Application/Models/CsvValueSetRecord.cs
+++ b/DotNet/Terminology/Application/Models/CsvValueSetRecord.cs
@@ -26,4 +26,13 @@ public class CsvValueSetRecord
     /// </summary>
     [Index(2)]
     public required string Display { get; set; }
+
+    /// <summary>
+    /// Indicates the value set membership status of the code, Active or Inactive.
+    /// This column is optional; files without it are treated as having no membership status.
+    /// </summary>
+    [Index(3)]
+    [Default(CodeStatus.Active)]
+    [EnumIgnoreCase]
+    public CodeStatus Status { get; set; } = CodeStatus.Active;
 }

--- a/DotNet/Terminology/Application/Models/ValueSetCode.cs
+++ b/DotNet/Terminology/Application/Models/ValueSetCode.cs
@@ -1,0 +1,19 @@
+namespace LantanaGroup.Link.Terminology.Application.Models;
+
+/// <summary>
+/// Represents a value set member code that carries its own membership status.
+/// </summary>
+/// <remarks>
+/// Value set membership status is independent of the underlying code system status: an intensional
+/// value set is expanded from a code system, and a code can remain active in the code system yet be
+/// dropped from the value set's membership. When a value set member is loaded as a <see cref="ValueSetCode"/>
+/// its <see cref="Status"/> is authoritative and overrides the code system. Members loaded as a plain
+/// <see cref="Code"/> (a value set file with no status column) fall back to the code system status.
+/// </remarks>
+public class ValueSetCode : Code
+{
+    /// <summary>
+    /// Gets or sets the value set membership status of the code.
+    /// </summary>
+    public CodeStatus Status { get; set; } = CodeStatus.Active;
+}

--- a/DotNet/Terminology/Services/CodeGroupCacheService.cs
+++ b/DotNet/Terminology/Services/CodeGroupCacheService.cs
@@ -238,10 +238,15 @@ public class CodeGroupCacheService(
         csv.Read();
         csv.ReadHeader();
         var headers = csv.HeaderRecord;
-        if (headers == null || headers.Length != 3)
+        if (headers == null || headers.Length > 4 || headers.Length < 3)
         {
-            throw new InvalidOperationException("ValueSet CSV must have exactly 3 columns: code, display, and system");
+            throw new InvalidOperationException("ValueSet CSV must have 3 or 4 columns: system, code, display, and optionally status.");
         }
+
+        // A 4-column file carries value set membership status; a 3-column file does not.
+        // Members loaded with membership status are authoritative; members without it fall back to
+        // the code system status when validated (see FhirService.ResolveIsActive).
+        bool hasStatusColumn = headers.Length == 4;
 
         var records = csv.GetRecords<CsvValueSetRecord>();
         string? system = null;
@@ -277,11 +282,23 @@ public class CodeGroupCacheService(
                 continue;
             }
 
-            systemCodes.Add(new Code
+            if (hasStatusColumn)
             {
-                Value = code,
-                Display = display
-            });
+                systemCodes.Add(new ValueSetCode
+                {
+                    Value = code,
+                    Display = display,
+                    Status = record.Status
+                });
+            }
+            else
+            {
+                systemCodes.Add(new Code
+                {
+                    Value = code,
+                    Display = display
+                });
+            }
         }
 
         SetCodeGroup(codeGroup);
@@ -389,9 +406,10 @@ public class CodeGroupCacheService(
                 using var reader = new StringReader(csvContent);
                 var config = new CsvConfiguration(CultureInfo.InvariantCulture);
 
-                // CodeSystem CSVs have an optional trailing status column, so a missing field is
-                // tolerated there. ValueSet keeps strict missing-field validation.
-                if (codeGroup.Type == CodeGroup.CodeGroupTypes.CodeSystem)
+                // Both CodeSystem and ValueSet CSVs have an optional trailing status column, so a
+                // missing field is tolerated (a 3-column value set has no Status field to map).
+                if (codeGroup.Type == CodeGroup.CodeGroupTypes.CodeSystem ||
+                    codeGroup.Type == CodeGroup.CodeGroupTypes.ValueSet)
                     config.MissingFieldFound = null;
 
                 using var csv = new CsvReader(reader, config);

--- a/DotNet/Terminology/Services/FhirService.cs
+++ b/DotNet/Terminology/Services/FhirService.cs
@@ -620,8 +620,10 @@ public class FhirService(ICodeGroupCacheService cacheService, ILogger<FhirServic
     }
 
     /// <summary>
-    /// Determines whether a matched code is active. CodeSystem members carry their own status; ValueSet members
-    /// are plain codes with no status, so their status is rejoined from the CodeSystem identified by <paramref name="system"/>.
+    /// Determines whether a matched code is active. CodeSystem members carry their own status. ValueSet members
+    /// that carry a membership status (loaded as a <see cref="ValueSetCode"/>) are authoritative and override the
+    /// code system. ValueSet members with no membership status (plain <see cref="Application.Models.Code"/>) have
+    /// their status rejoined from the CodeSystem identified by <paramref name="system"/>.
     /// Defaults to active when the code cannot be resolved to a loaded CodeSystem, preserving prior behavior.
     /// </summary>
     private bool ResolveIsActive(Application.Models.Code codeObject, string? system)
@@ -629,6 +631,12 @@ public class FhirService(ICodeGroupCacheService cacheService, ILogger<FhirServic
         if (codeObject is CodeSystemCode codeSystemCode)
         {
             return codeSystemCode.Status == CodeStatus.Active;
+        }
+
+        // Value set membership status, when present, is authoritative and overrides the code system.
+        if (codeObject is ValueSetCode valueSetCode)
+        {
+            return valueSetCode.Status == CodeStatus.Active;
         }
 
         if (string.IsNullOrEmpty(system))


### PR DESCRIPTION
### 🛠️ Description of Changes

Extends the optional `Status` (active/inactive) column support from CodeSystem CSV files to **ValueSet** CSV files, so value-set membership status is honored independently of code-system status.

Per Irene Zhuo, value-set *membership* carries its own active/inactive status: an intensional value set is expanded from a code system, and a code can remain **active in the code system yet be dropped from the value set's membership**. When a member carries a membership status it is **authoritative and overrides** the code system; a member with no membership status falls back to the existing code-system rejoin (LEGLINK-580 behavior).

- Added `ValueSetCode : Code` carrying its own `CodeStatus`.
- `CsvValueSetRecord` gains an optional `[Index(3)] Status` column (`[Default(Active)]` + `[EnumIgnoreCase]`), mirroring `CsvCodeSystemRecord`.
- `CodeGroupCacheService.ProcessValueSetCsv` now accepts **3 or 4 columns** (`system,code,display[,status]`) and selects the member type by header width — 4-col → `ValueSetCode`, 3-col → plain `Code`. This also fixes a latent bug where a 4-column value-set file threw in `ProcessValueSetCsv` and was silently swallowed by `LoadCache`, leaving that value set absent from the cache.
- `CodeGroupCacheService.LoadCache` now tolerates a missing trailing field for ValueSet (not just CodeSystem).
- `FhirService.ResolveIsActive` treats a `ValueSetCode` status as authoritative, falling through to the code-system rejoin only for plain `Code` members.

This is a Terminology-service-only change. The terminology service already emits the same `Code is inactive.` OperationOutcome whenever a code is inactive, so value-set-membership inactivation surfaces and categorizes through the identical Validation path — no Java, `categories.json`, `app-config.yaml`, or migration changes.

### 🧪 Testing Performed

- Ran the Terminology unit suite: `dotnet test DotNet/ServiceTests/ServiceTests.csproj --filter "FullyQualifiedName~Terminology"` → **62/62 passing** (includes the new value-set tests below and the existing CodeSystem/rejoin coverage).
- Verified the branch builds clean and rebased onto the latest `dev` (including LEGLINK-814 duplicate-CSV-code handling) with tests still green.

### 🧑‍🔬 Unit Testing

- Coverage: 100.0%

- [x] `CodeGroupCacheServiceTests.LoadCache_ValueSetWithStatusColumn_LoadsValueSetCodeWithStatus` — 4-col file loads `ValueSetCode` with the file's Active/Inactive status.
- [x] `CodeGroupCacheServiceTests.LoadCache_ValueSetBlankStatus_DefaultsToActive` — blank status defaults to Active.
- [x] `CodeGroupCacheServiceTests.LoadCache_ValueSetNoStatusColumn_LoadsPlainCode` — 3-col file loads plain `Code` (no membership status → rejoin path preserved).
- [x] `CodeGroupCacheServiceTests.LoadCache_ValueSetMixedCaseStatus_ParsesCaseInsensitively` — mixed-case status parses correctly.
- [x] `FhirServiceTests.ValidateCodeInValueSet_ValueSetCodeInactive_OverridesActiveCodeSystem_ReturnsInactiveIssue` — inactive membership overrides an active code system.
- [x] `FhirServiceTests.ValidateCodeInValueSet_ValueSetCodeActive_OverridesInactiveCodeSystem_ReturnsNoIssue` — active membership overrides an inactive code system.
- [x] Updated `ProcessValueSetCsv_InvalidColumnCount_ThrowsException` (4 columns is now valid; asserts on a 5-column header) and switched `ProcessValueSetCsv_WithValidData_CallsSetCodeGroup` to the shared `CreateCsvReader` helper.

### 📓 Documentation Updated

No documentation changes required — this is a data-format extension to an existing feature with no new config keys or public API surface.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - ValueSet CSV files now support an optional membership status column.
  - Membership statuses are parsed case-insensitively, default to Active when blank or omitted, and can override the underlying CodeSystem status.
  - ValueSet entries without a status continue to load as standard codes.

- **Bug Fixes**
  - Code activity validation now correctly honors ValueSet membership status when determining whether a code is active.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
