### PR TITLE
LEGLINK-816: Chunk logs across documents

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,3 +1,12 @@
+﻿# Copilot Instructions
+
+## Azure Guidelines
 - @azure Rule - Use Azure Tools - When handling requests related to Azure, always use your tools.
 - @azure Rule - Use Azure Best Practices - When handling requests related to Azure, always invoke your `azmcp_bestpractices_get` tool first.
-- @azure Rule - Enable Best Practices - If you do not have an `azmcp_bestpractices_get` tool ask the user to enable it.
+- @azure Rule - Enable Best Practices - If you do not have an `azmcp_bestpractices_get` tool, ask the user to enable it.
+
+## Cosmos DB Guidelines
+- Avoid introducing new indexes on existing collections in Cosmos DB for MongoDB API; use existing/default index paths instead.
+
+## Automation Guidelines
+- For Automation.UI run logs, prefer chunked persistence in the existing data store; do not add Azure Blob Storage archiving unless explicitly requested.

--- a/DotNet/Automation.UI/Services/Persistence/MongoDocuments.cs
+++ b/DotNet/Automation.UI/Services/Persistence/MongoDocuments.cs
@@ -89,13 +89,17 @@ public sealed class DomainSnapshotDocument
     public DateTimeOffset UpdatedAt { get; set; }
 }
 
-/// <summary>MongoDB document for automation_run_logs collection (one per run).</summary>
+/// <summary>MongoDB document for an ordered chunk in automation_run_logs.</summary>
 public sealed class RunLogDocument
 {
     [BsonId]
+    public string Id { get; set; } = string.Empty;
+
     [BsonRepresentation(BsonType.String)]
     public Guid RunId { get; set; }
 
+    public int ChunkNumber { get; set; }
+    public int LineCount { get; set; }
     public List<string> Lines { get; set; } = [];
     public DateTimeOffset UpdatedAt { get; set; }
 }

--- a/DotNet/Automation.UI/Services/Persistence/MongoDocuments.cs
+++ b/DotNet/Automation.UI/Services/Persistence/MongoDocuments.cs
@@ -100,6 +100,17 @@ public sealed class RunLogDocument
 
     public int ChunkNumber { get; set; }
     public int LineCount { get; set; }
+    public int BsonByteCount { get; set; }
     public List<string> Lines { get; set; } = [];
+    public List<long> LineSequences { get; set; } = [];
     public DateTimeOffset UpdatedAt { get; set; }
+}
+
+public sealed class RunLogSequenceDocument
+{
+    [BsonId]
+    [BsonRepresentation(BsonType.String)]
+    public Guid RunId { get; set; }
+
+    public long NextSequence { get; set; }
 }

--- a/DotNet/Automation.UI/Services/Persistence/MongoSnapshotStore.cs
+++ b/DotNet/Automation.UI/Services/Persistence/MongoSnapshotStore.cs
@@ -18,6 +18,8 @@ namespace Automation.UI.Services.Persistence;
 /// </summary>
 public sealed class MongoSnapshotStore : ISnapshotStore
 {
+    private const int MaxLogLinesPerChunk = 1_000;
+
     private readonly IMongoCollection<AutomationRunDocument> _runs;
     private readonly IMongoCollection<AutomationRunInputDocument> _runInputs;
     private readonly IMongoCollection<DomainSnapshotDocument> _snapshots;
@@ -244,7 +246,8 @@ public sealed class MongoSnapshotStore : ISnapshotStore
         await _runs.DeleteOneAsync(r => r.RunId == runId, ct);
         await _runInputs.DeleteOneAsync(r => r.RunId == runId, ct);
         await _snapshots.DeleteManyAsync(s => s.RunId == runId, ct);
-        await _logs.DeleteOneAsync(l => l.RunId == runId, ct);
+        await _logs.DeleteManyAsync(CreateLogChunkFilter(runId), ct);
+        await _logs.DeleteOneAsync(l => l.Id == runId.ToString(), ct);
     }
 
     private async Task<string?> BuildHydratedRunConfigurationJsonAsync(AutomationRunInputSnapshot input, CancellationToken ct)
