### PR TITLE
LEGLINK-837: Report persists PendingValidation before producing ReadyForValidation

### DIFF
--- a/DotNet/Report/KafkaProducers/ReadyForValidationProducer.cs
+++ b/DotNet/Report/KafkaProducers/ReadyForValidationProducer.cs
@@ -2,7 +2,6 @@
 using LantanaGroup.Link.Report.Domain.Managers;
 using LantanaGroup.Link.Report.Models;
 using LantanaGroup.Link.Shared.Application.Models;
-using LantanaGroup.Link.Shared.Application.Models.Integration.Report;
 using ReportingStatus = LantanaGroup.Link.Report.Domain.Enums.ReportingStatus;
 using SubmissionStatus = LantanaGroup.Link.Report.Domain.Enums.SubmissionStatus;
 using System.Text;
@@ -44,6 +43,24 @@ namespace LantanaGroup.Link.Report.KafkaProducers
         {
             cancellationToken.ThrowIfCancellationRequested();
 
+            // The PendingValidation status must be persisted before the message is produced.
+            // Otherwise a fast ValidationComplete round-trip can set PassedValidation/FailedValidation
+            // first, and the write below would regress the entry to PendingValidation after a
+            // SubmitPayload was already produced, permanently blocking report completion.
+            using var scope = _serviceScopeFactory.CreateScope();
+            var reportEntryManager = scope.ServiceProvider.GetRequiredService<IReportEntryManager>();
+            var entry = await reportEntryManager.GetEntry(scheduleId, patientId, cancellationToken);
+
+            if (entry == null)
+            {
+                throw new Exception($"No report entry record was found (ReportId = {scheduleId}, FacilityId = {facilityId}).");
+            }
+
+            entry.ReportingStatus = ReportingStatus.PendingValidation;
+            entry.SubmissionStatus = SubmissionStatus.PendingValidation;
+
+            await reportEntryManager.UpdateAsync(entry, cancellationToken);
+
             _logger.LogDebug("Producing ReadyForValidation (Facility = {FacilityId}, PatientId = {PatientId}, ReportScheduleId = {ReportScheduleId})", facilityId.SanitizeForLog(), patientId.SanitizeForLog(), scheduleId.SanitizeForLog());
 
             _readyForValidationProducer.Produce(nameof(KafkaTopic.ReadyForValidation),
@@ -68,19 +85,6 @@ namespace LantanaGroup.Link.Report.KafkaProducers
                 });
 
             _readyForValidationProducer.Flush();
-
-            var reportEntryManager = _serviceScopeFactory.CreateScope().ServiceProvider.GetRequiredService<IReportEntryManager>();
-            var entry = await reportEntryManager.GetEntry(scheduleId, patientId, CancellationToken.None);
-
-            if (entry == null)
-            {
-                throw new Exception($"No report entry record was found (ReportId = {scheduleId}, FacilityId = {facilityId}).");
-            }
-
-            entry.ReportingStatus = ReportingStatus.PendingValidation;
-            entry.SubmissionStatus = SubmissionStatus.PendingValidation;
-
-            await reportEntryManager.UpdateAsync(entry, CancellationToken.None);
         }
     }
 }


### PR DESCRIPTION

### 🛠️ Description of Changes

Report should persists PendingValidation before producing ReadyForValidation event

### 🧪 Testing Performed

Tested locally

### 🧑‍🔬 Unit Testing

- [ ] I have written or updated unit tests to cover my changes
- Coverage: 87.5%

### 📓 Documentation Updated

Please update any relevant sections in the project documentation that were impacted by the changes in the PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reports are now marked as **Pending Validation** before validation messages are sent.
  * Improved cancellation handling during report updates and message production.
  * Removed outdated post-production persistence behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
