### PR TITLE
LEGLINK-888: ValueSet $validate-code rejects a blank "system" with a 400

### DIFF
--- a/DotNet/ServiceTests/UnitTests/Terminology/Controllers/FhirControllerHttpTests.cs
+++ b/DotNet/ServiceTests/UnitTests/Terminology/Controllers/FhirControllerHttpTests.cs
@@ -1,0 +1,255 @@
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using LantanaGroup.Link.Terminology.Application.Formatters;
+using LantanaGroup.Link.Terminology.Application.Interfaces;
+using LantanaGroup.Link.Terminology.Application.Models;
+using LantanaGroup.Link.Terminology.Controllers;
+using LantanaGroup.Link.Terminology.Services;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Xunit;
+using Code = LantanaGroup.Link.Terminology.Application.Models.Code;
+using Task = System.Threading.Tasks.Task;
+
+namespace UnitTests.Terminology;
+
+/// <summary>
+/// Exercises ValueSet $validate-code over real HTTP, through the same model binding and MVC options
+/// <c>Program.cs</c> configures, for the four blank-system requests QA covers in TestRail 10992, 11015,
+/// 11342 and 11343 (LEGLINK-888).
+/// </summary>
+/// <remarks>
+/// Calling the action method directly cannot cover these. MVC converts an empty query value to null before
+/// an action runs unless <see cref="PreserveEmptyStringMetadataProvider"/> is registered, so a direct call
+/// passing <c>string.Empty</c> exercises a state real traffic could not produce and would report a blank
+/// <c>?system=</c> as rejected while the deployed service answered 200.
+///
+/// The MVC options below mirror <c>Program.cs</c> by hand rather than booting the real host, whose startup
+/// needs Kafka, the cache and App Configuration. The two must be kept in step: dropping the metadata
+/// provider from <c>Program.cs</c> alone would break the deployed service without failing these tests.
+/// </remarks>
+public class FhirControllerHttpTests
+{
+    private const string ValueSetUrl = "http://hl7.org/fhir/ValueSet/address-type";
+    private const string CodeSystemUrl = "http://hl7.org/fhir/address-type";
+    private const string Endpoint = "/api/terminology/fhir/ValueSet/$validate-code";
+
+    /// <summary>
+    /// Stands up the controller behind a real request pipeline, mirroring the MVC configuration in
+    /// <c>Program.cs</c>. The value set is populated so a request that still fails did so on the system
+    /// rather than on a failed lookup.
+    /// </summary>
+    private static TestServer BuildServer()
+    {
+        var cache = new Mock<ICodeGroupCacheService>();
+        cache.Setup(x => x.GetCodeGroup(CodeGroup.CodeGroupTypes.ValueSet, ValueSetUrl, It.IsAny<string>()))
+            .Returns(new CodeGroup
+            {
+                Id = "address-type",
+                Type = CodeGroup.CodeGroupTypes.ValueSet,
+                Url = ValueSetUrl,
+                Codes = new Dictionary<string, List<Code>>
+                {
+                    { CodeSystemUrl, new List<Code> { new() { Value = "postal", Display = "Postal" } } }
+                }
+            });
+
+        var builder = new WebHostBuilder()
+            .ConfigureServices(services =>
+            {
+                services.AddLogging();
+                services.AddSingleton(cache.Object);
+                services.AddSingleton<FhirService>();
+                services.AddControllers(options =>
+                    {
+                        options.ModelBinderProviders.Insert(0, new FhirModelBinderProvider());
+                        options.OutputFormatters.Insert(0, new FhirOutputFormatter());
+                        options.ModelMetadataDetailsProviders.Add(new PreserveEmptyStringMetadataProvider());
+                    })
+                    .AddApplicationPart(typeof(FhirController).Assembly);
+            })
+            .Configure(app =>
+            {
+                app.UseRouting();
+                app.UseEndpoints(endpoints => endpoints.MapControllers());
+            });
+
+        return new TestServer(builder);
+    }
+
+    private static async Task<(HttpStatusCode Status, string Body)> PostAsync(string query, string body)
+    {
+        using var server = BuildServer();
+        using var client = server.CreateClient();
+
+        var content = new StringContent(body, Encoding.UTF8, "application/json");
+        var response = await client.PostAsync($"{Endpoint}{query}", content);
+
+        return (response.StatusCode, await response.Content.ReadAsStringAsync());
+    }
+
+    private static void AssertBadRequestDetail(HttpStatusCode status, string body, string expectedDetail)
+    {
+        Assert.Equal(HttpStatusCode.BadRequest, status);
+
+        using var document = JsonDocument.Parse(body);
+        var root = document.RootElement;
+
+        Assert.Equal("https://tools.ietf.org/html/rfc9110#section-15.5.1", root.GetProperty("type").GetString());
+        Assert.Equal("Bad Request", root.GetProperty("title").GetString());
+        Assert.Equal(400, root.GetProperty("status").GetInt32());
+        Assert.Equal(expectedDetail, root.GetProperty("detail").GetString());
+    }
+
+    /// <summary>TestRail 10992 — blank system inside the body's coding.</summary>
+    [Fact]
+    public async Task ValidateCodeInValueSet_BlankSystemInCodingBody_Returns400()
+    {
+        const string body = """
+        {
+          "resourceType" : "Parameters",
+          "parameter" : [{
+            "name": "url",
+            "valueUri": "http://hl7.org/fhir/ValueSet/address-type"
+          }, {
+            "name" : "coding",
+            "valueCoding": { "code": "postal", "system": "" }
+          }]
+        }
+        """;
+
+        var (status, payload) = await PostAsync(string.Empty, body);
+
+        AssertBadRequestDetail(status, payload, "The 'coding.system' parameter cannot be blank.");
+    }
+
+    /// <summary>TestRail 11015 — blank system on the query string, valid system in the body.</summary>
+    [Fact]
+    public async Task ValidateCodeInValueSet_BlankSystemQueryParameter_Returns400()
+    {
+        const string body = """
+        {
+          "resourceType" : "Parameters",
+          "parameter" : [{
+            "name": "url",
+            "valueUri": "http://hl7.org/fhir/ValueSet/address-type"
+          }, {
+            "name" : "coding",
+            "valueCoding": { "code": "postal", "system": "http://hl7.org/fhir/address-type" }
+          }]
+        }
+        """;
+
+        var (status, payload) = await PostAsync("?system=", body);
+
+        AssertBadRequestDetail(status, payload, "The 'system' parameter cannot be blank.");
+    }
+
+    /// <summary>TestRail 11342 — blank system as a top-level body parameter.</summary>
+    [Fact]
+    public async Task ValidateCodeInValueSet_BlankSystemParameterInBody_Returns400()
+    {
+        const string body = """
+        {
+          "resourceType" : "Parameters",
+          "parameter" : [{
+            "name": "url",
+            "valueUri": "http://hl7.org/fhir/ValueSet/address-type"
+          }, {
+            "name" : "code",
+            "valueCode": "postal"
+          }, {
+            "name": "system",
+            "valueUri": ""
+          }]
+        }
+        """;
+
+        var (status, payload) = await PostAsync(string.Empty, body);
+
+        AssertBadRequestDetail(status, payload, "The 'system' parameter cannot be blank.");
+    }
+
+    /// <summary>TestRail 11343 — blank system inside the body's codeableConcept.</summary>
+    [Fact]
+    public async Task ValidateCodeInValueSet_BlankSystemInCodeableConcept_Returns400()
+    {
+        const string body = """
+        {
+          "resourceType" : "Parameters",
+          "parameter" : [{
+            "name": "url",
+            "valueUri": "http://hl7.org/fhir/ValueSet/address-type"
+          }, {
+            "name" : "codeableConcept",
+            "valueCodeableConcept": {
+              "coding": [{ "code": "postal", "system": "" }]
+            }
+          }]
+        }
+        """;
+
+        var (status, payload) = await PostAsync(string.Empty, body);
+
+        AssertBadRequestDetail(status, payload, "The 'codeableConcept.coding.system' parameter cannot be blank.");
+    }
+
+    /// <summary>
+    /// An omitted system keeps its FHIR meaning of "search every code system in the value set", so the
+    /// rejection above must not be reached by simply leaving the parameter out.
+    /// </summary>
+    [Fact]
+    public async Task ValidateCodeInValueSet_AbsentSystem_SearchesAllSystemsAndSucceeds()
+    {
+        const string body = """
+        {
+          "resourceType" : "Parameters",
+          "parameter" : [{
+            "name": "url",
+            "valueUri": "http://hl7.org/fhir/ValueSet/address-type"
+          }, {
+            "name" : "coding",
+            "valueCoding": { "code": "postal" }
+          }]
+        }
+        """;
+
+        var (status, payload) = await PostAsync(string.Empty, body);
+
+        Assert.Equal(HttpStatusCode.OK, status);
+        Assert.Contains("\"result\"", payload);
+        Assert.Contains("true", payload);
+    }
+
+    /// <summary>
+    /// Per LEGLINK-888, a client that interpolated an unset variable into the query string is treated as
+    /// having omitted the parameter. This is deliberate non-FHIR leniency, so it is pinned by a test.
+    /// </summary>
+    [Theory]
+    [InlineData("?system=null")]
+    [InlineData("?system=undefined")]
+    public async Task ValidateCodeInValueSet_PlaceholderSystem_TreatedAsAbsent(string query)
+    {
+        const string body = """
+        {
+          "resourceType" : "Parameters",
+          "parameter" : [{
+            "name": "url",
+            "valueUri": "http://hl7.org/fhir/ValueSet/address-type"
+          }, {
+            "name" : "code",
+            "valueCode": "postal"
+          }]
+        }
+        """;
+
+        var (status, payload) = await PostAsync(query, body);
+
+        Assert.Equal(HttpStatusCode.OK, status);
+        Assert.Contains("\"result\"", payload);
+    }
+}

