### PR TITLE
LEGLINK-567: expose the vendor's signing key secret id on the facility response

### DIFF
--- a/DotNet/ServiceTests/IntegrationTests/Census/CensusIntegrationTestFixture.cs
+++ b/DotNet/ServiceTests/IntegrationTests/Census/CensusIntegrationTestFixture.cs
@@ -190,4 +190,6 @@ internal class NullTenantApiService : ITenantApiService
     public Task<bool> CheckFacilityExists(string facilityId, CancellationToken cancellationToken = default) => Task.FromResult(true);
     public Task<FacilityModel> GetFacilityConfig(string facilityId, CancellationToken cancellationToken = default)
         => Task.FromResult(new FacilityModel { FacilityId = facilityId });
+    public Task<string?> GetVendorSigningKeySecretId(string facilityId, CancellationToken cancellationToken = default)
+        => Task.FromResult<string?>(null);
 }

--- a/DotNet/ServiceTests/IntegrationTests/Tenant/FacilityVendorAuthenticationTests.cs
+++ b/DotNet/ServiceTests/IntegrationTests/Tenant/FacilityVendorAuthenticationTests.cs
@@ -1,0 +1,92 @@
+using LantanaGroup.Link.Shared.Application.Models.Tenant;
+using LantanaGroup.Link.Tenant.Business.Queries;
+using LantanaGroup.Link.Tenant.Data.Entities;
+using LantanaGroup.Link.Tenant.Entities;
+using LantanaGroup.Link.Tenant.Repository.Context;
+using Microsoft.Extensions.DependencyInjection;
+using Task = System.Threading.Tasks.Task;
+
+namespace IntegrationTests.Tenant;
+
+/// <summary>
+/// Data Acquisition reads the vendor's signing key off the facility response rather than making a
+/// second call for the vendor, so the facility projection has to carry it.
+/// </summary>
+[Collection("IntegrationTests")]
+[Trait("Category", "IntegrationTests")]
+public class FacilityVendorAuthenticationTests : IDisposable
+{
+    private readonly IServiceScope _scope;
+    private readonly IFacilityQueries _facilityQueries;
+    private readonly TenantDbContext _dbContext;
+
+    public FacilityVendorAuthenticationTests(TenantIntegrationTestFixture fixture)
+    {
+        _scope = fixture.ServiceProvider.CreateScope();
+        var serviceProvider = _scope.ServiceProvider;
+
+        _facilityQueries = serviceProvider.GetRequiredService<IFacilityQueries>();
+        _dbContext = serviceProvider.GetRequiredService<TenantDbContext>();
+    }
+
+    public void Dispose() => _scope.Dispose();
+
+    [Fact]
+    public async Task GetAsync_CarriesTheVendorsSigningKeySecretId()
+    {
+        var facilityId = await CreateFacilityWithVendorAsync(
+            new VendorAuthenticationSettings { SigningKeySecretId = "epic-signing-key" });
+
+        var facility = await _facilityQueries.GetAsync(facilityId, null, CancellationToken.None);
+
+        Assert.Equal("epic-signing-key", facility?.Vendor?.Authentication?.SigningKeySecretId);
+    }
+
+    [Fact]
+    public async Task GetAsync_ReturnsNoSigningKey_WhenTheVendorHasNoneConfigured()
+    {
+        var facilityId = await CreateFacilityWithVendorAsync(authentication: null);
+
+        var facility = await _facilityQueries.GetAsync(facilityId, null, CancellationToken.None);
+
+        Assert.NotNull(facility?.Vendor);
+        Assert.Null(facility!.Vendor!.Authentication?.SigningKeySecretId);
+    }
+
+    private async Task<string> CreateFacilityWithVendorAsync(VendorAuthenticationSettings? authentication)
+    {
+        var vendor = new Vendor
+        {
+            Id = Guid.NewGuid(),
+            Name = $"Vendor-{Guid.NewGuid():N}",
+            Authentication = authentication
+        };
+        var vendorVersion = new VendorVersion
+        {
+            Id = Guid.NewGuid(),
+            VendorId = vendor.Id,
+            Version = "default"
+        };
+        var facility = new Facility
+        {
+            Id = Guid.NewGuid(),
+            FacilityId = $"facility-{Guid.NewGuid():N}",
+            FacilityName = "Vendor Authentication Test Facility",
+            TimeZone = "America/Chicago",
+            VendorVersionId = vendorVersion.Id,
+            ScheduledReports = new ScheduledReportModel
+            {
+                Daily = [],
+                Weekly = [],
+                Monthly = []
+            }
+        };
+
+        await _dbContext.Vendors.AddAsync(vendor);
+        await _dbContext.VendorVersions.AddAsync(vendorVersion);
+        await _dbContext.Facilities.AddAsync(facility);
+        await _dbContext.SaveChangesAsync();
+
+        return facility.FacilityId;
+    }
+}