@@ -398,40 +401,78 @@ public sealed class MongoSnapshotStore : ISnapshotStore
 
     public async Task AppendLogsAsync(Guid runId, IReadOnlyList<string> newLines, CancellationToken ct = default)
     {
-        if (newLines.Count == 0) return;
-
-        var filter = Builders<RunLogDocument>.Filter.Eq(l => l.RunId, runId);
-
-        try
+        foreach (var line in newLines)
         {
-            var update = Builders<RunLogDocument>.Update
-                .PushEach(l => l.Lines, newLines)
-                .Set(l => l.UpdatedAt, DateTimeOffset.UtcNow)
-                .SetOnInsert(l => l.RunId, runId);
+            while (true)
+            {
+                var currentChunk = await _logs.Find(CreateLogChunkFilter(runId))
+                    .SortByDescending(l => l.Id)
+                    .FirstOrDefaultAsync(ct);
 
-            await _logs.UpdateOneAsync(filter, update, new UpdateOptions { IsUpsert = true }, ct);
-        }
-        catch (MongoCommandException)
-        {
-            // Cosmos DB may reject $push/$each in some configurations — fall back to read-modify-write.
-            var doc = await _logs.Find(filter).FirstOrDefaultAsync(ct);
-            if (doc == null)
-            {
-                doc = new RunLogDocument { RunId = runId, Lines = new List<string>(newLines), UpdatedAt = DateTimeOffset.UtcNow };
-                await _logs.InsertOneAsync(doc, cancellationToken: ct);
-            }
-            else
-            {
-                doc.Lines.AddRange(newLines);
-                doc.UpdatedAt = DateTimeOffset.UtcNow;
-                await _logs.ReplaceOneAsync(filter, doc, cancellationToken: ct);
+                if (currentChunk == null || currentChunk.LineCount >= MaxLogLinesPerChunk)
+                {
+                    var nextChunkNumber = currentChunk?.ChunkNumber + 1 ?? 0;
+                    var nextChunk = new RunLogDocument
+                    {
+                        Id = CreateLogChunkId(runId, nextChunkNumber),
+                        RunId = runId,
+                        ChunkNumber = nextChunkNumber,
+                        LineCount = 1,
+                        Lines = [line],
+                        UpdatedAt = DateTimeOffset.UtcNow
+                    };
+
+                    try
+                    {
+                        await _logs.InsertOneAsync(nextChunk, cancellationToken: ct);
+                        break;
+                    }
+                    catch (MongoWriteException)
+                    {
+                        // Another concurrent logger created this chunk first. Re-read and append to it.
+                    }
+
+                    continue;
+                }
+
+                var filter = Builders<RunLogDocument>.Filter.And(
+                    Builders<RunLogDocument>.Filter.Eq(l => l.Id, currentChunk.Id),
+                    Builders<RunLogDocument>.Filter.Lt(l => l.LineCount, MaxLogLinesPerChunk));
+                var update = Builders<RunLogDocument>.Update
+                    .Push(l => l.Lines, line)
+                    .Inc(l => l.LineCount, 1)
+                    .Set(l => l.UpdatedAt, DateTimeOffset.UtcNow);
+
+                var result = await _logs.UpdateOneAsync(filter, update, cancellationToken: ct);
+                if (result.ModifiedCount == 1)
+                    break;
             }
         }
     }
 
     public async Task<List<string>> GetLogsAsync(Guid runId, CancellationToken ct = default)
     {
-        var doc = await _logs.Find(l => l.RunId == runId).FirstOrDefaultAsync(ct);
-        return doc?.Lines ?? [];
+        var legacyLog = await _logs.Find(l => l.Id == runId.ToString()).FirstOrDefaultAsync(ct);
+        var chunks = await _logs.Find(CreateLogChunkFilter(runId))
+            .SortBy(l => l.Id)
+            .ToListAsync(ct);
+
+        var lines = legacyLog?.Lines.ToList() ?? [];
+        foreach (var chunk in chunks)
+            lines.AddRange(chunk.Lines);
+
+        return lines;
     }
+
+    private static FilterDefinition<RunLogDocument> CreateLogChunkFilter(Guid runId)
+    {
+        var prefix = CreateLogChunkPrefix(runId);
+        return Builders<RunLogDocument>.Filter.And(
+            Builders<RunLogDocument>.Filter.Gte(l => l.Id, prefix),
+            Builders<RunLogDocument>.Filter.Lt(l => l.Id, prefix + '\uffff'));
+    }
+
+    private static string CreateLogChunkId(Guid runId, int chunkNumber) => $"{CreateLogChunkPrefix(runId)}{chunkNumber:D8}";
+
+    private static string CreateLogChunkPrefix(Guid runId) => $"{runId:N}:";
 }

--- a/DotNet/Automation.UI/Services/Persistence/MongoSnapshotStore.cs
+++ b/DotNet/Automation.UI/Services/Persistence/MongoSnapshotStore.cs
@@ -1,4 +1,5 @@
 ﻿using MongoDB.Driver;