--- a/DotNet/ServiceTests/UnitTests/Terminology/Controllers/FhirControllerHttpTests.cs
+++ b/DotNet/ServiceTests/UnitTests/Terminology/Controllers/FhirControllerHttpTests.cs
@@ -92,6 +92,39 @@ public class FhirControllerHttpTests
         return (response.StatusCode, await response.Content.ReadAsStringAsync());
     }
 
+    /// <summary>
+    /// Asserts a 200 carrying a FHIR Parameters resource whose <c>result</c> is the expected verdict.
+    /// </summary>
+    /// <remarks>
+    /// A substring check over the raw payload cannot tell result=true from result=false: the placeholder
+    /// test below exists to pin that "?system=null" is treated as an omitted parameter rather than looked
+    /// up as a code system literally named "null", and those two outcomes differ only in this boolean.
+    /// </remarks>
+    private static void AssertValidationResult(HttpStatusCode status, string body, bool expectedResult)
+    {
+        Assert.Equal(HttpStatusCode.OK, status);
+
+        using var document = JsonDocument.Parse(body);
+        var root = document.RootElement;
+
+        Assert.Equal("Parameters", root.GetProperty("resourceType").GetString());
+
+        var found = false;
+        var result = default(JsonElement);
+        foreach (var parameter in root.GetProperty("parameter").EnumerateArray())
+        {
+            if (parameter.GetProperty("name").GetString() == "result")
+            {
+                result = parameter;
+                found = true;
+                break;
+            }
+        }
+
+        Assert.True(found, "no 'result' parameter in the response");
+        Assert.Equal(expectedResult, result.GetProperty("valueBoolean").GetBoolean());
+    }
+
     private static void AssertBadRequestDetail(HttpStatusCode status, string body, string expectedDetail)
     {
         Assert.Equal(HttpStatusCode.BadRequest, status);
@@ -220,9 +253,7 @@ public class FhirControllerHttpTests
 
         var (status, payload) = await PostAsync(string.Empty, body);
 
-        Assert.Equal(HttpStatusCode.OK, status);
-        Assert.Contains("\"result\"", payload);
-        Assert.Contains("true", payload);
+        AssertValidationResult(status, payload, expectedResult: true);
     }
 
     /// <summary>
