### PR TITLE
LEGLINK-886: ValueSet $validate-code returns a message when the code is not found

### DIFF
--- a/DotNet/ServiceTests/UnitTests/Terminology/Controllers/FhirControllerTests.cs
+++ b/DotNet/ServiceTests/UnitTests/Terminology/Controllers/FhirControllerTests.cs
@@ -1,0 +1,144 @@
+using Hl7.Fhir.Model;
+using LantanaGroup.Link.Terminology.Application.Interfaces;
+using LantanaGroup.Link.Terminology.Application.Models;
+using LantanaGroup.Link.Terminology.Controllers;
+using LantanaGroup.Link.Terminology.Services;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+using Code = LantanaGroup.Link.Terminology.Application.Models.Code;
+
+namespace UnitTests.Terminology;
+
+/// <summary>
+/// Unit tests for the request handling in <see cref="FhirController"/>'s $validate-code actions:
+/// how untrusted query parameters are sanitized before they are compared against loaded terminology
+/// (LEGLINK-886) and which malformed requests are rejected with a 400 (LEGLINK-887).
+/// </summary>
+public class FhirControllerTests
+{
+    private readonly Mock<ICodeGroupCacheService> _mockCacheService;
+    private readonly FhirController _controller;
+
+    private const string ValueSetUrl = "http://test.org/ValueSet/loinc-subset";
+    private const string CodeSystemUrl = "http://loinc.org";
+    private const string LoincCode = "100105-6";
+
+    // A display carrying a character the HTML sanitizer would otherwise encode. Over 2,000 LOINC
+    // displays contain an ampersand, so this is the common case rather than an exotic one.
+    private const string DisplayWithAmpersand = "Filaria Ab.IgG & IgM panel";
+
+    public FhirControllerTests()
+    {
+        _mockCacheService = new Mock<ICodeGroupCacheService>();
+        var service = new FhirService(_mockCacheService.Object, new Mock<ILogger<FhirService>>().Object);
+        _controller = new FhirController(service);
+    }
+
+    private static CodeGroup BuildCodeGroup(CodeGroup.CodeGroupTypes type, string system) => new()
+    {
+        Id = "test-group",
+        Type = type,
+        Url = system,
+        Codes = new Dictionary<string, List<Code>>
+        {
+            { system, new List<Code> { new() { Value = LoincCode, Display = DisplayWithAmpersand } } }
+        }
+    };
+
+    private static Parameters AssertOkParameters(ActionResult<Parameters> result)
+    {
+        var okResult = Assert.IsType<OkObjectResult>(result.Result);
+        return Assert.IsType<Parameters>(okResult.Value);
+    }
+
+    [Fact]
+    public void ValidateCodeInValueSet_WithDisplayContainingAmpersand_ReturnsTrue()
+    {
+        // Arrange
+        _mockCacheService
+            .Setup(x => x.GetCodeGroup(CodeGroup.CodeGroupTypes.ValueSet, ValueSetUrl, It.IsAny<string>()))
+            .Returns(BuildCodeGroup(CodeGroup.CodeGroupTypes.ValueSet, CodeSystemUrl));
+
+        // Act
+        var result = _controller.ValidateCodeInValueSet(ValueSetUrl, null, CodeSystemUrl, LoincCode, DisplayWithAmpersand, null);
+
+        // Assert - encoding the "&" would report a spurious display mismatch
+        var parameters = AssertOkParameters(result);
+        Assert.True(parameters.GetSingleValue<FhirBoolean>("result")?.Value);
+    }
+
+    [Fact]
+    public void ValidateCodeInCodeSystem_WithDisplayContainingAmpersand_ReturnsTrue()
+    {
+        // Arrange
+        _mockCacheService
+            .Setup(x => x.GetCodeGroup(CodeGroup.CodeGroupTypes.CodeSystem, CodeSystemUrl, It.IsAny<string>()))
+            .Returns(BuildCodeGroup(CodeGroup.CodeGroupTypes.CodeSystem, CodeSystemUrl));
+
+        // Act
+        var result = _controller.ValidateCodeInCodeSystem(CodeSystemUrl, null, LoincCode, DisplayWithAmpersand, null);
+
+        // Assert
+        var parameters = AssertOkParameters(result);
+        Assert.True(parameters.GetSingleValue<FhirBoolean>("result")?.Value);
+    }
+
+    [Fact]
+    public void ValidateCodeInValueSet_WithMarkupOnlyDisplay_ReturnsBadRequest()
+    {
+        // Arrange
+        _mockCacheService
+            .Setup(x => x.GetCodeGroup(CodeGroup.CodeGroupTypes.ValueSet, ValueSetUrl, It.IsAny<string>()))
+            .Returns(BuildCodeGroup(CodeGroup.CodeGroupTypes.ValueSet, CodeSystemUrl));
+
+        // Act
+        var result = _controller.ValidateCodeInValueSet(
+            ValueSetUrl, null, CodeSystemUrl, LoincCode, "<script>alert('x')</script>", null);
+
+        // Assert - the display sanitizes away to nothing; passing the empty value on would skip the
+        // display check and answer result=true, so the request is rejected instead
+        var badRequest = Assert.IsType<BadRequestObjectResult>(result.Result);
+        Assert.Equal("Invalid value supplied for 'display'", badRequest.Value);
+    }
+
+    [Fact]
+    public void ValidateCodeInCodeSystem_WithMarkupOnlyDisplay_ReturnsBadRequest()
+    {
+        // Arrange
+        _mockCacheService
+            .Setup(x => x.GetCodeGroup(CodeGroup.CodeGroupTypes.CodeSystem, CodeSystemUrl, It.IsAny<string>()))
+            .Returns(BuildCodeGroup(CodeGroup.CodeGroupTypes.CodeSystem, CodeSystemUrl));
+
+        // Act
+        var result = _controller.ValidateCodeInCodeSystem(
+            CodeSystemUrl, null, LoincCode, "<script>alert('x')</script>", null);
+
+        // Assert
+        var badRequest = Assert.IsType<BadRequestObjectResult>(result.Result);
+        Assert.Equal("Invalid value supplied for 'display'", badRequest.Value);
+    }
+
+    [Fact]
+    public void ValidateCodeInValueSet_WithNoUrlOrId_ReturnsBadRequest()
+    {
+        // Act
+        var result = _controller.ValidateCodeInValueSet(null, null, null, LoincCode, null, null);
+
+        // Assert
+        var badRequest = Assert.IsType<BadRequestObjectResult>(result.Result);
+        Assert.Equal("No id or url parameter specified", badRequest.Value);
+    }
+
+    [Fact]
+    public void ValidateCodeInValueSet_WithEmptyUrl_ReturnsBadRequest()
+    {
+        // Act
+        var result = _controller.ValidateCodeInValueSet(string.Empty, null, null, LoincCode, null, null);
+
+        // Assert
+        var badRequest = Assert.IsType<BadRequestObjectResult>(result.Result);
+        Assert.Equal("No id or url parameter specified", badRequest.Value);
+    }
+}