+using System.Text;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 
@@ -19,11 +20,15 @@ namespace Automation.UI.Services.Persistence;
 public sealed class MongoSnapshotStore : ISnapshotStore
 {
     private const int MaxLogLinesPerChunk = 1_000;
+    private const int MaxLogChunkEstimatedBsonBytes = 12 * 1024 * 1024;
+    private const int EstimatedBsonBytesPerLineOverhead = 64;
+    private const string OversizedLogLineSuffix = " [truncated: exceeded log chunk byte budget]";
 
     private readonly IMongoCollection<AutomationRunDocument> _runs;
     private readonly IMongoCollection<AutomationRunInputDocument> _runInputs;
     private readonly IMongoCollection<DomainSnapshotDocument> _snapshots;
     private readonly IMongoCollection<RunLogDocument> _logs;
+    private readonly IMongoCollection<RunLogSequenceDocument> _logSequences;
     private readonly IMongoCollection<ImportedBundleDocument> _importedBundles;
     private readonly ILogger<MongoSnapshotStore> _logger;
 
@@ -33,6 +38,7 @@ public sealed class MongoSnapshotStore : ISnapshotStore
         _runInputs = database.GetCollection<AutomationRunInputDocument>("automation_run_inputs");
         _snapshots = database.GetCollection<DomainSnapshotDocument>("automation_snapshots");
         _logs = database.GetCollection<RunLogDocument>("automation_logs");
+        _logSequences = database.GetCollection<RunLogSequenceDocument>("automation_log_sequences");
         _importedBundles = database.GetCollection<ImportedBundleDocument>("automation_imported_bundles");
         _logger = logger;
     }
@@ -401,15 +407,52 @@ public sealed class MongoSnapshotStore : ISnapshotStore
 
     public async Task AppendLogsAsync(Guid runId, IReadOnlyList<string> newLines, CancellationToken ct = default)
     {
-        foreach (var line in newLines)
+        if (newLines.Count == 0)
+            return;
+
+        var nextLineSequence = await ReserveLogSequenceRangeAsync(runId, newLines.Count, ct);
+
+        foreach (var rawLine in newLines)
         {
+            var lineSequence = nextLineSequence++;
+            var line = NormalizeLineForChunkBudget(runId, rawLine);
+            var lineEstimatedBsonBytes = EstimateLogLineBsonBytes(line);
+
             while (true)
             {
                 var currentChunk = await _logs.Find(CreateLogChunkFilter(runId))
                     .SortByDescending(l => l.Id)
                     .FirstOrDefaultAsync(ct);
 
-                if (currentChunk == null || currentChunk.LineCount >= MaxLogLinesPerChunk)
+                if (currentChunk != null && currentChunk.BsonByteCount == 0 && currentChunk.LineCount > 0)
+                {
+                    var estimatedChunkBsonBytes = EstimateChunkLinesBsonBytes(currentChunk.Lines);
+                    var initializeBsonBytesFilter = Builders<RunLogDocument>.Filter.And(
+                        Builders<RunLogDocument>.Filter.Eq(l => l.Id, currentChunk.Id),
+                        Builders<RunLogDocument>.Filter.Or(
+                            Builders<RunLogDocument>.Filter.Eq(l => l.BsonByteCount, 0),
+                            Builders<RunLogDocument>.Filter.Exists(nameof(RunLogDocument.BsonByteCount), false)));
+
+                    var initializeBsonBytesResult = await _logs.UpdateOneAsync(
+                        initializeBsonBytesFilter,
+                        Builders<RunLogDocument>.Update.Set(l => l.BsonByteCount, estimatedChunkBsonBytes),
+                        cancellationToken: ct);
+
+                    if (initializeBsonBytesResult.ModifiedCount == 1)
+                    {
+                        currentChunk.BsonByteCount = estimatedChunkBsonBytes;
+                    }
+                    else
+                    {
+                        continue;
+                    }
+                }
+
+                var currentChunkEstimatedBsonBytes = currentChunk?.BsonByteCount ?? 0;
+                if (currentChunk == null
+                    || currentChunk.LineCount >= MaxLogLinesPerChunk
+                    || currentChunkEstimatedBsonBytes + lineEstimatedBsonBytes > MaxLogChunkEstimatedBsonBytes
+                    || (currentChunk.LineSequences?.Count ?? 0) != currentChunk.LineCount)
                 {
                     var nextChunkNumber = currentChunk?.ChunkNumber + 1 ?? 0;
                     var nextChunk = new RunLogDocument
@@ -418,7 +461,9 @@ public sealed class MongoSnapshotStore : ISnapshotStore
                         RunId = runId,
                         ChunkNumber = nextChunkNumber,
                         LineCount = 1,
+                        BsonByteCount = lineEstimatedBsonBytes,
                         Lines = [line],
+                        LineSequences = [lineSequence],
                         UpdatedAt = DateTimeOffset.UtcNow
                     };
 
@@ -427,7 +472,7 @@ public sealed class MongoSnapshotStore : ISnapshotStore
                         await _logs.InsertOneAsync(nextChunk, cancellationToken: ct);
                         break;
                     }
-                    catch (MongoWriteException)
+                    catch (MongoWriteException ex) when (ex.WriteError.Category == ServerErrorCategory.DuplicateKey)
                     {
                         // Another concurrent logger created this chunk first. Re-read and append to it.
                     }
@@ -437,10 +482,13 @@ public sealed class MongoSnapshotStore : ISnapshotStore
 
                 var filter = Builders<RunLogDocument>.Filter.And(
                     Builders<RunLogDocument>.Filter.Eq(l => l.Id, currentChunk.Id),
-                    Builders<RunLogDocument>.Filter.Lt(l => l.LineCount, MaxLogLinesPerChunk));
+                    Builders<RunLogDocument>.Filter.Lt(l => l.LineCount, MaxLogLinesPerChunk),
+                    Builders<RunLogDocument>.Filter.Lte(l => l.BsonByteCount, MaxLogChunkEstimatedBsonBytes - lineEstimatedBsonBytes));
                 var update = Builders<RunLogDocument>.Update
                     .Push(l => l.Lines, line)
+                    .Push(l => l.LineSequences, lineSequence)
                     .Inc(l => l.LineCount, 1)
+                    .Inc(l => l.BsonByteCount, lineEstimatedBsonBytes)
                     .Set(l => l.UpdatedAt, DateTimeOffset.UtcNow);
 
                 var result = await _logs.UpdateOneAsync(filter, update, cancellationToken: ct);
@@ -450,6 +498,97 @@ public sealed class MongoSnapshotStore : ISnapshotStore
         }
     }
 