@@ -249,7 +280,9 @@ public class FhirControllerHttpTests
 
         var (status, payload) = await PostAsync(query, body);
 
-        Assert.Equal(HttpStatusCode.OK, status);
-        Assert.Contains("\"result\"", payload);
+        // result=true is the whole point: the placeholder must be treated as an omitted system, so the
+        // code is found across every system in the value set. Looking "null" up as a code system would
+        // answer result=false, which the previous payload-substring assertion could not distinguish.
+        AssertValidationResult(status, payload, expectedResult: true);
     }
 }

--- a/DotNet/ServiceTests/UnitTests/Terminology/Controllers/FhirControllerTests.cs
+++ b/DotNet/ServiceTests/UnitTests/Terminology/Controllers/FhirControllerTests.cs
@@ -187,6 +187,58 @@ public class FhirControllerTests
     }
 
     [Fact]
+    public void ValidateCodeInValueSet_WithBlankSystemInCodingBody_ReturnsBadRequest()
+    {
+        // Arrange - LEGLINK-888's reported request: a resolvable value set and a code that does match,
+        // with the coding's system blank. The value set is wired up deliberately, so the 400 proves the
+        // blank is rejected rather than the request merely failing to find anything.
+        _mockCacheService
+            .Setup(x => x.GetCodeGroup(CodeGroup.CodeGroupTypes.ValueSet, ValueSetUrl, It.IsAny<string>()))
+            .Returns(BuildCodeGroup(CodeGroup.CodeGroupTypes.ValueSet, CodeSystemUrl));
+
+        var parameters = new Parameters();
+        parameters.Add("url", new FhirUri(ValueSetUrl));
+        parameters.Add("coding", new Coding { Code = LoincCode, System = string.Empty });
+
+        // Act
+        var result = _controller.ValidateCodeInValueSet(null, null, null, null, null, parameters);
+
+        // Assert - previously this answered 200 result=true by searching every system in the value set
+        AssertBadRequestProblem(result, "The 'coding.system' parameter cannot be blank.");
+    }
+
+    [Fact]
+    public void ValidateCodeInValueSet_WithBlankSystemQueryParameter_ReturnsBadRequest()
+    {
+        // Arrange
+        _mockCacheService
+            .Setup(x => x.GetCodeGroup(CodeGroup.CodeGroupTypes.ValueSet, ValueSetUrl, It.IsAny<string>()))
+            .Returns(BuildCodeGroup(CodeGroup.CodeGroupTypes.ValueSet, CodeSystemUrl));
+
+        // Act - an empty query string value binds as "", not as an absent parameter
+        var result = _controller.ValidateCodeInValueSet(ValueSetUrl, null, string.Empty, LoincCode, null, null);
+
+        // Assert
+        AssertBadRequestProblem(result, "The 'system' parameter cannot be blank.");
+    }
+
+    [Fact]
+    public void ValidateCodeInValueSet_WithNullPlaceholderSystem_SearchesAllSystems()
+    {
+        // Arrange
+        _mockCacheService
+            .Setup(x => x.GetCodeGroup(CodeGroup.CodeGroupTypes.ValueSet, ValueSetUrl, It.IsAny<string>()))
+            .Returns(BuildCodeGroup(CodeGroup.CodeGroupTypes.ValueSet, CodeSystemUrl));
+
+        // Act - a client that interpolated an unset variable sends the literal string "null"
+        var result = _controller.ValidateCodeInValueSet(ValueSetUrl, null, "null", LoincCode, null, null);
+
+        // Assert - treated as if the system had been omitted rather than looked up as a system URL
+        var parameters = AssertOkParameters(result);
+        Assert.True(parameters.GetSingleValue<FhirBoolean>("result")?.Value);
+    }
+
+    [Fact]
     public void GetValueSetById_WhenValueSetNotLoaded_ReturnsNotFoundProblem()
     {
         // Arrange - the cache has no value set under this id

--- a/DotNet/ServiceTests/UnitTests/Terminology/Services/FhirServiceTests.cs
+++ b/DotNet/ServiceTests/UnitTests/Terminology/Services/FhirServiceTests.cs
@@ -1422,4 +1422,135 @@ public class FhirServiceTests
     }
 
     #endregion