--- a/DotNet/ServiceTests/UnitTests/Terminology/Services/FhirServiceTests.cs
+++ b/DotNet/ServiceTests/UnitTests/Terminology/Services/FhirServiceTests.cs
@@ -1307,4 +1307,119 @@ public class FhirServiceTests
     }
 
     #endregion
+
+    #region ValueSet $validate-code request handling (LEGLINK-886 / LEGLINK-887)
+
+    [Fact]
+    public void ValidateCodeInValueSet_WithCodeNotInAnySystem_ReturnsMessage()
+    {
+        // Arrange
+        var valueSetId = "test-vs-no-system";
+        var system = "http://test.system";
+
+        var mockCodeGroup = new CodeGroup
+        {
+            Id = valueSetId,
+            Type = CodeGroup.CodeGroupTypes.ValueSet,
+            Codes = new Dictionary<string, List<Code>>
+            {
+                { system, new List<Code> { new() { Value = "valid-code", Display = "Valid Code" } } }
+            }
+        };
+
+        _mockCacheService
+            .Setup(x => x.GetCodeGroupById(CodeGroup.CodeGroupTypes.ValueSet, valueSetId, It.IsAny<string>()))
+            .Returns(mockCodeGroup);
+
+        // Act (no system supplied -> the across-systems path, which previously omitted the message)
+        var result = _service.ValidateCodeInValueSet(null, valueSetId, null, "missing-code", null, null);
+
+        // Assert
+        var resultParameter = result.GetSingleValue<FhirBoolean>("result");
+        var messageParameter = result.GetSingleValue<FhirString>("message");
+
+        Assert.NotNull(resultParameter);
+        Assert.False(resultParameter.Value);
+        Assert.Equal("Code not found in ValueSet", messageParameter?.Value);
+    }
+
+    [Fact]
+    public void ValidateCodeInValueSet_WithCodeNotInAnySystem_MatchesSingleSystemMessage()
+    {
+        // Arrange
+        var valueSetId = "test-vs-message-parity";
+        var system = "http://test.system";
+
+        var mockCodeGroup = new CodeGroup
+        {
+            Id = valueSetId,
+            Type = CodeGroup.CodeGroupTypes.ValueSet,
+            Codes = new Dictionary<string, List<Code>>
+            {
+                { system, new List<Code> { new() { Value = "valid-code", Display = "Valid Code" } } }
+            }
+        };
+
+        _mockCacheService
+            .Setup(x => x.GetCodeGroupById(CodeGroup.CodeGroupTypes.ValueSet, valueSetId, It.IsAny<string>()))
+            .Returns(mockCodeGroup);
+
+        // Act
+        var withoutSystem = _service.ValidateCodeInValueSet(null, valueSetId, null, "missing-code", null, null);
+        var withSystem = _service.ValidateCodeInValueSet(null, valueSetId, system, "missing-code", null, null);
+
+        // Assert - supplying the system must not change the shape of the answer
+        Assert.Equal(
+            withSystem.GetSingleValue<FhirString>("message")?.Value,
+            withoutSystem.GetSingleValue<FhirString>("message")?.Value);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public void ValidateCodeInValueSet_WithNoValueSetIdentifier_ThrowsArgumentException(string? url)
+    {
+        // Act / Assert - a request that names no value set is malformed, so it must surface as a 400
+        var exception = Assert.Throws<ArgumentException>(() =>
+            _service.ValidateCodeInValueSet(url, null, null, "any-code", null, null));
+
+        Assert.Equal("No id or url parameter specified", exception.Message);
+    }
+
+    [Fact]
+    public void ValidateCodeInValueSet_WithQueryCodeAndParametersSystem_UsesParametersSystem()
+    {
+        // Arrange
+        var valueSetId = "test-vs-mixed-inputs";
+        var code = "test-code";
+        var matchingSystem = "http://test.system/b";
+
+        var mockCodeGroup = new CodeGroup
+        {
+            Id = valueSetId,
+            Type = CodeGroup.CodeGroupTypes.ValueSet,
+            Codes = new Dictionary<string, List<Code>>
+            {
+                { "http://test.system/a", new List<Code> { new() { Value = code, Display = "Wrong System" } } },
+                { matchingSystem, new List<Code> { new() { Value = code, Display = "Right System" } } }
+            }
+        };
+
+        _mockCacheService
+            .Setup(x => x.GetCodeGroupById(CodeGroup.CodeGroupTypes.ValueSet, valueSetId, It.IsAny<string>()))
+            .Returns(mockCodeGroup);
+
+        var parameters = new Parameters();
+        parameters.Add("system", new FhirUri(matchingSystem));
+
+        // Act - code arrives as a query parameter, system only in the body
+        var result = _service.ValidateCodeInValueSet(null, valueSetId, null, code, "Right System", parameters);
+
+        // Assert - without the body system the code resolves against the first system and the display fails
+        var resultParameter = result.GetSingleValue<FhirBoolean>("result");
+        Assert.NotNull(resultParameter);
+        Assert.True(resultParameter.Value);
+    }
+
+    #endregion
 }