--- a/DotNet/Shared/Application/Services/ITenantApiService.cs
+++ b/DotNet/Shared/Application/Services/ITenantApiService.cs
@@ -6,4 +6,10 @@ public interface ITenantApiService
 {
     Task<bool> CheckFacilityExists(string facilityId, CancellationToken cancellationToken = default);
     Task<FacilityModel> GetFacilityConfig(string facilityId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Returns the Key Vault secret name holding the signing key for the facility's vendor, or
+    /// null when the facility has no vendor or that vendor has no key configured.
+    /// </summary>
+    Task<string?> GetVendorSigningKeySecretId(string facilityId, CancellationToken cancellationToken = default);
 }

--- a/DotNet/Shared/Application/Services/TenantApiService.cs
+++ b/DotNet/Shared/Application/Services/TenantApiService.cs
@@ -81,6 +81,13 @@ public class TenantApiService : ITenantApiService
         throw new Exception($"Error checking if facility ({sanitizedFacilityId}) exists in Tenant Service. Status Code: {response.StatusCode}");
     }
 
+    public async Task<string?> GetVendorSigningKeySecretId(string facilityId, CancellationToken cancellationToken = default)
+    {
+        var facility = await GetFacilityConfig(facilityId, cancellationToken);
+
+        return facility?.Vendor?.Authentication?.SigningKeySecretId;
+    }
+
     public async Task<FacilityModel> GetFacilityConfig(string facilityId, CancellationToken cancellationToken = default)
     {
         string sanitizedFacilityId = HtmlInputSanitizer.SanitizeAndRemove(facilityId);

--- a/DotNet/Tenant/Business/Queries/FacilityQueries.cs
+++ b/DotNet/Tenant/Business/Queries/FacilityQueries.cs
@@ -123,8 +123,9 @@ namespace LantanaGroup.Link.Tenant.Business.Queries
                     Vendor = new VendorModel()
                     {
                         Id = f.VendorVersion.Vendor!.Id,
-                        Name = f.VendorVersion.Vendor.Name
-                    },  
+                        Name = f.VendorVersion.Vendor.Name,
+                        Authentication = f.VendorVersion.Vendor.Authentication
+                    },
                     ScheduledReports = new TenantScheduledReportConfig
                     {
                         Daily = f.ScheduledReports.Daily,


### PR DESCRIPTION

### 🛠️ Description of Changes

Expose the vendor's signing key secret id on the facility response - This makes it retrievable by the services that will need it, and stops there.

### 🧪 Testing Performed

Tested locally

### 🧑‍🔬 Unit Testing

- [ ] I have written or updated unit tests to cover my changes
- Coverage: 50.0%

### 📓 Documentation Updated

Please update any relevant sections in the project documentation that were impacted by the changes in the PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Facility information now includes a vendor’s signing-key secret ID when configured.
  * Facilities without vendor authentication return no signing-key information.

* **Tests**
  * Added integration coverage for configured and missing vendor signing-key scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