+
+    #region Blank system handling (LEGLINK-888)
+
+    private const string BlankSystemValueSetId = "test-vs-blank-system";
+    private const string BlankSystemCode = "test-code";
+    private const string BlankSystemSystem = "http://test.system";
+
+    /// <summary>
+    /// A single-system value set containing <see cref="BlankSystemCode"/>, so a request that reaches the
+    /// validator resolves successfully. Anything that still fails did so on the system, not the lookup.
+    /// </summary>
+    private void ArrangeBlankSystemValueSet()
+    {
+        _mockCacheService
+            .Setup(x => x.GetCodeGroupById(CodeGroup.CodeGroupTypes.ValueSet, BlankSystemValueSetId, It.IsAny<string>()))
+            .Returns(new CodeGroup
+            {
+                Id = BlankSystemValueSetId,
+                Type = CodeGroup.CodeGroupTypes.ValueSet,
+                Codes = new Dictionary<string, List<Code>>
+                {
+                    { BlankSystemSystem, new List<Code> { new() { Value = BlankSystemCode, Display = "Test Code" } } }
+                }
+            });
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("\t")]
+    public void ValidateCodeInValueSet_WithBlankQuerySystem_ThrowsArgumentException(string system)
+    {
+        // Arrange
+        ArrangeBlankSystemValueSet();
+
+        // Act / Assert - FHIR primitives require at least one non-whitespace character, so each of these
+        // is malformed input rather than a request to search every system
+        var exception = Assert.Throws<ArgumentException>(() =>
+            _service.ValidateCodeInValueSet(null, BlankSystemValueSetId, system, BlankSystemCode, null, null));
+
+        Assert.Equal("The 'system' parameter cannot be blank", exception.Message);
+    }
+
+    [Fact]
+    public void ValidateCodeInValueSet_WithBlankSystemParameterInBody_ThrowsArgumentException()
+    {
+        // Arrange
+        ArrangeBlankSystemValueSet();
+
+        var parameters = new Parameters();
+        parameters.Add("system", new FhirUri(string.Empty));
+        parameters.Add("code", new FhirString(BlankSystemCode));
+
+        // Act / Assert
+        var exception = Assert.Throws<ArgumentException>(() =>
+            _service.ValidateCodeInValueSet(null, BlankSystemValueSetId, null, null, null, parameters));
+
+        Assert.Equal("The 'system' parameter cannot be blank", exception.Message);
+    }
+
+    [Fact]
+    public void ValidateCodeInValueSet_WithBlankQuerySystemAndValidBodySystem_ThrowsArgumentException()
+    {
+        // Arrange - the body carries a usable system, so only up-front validation catches the blank:
+        // the merge treats an empty string as "not supplied" and would overwrite it before any check
+        ArrangeBlankSystemValueSet();
+
+        var parameters = new Parameters();
+        parameters.Add("system", new FhirUri(BlankSystemSystem));
+
+        // Act / Assert
+        var exception = Assert.Throws<ArgumentException>(() =>
+            _service.ValidateCodeInValueSet(
+                null, BlankSystemValueSetId, string.Empty, BlankSystemCode, null, parameters));
+
+        Assert.Equal("The 'system' parameter cannot be blank", exception.Message);
+    }
+
+    [Fact]
+    public void ValidateCodeInValueSet_WithBlankSystemInLaterCodeableConceptCoding_ThrowsArgumentException()
+    {
+        // Arrange - the first coding matches, so a check performed at the point of use would return
+        // result=true and never reach the malformed second coding
+        ArrangeBlankSystemValueSet();
+
+        var codeableConcept = new CodeableConcept();
+        codeableConcept.Coding.Add(new Coding(BlankSystemSystem, BlankSystemCode));
+        codeableConcept.Coding.Add(new Coding { Code = "other-code", System = string.Empty });
+
+        var parameters = new Parameters();
+        parameters.Add("codeableConcept", codeableConcept);
+
+        // Act / Assert - validation is up front, so the verdict does not depend on match order
+        var exception = Assert.Throws<ArgumentException>(() =>
+            _service.ValidateCodeInValueSet(null, BlankSystemValueSetId, null, null, null, parameters));
+
+        Assert.Equal("The 'codeableConcept.coding.system' parameter cannot be blank", exception.Message);
+    }
+
+    [Theory]
+    [InlineData("null")]
+    [InlineData("undefined")]
+    [InlineData("NULL")]
+    public void ValidateCodeInValueSet_WithPlaceholderSystem_SearchesAllSystems(string system)
+    {
+        // Arrange - a client that interpolated an unset variable into the request rather than omitting it
+        ArrangeBlankSystemValueSet();
+
+        // Act
+        var result = _service.ValidateCodeInValueSet(
+            null, BlankSystemValueSetId, system, BlankSystemCode, null, null);
+
+        // Assert - treated as absent, so the code is found; looking "null" up as a system URL would miss
+        Assert.True(result.GetSingleValue<FhirBoolean>("result")?.Value);
+    }
+
+    [Fact]
+    public void ValidateCodeInValueSet_WithAbsentSystem_StillSearchesAllSystems()
+    {
+        // Arrange - the behaviour a blank system used to borrow, which must survive the fix
+        ArrangeBlankSystemValueSet();
+
+        // Act
+        var result = _service.ValidateCodeInValueSet(
+            null, BlankSystemValueSetId, null, BlankSystemCode, null, null);
+
+        // Assert
+        Assert.True(result.GetSingleValue<FhirBoolean>("result")?.Value);
+    }
+
+    #endregion
 }