--- a/DotNet/Terminology/Controllers/FhirController.cs
+++ b/DotNet/Terminology/Controllers/FhirController.cs
@@ -1,4 +1,5 @@
-﻿using Hl7.Fhir.Model;
+﻿using System.Net;
+using Hl7.Fhir.Model;
 using Hl7.Fhir.Rest;
 using LantanaGroup.Link.Shared.Application.Services.Security;
 using LantanaGroup.Link.Terminology.Services;
@@ -20,6 +21,39 @@ namespace LantanaGroup.Link.Terminology.Controllers;
 [ApiController]
 public class FhirController(FhirService fhirService) : Controller
 {
+    /// <summary>
+    /// Sanitizes an untrusted terminology value (url, system, code or display) that is compared
+    /// against loaded terminology content rather than rendered as markup.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="HtmlInputSanitizer.Sanitize"/> strips markup but also HTML-encodes the surviving text,
+    /// which corrupts values that legitimately contain reserved characters — over 2,000 LOINC displays
+    /// contain "&amp;", and encoding one to "&amp;amp;" turns a correct display into a spurious
+    /// "Display does not match code". Decoding afterwards restores the plain text while still dropping
+    /// any markup the sanitizer removed.
+    /// </remarks>
+    /// <exception cref="ArgumentException">
+    /// Thrown when a non-empty value sanitizes away to nothing, i.e. the caller supplied markup and no
+    /// content. The emptied value must not be passed on: an empty display disables the display check
+    /// entirely, so the request would be answered with result=true instead of being rejected.
+    /// </exception>
+    private static string? SanitizeTerminologyValue(string? value, string parameterName)
+    {
+        if (value is null)
+        {
+            return null;
+        }
+
+        var sanitized = WebUtility.HtmlDecode(value.Sanitize());
+
+        if (value.Length > 0 && sanitized.Length == 0)
+        {
+            throw new ArgumentException($"Invalid value supplied for '{parameterName}'");
+        }
+
+        return sanitized;
+    }
+
     #region Value Sets
 
     /// <summary>
@@ -193,10 +227,10 @@ public class FhirController(FhirService fhirService) : Controller
         try
         {
             return Ok(fhirService.ValidateCodeInCodeSystem(
-                url?.Sanitize(),
-                id?.Sanitize(),
-                code?.Sanitize(),
-                display?.Sanitize(),
+                SanitizeTerminologyValue(url, nameof(url)),
+                SanitizeTerminologyValue(id, nameof(id)),
+                SanitizeTerminologyValue(code, nameof(code)),
+                SanitizeTerminologyValue(display, nameof(display)),
                 parameters));
         }
         catch (ArgumentException ex)
@@ -216,7 +250,8 @@ public class FhirController(FhirService fhirService) : Controller
     /// <param name="parameters">Additional parameters supplied in the request body to guide the validation operation. This parameter is optional.</param>
     /// <returns>
     /// A <see cref="Parameters"/> resource that indicates the result of the validation and may contain
-    /// additional information about the validation outcome.
+    /// additional information about the validation outcome, or a 400 Bad Request response when neither
+    /// <paramref name="url"/> nor <paramref name="id"/> identifies a ValueSet.
     /// </returns>
     [HttpPost("ValueSet/$validate-code")]
     [HttpPost("ValueSet/{id}/$validate-code")]
@@ -226,7 +261,13 @@ public class FhirController(FhirService fhirService) : Controller
     {
         try
         {
-            return Ok(fhirService.ValidateCodeInValueSet(url, id, system, code, display, parameters));
+            return Ok(fhirService.ValidateCodeInValueSet(
+                SanitizeTerminologyValue(url, nameof(url)),
+                SanitizeTerminologyValue(id, nameof(id)),
+                SanitizeTerminologyValue(system, nameof(system)),
+                SanitizeTerminologyValue(code, nameof(code)),
+                SanitizeTerminologyValue(display, nameof(display)),
+                parameters));
         }
         catch (ArgumentException ex)
         {

--- a/DotNet/Terminology/Services/FhirService.cs
+++ b/DotNet/Terminology/Services/FhirService.cs
@@ -365,14 +365,16 @@ public class FhirService(ICodeGroupCacheService cacheService, ILogger<FhirServic
             codeGroup = cacheService.GetCodeGroupById(CodeGroup.CodeGroupTypes.ValueSet, id);
             url = codeGroup?.Url;
         }
+        else if (!string.IsNullOrEmpty(url))
+        {
+            codeGroup = cacheService.GetCodeGroup(CodeGroup.CodeGroupTypes.ValueSet, url);
+        }
         else
         {
-            if (url == null)
-            {
-                return CreateValidationParameters(false, "url parameter is required");
-            }
-
-            codeGroup = cacheService.GetCodeGroup(CodeGroup.CodeGroupTypes.ValueSet, url);
+            // A request that identifies no value set is malformed, not a failed validation. Throwing
+            // surfaces it as a 400 and matches ValidateCodeInCodeSystem; returning result=false here
+            // reported a well-formed "this code is invalid" answer to a question never asked (LEGLINK-887).
+            throw new ArgumentException("No id or url parameter specified");
         }
 
         if (codeGroup == null)
@@ -383,6 +385,11 @@ public class FhirService(ICodeGroupCacheService cacheService, ILogger<FhirServic
         // Priority 1: Direct parameters
         if (!string.IsNullOrEmpty(code))
         {
+            if (systemComponent?.Value != null && string.IsNullOrEmpty(system))
+            {
+                system = systemComponent.Value.ToString();
+            }
+
             if (displayComponent?.Value != null && string.IsNullOrEmpty(display))
             {
                 display = displayComponent.Value.ToString();
@@ -595,7 +602,10 @@ public class FhirService(ICodeGroupCacheService cacheService, ILogger<FhirServic
             }
         }
 
-        return CreateValidationParameters(false);
+        // Carry the same message as the single-system path. Omitting it left callers with a bare
+        // result=false — the Java validation support reads the "message" parameter to populate its
+        // CodeValidationResult, so the failure reached the report with no explanation (LEGLINK-886).
+        return CreateValidationParameters(false, $"Code not found in {codeGroup.Type}");
     }
 
     /// <summary>


### PR DESCRIPTION
### 🛠️ Description of Changes

Fixes [LEGLINK-886](https://lantana.atlassian.net/browse/LEGLINK-886): `POST /api/terminology/fhir/ValueSet/$validate-code` with an invalid `code` returned `200` with an incomplete payload — `{"result": false}` and no `message`.

The gap is in `ValidateCodeAcrossSystems`, the branch taken when the caller supplies no `system`. Every sibling path supplies a message; this one returned a bare `result`. Supplying `system` already produced `"Code not found in ValueSet"`, which is why it only surfaced on some requests. It's not cosmetic — `RemoteTermServiceValidation.getCodeResult` in the Java validation service reads the `message` parameter to populate its `CodeValidationResult`, so the failure reached the report with no explanation.

Four related defects in the same two `$validate-code` actions are fixed alongside it:

| Issue | Before | After |
|---|---|---|
| No `url` and no `id` ([LEGLINK-887](https://lantana.atlassian.net/browse/LEGLINK-887)) | `200 {"result": false, "message": "url parameter is required"}` | `400 No id or url parameter specified` |
| Correct display containing `&` | `200 {"result": false, "message": "Display does not match code"}` | `200 {"result": true}` |
| Display that is only markup | display silently emptied → `200 {"result": true}` | `400 Invalid value supplied for 'display'` |
| Query `code` + body `system` | body `system` ignored | body `system` honoured |

Two notes on the above:

- **The `&` bug is a distinct defect from 886 and is not currently ticketed.** `HtmlInputSanitizer.Sanitize()` strips markup but HTML-encodes the text it preserves, so a correct display containing `&` became `&amp;` and never matched. **2,204 LOINC displays contain an ampersand**, so any resource carrying one was getting a false `Display does not match code` through the validation pipeline. Sanitized values are now HTML-decoded, which drops markup without corrupting plain text. Happy to split this out if reviewers prefer.
- `ValueSet/$validate-code` was not sanitizing its query parameters at all, against the repo's input-sanitization rule. It now uses the same path as `CodeSystem/$validate-code`.

Nothing about the inactive-code behaviour from LEGLINK-639 changes; a regression check for it is included below.

### 🧪 Testing Performed

**Unit:** `dotnet test DotNet/ServiceTests/ServiceTests.csproj --filter FullyQualifiedName~UnitTests.Terminology` → **72 passed, 0 failed** (7 new).

**Manual against the local docker-compose stack** (`link-terminology` on :8076, real terminology data — 98 value sets, 91 code systems). Each case was run before and after the change:

| Request | Before | After |
|---|---|---|
| `ValueSet/$validate-code?url=<vs>&code=nosuchcode` | `{"result":false}` | `{"result":false,"message":"Code not found in ValueSet"}` |
| same, with `&system=<sys>` | `…"Code not found in ValueSet"` | unchanged |
| `ValueSet/$validate-code?url=&code=<valid>` | `200 {"result":false}` | `400` |
| `ValueSet/$validate-code?code=<valid>` (no `url`) | `200 {"result":false}` | `400` |
| `CodeSystem/$validate-code?url=http://loinc.org&code=100105-6&display=Filaria Ab.IgG & IgM panel` | `{"result":false,"message":"Display does not match code"}` | `{"result":true}` |
| `ValueSet/$validate-code` with `display=<script>alert(1)</script>` | `200` | `400 Invalid value supplied for 'display'` |
| valid code + system + display | `{"result":true}` | unchanged |
| wrong display | `…"Display does not match code"` | unchanged |
| inactive code `SS` in `v3-ActEncounterCode` | `{"result":true}` + inactive `issues` outcome | unchanged |

### 🧑‍🔬 Unit Testing

- [x] I have written or updated unit tests to cover my changes
- Coverage: 100.0%

### 📓 Documentation Updated

No documentation changes. `docs/command-validatevaluesetcode.html` already documents the `{result, message}` failure payload this PR makes the ValueSet endpoint produce consistently, and no config keys were added.


[LEGLINK-886]: https://lantana.atlassian.net/browse/LEGLINK-886?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LEGLINK-887]: https://lantana.atlassian.net/browse/LEGLINK-887?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminology validation for displays containing ampersands and HTML markup.
  * Invalid or missing ValueSet identifiers now return clearer 400-level errors.
  * Validation now correctly resolves the coding system when supplied through request parameters.
  * Failed cross-system validation responses now include a descriptive “Code not found” message.
* **Documentation**
  * Clarified that ValueSet validation requires an identifier and may return a 400 response.
* **Tests**
  * Added coverage for validation errors, identifier handling, display sanitization, and system resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->