+    private async Task<long> ReserveLogSequenceRangeAsync(Guid runId, int lineCount, CancellationToken ct)
+    {
+        await EnsureLogSequenceCounterInitializedAsync(runId, ct);
+
+        var update = Builders<RunLogSequenceDocument>.Update.Inc(s => s.NextSequence, lineCount);
+        var updated = await _logSequences.FindOneAndUpdateAsync(
+            s => s.RunId == runId,
+            update,
+            new FindOneAndUpdateOptions<RunLogSequenceDocument>
+            {
+                ReturnDocument = ReturnDocument.After
+            },
+            ct);
+
+        return updated.NextSequence - lineCount;
+    }
+
+    private async Task EnsureLogSequenceCounterInitializedAsync(Guid runId, CancellationToken ct)
+    {
+        var existing = await _logSequences.Find(s => s.RunId == runId).AnyAsync(ct);
+        if (existing)
+            return;
+
+        var legacyLog = await _logs.Find(l => l.Id == runId.ToString()).FirstOrDefaultAsync(ct);
+        var chunks = await _logs.Find(CreateLogChunkFilter(runId)).ToListAsync(ct);
+        var existingLineCount = (legacyLog?.Lines.Count ?? 0) + chunks.Sum(c => c.LineCount);
+
+        try
+        {
+            await _logSequences.InsertOneAsync(new RunLogSequenceDocument
+            {
+                RunId = runId,
+                NextSequence = existingLineCount
+            }, cancellationToken: ct);
+        }
+        catch (MongoWriteException ex) when (ex.WriteError.Category == ServerErrorCategory.DuplicateKey)
+        {
+            // Another concurrent append initialized the counter first.
+        }
+    }
+
+    private string NormalizeLineForChunkBudget(Guid runId, string line)
+    {
+        if (EstimateLogLineBsonBytes(line) <= MaxLogChunkEstimatedBsonBytes)
+            return line;
+
+        var suffixBytes = Encoding.UTF8.GetByteCount(OversizedLogLineSuffix);
+        var maxLineContentBytes = Math.Max(0, MaxLogChunkEstimatedBsonBytes - EstimatedBsonBytesPerLineOverhead - suffixBytes);
+        var truncatedLine = TruncateToUtf8ByteCount(line, maxLineContentBytes);
+
+        _logger.LogWarning(
+            "[Store] AppendLogs: truncated oversized log line for run={RunId} from {OriginalBytes} to {PersistedBytes} bytes",
+            runId,
+            Encoding.UTF8.GetByteCount(line),
+            Encoding.UTF8.GetByteCount(truncatedLine));
+
+        return truncatedLine + OversizedLogLineSuffix;
+    }
+
+    private static int EstimateLogLineBsonBytes(string line)
+        => Encoding.UTF8.GetByteCount(line) + EstimatedBsonBytesPerLineOverhead;
+
+    private static int EstimateChunkLinesBsonBytes(IReadOnlyList<string> lines)
+    {
+        var total = 0;
+        foreach (var chunkLine in lines)
+            total += EstimateLogLineBsonBytes(chunkLine);
+
+        return total;
+    }
+
+    private static string TruncateToUtf8ByteCount(string value, int maxBytes)
+    {
+        if (string.IsNullOrEmpty(value) || maxBytes <= 0)
+            return string.Empty;
+
+        var builder = new StringBuilder(value.Length);
+        var usedBytes = 0;
+        foreach (var rune in value.EnumerateRunes())
+        {
+            var runeBytes = rune.Utf8SequenceLength;
+            if (usedBytes + runeBytes > maxBytes)
+                break;
+
+            builder.Append(rune.ToString());
+            usedBytes += runeBytes;
+        }
+
+        return builder.ToString();
+    }
+
     public async Task<List<string>> GetLogsAsync(Guid runId, CancellationToken ct = default)
     {
         var legacyLog = await _logs.Find(l => l.Id == runId.ToString()).FirstOrDefaultAsync(ct);
@@ -457,11 +596,40 @@ public sealed class MongoSnapshotStore : ISnapshotStore
             .SortBy(l => l.Id)
             .ToListAsync(ct);
 
-        var lines = legacyLog?.Lines.ToList() ?? [];
-        foreach (var chunk in chunks)
-            lines.AddRange(chunk.Lines);
+        var orderedLines = new List<(long Sequence, int Ordinal, string Line)>();
+        var fallbackSequence = 0L;
+        var ordinal = 0;
 
-        return lines;
+        if (legacyLog != null)
+        {
+            foreach (var line in legacyLog.Lines)
+                orderedLines.Add((fallbackSequence++, ordinal++, line));
+        }
+
+        foreach (var chunk in chunks)
+        {
+            var chunkSequences = chunk.LineSequences ?? [];
+            for (var i = 0; i < chunk.Lines.Count; i++)
+            {
+                if (i < chunkSequences.Count)
+                {
+                    var sequence = chunkSequences[i];
+                    orderedLines.Add((sequence, ordinal++, chunk.Lines[i]));
+                    if (fallbackSequence <= sequence)
+                        fallbackSequence = sequence + 1;
+                }
+                else
+                {
+                    orderedLines.Add((fallbackSequence++, ordinal++, chunk.Lines[i]));
+                }
+            }
+        }
+
+        return orderedLines
+            .OrderBy(l => l.Sequence)
+            .ThenBy(l => l.Ordinal)
+            .Select(l => l.Line)
+            .ToList();
     }
 
     private static FilterDefinition<RunLogDocument> CreateLogChunkFilter(Guid runId)