--- a/DotNet/ServiceTests/UnitTests/Terminology/Services/FhirServiceTests.cs
+++ b/DotNet/ServiceTests/UnitTests/Terminology/Services/FhirServiceTests.cs
@@ -1521,10 +1521,27 @@ public class FhirServiceTests
         Assert.Equal("The 'codeableConcept.coding.system' parameter cannot be blank", exception.Message);
     }
 
+    [Fact]
+    public void ValidateCodeInValueSet_WithPaddedSystem_StillMatchesThatSystem()
+    {
+        // Arrange - the code system lookup is an exact dictionary match, so an untrimmed value would
+        // report "Code system not found" for a system that is right there in the value set.
+        ArrangeBlankSystemValueSet();
+
+        // Act
+        var result = _service.ValidateCodeInValueSet(
+            null, BlankSystemValueSetId, $"  {BlankSystemSystem}  ", BlankSystemCode, null, null);
+
+        // Assert
+        Assert.True(result.GetSingleValue<FhirBoolean>("result")?.Value);
+    }
+
     [Theory]
     [InlineData("null")]
     [InlineData("undefined")]
     [InlineData("NULL")]
+    [InlineData("  null  ")]
+    [InlineData("\tundefined\t")]
     public void ValidateCodeInValueSet_WithPlaceholderSystem_SearchesAllSystems(string system)
     {
         // Arrange - a client that interpolated an unset variable into the request rather than omitting it

--- a/DotNet/Terminology/Application/Formatters/PreserveEmptyStringAttribute.cs
+++ b/DotNet/Terminology/Application/Formatters/PreserveEmptyStringAttribute.cs
@@ -1,0 +1,15 @@
+namespace LantanaGroup.Link.Terminology.Application.Formatters;
+
+/// <summary>
+/// Marks a bound parameter whose empty string must reach the action as an empty string rather than as null.
+/// </summary>
+/// <remarks>
+/// Apply this only where an omitted parameter and a blank one mean different things and the action has to
+/// tell them apart. MVC's default is <c>ConvertEmptyStringToNull = true</c>, which collapses both into null
+/// before the action runs; <see cref="PreserveEmptyStringMetadataProvider"/> honours this attribute by
+/// turning that conversion off for the marked parameter only.
+/// </remarks>
+[AttributeUsage(AttributeTargets.Parameter)]
+public sealed class PreserveEmptyStringAttribute : Attribute
+{
+}

--- a/DotNet/Terminology/Application/Formatters/PreserveEmptyStringMetadataProvider.cs
+++ b/DotNet/Terminology/Application/Formatters/PreserveEmptyStringMetadataProvider.cs
@@ -1,0 +1,30 @@
+using Microsoft.AspNetCore.Mvc.ModelBinding.Metadata;
+
+namespace LantanaGroup.Link.Terminology.Application.Formatters;
+
+/// <summary>
+/// Keeps an empty string supplied by a client as an empty string during model binding, rather than
+/// converting it to null.
+/// </summary>
+/// <remarks>
+/// MVC's default is <c>ConvertEmptyStringToNull = true</c>, which makes <c>?system=</c> arrive at an action
+/// as null and therefore indistinguishable from an omitted parameter. Those are not the same request: an
+/// omitted system means "search every code system in the value set", while a blank one is malformed FHIR
+/// and has to be rejected with a 400 (LEGLINK-888). Validation cannot make a distinction the binder has
+/// already erased, so the transformation is turned off rather than worked around in the controller.
+///
+/// Every other query parameter in this service guards with <c>string.IsNullOrEmpty</c> or
+/// <c>string.IsNullOrWhiteSpace</c> — including ConfigController's <c>version</c>, which normalizes blank
+/// to null itself — so preserving the empty string leaves their behavior unchanged.
+/// </remarks>
+public class PreserveEmptyStringMetadataProvider : IDisplayMetadataProvider
+{
+    /// <summary>
+    /// Clears <c>ConvertEmptyStringToNull</c> for every bound model in the service.
+    /// </summary>
+    /// <param name="context">The metadata being built for a model.</param>
+    public void CreateDisplayMetadata(DisplayMetadataProviderContext context)
+    {
+        context.DisplayMetadata.ConvertEmptyStringToNull = false;
+    }
+}

--- a/DotNet/Terminology/Application/Formatters/PreserveEmptyStringMetadataProvider.cs
+++ b/DotNet/Terminology/Application/Formatters/PreserveEmptyStringMetadataProvider.cs
@@ -1,10 +1,11 @@
+using System.Reflection;
 using Microsoft.AspNetCore.Mvc.ModelBinding.Metadata;
 
 namespace LantanaGroup.Link.Terminology.Application.Formatters;
 
 /// <summary>
 /// Keeps an empty string supplied by a client as an empty string during model binding, rather than
-/// converting it to null.
+/// converting it to null, for parameters marked with <see cref="PreserveEmptyStringAttribute"/>.
 /// </summary>
 /// <remarks>
 /// MVC's default is <c>ConvertEmptyStringToNull = true</c>, which makes <c>?system=</c> arrive at an action
@@ -13,18 +14,21 @@ namespace LantanaGroup.Link.Terminology.Application.Formatters;
 /// and has to be rejected with a 400 (LEGLINK-888). Validation cannot make a distinction the binder has
 /// already erased, so the transformation is turned off rather than worked around in the controller.
 ///
-/// Every other query parameter in this service guards with <c>string.IsNullOrEmpty</c> or
-/// <c>string.IsNullOrWhiteSpace</c> — including ConfigController's <c>version</c>, which normalizes blank
-/// to null itself — so preserving the empty string leaves their behavior unchanged.
+/// The attribute keeps that off-switch to the one parameter that needs it, leaving every other bound value
+/// in the service on MVC's default behavior.
 /// </remarks>
 public class PreserveEmptyStringMetadataProvider : IDisplayMetadataProvider
 {
     /// <summary>
-    /// Clears <c>ConvertEmptyStringToNull</c> for every bound model in the service.
+    /// Clears <c>ConvertEmptyStringToNull</c> for a parameter carrying <see cref="PreserveEmptyStringAttribute"/>.
     /// </summary>
     /// <param name="context">The metadata being built for a model.</param>
     public void CreateDisplayMetadata(DisplayMetadataProviderContext context)
     {
-        context.DisplayMetadata.ConvertEmptyStringToNull = false;
+        ParameterInfo? parameter = context.Key.ParameterInfo;
+        if (parameter is not null && parameter.IsDefined(typeof(PreserveEmptyStringAttribute), inherit: false))
+        {
+            context.DisplayMetadata.ConvertEmptyStringToNull = false;
+        }
     }
 }

--- a/DotNet/Terminology/Controllers/FhirController.cs
+++ b/DotNet/Terminology/Controllers/FhirController.cs
@@ -2,6 +2,7 @@
 using Hl7.Fhir.Model;
 using Hl7.Fhir.Rest;
 using LantanaGroup.Link.Shared.Application.Services.Security;
+using LantanaGroup.Link.Terminology.Application.Formatters;
 using LantanaGroup.Link.Terminology.Services;
 using Microsoft.AspNetCore.Mvc;
 using Swashbuckle.AspNetCore.Annotations;
@@ -376,7 +377,7 @@ public class FhirController(FhirService fhirService) : Controller
     [HttpPost("ValueSet/$validate-code")]
     [HttpPost("ValueSet/{id}/$validate-code")]
     public ActionResult<Parameters> ValidateCodeInValueSet([FromQuery] string? url, [FromRoute] string? id,
-        [FromQuery] string? system, [FromQuery] string? code, [FromQuery] string? display,
+        [FromQuery][PreserveEmptyString] string? system, [FromQuery] string? code, [FromQuery] string? display,
         [FromBody] Parameters? parameters)
     {
         try

--- a/DotNet/Terminology/Program.cs
+++ b/DotNet/Terminology/Program.cs
@@ -52,6 +52,7 @@ static void RegisterServices(WebApplicationBuilder builder)
     {
         options.ModelBinderProviders.Insert(0, new FhirModelBinderProvider());
         options.OutputFormatters.Insert(0, new FhirOutputFormatter());
+        options.ModelMetadataDetailsProviders.Add(new PreserveEmptyStringMetadataProvider());
     });
 
     builder.Services.AddTerminologyProblemDetails(

--- a/DotNet/Terminology/Services/FhirService.cs
+++ b/DotNet/Terminology/Services/FhirService.cs
@@ -352,6 +352,19 @@ public class FhirService(ICodeGroupCacheService cacheService, ILogger<FhirServic
         var systemComponent = parameters?.Get("system").FirstOrDefault();
         var codeComponent = parameters?.Get("code").FirstOrDefault();
         var displayComponent = parameters?.Get("display").FirstOrDefault();
+        var coding = parameters?.Get("coding").FirstOrDefault()?.Value as Coding;
+        var codeableConcept = parameters?.Get("codeableConcept").FirstOrDefault()?.Value as CodeableConcept;
+
+        // Every client-supplied system is normalized here, ahead of the merges below and of the value set
+        // lookup. The merges treat an empty string as "not supplied", so a blank reaching them would be
+        // silently overwritten and never rejected; validating up front also keeps the answer for a
+        // malformed codeableConcept independent of which coding happens to match first (LEGLINK-888).
+        system = NormalizeSystem(system, "system");
+        var bodySystem = NormalizeSystem(systemComponent?.Value?.ToString(), "system");
+        var codingSystem = coding == null ? null : NormalizeSystem(coding.System, "coding.system");
+        var conceptSystems = (codeableConcept?.Coding ?? [])
+            .Select(conceptCoding => NormalizeSystem(conceptCoding.System, "codeableConcept.coding.system"))
+            .ToList();
 
         if (urlComponent?.Value != null && string.IsNullOrEmpty(url))
         {
@@ -385,9 +398,11 @@ public class FhirService(ICodeGroupCacheService cacheService, ILogger<FhirServic
         // Priority 1: Direct parameters
         if (!string.IsNullOrEmpty(code))
         {
-            if (systemComponent?.Value != null && string.IsNullOrEmpty(system))
+            // A normalized system is either null or a real value, so "not supplied" is a null check.
+            // string.IsNullOrEmpty here would fold a blank back into the absent case (LEGLINK-888).
+            if (bodySystem != null && system == null)
             {
-                system = systemComponent.Value.ToString();
+                system = bodySystem;
             }
 
             if (displayComponent?.Value != null && string.IsNullOrEmpty(display))
@@ -401,9 +416,9 @@ public class FhirService(ICodeGroupCacheService cacheService, ILogger<FhirServic
         // Priority 2: Parameters.code and Parameters.system
         if (codeComponent?.Value != null)
         {
-            if (systemComponent?.Value != null && string.IsNullOrEmpty(system))
+            if (bodySystem != null && system == null)
             {
-                system = systemComponent.Value.ToString();
+                system = bodySystem;
             }
 
             if (displayComponent?.Value != null && string.IsNullOrEmpty(display))
@@ -415,19 +430,17 @@ public class FhirService(ICodeGroupCacheService cacheService, ILogger<FhirServic
         }
 
         // Priority 3: Parameters.coding
-        var coding = parameters?.Get("coding").FirstOrDefault()?.Value as Coding;
         if (coding != null)
         {
-            return ValidateCodeInCodeGroup(codeGroup, coding.Code, coding.System, coding.Display);
+            return ValidateCodeInCodeGroup(codeGroup, coding.Code, codingSystem, coding.Display);
         }
 
         // Priority 4: Parameters.codeableConcept
-        var codeableConcept = parameters?.Get("codeableConcept").FirstOrDefault()?.Value as CodeableConcept;
         if (codeableConcept?.Coding != null)
         {
-            foreach (var conceptCoding in codeableConcept.Coding)
+            foreach (var (conceptCoding, conceptSystem) in codeableConcept.Coding.Zip(conceptSystems))
             {
-                var result = ValidateCodeInCodeGroup(codeGroup, conceptCoding.Code, conceptCoding.System, conceptCoding.Display);
+                var result = ValidateCodeInCodeGroup(codeGroup, conceptCoding.Code, conceptSystem, conceptCoding.Display);
                 var resultBoolean = result.GetSingleValue<FhirBoolean>("result");
                 if (resultBoolean?.Value == true)
                 {
@@ -560,8 +573,49 @@ public class FhirService(ICodeGroupCacheService cacheService, ILogger<FhirServic
         return parameters;
     }
 
+    /// <summary>
+    /// Placeholders a client produces by interpolating an unset variable into a request rather than
+    /// omitting the parameter — JavaScript renders null and undefined this way. They are accepted as
+    /// meaning "no system supplied".
+    /// </summary>
+    private static readonly string[] SystemPlaceholders = ["null", "undefined"];
+
+    /// <summary>
+    /// Validates and normalizes a client-supplied <c>system</c> for a ValueSet $validate-code request,
+    /// mapping it onto the two states the validator understands: a real system to look up, or null
+    /// meaning "search every system in the value set".
+    /// </summary>
+    /// <remarks>
+    /// An absent system is legitimate FHIR and keeps its search-all-systems meaning. A blank one is not:
+    /// no FHIR primitive may be an empty string, so the request is malformed and is rejected rather than
+    /// reinterpreted. Folding a blank into the absent case answered a broader question than the caller
+    /// asked and reported result=true without disclosing which system matched (LEGLINK-888).
+    /// </remarks>
+    /// <exception cref="ArgumentException">
+    /// Thrown when the value is present but blank, which the caller surfaces as a 400.
+    /// </exception>
+    private static string? NormalizeSystem(string? system, string parameterName)
+    {
+        if (system == null)
+        {
+            return null;
+        }
+
+        // FHIR requires at least one character of non-whitespace content, so "   " is as malformed as "".
+        if (string.IsNullOrWhiteSpace(system))
+        {
+            throw new ArgumentException($"The '{parameterName}' parameter cannot be blank");
+        }
+
+        return SystemPlaceholders.Contains(system, StringComparer.OrdinalIgnoreCase) ? null : system;
+    }
+
     private Parameters ValidateCodeInCodeGroup(CodeGroup codeGroup, string code, string? system, string? display)
     {
+        // string.IsNullOrEmpty rather than a null check: this is shared with ValidateCodeInCodeSystem,
+        // which passes the code group's own Url here. That is cache content, not client input, so an
+        // empty one must keep falling back to a search rather than being blamed on the caller.
+        // ValueSet input reaching this point has already been through NormalizeSystem.
         return string.IsNullOrEmpty(system)
             ? ValidateCodeAcrossSystems(codeGroup, code, display)
             : ValidateCodeInSystem(codeGroup, code, system, display);

--- a/DotNet/Terminology/Services/FhirService.cs
+++ b/DotNet/Terminology/Services/FhirService.cs
@@ -602,12 +602,19 @@ public class FhirService(ICodeGroupCacheService cacheService, ILogger<FhirServic
         }
 
         // FHIR requires at least one character of non-whitespace content, so "   " is as malformed as "".
+        // Checked before trimming, so a whitespace-only value is rejected rather than trimmed to empty.
         if (string.IsNullOrWhiteSpace(system))
         {
             throw new ArgumentException($"The '{parameterName}' parameter cannot be blank");
         }
 
-        return SystemPlaceholders.Contains(system, StringComparer.OrdinalIgnoreCase) ? null : system;
+        // Surrounding whitespace is not significant, but the lookup in ValidateCodeInSystem is an exact
+        // dictionary match, so an untrimmed " http://x " reports "Code system not found" for a system
+        // that is present -- the same confidently-wrong answer to a malformed request this method exists
+        // to prevent. Trimming also lets a padded placeholder resolve to null.
+        var trimmed = system.Trim();
+
+        return SystemPlaceholders.Contains(trimmed, StringComparer.OrdinalIgnoreCase) ? null : trimmed;
     }
 
     private Parameters ValidateCodeInCodeGroup(CodeGroup codeGroup, string code, string? system, string? display)


### PR DESCRIPTION
### 🛠️ Description of Changes

`ValueSet/$validate-code` treated a blank `system` as if none had been supplied. `string.IsNullOrEmpty` sent both `""` and `null` down the same branch, so a malformed request was answered by searching every code system in the value set and reporting `200 result=false`/`result=true` — an answer to a broader question than the caller asked, with no indication in the payload of which system matched.

An absent `system` is legitimate FHIR and keeps its "search every system" meaning. An empty string is not valid for any FHIR primitive, so the request is now rejected rather than reinterpreted.

- Adds `NormalizeSystem` and validates every client-supplied system up front in `ValidateCodeInValueSet`: the query parameter, the body `system` parameter, `coding.system`, and each `codeableConcept.coding.system`. Validating before the merges matters because they treat an empty string as "not supplied" and would overwrite a blank before anything could see it; doing it up front also keeps the verdict for a malformed `codeableConcept` independent of which coding happens to match first.
- Whitespace-only is treated as blank, matching the FHIR rule that a primitive carries at least one character of non-whitespace content.
- The `string.IsNullOrEmpty` check in `ValidateCodeInCodeGroup` is deliberately left alone. It is shared with `ValidateCodeInCodeSystem`, which passes the code group's own `Url` into that slot — cache content, not client input — so an empty one must keep falling back to a search rather than being blamed on the caller.

**Two things worth a reviewer's attention:**

**1. Deliberate non-FHIR leniency.** The literal strings `"null"` and `"undefined"` are treated as an omitted parameter, for clients that interpolate an unset variable into a request. This is not FHIR behaviour and no spec text will explain it, so it is pinned by tests and called out here. Agreed with QA on LEGLINK-888.

**2. A service-wide MVC change.** `PreserveEmptyStringMetadataProvider` turns off MVC's `ConvertEmptyStringToNull`. Without it, `?system=` arrives at the action as `null` and is indistinguishable from an omitted parameter, so the validation above could never fire for the query-string form — validation cannot restore a distinction the binder has already erased. `MvcOptions` exposes no setting for this and `DisplayFormatAttribute` cannot target an action parameter, so a display-metadata provider is the supported route.

Blast radius is contained: 8 string query parameters across the two Terminology controllers, all guarded by `IsNullOrEmpty`/`IsNullOrWhiteSpace`, and `ConfigController`'s `version` already normalises blank to null itself. Body binding is unaffected — `FhirModelBinder` deserialises with System.Text.Json and never consults MVC metadata.

### 🧪 Testing Performed

**Unit tests:** 1185 pass, 0 fail (`dotnet test DotNet/ServiceTests/ServiceTests.csproj --filter FullyQualifiedName~UnitTests`). Terminology suite is 97, up from 77.

**Confirmed the metadata provider is load-bearing** by removing it and re-running: exactly one test fails, the `?system=` case. Without it that scenario silently returns 200.

**Verified against the local docker-compose stack**, before and after rebuilding the Terminology image:

| Request | Before | After |
|---|---|---|
| `coding.system` blank in body | `200 result=true` | `400` — `The 'coding.system' parameter cannot be blank.` |
| `?system=` on the query string | `200 result=true` | `400` — `The 'system' parameter cannot be blank.` |
| `system` blank in body | `200 result=true` | `400` — `The 'system' parameter cannot be blank.` |
| inside `codeableConcept` | `200 result=true` | `400` — `The 'codeableConcept.coding.system' parameter cannot be blank.` |
| omitted `system` | `200 result=true` | unchanged |
| valid `system` | `200 result=true` | unchanged |
| `?system=null` | `200 result=false` | `200 result=true` (now searches all systems) |

Each 400 returns `application/problem+json` carrying `type`, `title`, `status`, `detail` and a W3C `traceId`.

**QA cases:** TestRail 10992, 11015, 11342 and 11343 were updated by QA to match these responses, and all four have been exercised end to end from Postman against the DEV terminology service.

### 🧑‍🔬 Unit Testing

- [x] I have written or updated unit tests to cover my changes
- Coverage: 96.3%

### 📓 Documentation Updated

No documentation changes are required by this PR:

- No new configuration keys, so `app-config.yaml` is unchanged.
- No entity changes, so no EF migration.
- No REST route or status-code changes beyond the corrected 400, which the API guidance already prescribes for input that fails validation.

The `"null"`/`"undefined"` leniency in item 1 above is behaviour the spec will not document. It is recorded on LEGLINK-888 so QA can cover it; there is currently **no TestRail case for it**.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `$validate-code` handling for blank, omitted, `"null"`, and `"undefined"` system values.
  * Blank system values now return standardized 400 responses instead of being treated as missing.
  * Omitted or placeholder systems continue searching across all systems and validate successfully when appropriate.
  * Applied consistent behavior across coding, codeable-concept, query, and request-body inputs.

* **Tests**
  * Added comprehensive coverage for system-value validation and HTTP responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