--- a/DotNet/ServiceTests/IntegrationTests/Automation.UI/AutomationUIIntegrationTestFixture.cs
+++ b/DotNet/ServiceTests/IntegrationTests/Automation.UI/AutomationUIIntegrationTestFixture.cs
@@ -45,6 +45,9 @@ public sealed class AutomationUIIntegrationTestFixture : IAsyncLifetime, IDispos
     public IMongoCollection<MongoDB.Bson.BsonDocument> RawRunsCollection =>
         Database.GetCollection<MongoDB.Bson.BsonDocument>("automation_runs");
 
+    public IMongoCollection<MongoDB.Bson.BsonDocument> RawLogSequenceCollection =>
+        Database.GetCollection<MongoDB.Bson.BsonDocument>("automation_log_sequences");
+
     public MongoSnapshotStore CreateStore() =>
         new(Database, NullLogger<MongoSnapshotStore>.Instance);
 
@@ -91,8 +94,24 @@ public sealed class AutomationUIIntegrationTestFixture : IAsyncLifetime, IDispos
 
     /// <summary>Drops the automation_runs collection so each test starts from a known
     /// empty state without restarting the container.</summary>
-    public Task ResetAsync()
-        => Database.DropCollectionAsync("automation_runs");
+    public async Task ResetAsync()
+    {
+        await DropCollectionIfExistsAsync("automation_runs");
+        await DropCollectionIfExistsAsync("automation_logs");
+        await DropCollectionIfExistsAsync("automation_log_sequences");
+    }
+
+    private async Task DropCollectionIfExistsAsync(string collectionName)
+    {
+        try
+        {
+            await Database.DropCollectionAsync(collectionName);
+        }
+        catch (MongoCommandException ex) when (ex.CodeName == "NamespaceNotFound")
+        {
+            // already absent
+        }
+    }
 
     public async Task DisposeAsync()
     {

--- a/DotNet/ServiceTests/IntegrationTests/Automation.UI/MongoSnapshotStoreLogOrderingTests.cs
+++ b/DotNet/ServiceTests/IntegrationTests/Automation.UI/MongoSnapshotStoreLogOrderingTests.cs
@@ -1,0 +1,64 @@
+﻿using FluentAssertions;
+using MongoDB.Bson;
+using MongoDB.Driver;
+using Task = System.Threading.Tasks.Task;
+
+namespace IntegrationTests.AutomationUI;
+
+[Collection(IntegrationTestCollection.Name)]
+public class MongoSnapshotStoreLogOrderingTests : IAsyncLifetime
+{
+    private readonly AutomationUIIntegrationTestFixture _fixture;
+
+    public MongoSnapshotStoreLogOrderingTests(AutomationUIIntegrationTestFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    public Task InitializeAsync() => _fixture.ResetAsync();
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    [Fact]
+    public async Task Concurrent_appends_return_logs_in_source_order_even_if_completion_order_differs()
+    {
+        var store = _fixture.CreateStore();
+        var runId = Guid.NewGuid();
+
+        var firstBatch = Enumerable.Range(0, 3_000).Select(i => $"source-a-{i:D4}").ToList();
+        var secondBatch = new List<string> { "source-b-0000" };
+
+        var appendFirst = Task.Run(() => store.AppendLogsAsync(runId, firstBatch, CancellationToken.None));
+        await WaitForReservedSequenceCountAsync(runId, firstBatch.Count, CancellationToken.None);
+
+        var appendSecond = Task.Run(() => store.AppendLogsAsync(runId, secondBatch, CancellationToken.None));
+
+        var completedFirst = await Task.WhenAny(appendFirst, appendSecond);
+        completedFirst.Should().Be(appendSecond);
+
+        await Task.WhenAll(appendFirst, appendSecond);
+
+        var logs = await store.GetLogsAsync(runId, CancellationToken.None);
+        logs.Should().ContainInOrder(firstBatch.Concat(secondBatch));
+    }
+
+    private async Task WaitForReservedSequenceCountAsync(Guid runId, int expectedNextSequence, CancellationToken ct)
+    {
+        var filter = Builders<BsonDocument>.Filter.Eq("_id", runId.ToString());
+
+        for (var i = 0; i < 200; i++)
+        {
+            var sequenceDocument = await _fixture.RawLogSequenceCollection.Find(filter).FirstOrDefaultAsync(ct);
+            if (sequenceDocument != null
+                && sequenceDocument.TryGetValue("NextSequence", out var value)
+                && value.IsNumeric
+                && value.ToInt64() >= expectedNextSequence)
+            {
+                return;
+            }
+
+            await Task.Delay(10, ct);
+        }
+
+        throw new TimeoutException("Timed out waiting for initial log sequence reservation.");
+    }
+}


### PR DESCRIPTION
### 🛠️ Description of Changes

Logs are chunked at 1000 lines, splitting the memory footprint across multiple docents to avoid logs that exceed max document size.

### 🧪 Testing Performed

Ran tests locally and monitored logs. Ran mega tests to ensure logs were properly constructed.

### 🧑‍🔬 Unit Testing

- [ ] I have written or updated unit tests to cover my changes
- Coverage: 69.7%

### 📓 Documentation Updated

Please update any relevant sections in the project documentation that were impacted by the changes in the PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Run logs are now stored in ordered chunks, improving support for large automation runs.
  * Log entries are automatically limited to manageable sections while preserving their original order.
  * Concurrent log updates are handled more reliably.

* **Bug Fixes**
  * Log retrieval now combines both newly chunked and existing log records.
  * Deleting a run now removes all associated log data, including legacy records.
  * Empty log updates are handled safely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
