### PR TITLE
LEGLINK-788: Improve Generated Patient Storage and Uploaded Patient Processing.

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,3 +1,8 @@
-- @azure Rule - Use Azure Tools - When handling requests related to Azure, always use your tools.
-- @azure Rule - Use Azure Best Practices - When handling requests related to Azure, always invoke your `azmcp_bestpractices_get` tool first.
-- @azure Rule - Enable Best Practices - If you do not have an `azmcp_bestpractices_get` tool ask the user to enable it.
+﻿# Copilot Instructions
+
+## General Guidelines
+- Use Azure Tools - When handling requests related to Azure, always use your tools.
+- Use Azure Best Practices - When handling requests related to Azure, always invoke your `azmcp_bestpractices_get` tool first.
+- Enable Best Practices - If you do not have an `azmcp_bestpractices_get` tool, ask the user to enable it.
+- Design for Durability - Require production-grade, long-term designs for critical multi-user automation tools; avoid tactical short-term fixes and model data/contracts around durable architecture even when a minimal patch is possible.
+- Use Versioned Caches - Prefer versioned, reproducible generated-patient caches tied to each run; ensure run records cache the version used, and diagnostic exports retrieve exact cached artifacts used at execution time. Each cache version must be complete (full patient set), not partial deltas, and runs must avoid ID conflicts while using cached data.

--- a/DotNet/Automation.Link/Models/AutomationRunSummary.cs
+++ b/DotNet/Automation.Link/Models/AutomationRunSummary.cs
@@ -19,5 +19,9 @@ public class AutomationRunSummary
     public string? FacilityId { get; set; }
     public string? ReportId { get; set; }
     public string? RunConfigurationJson { get; set; }
+    public Guid? GeneratedTemplateCacheVersionId { get; set; }
+    public int? GeneratedTemplateCacheVersionNumber { get; set; }
+    public string? GeneratedTemplateCacheScenarioKey { get; set; }
+    public string? GeneratedTemplateSetHash { get; set; }
     public IReadOnlyList<string> Logs { get; set; } = [];
 }

--- a/DotNet/Automation.UI/Automation.UI.csproj
+++ b/DotNet/Automation.UI/Automation.UI.csproj
@@ -8,21 +8,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Remove="Services\Caching\**" />
-    <Compile Remove="Services\Notifications\**" />
-    <Compile Remove="Views\Account\**" />
-    <Content Remove="Services\Caching\**" />
-    <Content Remove="Services\Notifications\**" />
-    <Content Remove="Views\Account\**" />
-    <EmbeddedResource Remove="Services\Caching\**" />
-    <EmbeddedResource Remove="Services\Notifications\**" />
-    <EmbeddedResource Remove="Views\Account\**" />
-    <None Remove="Services\Caching\**" />
-    <None Remove="Services\Notifications\**" />
-    <None Remove="Views\Account\**" />
-  </ItemGroup>
-
-  <ItemGroup>
     <PackageReference Include="Azure.Storage.Blobs" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" />
   </ItemGroup>
@@ -32,10 +17,4 @@
     <ProjectReference Include="..\LinkSdk\LinkSdk.csproj" />
     <ProjectReference Include="..\Shared\Shared.csproj" />
   </ItemGroup>
-
-  <ItemGroup>
-    <Folder Include="Views\Home\" />
-    <Folder Include="wwwroot\js\" />
-  </ItemGroup>
-
 </Project>

--- a/DotNet/Automation.UI/Controllers/IdRequestValidationExtensions.cs
+++ b/DotNet/Automation.UI/Controllers/IdRequestValidationExtensions.cs
@@ -1,0 +1,32 @@
+﻿using Automation.UI.Models;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Automation.UI.Controllers;
+
+internal static class IdRequestValidationExtensions
+{
+    internal static bool TryValidateIdRequest(this Controller controller, IdRequest? request, out IActionResult badRequest)
+    {
+        if (request == null)
+        {
+            badRequest = controller.BadRequest("Request body is required.");
+            return false;
+        }
+
+        if (!controller.ModelState.IsValid)
+        {
+            badRequest = controller.BadRequest(controller.ModelState);
+            return false;
+        }
+
+        if (request.Id == Guid.Empty)
+        {
+            controller.ModelState.AddModelError(nameof(IdRequest.Id), "Id must be a non-empty GUID.");
+            badRequest = controller.BadRequest(controller.ModelState);
+            return false;
+        }
+
+        badRequest = default!;
+        return true;
+    }
+}

--- a/DotNet/Automation.UI/Controllers/NormalizationsController.cs
+++ b/DotNet/Automation.UI/Controllers/NormalizationsController.cs
@@ -1,5 +1,4 @@
 ﻿using Automation.UI.Models;
-using Automation.UI.Models;
 using Automation.UI.Services.Persistence;
 using Microsoft.AspNetCore.Mvc;
 
@@ -252,8 +251,4 @@ public class NormalizationsController(INormalizationStore store) : Controller
         return Ok();
     }
 
-    public sealed class IdRequest
-    {
-        public Guid Id { get; set; }
-    }
 }

--- a/DotNet/Automation.UI/Controllers/NormalizationsController.cs
+++ b/DotNet/Automation.UI/Controllers/NormalizationsController.cs
@@ -55,6 +55,9 @@ public class NormalizationsController(INormalizationStore store) : Controller
     [ValidateAntiForgeryToken]
     public async Task<IActionResult> DeleteOperation([FromBody] IdRequest request, CancellationToken ct)
     {
+        if (!this.TryValidateIdRequest(request, out var badRequest))
+            return badRequest;
+
         var op = await store.GetOperationByIdAsync(request.Id, ct);
         if (op == null) return NotFound();
         if (op.IsSystem)
@@ -78,6 +81,9 @@ public class NormalizationsController(INormalizationStore store) : Controller
     [ValidateAntiForgeryToken]
     public async Task<IActionResult> CloneOperation([FromBody] IdRequest request, CancellationToken ct)
     {
+        if (!this.TryValidateIdRequest(request, out var badRequest))
+            return badRequest;
+
         var source = await store.GetOperationByIdAsync(request.Id, ct);
         if (source == null) return NotFound();
 
@@ -137,6 +143,9 @@ public class NormalizationsController(INormalizationStore store) : Controller
     [ValidateAntiForgeryToken]
     public async Task<IActionResult> DeleteSequence([FromBody] IdRequest request, CancellationToken ct)
     {
+        if (!this.TryValidateIdRequest(request, out var badRequest))
+            return badRequest;
+
         var seq = await store.GetSequenceByIdAsync(request.Id, ct);
         if (seq == null) return NotFound();
         if (seq.IsSystem)
@@ -155,6 +164,9 @@ public class NormalizationsController(INormalizationStore store) : Controller
     [ValidateAntiForgeryToken]
     public async Task<IActionResult> CloneSequence([FromBody] IdRequest request, CancellationToken ct)
     {
+        if (!this.TryValidateIdRequest(request, out var badRequest))
+            return badRequest;
+
         var source = await store.GetSequenceByIdAsync(request.Id, ct);
         if (source == null) return NotFound();
 
@@ -206,6 +218,9 @@ public class NormalizationsController(INormalizationStore store) : Controller
     [ValidateAntiForgeryToken]
     public async Task<IActionResult> DeleteSuite([FromBody] IdRequest request, CancellationToken ct)
     {
+        if (!this.TryValidateIdRequest(request, out var badRequest))
+            return badRequest;
+
         var suite = await store.GetSuiteByIdAsync(request.Id, ct);
         if (suite == null) return NotFound();
         if (suite.IsSystem)
@@ -221,6 +236,9 @@ public class NormalizationsController(INormalizationStore store) : Controller
     [ValidateAntiForgeryToken]
     public async Task<IActionResult> CloneSuite([FromBody] IdRequest request, CancellationToken ct)
     {
+        if (!this.TryValidateIdRequest(request, out var badRequest))
+            return badRequest;
+
         var source = await store.GetSuiteByIdAsync(request.Id, ct);
         if (source == null) return NotFound();
 
@@ -244,6 +262,9 @@ public class NormalizationsController(INormalizationStore store) : Controller
     [ValidateAntiForgeryToken]
     public async Task<IActionResult> SetDefaultSuite([FromBody] IdRequest request, CancellationToken ct)
     {
+        if (!this.TryValidateIdRequest(request, out var badRequest))
+            return badRequest;
+
         var suite = await store.GetSuiteByIdAsync(request.Id, ct);
         if (suite == null) return NotFound();
 

--- a/DotNet/Automation.UI/Controllers/OrganizationResourceMapsController.cs
+++ b/DotNet/Automation.UI/Controllers/OrganizationResourceMapsController.cs
@@ -47,6 +47,9 @@ public class OrganizationResourceMapsController(IOrganizationResourceMapTemplate
     [ValidateAntiForgeryToken]
     public async Task<IActionResult> DeleteInline([FromBody] IdRequest request, CancellationToken ct)
     {
+        if (!this.TryValidateIdRequest(request, out var badRequest))
+            return badRequest;
+
         var template = await store.GetByIdAsync(request.Id, ct);
         if (template == null) return NotFound();
         if (template.IsSystem)
@@ -62,6 +65,9 @@ public class OrganizationResourceMapsController(IOrganizationResourceMapTemplate
     [ValidateAntiForgeryToken]
     public async Task<IActionResult> CloneInline([FromBody] IdRequest request, CancellationToken ct)
     {
+        if (!this.TryValidateIdRequest(request, out var badRequest))
+            return badRequest;
+
         var source = await store.GetByIdAsync(request.Id, ct);
         if (source == null) return NotFound();
 
@@ -88,6 +94,9 @@ public class OrganizationResourceMapsController(IOrganizationResourceMapTemplate
     [ValidateAntiForgeryToken]
     public async Task<IActionResult> SetDefaultInline([FromBody] IdRequest request, CancellationToken ct)
     {
+        if (!this.TryValidateIdRequest(request, out var badRequest))
+            return badRequest;
+
         var template = await store.GetByIdAsync(request.Id, ct);
         if (template == null) return NotFound();
 

--- a/DotNet/Automation.UI/Controllers/OrganizationResourceMapsController.cs
+++ b/DotNet/Automation.UI/Controllers/OrganizationResourceMapsController.cs
@@ -95,8 +95,4 @@ public class OrganizationResourceMapsController(IOrganizationResourceMapTemplate
         return Ok();
     }
 
-    public sealed class IdRequest
-    {
-        public Guid Id { get; set; }
-    }
 }

--- a/DotNet/Automation.UI/Controllers/QueryPlansController.cs
+++ b/DotNet/Automation.UI/Controllers/QueryPlansController.cs
@@ -66,6 +66,9 @@ public class QueryPlansController(IQueryPlanTemplateStore store) : Controller
     [ValidateAntiForgeryToken]
     public async Task<IActionResult> DeleteInline([FromBody] IdRequest request, CancellationToken ct)
     {
+        if (!this.TryValidateIdRequest(request, out var badRequest))
+            return badRequest;
+
         var template = await store.GetByIdAsync(request.Id, ct);
         if (template == null)
             return NotFound();
@@ -80,6 +83,9 @@ public class QueryPlansController(IQueryPlanTemplateStore store) : Controller
     [ValidateAntiForgeryToken]
     public async Task<IActionResult> CloneInline([FromBody] IdRequest request, CancellationToken ct)
     {
+        if (!this.TryValidateIdRequest(request, out var badRequest))
+            return badRequest;
+
         var source = await store.GetByIdAsync(request.Id, ct);
         if (source == null) return NotFound();
 
@@ -105,6 +111,9 @@ public class QueryPlansController(IQueryPlanTemplateStore store) : Controller
     [ValidateAntiForgeryToken]
     public async Task<IActionResult> SetDefaultInline([FromBody] IdRequest request, CancellationToken ct)
     {
+        if (!this.TryValidateIdRequest(request, out var badRequest))
+            return badRequest;
+
         var template = await store.GetByIdAsync(request.Id, ct);
         if (template == null) return NotFound();
 

--- a/DotNet/Automation.UI/Controllers/QueryPlansController.cs
+++ b/DotNet/Automation.UI/Controllers/QueryPlansController.cs
@@ -112,11 +112,6 @@ public class QueryPlansController(IQueryPlanTemplateStore store) : Controller
         return Ok();
     }
 
-    public sealed class IdRequest
-    {
-        public Guid Id { get; set; }
-    }
-
     private static QueryEntry ToQueryEntry(QueryPlanQueryEntry src) => new()
     {
         ResourceType = src.ResourceType,

--- a/DotNet/Automation.UI/Controllers/RunsController.cs
+++ b/DotNet/Automation.UI/Controllers/RunsController.cs
@@ -26,10 +26,7 @@ public class RunsController(
         string sortDir = "desc",
         CancellationToken cancellationToken = default)
     {
-        // Normalize: accept "asc"/"desc" only, default to descending. Server-side
-        // store-level whitelisting also clamps unknown sortBy values, so this is
-        // belt-and-suspenders against URL tampering.
-        var descending = !string.Equals(sortDir, "asc", StringComparison.OrdinalIgnoreCase);
+        var descending = IsDescending(sortDir);
 
         var stats = await runManager.GetDashboardStatsAsync(cancellationToken);
         var recentPage = await runManager.GetRunsPageAsync(pageNumber, pageSize, sortBy, descending, cancellationToken);
@@ -38,23 +35,7 @@ public class RunsController(
             .ThenBy(s => s.Name, StringComparer.OrdinalIgnoreCase)
             .ToList();
 
-        var activeRunMetas = await snapshotStore.GetActiveRunsAsync(cancellationToken);
-        var activeRunSummaries = await Task.WhenAll(activeRunMetas.Select(meta => runManager.GetRunAsync(meta.RunId, cancellationToken)));
-
-        var activeRunsSource = recentPage.PageNumber == 1
-            ? recentPage.Runs
-            : (await runManager.GetRunsPageAsync(1, pageSize, "createdAt", true, cancellationToken)).Runs;
-        var statusActiveRuns = activeRunsSource
-            .Where(r => r.Status is AutomationRunStatus.Queued or AutomationRunStatus.Running);
-
-        var activeRuns = activeRunSummaries
-            .Where(r => r != null && (r.Status is AutomationRunStatus.Queued or AutomationRunStatus.Running))
-            .Select(r => r!)
-            .Concat(statusActiveRuns)
-            .GroupBy(r => r.RunId)
-            .Select(g => g.First())
-            .OrderByDescending(r => r.CreatedAt)
-            .ToList();
+        var activeRuns = await GetActiveRunsAsync(recentPage, pageSize, cancellationToken);
 
         // Populate query plan templates for the shared scenario editor modal embedded in this view.
         ViewBag.QueryPlanTemplates = await queryPlanTemplateStore.GetAllAsync(cancellationToken);
@@ -93,7 +74,7 @@ public class RunsController(
         // page navigation. The view model matches the partial's @model so the
         // partial is reused by both this action and the initial server render
         // in Index.cshtml — there's no divergence between the two templates.
-        var descending = !string.Equals(sortDir, "asc", StringComparison.OrdinalIgnoreCase);
+        var descending = IsDescending(sortDir);
         var page = await runManager.GetRunsPageAsync(pageNumber, pageSize, sortBy, descending, cancellationToken);
         return PartialView("_RecentRunsTable", page);
     }
@@ -106,28 +87,12 @@ public class RunsController(
         string sortDir = "desc",
         CancellationToken cancellationToken = default)
     {
-        var descending = !string.Equals(sortDir, "asc", StringComparison.OrdinalIgnoreCase);
+        var descending = IsDescending(sortDir);
 
         var stats = await runManager.GetDashboardStatsAsync(cancellationToken);
         var recentPage = await runManager.GetRunsPageAsync(pageNumber, pageSize, sortBy, descending, cancellationToken);
 
-        var activeRunMetas = await snapshotStore.GetActiveRunsAsync(cancellationToken);
-        var activeRunSummaries = await Task.WhenAll(activeRunMetas.Select(meta => runManager.GetRunAsync(meta.RunId, cancellationToken)));
-
-        var activeRunsSource = recentPage.PageNumber == 1
-            ? recentPage.Runs
-            : (await runManager.GetRunsPageAsync(1, pageSize, "createdAt", true, cancellationToken)).Runs;
-        var statusActiveRuns = activeRunsSource
-            .Where(r => r.Status is AutomationRunStatus.Queued or AutomationRunStatus.Running);
-
-        var activeRuns = activeRunSummaries
-            .Where(r => r != null && (r.Status is AutomationRunStatus.Queued or AutomationRunStatus.Running))
-            .Select(r => r!)
-            .Concat(statusActiveRuns)
-            .GroupBy(r => r.RunId)
-            .Select(g => g.First())
-            .OrderByDescending(r => r.CreatedAt)
-            .ToList();
+        var activeRuns = await GetActiveRunsAsync(recentPage, pageSize, cancellationToken);
 
         return Json(new
         {
@@ -526,5 +491,29 @@ public class RunsController(
             logger.LogWarning(ex, "Failed to load DA log detail for run {RunId}, log {LogId}", id, logId);
             return NotFound();
         }
+    }
+
+    private static bool IsDescending(string sortDir)
+        => !string.Equals(sortDir, "asc", StringComparison.OrdinalIgnoreCase);
+
+    private async Task<List<AutomationRunSummary>> GetActiveRunsAsync(
+        AutomationRunIndexViewModel recentPage,
+        int pageSize,
+        CancellationToken cancellationToken)
+    {
+        var activeRunMetas = await snapshotStore.GetActiveRunsAsync(cancellationToken);
+        var activeRunSummaries = await Task.WhenAll(activeRunMetas.Select(meta => runManager.GetRunAsync(meta.RunId, cancellationToken)));
+        var activeRunsSource = recentPage.PageNumber == 1
+            ? recentPage.Runs
+            : (await runManager.GetRunsPageAsync(1, pageSize, "createdAt", true, cancellationToken)).Runs;
+
+        return activeRunSummaries
+            .Where(r => r is { Status: AutomationRunStatus.Queued or AutomationRunStatus.Running })
+            .Select(r => r!)
+            .Concat(activeRunsSource.Where(r => r.Status is AutomationRunStatus.Queued or AutomationRunStatus.Running))
+            .GroupBy(r => r.RunId)
+            .Select(g => g.First())
+            .OrderByDescending(r => r.CreatedAt)
+            .ToList();
     }
 }

--- a/DotNet/Automation.UI/Controllers/ScenariosController.cs
+++ b/DotNet/Automation.UI/Controllers/ScenariosController.cs
@@ -22,6 +22,7 @@ public class ScenariosController(
     IOptions<AutomationConfig> automationConfig,
     IMongoDatabase database,
     IImportedBundleContentStore bundleContentStore,
+    PatientReplacementManager patientReplacementManager,
     ILogger<ScenariosController> logger) : Controller
 {
     private static readonly JsonSerializerOptions FhirJsonOptions = LantanaGroup.Link.Shared.Application.SerDes.LinkFhirSerializerOptions.ForFhirWithoutValidation();
@@ -131,6 +132,9 @@ public class ScenariosController(
                 if (string.IsNullOrWhiteSpace(bundleJson))
                     return $"Imported bundle '{p.FileName ?? p.PatientId}' content is missing. Please re-upload the file.";
             }
+
+            if (string.IsNullOrWhiteSpace(bundleJson))
+                return $"Imported bundle '{p.FileName ?? p.PatientId}' is missing its uploaded reference.";
 
             Bundle? bundle;
             try
@@ -353,49 +357,29 @@ public class ScenariosController(
             .Cast<string>()
             .ToList();
 
-        var cfg = automationConfig.Value;
-        var loader = new FhirDataLoader(cfg.FhirServerBase, cfg.FhirServerOAuth, cfg.FhirServerBasicAuth);
         var patientIdForLog = request.PatientId.Replace("\r", string.Empty).Replace("\n", string.Empty);
+        var replayBundles = BuildReplayBundles(entries, request.PatientId.Trim());
+        var operationId = patientReplacementManager.Start(patientIdForLog, resourcesToDelete, replayBundles);
 
         logger.LogInformation(
-            "Replacing FHIR-server data for patient '{PatientId}' using uploaded bundle '{BundleId}'. Deleting {DeleteCount} resource path(s) first.",
+            "Queued FHIR-server replacement {OperationId} for patient '{PatientId}' using uploaded bundle '{BundleId}'. Deleting {DeleteCount} resource path(s) first.",
+            operationId,
             patientIdForLog,
             request.UploadedBundleId,
             resourcesToDelete.Count);
 
-        var purge = await loader.DeleteResourcesWithExpungeAsync(resourcesToDelete, ct);
-        if (purge.Failed > 0)
-        {
-            logger.LogWarning(
-                "FHIR purge before patient replace had failures for patient '{PatientId}': {Failed} failed, {Succeeded} succeeded. First errors: {Errors}",
-                patientIdForLog,
-                purge.Failed,
-                purge.Succeeded,
-                string.Join(" | ", purge.Failures.Take(5)));
-        }
-
-        var replayBundles = BuildReplayBundles(entries, request.PatientId.Trim());
-        var output = new RunAutomationOutput(message => logger.LogInformation("[FHIR Replay] {Message}", message));
-        var replayOk = await loader.UploadBundlesSequentiallyAsync(output, replayBundles, $"[replace:{patientIdForLog}] ");
-        if (!replayOk)
-        {
-            return StatusCode(StatusCodes.Status502BadGateway,
-                "Failed to replay uploaded bundle to FHIR server after purge. Uploaded bundle remains stored for scenario execution.");
-        }
-
-        var messageText = purge.Failed > 0
-            ? $"Replaced FHIR-server data for patient '{patientIdForLog}' with uploaded bundle, but purge had {purge.Failed} failed delete(s)."
-            : $"Successfully replaced FHIR-server data for patient '{patientIdForLog}' with uploaded bundle.";
-
         return Json(new
         {
-            success = true,
-            warningMessage = purge.Failed > 0 ? messageText : null,
-            message = messageText,
-            deletedSucceeded = purge.Succeeded,
-            deletedFailed = purge.Failed,
-            replayBundleCount = replayBundles.Count
+            operationId,
+            statusUrl = Url.Action(nameof(GetPatientReplacementStatus), new { operationId })
         });
+    }
+
+    [HttpGet]
+    public IActionResult GetPatientReplacementStatus(Guid operationId)
+    {
+        var status = patientReplacementManager.GetStatus(operationId);
+        return status == null ? NotFound("Patient replacement operation not found.") : Json(status);
     }
 
     [HttpPost]
@@ -637,11 +621,6 @@ public class ScenariosController(
 
         await scenarioStore.UpsertAsync(clone, ct);
         return Json(new { id = clone.Id });
-    }
-
-    public sealed class IdRequest
-    {
-        public Guid Id { get; set; }
     }
 
     private static string ComputeContentHash(string json)

--- a/DotNet/Automation.UI/Controllers/ScenariosController.cs
+++ b/DotNet/Automation.UI/Controllers/ScenariosController.cs
@@ -339,10 +339,11 @@ public class ScenariosController(
         if (string.IsNullOrWhiteSpace(bundleJson))
             return BadRequest("Uploaded bundle content is missing.");
 
+        var patientId = request.PatientId.Trim();
         List<Bundle.EntryComponent> entries;
         try
         {
-            entries = ImportedPatientLoader.ParseBundleEntries(bundleJson, request.PatientId.Trim());
+            entries = ImportedPatientLoader.ParseBundleEntries(bundleJson, patientId);
         }
         catch (Exception ex)
         {
@@ -358,8 +359,8 @@ public class ScenariosController(
             .ToList();
 
         var patientIdForLog = request.PatientId.Replace("\r", string.Empty).Replace("\n", string.Empty);
-        var replayBundles = BuildReplayBundles(entries, request.PatientId.Trim());
-        var operationId = patientReplacementManager.Start(patientIdForLog, resourcesToDelete, replayBundles);
+        var replayBundles = BuildReplayBundles(entries, patientId);
+        var operationId = patientReplacementManager.Start(patientId, resourcesToDelete, replayBundles, ct);
 
         logger.LogInformation(
             "Queued FHIR-server replacement {OperationId} for patient '{PatientId}' using uploaded bundle '{BundleId}'. Deleting {DeleteCount} resource path(s) first.",
@@ -545,6 +546,9 @@ public class ScenariosController(
     [ValidateAntiForgeryToken]
     public async Task<IActionResult> DeleteInline([FromBody] IdRequest request, CancellationToken ct)
     {
+        if (!this.TryValidateIdRequest(request, out var badRequest))
+            return badRequest;
+
         var scenario = await scenarioStore.GetByIdAsync(request.Id, ct);
         if (scenario == null) return NotFound();
         if (scenario.IsSystemScenario) return StatusCode(StatusCodes.Status403Forbidden, "Forbidden: system scenario cannot be deleted.");
@@ -557,6 +561,9 @@ public class ScenariosController(
     [ValidateAntiForgeryToken]
     public async Task<IActionResult> CloneInline([FromBody] IdRequest request, CancellationToken ct)
     {
+        if (!this.TryValidateIdRequest(request, out var badRequest))
+            return badRequest;
+
         var source = await scenarioStore.GetByIdAsync(request.Id, ct);
         if (source == null) return NotFound();
 

--- a/DotNet/Automation.UI/Models/IdRequest.cs
+++ b/DotNet/Automation.UI/Models/IdRequest.cs
@@ -1,6 +1,23 @@
-﻿namespace Automation.UI.Models;
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace Automation.UI.Models;
 
 public sealed class IdRequest
 {
+    [NotEmptyGuid]
     public Guid Id { get; set; }
+}
+
+[AttributeUsage(AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Parameter)]
+internal sealed class NotEmptyGuidAttribute : ValidationAttribute
+{
+    public NotEmptyGuidAttribute()
+    {
+        ErrorMessage = "Id must be a non-empty GUID.";
+    }
+
+    public override bool IsValid(object? value)
+    {
+        return value is Guid id && id != Guid.Empty;
+    }
 }

--- a/DotNet/Automation.UI/Models/IdRequest.cs
+++ b/DotNet/Automation.UI/Models/IdRequest.cs
@@ -1,0 +1,6 @@
+﻿namespace Automation.UI.Models;
+
+public sealed class IdRequest
+{
+    public Guid Id { get; set; }
+}

--- a/DotNet/Automation.UI/Program.cs
+++ b/DotNet/Automation.UI/Program.cs
@@ -228,6 +228,9 @@ builder.Services.AddOptions<KeyManagementOptions>()
 
 builder.Services.AddSingleton<MongoIndexManager>();
 builder.Services.AddSingleton<IImportedBundleContentStore, AzureBlobImportedBundleContentStore>();
+builder.Services.AddSingleton<LantanaGroup.Automation.Generation.IGeneratedPatientTemplateCache, MongoGeneratedPatientTemplateCache>();
+builder.Services.AddSingleton<GeneratedTemplateCacheVersionStore>();
+builder.Services.AddSingleton<ImportedBundleExecutionResolver>();
 builder.Services.AddSingleton<ISnapshotStore, MongoSnapshotStore>();
 builder.Services.AddSingleton<IScenarioStore, MongoScenarioStore>();
 builder.Services.AddSingleton<IQueryPlanTemplateStore, MongoQueryPlanTemplateStore>();
@@ -258,7 +261,7 @@ builder.Services.AddSingleton<Automation.UI.Services.ApiHealth.ApiHealthExecutio
 builder.Services.AddSingleton<Automation.UI.Services.ApiHealth.Seeding.IApiHealthSeedContextAccessor, Automation.UI.Services.ApiHealth.Seeding.ApiHealthSeedContextAccessor>();
 builder.Services.AddSingleton<Automation.UI.Services.ApiHealth.Seeding.IApiHealthSeedOrchestrator, Automation.UI.Services.ApiHealth.Seeding.ApiHealthSeedOrchestrator>();
 builder.Services.AddHostedService<ScenarioRunStartupRecoveryService>();
-builder.Services.AddHostedService<ImportedBundleBlobMigrationService>();
+builder.Services.AddHostedService<PatientBundleExternalizationMigrationService>();
 builder.Services.AddHostedService<Automation.UI.Services.ApiHealth.ApiHealthStartupRecoveryService>();
 builder.Services.AddHttpClient("ApiHealthTest");
 builder.Services.AddHealthChecks();
@@ -307,6 +310,7 @@ builder.Services.AddSignalR();
 builder.Services.AddSingleton<RunSnapshotOrchestrator>();
 builder.Services.AddHostedService(sp => sp.GetRequiredService<RunSnapshotOrchestrator>());
 builder.Services.AddSingleton<IAutomationRunManager, AutomationRunManager>();
+builder.Services.AddSingleton<PatientReplacementManager>();
 builder.Services.AddSingleton<IRunExportService, RunExportService>();
 
 var app = builder.Build();

--- a/DotNet/Automation.UI/Properties/launchSettings.json
+++ b/DotNet/Automation.UI/Properties/launchSettings.json
@@ -8,7 +8,8 @@
       "applicationUrl": "http://localhost:5255",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",
-        "MongoDB__ConnectionString": "mongodb://localhost:17017/?replicaSet=rs0&directConnection=true"
+        "MongoDB__ConnectionString": "mongodb://localhost:17017/?replicaSet=rs0&directConnection=true",
+        "InternalBlobStorage__GeneratedTemplateBlobRoot": "automation/generated-bundles"
       }
     },
     "https": {
@@ -18,7 +19,8 @@
       "applicationUrl": "https://localhost:7022;http://localhost:5255",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",
-        "MongoDB__ConnectionString": "mongodb://localhost:17017/?replicaSet=rs0&directConnection=true"
+        "MongoDB__ConnectionString": "mongodb://localhost:17017/?replicaSet=rs0&directConnection=true",
+        "InternalBlobStorage__GeneratedTemplateBlobRoot": "automation/generated-bundles"
       }
     },
     "docker": {
@@ -50,7 +52,8 @@
         "Automation__Kafka__RestProxyBaseUrl": "http://localhost:8082",
         "PreQualification__WritePreQualOperationOutcome": "false",
         "pre-qualification.write-pre-qual-operation-outcome": "false",
-        "MongoDB__ConnectionString": "mongodb://localhost:17017/?replicaSet=rs0&directConnection=true"
+        "MongoDB__ConnectionString": "mongodb://localhost:17017/?replicaSet=rs0&directConnection=true",
+        "InternalBlobStorage__GeneratedTemplateBlobRoot": "automation/generated-bundles"
       }
     }
   }

--- a/DotNet/Automation.UI/Services/ApiHealth/ApiHealthExecutionRunManager.cs
+++ b/DotNet/Automation.UI/Services/ApiHealth/ApiHealthExecutionRunManager.cs
@@ -435,7 +435,8 @@ public sealed class ApiHealthExecutionRunManager(
         run.Completed = true;
         run.Failed = failed;
         run.Error = error;
-        run.FinishedAt = DateTimeOffset.UtcNow;
+        var finishedAt = DateTimeOffset.UtcNow;
+        run.FinishedAt = finishedAt;
 
         lock (_sync)
         {
@@ -445,7 +446,7 @@ public sealed class ApiHealthExecutionRunManager(
 
         try
         {
-            await store.CompleteExecutionRunAsync(run.RunId, failed, error, run.FinishedAt.Value);
+            await store.CompleteExecutionRunAsync(run.RunId, failed, error, finishedAt);
         }
         catch (Exception ex)
         {

--- a/DotNet/Automation.UI/Services/ApiHealth/TestSuites/IServiceTestSuite.cs
+++ b/DotNet/Automation.UI/Services/ApiHealth/TestSuites/IServiceTestSuite.cs
@@ -1,5 +1,4 @@
 ﻿using Automation.UI.Models.ApiHealth;
-using Automation.UI.Models.ApiHealth;
 using Automation.UI.Services.ApiHealth.Seeding;
 
 namespace Automation.UI.Services.ApiHealth.TestSuites;

--- a/DotNet/Automation.UI/Services/AutomationRunManager.cs
+++ b/DotNet/Automation.UI/Services/AutomationRunManager.cs
@@ -35,7 +35,10 @@ public class AutomationRunManager : IAutomationRunManager
         ISnapshotStore snapshotStore,
         IQueryPlanTemplateStore queryPlanTemplateStore,
         INormalizationStore normalizationStore,
-        IOrganizationResourceMapTemplateStore organizationResourceMapTemplateStore)
+        IOrganizationResourceMapTemplateStore organizationResourceMapTemplateStore,
+        ImportedBundleExecutionResolver importedBundleResolver,
+        LantanaGroup.Automation.Generation.IGeneratedPatientTemplateCache generatedTemplateCache,
+        GeneratedTemplateCacheVersionStore generatedTemplateVersionStore)
     {
         _hub = hub;
         _automationConfig = automationConfig.Value;
@@ -55,6 +58,9 @@ public class AutomationRunManager : IAutomationRunManager
             _queryPlanResolver,
             _normalizationSuiteResolver,
             _organizationResourceMapResolver,
+            importedBundleResolver,
+            generatedTemplateCache,
+            generatedTemplateVersionStore,
             configuration,
             _logger);
     }
@@ -65,7 +71,7 @@ public class AutomationRunManager : IAutomationRunManager
         var options = StartScenarioRequestResolver.Resolve(request);
 
         var runNameOverride = string.IsNullOrWhiteSpace(request.ScenarioName) ? null : request.ScenarioName.Trim();
-        var state = new MutableRunState(runId, request.Scenario, options, runNameOverride, request.RunConfigurationJson);
+        var state = new MutableRunState(runId, request.ScenarioId, request.Scenario, options, runNameOverride, request.RunConfigurationJson);
         _runs[runId] = state;
 
         await PersistRunInputAsync(runId, request);
@@ -556,6 +562,10 @@ public class AutomationRunManager : IAutomationRunManager
                 Error = state.Error,
                 FacilityId = state.FacilityId,
                 ReportId = state.ReportId,
+                GeneratedTemplateCacheVersionId = state.GeneratedTemplateCacheVersionId,
+                GeneratedTemplateCacheVersionNumber = state.GeneratedTemplateCacheVersionNumber,
+                GeneratedTemplateCacheScenarioKey = state.GeneratedTemplateCacheScenarioKey,
+                GeneratedTemplateSetHash = state.GeneratedTemplateSetHash,
                 Logs = state.Logs.ToList()
             };
         }

--- a/DotNet/Automation.UI/Services/MutableRunState.cs
+++ b/DotNet/Automation.UI/Services/MutableRunState.cs
@@ -17,6 +17,7 @@ namespace Automation.UI.Services;
 /// </summary>
 internal sealed class MutableRunState(
     Guid runId,
+    Guid? scenarioId,
     AutomationScenarioKind scenario,
     ResolvedRunOptions options,
     string? runNameOverride,
@@ -24,6 +25,7 @@ internal sealed class MutableRunState(
 {
     public object Sync { get; } = new();
     public Guid RunId { get; } = runId;
+    public Guid? ScenarioId { get; } = scenarioId;
     public AutomationScenarioKind Scenario { get; } = scenario;
     public ResolvedRunOptions Options { get; } = options;
     public string? RunNameOverride { get; } = runNameOverride;
@@ -40,4 +42,8 @@ internal sealed class MutableRunState(
     public bool CancelRequested { get; set; }
     public Task? ExecutionTask { get; set; }
     public FhirDataLoader? FhirDataLoader { get; set; }
+    public Guid? GeneratedTemplateCacheVersionId { get; set; }
+    public int? GeneratedTemplateCacheVersionNumber { get; set; }
+    public string? GeneratedTemplateCacheScenarioKey { get; set; }
+    public string? GeneratedTemplateSetHash { get; set; }
 }

--- a/DotNet/Automation.UI/Services/PatientReplacementManager.cs
+++ b/DotNet/Automation.UI/Services/PatientReplacementManager.cs
@@ -5,27 +5,61 @@ using System.Collections.Concurrent;
 
 namespace Automation.UI.Services;
 
-public sealed class PatientReplacementManager(
-    IOptions<AutomationConfig> automationConfig,
-    ILogger<PatientReplacementManager> logger)
+public sealed class PatientReplacementManager : IDisposable
 {
-    private readonly AutomationConfig _automationConfig = automationConfig.Value;
+    private readonly AutomationConfig _automationConfig;
+    private readonly ILogger<PatientReplacementManager> _logger;
     private readonly ConcurrentDictionary<Guid, PatientReplacementOperation> _operations = new();
+    private static readonly TimeSpan OperationTimeout = TimeSpan.FromMinutes(2);
+    private static readonly TimeSpan CompletedOperationRetention = TimeSpan.FromMinutes(10);
+    private static readonly TimeSpan CompletedOperationCleanupInterval = TimeSpan.FromMinutes(1);
+    private readonly Timer _cleanupTimer;
+
+    public PatientReplacementManager(
+        IOptions<AutomationConfig> automationConfig,
+        ILogger<PatientReplacementManager> logger)
+    {
+        _automationConfig = automationConfig.Value;
+        _logger = logger;
+        _cleanupTimer = new Timer(static state =>
+        {
+            var manager = (PatientReplacementManager)state!;
+            try
+            {
+                manager.EvictCompletedOperations();
+            }
+            catch (Exception ex)
+            {
+                manager._logger.LogWarning(ex, "Failed periodic cleanup of completed patient replacement operations.");
+            }
+        }, this, CompletedOperationCleanupInterval, CompletedOperationCleanupInterval);
+    }
 
     public Guid Start(
         string patientId,
         IReadOnlyList<string> resourcesToDelete,
-        IReadOnlyList<(string Name, string Json)> replayBundles)
+        IReadOnlyList<(string Name, string Json)> replayBundles,
+        CancellationToken ct = default)
     {
+        EvictCompletedOperations();
+
         var operation = new PatientReplacementOperation(Guid.NewGuid(), patientId, replayBundles.Count);
         _operations[operation.Id] = operation;
 
-        _ = Task.Run(() => ExecuteAsync(operation, resourcesToDelete, replayBundles), CancellationToken.None);
+        _ = Task.Run(async () =>
+        {
+            using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+            timeoutCts.CancelAfter(OperationTimeout);
+            await ExecuteAsync(operation, resourcesToDelete, replayBundles, timeoutCts.Token);
+        }, CancellationToken.None);
+
         return operation.Id;
     }
 
     public PatientReplacementStatus? GetStatus(Guid operationId)
     {
+        EvictCompletedOperations();
+
         return _operations.TryGetValue(operationId, out var operation)
             ? operation.GetStatus()
             : null;
@@ -34,7 +68,8 @@ public sealed class PatientReplacementManager(
     private async Task ExecuteAsync(
         PatientReplacementOperation operation,
         IReadOnlyList<string> resourcesToDelete,
-        IReadOnlyList<(string Name, string Json)> replayBundles)
+        IReadOnlyList<(string Name, string Json)> replayBundles,
+        CancellationToken ct)
     {
         try
         {
@@ -44,11 +79,15 @@ public sealed class PatientReplacementManager(
                 _automationConfig.FhirServerBasicAuth);
 
             operation.Update("purging", "Requesting FHIR resource expunge.");
-            var purge = await loader.DeleteResourcesWithExpungeAsync(resourcesToDelete);
+            var purge = await loader.DeleteResourcesWithExpungeAsync(resourcesToDelete, ct);
             operation.SetPurgeResult(purge.Succeeded, purge.Failed);
 
             operation.Update("waiting-for-purge", "Waiting for the patient to be removed from the FHIR server.");
-            await loader.WaitForPatientDeletionAsync(operation.PatientId, message => operation.Update("waiting-for-purge", message));
+            await loader.WaitForPatientDeletionAsync(
+                operation.PatientId,
+                message => operation.Update("waiting-for-purge", message),
+                OperationTimeout,
+                ct);
 
             operation.Update("uploading", $"Uploading {replayBundles.Count} replay bundle(s) to the FHIR server.");
             var output = new RunAutomationOutput(message => operation.Update("uploading", message));
@@ -65,11 +104,32 @@ public sealed class PatientReplacementManager(
 
             operation.Complete($"Successfully replaced FHIR-server data for patient '{operation.PatientId}'.");
         }
+        catch (OperationCanceledException)
+        {
+            operation.Fail($"FHIR patient replacement timed out or was canceled for patient '{operation.PatientId}'.");
+        }
         catch (Exception ex)
         {
-            logger.LogError(ex, "FHIR patient replacement {OperationId} failed for patient '{PatientId}'.", operation.Id, operation.PatientId);
+            _logger.LogError(ex, "FHIR patient replacement {OperationId} failed for patient '{PatientId}'.", operation.Id, operation.PatientId);
             operation.Fail(ex.Message);
         }
+    }
+
+    private void EvictCompletedOperations()
+    {
+        var cutoff = DateTimeOffset.UtcNow - CompletedOperationRetention;
+        foreach (var kvp in _operations)
+        {
+            if (kvp.Value.TryGetCompletedAt(out var completedAt) && completedAt <= cutoff)
+            {
+                _operations.TryRemove(kvp.Key, out _);
+            }
+        }
+    }
+
+    public void Dispose()
+    {
+        _cleanupTimer.Dispose();
     }
 }
 
@@ -92,6 +152,7 @@ internal sealed class PatientReplacementOperation(Guid id, string patientId, int
     private bool _succeeded;
     private int _deletedSucceeded;
     private int _deletedFailed;
+    private DateTimeOffset? _completedAt;
 
     public Guid Id { get; } = id;
     public string PatientId { get; } = patientId;
@@ -122,6 +183,7 @@ internal sealed class PatientReplacementOperation(Guid id, string patientId, int
             _message = message;
             _succeeded = true;
             _isComplete = true;
+            _completedAt = DateTimeOffset.UtcNow;
         }
     }
 
@@ -132,7 +194,23 @@ internal sealed class PatientReplacementOperation(Guid id, string patientId, int
             _state = "failed";
             _message = message;
             _isComplete = true;
+            _completedAt = DateTimeOffset.UtcNow;
         }
+    }
+
+    public bool TryGetCompletedAt(out DateTimeOffset completedAt)
+    {
+        lock (_sync)
+        {
+            if (_completedAt.HasValue)
+            {
+                completedAt = _completedAt.Value;
+                return true;
+            }
+        }
+
+        completedAt = default;
+        return false;
     }
 
     public PatientReplacementStatus GetStatus()

--- a/DotNet/Automation.UI/Services/PatientReplacementManager.cs
+++ b/DotNet/Automation.UI/Services/PatientReplacementManager.cs
@@ -1,0 +1,153 @@
+﻿using LantanaGroup.Automation;
+using LantanaGroup.Link.Automation.Link.Configuration;
+using Microsoft.Extensions.Options;
+using System.Collections.Concurrent;
+
+namespace Automation.UI.Services;
+
+public sealed class PatientReplacementManager(
+    IOptions<AutomationConfig> automationConfig,
+    ILogger<PatientReplacementManager> logger)
+{
+    private readonly AutomationConfig _automationConfig = automationConfig.Value;
+    private readonly ConcurrentDictionary<Guid, PatientReplacementOperation> _operations = new();
+
+    public Guid Start(
+        string patientId,
+        IReadOnlyList<string> resourcesToDelete,
+        IReadOnlyList<(string Name, string Json)> replayBundles)
+    {
+        var operation = new PatientReplacementOperation(Guid.NewGuid(), patientId, replayBundles.Count);
+        _operations[operation.Id] = operation;
+
+        _ = Task.Run(() => ExecuteAsync(operation, resourcesToDelete, replayBundles), CancellationToken.None);
+        return operation.Id;
+    }
+
+    public PatientReplacementStatus? GetStatus(Guid operationId)
+    {
+        return _operations.TryGetValue(operationId, out var operation)
+            ? operation.GetStatus()
+            : null;
+    }
+
+    private async Task ExecuteAsync(
+        PatientReplacementOperation operation,
+        IReadOnlyList<string> resourcesToDelete,
+        IReadOnlyList<(string Name, string Json)> replayBundles)
+    {
+        try
+        {
+            var loader = new FhirDataLoader(
+                _automationConfig.FhirServerBase,
+                _automationConfig.FhirServerOAuth,
+                _automationConfig.FhirServerBasicAuth);
+
+            operation.Update("purging", "Requesting FHIR resource expunge.");
+            var purge = await loader.DeleteResourcesWithExpungeAsync(resourcesToDelete);
+            operation.SetPurgeResult(purge.Succeeded, purge.Failed);
+
+            operation.Update("waiting-for-purge", "Waiting for the patient to be removed from the FHIR server.");
+            await loader.WaitForPatientDeletionAsync(operation.PatientId, message => operation.Update("waiting-for-purge", message));
+
+            operation.Update("uploading", $"Uploading {replayBundles.Count} replay bundle(s) to the FHIR server.");
+            var output = new RunAutomationOutput(message => operation.Update("uploading", message));
+            var replaySucceeded = await loader.UploadBundlesSequentiallyAsync(
+                output,
+                replayBundles,
+                $"[replace:{operation.PatientId}] ");
+
+            if (!replaySucceeded)
+            {
+                operation.Fail("Failed to replay the uploaded bundle after FHIR purge completion.");
+                return;
+            }
+
+            operation.Complete($"Successfully replaced FHIR-server data for patient '{operation.PatientId}'.");
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "FHIR patient replacement {OperationId} failed for patient '{PatientId}'.", operation.Id, operation.PatientId);
+            operation.Fail(ex.Message);
+        }
+    }
+}
+
+public sealed record PatientReplacementStatus(
+    Guid OperationId,
+    string State,
+    string Message,
+    bool IsComplete,
+    bool Succeeded,
+    int DeletedSucceeded,
+    int DeletedFailed,
+    int ReplayBundleCount);
+
+internal sealed class PatientReplacementOperation(Guid id, string patientId, int replayBundleCount)
+{
+    private readonly object _sync = new();
+    private string _state = "queued";
+    private string _message = "Replacement request queued.";
+    private bool _isComplete;
+    private bool _succeeded;
+    private int _deletedSucceeded;
+    private int _deletedFailed;
+
+    public Guid Id { get; } = id;
+    public string PatientId { get; } = patientId;
+
+    public void Update(string state, string message)
+    {
+        lock (_sync)
+        {
+            _state = state;
+            _message = message;
+        }
+    }
+
+    public void SetPurgeResult(int succeeded, int failed)
+    {
+        lock (_sync)
+        {
+            _deletedSucceeded = succeeded;
+            _deletedFailed = failed;
+        }
+    }
+
+    public void Complete(string message)
+    {
+        lock (_sync)
+        {
+            _state = "completed";
+            _message = message;
+            _succeeded = true;
+            _isComplete = true;
+        }
+    }
+
+    public void Fail(string message)
+    {
+        lock (_sync)
+        {
+            _state = "failed";
+            _message = message;
+            _isComplete = true;
+        }
+    }
+
+    public PatientReplacementStatus GetStatus()
+    {
+        lock (_sync)
+        {
+            return new PatientReplacementStatus(
+                Id,
+                _state,
+                _message,
+                _isComplete,
+                _succeeded,
+                _deletedSucceeded,
+                _deletedFailed,
+                replayBundleCount);
+        }
+    }
+}

--- a/DotNet/Automation.UI/Services/Persistence/ApiHealthRunDocument.cs
+++ b/DotNet/Automation.UI/Services/Persistence/ApiHealthRunDocument.cs
@@ -1,5 +1,4 @@
 ﻿using MongoDB.Bson;
-using MongoDB.Bson;
 using MongoDB.Bson.Serialization.Attributes;
 using Automation.UI.Models.ApiHealth;
 

--- a/DotNet/Automation.UI/Services/Persistence/GeneratedTemplateCacheVersionStore.cs
+++ b/DotNet/Automation.UI/Services/Persistence/GeneratedTemplateCacheVersionStore.cs
@@ -29,10 +29,17 @@ public sealed record GeneratedTemplateCacheVersionBinding(Guid VersionId, int Ve
 public sealed class GeneratedTemplateCacheVersionStore
 {
     private readonly IMongoCollection<GeneratedTemplateCacheVersionDocument> _versions;
+    private const string ScenarioHashUniqueIndexName = "ux_generated_template_versions_scenario_hash";
 
     public GeneratedTemplateCacheVersionStore(IMongoDatabase database)
     {
         _versions = database.GetCollection<GeneratedTemplateCacheVersionDocument>("automation_generated_template_versions");
+        var uniqueScenarioHashIndex = new CreateIndexModel<GeneratedTemplateCacheVersionDocument>(
+            Builders<GeneratedTemplateCacheVersionDocument>.IndexKeys
+                .Ascending(version => version.ScenarioKey)
+                .Ascending(version => version.TemplateSetHash),
+            new CreateIndexOptions { Unique = true, Name = ScenarioHashUniqueIndexName });
+        _versions.Indexes.CreateOne(uniqueScenarioHashIndex);
     }
 
     public async Task<GeneratedTemplateCacheVersionBinding?> BindRunAsync(
@@ -90,8 +97,32 @@ public sealed class GeneratedTemplateCacheVersionStore
             LastUsedAt = now
         };
 
-        await _versions.InsertOneAsync(doc, cancellationToken: ct);
-        return new GeneratedTemplateCacheVersionBinding(doc.Id, doc.VersionNumber, doc.ScenarioKey, doc.TemplateSetHash);
+        try
+        {
+            await _versions.InsertOneAsync(doc, cancellationToken: ct);
+            return new GeneratedTemplateCacheVersionBinding(doc.Id, doc.VersionNumber, doc.ScenarioKey, doc.TemplateSetHash);
+        }
+        catch (MongoWriteException ex) when (ex.WriteError?.Category == ServerErrorCategory.DuplicateKey)
+        {
+            var existingAfterRace = await _versions
+                .Find(version => version.ScenarioKey == scenarioKey && version.TemplateSetHash == hash)
+                .SortByDescending(version => version.VersionNumber)
+                .FirstOrDefaultAsync(ct);
+
+            if (existingAfterRace == null)
+                throw;
+
+            await _versions.UpdateOneAsync(
+                version => version.Id == existingAfterRace.Id,
+                Builders<GeneratedTemplateCacheVersionDocument>.Update.Set(version => version.LastUsedAt, DateTimeOffset.UtcNow),
+                cancellationToken: ct);
+
+            return new GeneratedTemplateCacheVersionBinding(
+                existingAfterRace.Id,
+                existingAfterRace.VersionNumber,
+                existingAfterRace.ScenarioKey,
+                existingAfterRace.TemplateSetHash);
+        }
     }
 
     private static string BuildScenarioKey(Guid? scenarioId, string? scenarioName, IReadOnlyList<string> templateKeys)

--- a/DotNet/Automation.UI/Services/Persistence/GeneratedTemplateCacheVersionStore.cs
+++ b/DotNet/Automation.UI/Services/Persistence/GeneratedTemplateCacheVersionStore.cs
@@ -1,0 +1,113 @@
+﻿using MongoDB.Bson.Serialization.Attributes;
+using MongoDB.Driver;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace Automation.UI.Services.Persistence;
+
+[BsonIgnoreExtraElements]
+public sealed class GeneratedTemplateCacheVersionDocument
+{
+    [BsonId]
+    [BsonRepresentation(MongoDB.Bson.BsonType.String)]
+    public Guid Id { get; set; }
+
+    public string ScenarioKey { get; set; } = string.Empty;
+    public int VersionNumber { get; set; }
+    public string TemplateSetHash { get; set; } = string.Empty;
+    public List<string> TemplateKeys { get; set; } = [];
+
+    [BsonRepresentation(MongoDB.Bson.BsonType.String)]
+    public Guid CreatedByRunId { get; set; }
+
+    public DateTimeOffset CreatedAt { get; set; }
+    public DateTimeOffset LastUsedAt { get; set; }
+}
+
+public sealed record GeneratedTemplateCacheVersionBinding(Guid VersionId, int VersionNumber, string ScenarioKey, string TemplateSetHash);
+
+public sealed class GeneratedTemplateCacheVersionStore
+{
+    private readonly IMongoCollection<GeneratedTemplateCacheVersionDocument> _versions;
+
+    public GeneratedTemplateCacheVersionStore(IMongoDatabase database)
+    {
+        _versions = database.GetCollection<GeneratedTemplateCacheVersionDocument>("automation_generated_template_versions");
+    }
+
+    public async Task<GeneratedTemplateCacheVersionBinding?> BindRunAsync(
+        Guid runId,
+        Guid? scenarioId,
+        string? scenarioName,
+        IReadOnlyList<string> templateKeys,
+        CancellationToken ct = default)
+    {
+        if (templateKeys.Count == 0)
+            return null;
+
+        var ordered = templateKeys
+            .Where(key => !string.IsNullOrWhiteSpace(key))
+            .Distinct(StringComparer.Ordinal)
+            .OrderBy(key => key, StringComparer.Ordinal)
+            .ToList();
+        if (ordered.Count == 0)
+            return null;
+
+        var scenarioKey = BuildScenarioKey(scenarioId, scenarioName, ordered);
+        var hash = ComputeTemplateSetHash(ordered);
+
+        var existing = await _versions
+            .Find(version => version.ScenarioKey == scenarioKey && version.TemplateSetHash == hash)
+            .SortByDescending(version => version.VersionNumber)
+            .FirstOrDefaultAsync(ct);
+
+        if (existing != null)
+        {
+            await _versions.UpdateOneAsync(
+                version => version.Id == existing.Id,
+                Builders<GeneratedTemplateCacheVersionDocument>.Update.Set(version => version.LastUsedAt, DateTimeOffset.UtcNow),
+                cancellationToken: ct);
+
+            return new GeneratedTemplateCacheVersionBinding(existing.Id, existing.VersionNumber, existing.ScenarioKey, existing.TemplateSetHash);
+        }
+
+        var latest = await _versions
+            .Find(version => version.ScenarioKey == scenarioKey)
+            .SortByDescending(version => version.VersionNumber)
+            .FirstOrDefaultAsync(ct);
+
+        var versionNumber = (latest?.VersionNumber ?? 0) + 1;
+        var now = DateTimeOffset.UtcNow;
+        var doc = new GeneratedTemplateCacheVersionDocument
+        {
+            Id = Guid.NewGuid(),
+            ScenarioKey = scenarioKey,
+            VersionNumber = versionNumber,
+            TemplateSetHash = hash,
+            TemplateKeys = ordered,
+            CreatedByRunId = runId,
+            CreatedAt = now,
+            LastUsedAt = now
+        };
+
+        await _versions.InsertOneAsync(doc, cancellationToken: ct);
+        return new GeneratedTemplateCacheVersionBinding(doc.Id, doc.VersionNumber, doc.ScenarioKey, doc.TemplateSetHash);
+    }
+
+    private static string BuildScenarioKey(Guid? scenarioId, string? scenarioName, IReadOnlyList<string> templateKeys)
+    {
+        if (scenarioId.HasValue)
+            return $"scenario:{scenarioId.Value:D}";
+
+        if (!string.IsNullOrWhiteSpace(scenarioName))
+            return $"name:{scenarioName.Trim()}";
+
+        return $"adhoc:{ComputeTemplateSetHash(templateKeys)}";
+    }
+
+    private static string ComputeTemplateSetHash(IReadOnlyList<string> templateKeys)
+    {
+        var payload = string.Join('|', templateKeys);
+        return Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(payload)));
+    }
+}

--- a/DotNet/Automation.UI/Services/Persistence/ImportedBundleBlobStorageSettings.cs
+++ b/DotNet/Automation.UI/Services/Persistence/ImportedBundleBlobStorageSettings.cs
@@ -7,4 +7,5 @@ public sealed class ImportedBundleBlobStorageSettings
     public string? ConnectionString { get; set; }
     public string? BlobContainerName { get; set; }
     public string? BlobRoot { get; set; }
+    public string? GeneratedTemplateBlobRoot { get; set; }
 }

--- a/DotNet/Automation.UI/Services/Persistence/ImportedBundleExecutionResolver.cs
+++ b/DotNet/Automation.UI/Services/Persistence/ImportedBundleExecutionResolver.cs
@@ -47,10 +47,6 @@ public sealed class ImportedBundleExecutionResolver
             contentById[bundleId] = content;
         }
 
-        var unresolvedInput = inputs.FirstOrDefault(input => !input.UploadedBundleId.HasValue);
-        if (unresolvedInput != null)
-            throw new InvalidOperationException($"Imported bundle '{unresolvedInput.FileName ?? unresolvedInput.PatientId}' has no external content reference.");
-
         return inputs.Select(input => new ImportedPatientInput
         {
             Source = input.Source,
@@ -59,7 +55,9 @@ public sealed class ImportedBundleExecutionResolver
             UploadedBundleId = input.UploadedBundleId,
             BundleJson = input.UploadedBundleId is Guid bundleId && contentById.TryGetValue(bundleId, out var content)
                 ? content
-                : throw new InvalidOperationException($"Imported bundle '{input.FileName ?? input.PatientId}' content is unavailable."),
+                : !string.IsNullOrWhiteSpace(input.BundleJson)
+                    ? input.BundleJson
+                    : throw new InvalidOperationException($"Imported bundle '{input.FileName ?? input.PatientId}' content is unavailable."),
             AutoDetect = input.AutoDetect,
             MeasureEligibilities = new Dictionary<ProfiledMeasureType, MeasureEligibility>(input.MeasureEligibilities ?? []),
             DetectedClinicalScenarioId = input.DetectedClinicalScenarioId

--- a/DotNet/Automation.UI/Services/Persistence/ImportedBundleExecutionResolver.cs
+++ b/DotNet/Automation.UI/Services/Persistence/ImportedBundleExecutionResolver.cs
@@ -1,0 +1,68 @@
+﻿using Automation.UI.Models;
+using LantanaGroup.Automation.Generation;
+using MongoDB.Driver;
+
+namespace Automation.UI.Services.Persistence;
+
+/// <summary>
+/// Resolves externally stored imported-bundle payloads for one execution without
+/// exposing raw JSON through scenario, request, or snapshot models.
+/// </summary>
+public sealed class ImportedBundleExecutionResolver
+{
+    private readonly IMongoCollection<ImportedBundleDocument> _bundles;
+    private readonly IImportedBundleContentStore _contentStore;
+
+    public ImportedBundleExecutionResolver(IMongoDatabase database, IImportedBundleContentStore contentStore)
+    {
+        _bundles = database.GetCollection<ImportedBundleDocument>("automation_imported_bundles");
+        _contentStore = contentStore;
+    }
+
+    public async Task<List<ImportedPatientInput>> ResolveAsync(
+        IReadOnlyList<ImportedPatientInput> inputs,
+        CancellationToken ct = default)
+    {
+        var bundleIds = inputs
+            .Where(input => input.UploadedBundleId.HasValue)
+            .Select(input => input.UploadedBundleId!.Value)
+            .Distinct()
+            .ToList();
+
+        var documents = bundleIds.Count == 0
+            ? []
+            : await _bundles.Find(Builders<ImportedBundleDocument>.Filter.In(bundle => bundle.Id, bundleIds)).ToListAsync(ct);
+        var documentsById = documents.ToDictionary(document => document.Id);
+        var contentById = new Dictionary<Guid, string>();
+
+        foreach (var bundleId in bundleIds)
+        {
+            if (!documentsById.TryGetValue(bundleId, out var document))
+                throw new InvalidOperationException($"Imported bundle '{bundleId}' was not found.");
+
+            var content = await _contentStore.ReadAsync(document, ct);
+            if (string.IsNullOrWhiteSpace(content))
+                throw new InvalidOperationException($"Imported bundle '{bundleId}' content is unavailable.");
+
+            contentById[bundleId] = content;
+        }
+
+        var unresolvedInput = inputs.FirstOrDefault(input => !input.UploadedBundleId.HasValue);
+        if (unresolvedInput != null)
+            throw new InvalidOperationException($"Imported bundle '{unresolvedInput.FileName ?? unresolvedInput.PatientId}' has no external content reference.");
+
+        return inputs.Select(input => new ImportedPatientInput
+        {
+            Source = input.Source,
+            PatientId = input.PatientId,
+            FileName = input.FileName,
+            UploadedBundleId = input.UploadedBundleId,
+            BundleJson = input.UploadedBundleId is Guid bundleId && contentById.TryGetValue(bundleId, out var content)
+                ? content
+                : throw new InvalidOperationException($"Imported bundle '{input.FileName ?? input.PatientId}' content is unavailable."),
+            AutoDetect = input.AutoDetect,
+            MeasureEligibilities = new Dictionary<ProfiledMeasureType, MeasureEligibility>(input.MeasureEligibilities ?? []),
+            DetectedClinicalScenarioId = input.DetectedClinicalScenarioId
+        }).ToList();
+    }
+}

--- a/DotNet/Automation.UI/Services/Persistence/MongoApiHealthRunStore.cs
+++ b/DotNet/Automation.UI/Services/Persistence/MongoApiHealthRunStore.cs
@@ -1,6 +1,5 @@
 ﻿using Automation.UI.Models.ApiHealth;
 using MongoDB.Driver;
-using Automation.UI.Models.ApiHealth;
 
 namespace Automation.UI.Services.Persistence;
 

--- a/DotNet/Automation.UI/Services/Persistence/MongoDocuments.cs
+++ b/DotNet/Automation.UI/Services/Persistence/MongoDocuments.cs
@@ -4,6 +4,7 @@ using MongoDB.Bson.Serialization.Attributes;
 namespace Automation.UI.Services.Persistence;
 
 /// <summary>MongoDB document for automation_runs collection.</summary>
+[BsonIgnoreExtraElements]
 public sealed class AutomationRunDocument
 {
     [BsonId]
@@ -39,10 +40,13 @@ public sealed class AutomationRunDocument
     public DateTimeOffset StartedAt { get; set; }
     [BsonRepresentation(BsonType.DateTime)]
     public DateTimeOffset? FinishedAt { get; set; }
-    [BsonRepresentation(BsonType.DateTime)]
-    public DateTimeOffset? CompletedAt { get; set; }
     /// <summary>Human-readable pipeline duration (report created ? submitted). Populated at run completion.</summary>
     public string? Duration { get; set; }
+    [BsonRepresentation(BsonType.String)]
+    public Guid? GeneratedTemplateCacheVersionId { get; set; }
+    public int? GeneratedTemplateCacheVersionNumber { get; set; }
+    public string? GeneratedTemplateCacheScenarioKey { get; set; }
+    public string? GeneratedTemplateSetHash { get; set; }
 }
 
 /// <summary>MongoDB document for automation_run_inputs collection.</summary>

--- a/DotNet/Automation.UI/Services/Persistence/MongoGeneratedPatientTemplateCache.cs
+++ b/DotNet/Automation.UI/Services/Persistence/MongoGeneratedPatientTemplateCache.cs
@@ -27,10 +27,15 @@ public sealed class MongoGeneratedPatientTemplateCache : IGeneratedPatientTempla
     private readonly IMongoCollection<GeneratedPatientTemplateDocument> _templates;
     private readonly BlobContainerClient _container;
     private readonly string _blobRoot;
+    private readonly ILogger<MongoGeneratedPatientTemplateCache> _logger;
 
-    public MongoGeneratedPatientTemplateCache(IMongoDatabase database, IOptions<ImportedBundleBlobStorageSettings> settings)
+    public MongoGeneratedPatientTemplateCache(
+        IMongoDatabase database,
+        IOptions<ImportedBundleBlobStorageSettings> settings,
+        ILogger<MongoGeneratedPatientTemplateCache> logger)
     {
         _templates = database.GetCollection<GeneratedPatientTemplateDocument>("automation_generated_patient_templates");
+        _logger = logger;
 
         var blobSettings = settings.Value;
         if (string.IsNullOrWhiteSpace(blobSettings.ConnectionString))
@@ -39,29 +44,43 @@ public sealed class MongoGeneratedPatientTemplateCache : IGeneratedPatientTempla
             throw new InvalidOperationException("InternalBlobStorage:BlobContainerName is required for generated patient templates.");
 
         _container = new BlobContainerClient(blobSettings.ConnectionString, blobSettings.BlobContainerName);
-        var configuredRoot = string.IsNullOrWhiteSpace(blobSettings.BlobRoot)
-            ? "automation"
-            : blobSettings.BlobRoot.Trim('/');
-        _blobRoot = $"{configuredRoot}/generated-patient-templates";
+        var configuredRoot = string.IsNullOrWhiteSpace(blobSettings.GeneratedTemplateBlobRoot)
+            ? string.Empty
+            : blobSettings.GeneratedTemplateBlobRoot.Trim('/');
+        _blobRoot = string.IsNullOrWhiteSpace(configuredRoot)
+            ? "generated-patient-templates"
+            : $"{configuredRoot}/generated-patient-templates";
     }
 
     public async Task<GeneratedPatientTemplate?> GetAsync(string key, CancellationToken ct = default)
     {
-        var doc = await _templates.Find(template => template.Key == key).FirstOrDefaultAsync(ct);
-        if (doc == null || string.IsNullOrWhiteSpace(doc.BlobName))
-            return null;
+        try
+        {
+            var doc = await _templates.Find(template => template.Key == key).FirstOrDefaultAsync(ct);
+            if (doc == null || string.IsNullOrWhiteSpace(doc.BlobName))
+                return null;
 
-        var blob = _container.GetBlobClient(doc.BlobName);
-        var exists = await blob.ExistsAsync(ct);
-        if (!exists.Value)
-            return null;
+            var blob = _container.GetBlobClient(doc.BlobName);
+            var exists = await blob.ExistsAsync(ct);
+            if (!exists.Value)
+                return null;
 
-        var download = await blob.DownloadContentAsync(ct);
-        var payload = JsonSerializer.Deserialize<TemplatePayload>(download.Value.Content.ToString());
-        if (payload == null || string.IsNullOrWhiteSpace(payload.TemplateRunTag) || payload.BundleJson is not { Count: > 0 })
-            return null;
+            var download = await blob.DownloadContentAsync(ct);
+            var payload = JsonSerializer.Deserialize<TemplatePayload>(download.Value.Content.ToString());
+            if (payload == null || string.IsNullOrWhiteSpace(payload.TemplateRunTag) || payload.BundleJson is not { Count: > 0 })
+                return null;
 
-        return new GeneratedPatientTemplate(payload.TemplateRunTag, payload.BundleJson);
+            return new GeneratedPatientTemplate(payload.TemplateRunTag, payload.BundleJson);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to read generated patient template cache entry for key '{TemplateKey}'.", key);
+            return null;
+        }
     }
 
     public async Task StoreAsync(string key, GeneratedPatientTemplate template, CancellationToken ct = default)
@@ -73,32 +92,44 @@ public sealed class MongoGeneratedPatientTemplateCache : IGeneratedPatientTempla
         if (template.BundleJson.Count == 0)
             throw new InvalidOperationException("Template bundles are required.");
 
-        var payload = new TemplatePayload(template.TemplateRunTag, template.BundleJson.ToList());
-        var json = JsonSerializer.Serialize(payload);
-        var bytes = Encoding.UTF8.GetBytes(json);
-        var contentHash = Convert.ToHexString(System.Security.Cryptography.SHA256.HashData(bytes));
-
-        await _container.CreateIfNotExistsAsync(cancellationToken: ct);
-
-        var blobName = $"{_blobRoot}/{key}-{contentHash}.json";
-        var blob = _container.GetBlobClient(blobName);
-        if (!(await blob.ExistsAsync(ct)).Value)
+        try
         {
-            using var stream = new MemoryStream(bytes, writable: false);
-            await blob.UploadAsync(stream, overwrite: true, cancellationToken: ct);
-            await blob.SetHttpHeadersAsync(new BlobHttpHeaders { ContentType = "application/json" }, cancellationToken: ct);
+            var payload = new TemplatePayload(template.TemplateRunTag, template.BundleJson.ToList());
+            var json = JsonSerializer.Serialize(payload);
+            var bytes = Encoding.UTF8.GetBytes(json);
+            var contentHash = Convert.ToHexString(System.Security.Cryptography.SHA256.HashData(bytes));
+
+            await _container.CreateIfNotExistsAsync(cancellationToken: ct);
+
+            var blobName = $"{_blobRoot}/{key}-{contentHash}.json";
+            var blob = _container.GetBlobClient(blobName);
+            if (!(await blob.ExistsAsync(ct)).Value)
+            {
+                using var stream = new MemoryStream(bytes, writable: false);
+                await blob.UploadAsync(stream, overwrite: true, cancellationToken: ct);
+                await blob.SetHttpHeadersAsync(new BlobHttpHeaders { ContentType = "application/json" }, cancellationToken: ct);
+            }
+
+            var now = DateTimeOffset.UtcNow;
+            var update = Builders<GeneratedPatientTemplateDocument>.Update
+                .Set(d => d.ContentHash, contentHash)
+                .Set(d => d.BlobName, blobName)
+                .Set(d => d.ByteCount, bytes.LongLength)
+                .Set(d => d.UpdatedAt, now)
+                .SetOnInsert(d => d.Key, key)
+                .SetOnInsert(d => d.CreatedAt, now);
+
+            await _templates.UpdateOneAsync(d => d.Key == key, update, new UpdateOptions { IsUpsert = true }, ct);
         }
-
-        var now = DateTimeOffset.UtcNow;
-        var update = Builders<GeneratedPatientTemplateDocument>.Update
-            .Set(d => d.ContentHash, contentHash)
-            .Set(d => d.BlobName, blobName)
-            .Set(d => d.ByteCount, bytes.LongLength)
-            .Set(d => d.UpdatedAt, now)
-            .SetOnInsert(d => d.Key, key)
-            .SetOnInsert(d => d.CreatedAt, now);
-
-        await _templates.UpdateOneAsync(d => d.Key == key, update, new UpdateOptions { IsUpsert = true }, ct);
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to store generated patient template cache entry for key '{TemplateKey}'.", key);
+            return;
+        }
     }
 
     private sealed record TemplatePayload(string TemplateRunTag, List<string> BundleJson);

--- a/DotNet/Automation.UI/Services/Persistence/MongoGeneratedPatientTemplateCache.cs
+++ b/DotNet/Automation.UI/Services/Persistence/MongoGeneratedPatientTemplateCache.cs
@@ -1,0 +1,105 @@
+﻿using Azure.Storage.Blobs;
+using Azure.Storage.Blobs.Models;
+using LantanaGroup.Automation.Generation;
+using Microsoft.Extensions.Options;
+using MongoDB.Bson;
+using MongoDB.Bson.Serialization.Attributes;
+using MongoDB.Driver;
+using System.Text;
+using System.Text.Json;
+
+namespace Automation.UI.Services.Persistence;
+
+[BsonIgnoreExtraElements]
+public sealed class GeneratedPatientTemplateDocument
+{
+    [BsonId]
+    public string Key { get; set; } = string.Empty;
+    public string ContentHash { get; set; } = string.Empty;
+    public string BlobName { get; set; } = string.Empty;
+    public long ByteCount { get; set; }
+    public DateTimeOffset CreatedAt { get; set; }
+    public DateTimeOffset UpdatedAt { get; set; }
+}
+
+public sealed class MongoGeneratedPatientTemplateCache : IGeneratedPatientTemplateCache
+{
+    private readonly IMongoCollection<GeneratedPatientTemplateDocument> _templates;
+    private readonly BlobContainerClient _container;
+    private readonly string _blobRoot;
+
+    public MongoGeneratedPatientTemplateCache(IMongoDatabase database, IOptions<ImportedBundleBlobStorageSettings> settings)
+    {
+        _templates = database.GetCollection<GeneratedPatientTemplateDocument>("automation_generated_patient_templates");
+
+        var blobSettings = settings.Value;
+        if (string.IsNullOrWhiteSpace(blobSettings.ConnectionString))
+            throw new InvalidOperationException("InternalBlobStorage:ConnectionString is required for generated patient templates.");
+        if (string.IsNullOrWhiteSpace(blobSettings.BlobContainerName))
+            throw new InvalidOperationException("InternalBlobStorage:BlobContainerName is required for generated patient templates.");
+
+        _container = new BlobContainerClient(blobSettings.ConnectionString, blobSettings.BlobContainerName);
+        var configuredRoot = string.IsNullOrWhiteSpace(blobSettings.BlobRoot)
+            ? "automation"
+            : blobSettings.BlobRoot.Trim('/');
+        _blobRoot = $"{configuredRoot}/generated-patient-templates";
+    }
+
+    public async Task<GeneratedPatientTemplate?> GetAsync(string key, CancellationToken ct = default)
+    {
+        var doc = await _templates.Find(template => template.Key == key).FirstOrDefaultAsync(ct);
+        if (doc == null || string.IsNullOrWhiteSpace(doc.BlobName))
+            return null;
+
+        var blob = _container.GetBlobClient(doc.BlobName);
+        var exists = await blob.ExistsAsync(ct);
+        if (!exists.Value)
+            return null;
+
+        var download = await blob.DownloadContentAsync(ct);
+        var payload = JsonSerializer.Deserialize<TemplatePayload>(download.Value.Content.ToString());
+        if (payload == null || string.IsNullOrWhiteSpace(payload.TemplateRunTag) || payload.BundleJson is not { Count: > 0 })
+            return null;
+
+        return new GeneratedPatientTemplate(payload.TemplateRunTag, payload.BundleJson);
+    }
+
+    public async Task StoreAsync(string key, GeneratedPatientTemplate template, CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(key))
+            throw new ArgumentException("Template key is required.", nameof(key));
+        if (string.IsNullOrWhiteSpace(template.TemplateRunTag))
+            throw new InvalidOperationException("Template run tag is required.");
+        if (template.BundleJson.Count == 0)
+            throw new InvalidOperationException("Template bundles are required.");
+
+        var payload = new TemplatePayload(template.TemplateRunTag, template.BundleJson.ToList());
+        var json = JsonSerializer.Serialize(payload);
+        var bytes = Encoding.UTF8.GetBytes(json);
+        var contentHash = Convert.ToHexString(System.Security.Cryptography.SHA256.HashData(bytes));
+
+        await _container.CreateIfNotExistsAsync(cancellationToken: ct);
+
+        var blobName = $"{_blobRoot}/{key}-{contentHash}.json";
+        var blob = _container.GetBlobClient(blobName);
+        if (!(await blob.ExistsAsync(ct)).Value)
+        {
+            using var stream = new MemoryStream(bytes, writable: false);
+            await blob.UploadAsync(stream, overwrite: true, cancellationToken: ct);
+            await blob.SetHttpHeadersAsync(new BlobHttpHeaders { ContentType = "application/json" }, cancellationToken: ct);
+        }
+
+        var now = DateTimeOffset.UtcNow;
+        var update = Builders<GeneratedPatientTemplateDocument>.Update
+            .Set(d => d.ContentHash, contentHash)
+            .Set(d => d.BlobName, blobName)
+            .Set(d => d.ByteCount, bytes.LongLength)
+            .Set(d => d.UpdatedAt, now)
+            .SetOnInsert(d => d.Key, key)
+            .SetOnInsert(d => d.CreatedAt, now);
+
+        await _templates.UpdateOneAsync(d => d.Key == key, update, new UpdateOptions { IsUpsert = true }, ct);
+    }
+
+    private sealed record TemplatePayload(string TemplateRunTag, List<string> BundleJson);
+}

--- a/DotNet/Automation.UI/Services/Persistence/MongoIndexManager.cs
+++ b/DotNet/Automation.UI/Services/Persistence/MongoIndexManager.cs
@@ -35,6 +35,7 @@ public sealed class MongoIndexManager
         EnsureSnapshotIndexes();
         EnsureScenarioIndexes();
         EnsureImportedBundleIndexes();
+        EnsureGeneratedTemplateCacheVersionIndexes();
         EnsureQueryPlanTemplateIndexes();
         EnsureNormalizationIndexes();
         EnsureOrganizationResourceMapTemplateIndexes();
@@ -145,6 +146,19 @@ public sealed class MongoIndexManager
         // (DetachAndPruneOrphansAsync): "find every bundle that references this scenario"
         // would otherwise scan the entire collection on every save and delete.
         CreateIndexSafe(collection, new BsonDocument { { "ScenarioIds", 1 } }, unique: false, "idx_scenarioIds");
+    }
+
+    // --- automation_generated_template_versions ---
+
+    private void EnsureGeneratedTemplateCacheVersionIndexes()
+    {
+        var collection = _database.GetCollection<BsonDocument>("automation_generated_template_versions");
+
+        // Supports latest-version lookup per scenario key (SortByDescending VersionNumber).
+        CreateIndexSafe(collection, new BsonDocument { { "ScenarioKey", 1 }, { "VersionNumber", -1 } }, unique: false, "idx_scenarioKey_versionNumber_desc");
+
+        // Supports exact lookup by scenario + template hash.
+        CreateIndexSafe(collection, new BsonDocument { { "ScenarioKey", 1 }, { "TemplateSetHash", 1 } }, unique: false, "idx_scenarioKey_templateSetHash");
     }
 
     // --- automation_query_plan_templates ---

--- a/DotNet/Automation.UI/Services/Persistence/MongoScenarioStore.cs
+++ b/DotNet/Automation.UI/Services/Persistence/MongoScenarioStore.cs
@@ -15,9 +15,8 @@ namespace Automation.UI.Services.Persistence;
 /// the scenario document. Metadata is persisted to the sibling
 /// <c>automation_imported_bundles</c> collection, content is externalized to Azure Blob
 /// Storage, and scenarios reference bundle ids via
-/// <see cref="TestScenarioDocument.ImportedBundleRefs"/>. This avoids Mongo/Cosmos document
-/// size limits while keeping reads transparent to callers (bundle JSON is hydrated back
-/// into each <see cref="ImportedPatientInput.BundleJson"/> on load).
+/// <see cref="TestScenarioDocument.ImportedBundleRefs"/>. Scenario reads retain those
+/// references; raw payloads are resolved only at the execution boundary.
 /// </para>
 ///
 /// <para>
@@ -76,14 +75,7 @@ public sealed class MongoScenarioStore : IScenarioStore
             .SortBy(d => d.Name)
             .ToListAsync(ct);
 
-        // Batch-fetch all referenced bundles in a single round trip rather than
-        // looking each one up per-scenario.
-        var allBundleIds = docs.SelectMany(d => d.ImportedBundleRefs.Select(r => r.BundleId))
-            .Distinct()
-            .ToList();
-        var bundlesById = await LoadBundlesByIdAsync(allBundleIds, ct);
-
-        return docs.Select(d => ToModel(d, bundlesById)).ToList();
+        return docs.Select(ToModel).ToList();
     }
 
     public async Task<TestScenarioDefinition?> GetByIdAsync(Guid id, CancellationToken ct = default)
@@ -91,10 +83,7 @@ public sealed class MongoScenarioStore : IScenarioStore
         var doc = await _scenarios.Find(d => d.Id == id).FirstOrDefaultAsync(ct);
         if (doc == null) return null;
 
-        var bundleIds = doc.ImportedBundleRefs.Select(r => r.BundleId).ToList();
-        var bundlesById = await LoadBundlesByIdAsync(bundleIds, ct);
-
-        return ToModel(doc, bundlesById);
+        return ToModel(doc);
     }
 
     public async Task UpsertAsync(TestScenarioDefinition scenario, CancellationToken ct = default)
@@ -157,11 +146,12 @@ public sealed class MongoScenarioStore : IScenarioStore
                 continue;
             }
 
-            if (string.IsNullOrWhiteSpace(input.BundleJson))
+            var bundleJson = input.BundleJson;
+            if (string.IsNullOrWhiteSpace(bundleJson))
                 continue; // ID-only entry mistakenly placed in the bundle list — nothing to externalize.
 
-            var hash = ComputeContentHash(input.BundleJson!);
-            var byteCount = Encoding.UTF8.GetByteCount(input.BundleJson!);
+            var hash = ComputeContentHash(bundleJson);
+            var byteCount = Encoding.UTF8.GetByteCount(bundleJson);
 
             // Single round-trip: find by hash, set immutable fields on insert, refresh
             // mutable metadata, and add this scenario id to the references set. The
@@ -186,7 +176,7 @@ public sealed class MongoScenarioStore : IScenarioStore
             var bundleDoc = await _bundles.FindOneAndUpdateAsync<ImportedBundleDocument>(
                 b => b.ContentHash == hash, update, options, ct);
 
-            var stored = await _bundleContentStore.StoreAsync(bundleDoc.Id, bundleDoc.ContentHash, input.BundleJson!, ct);
+            var stored = await _bundleContentStore.StoreAsync(bundleDoc.Id, bundleDoc.ContentHash, bundleJson, ct);
             await _bundles.UpdateOneAsync(
                 b => b.Id == bundleDoc.Id,
                 Builders<ImportedBundleDocument>.Update
@@ -398,25 +388,6 @@ public sealed class MongoScenarioStore : IScenarioStore
         return Convert.ToHexString(hash);
     }
 
-    private async Task<Dictionary<Guid, string>> LoadBundlesByIdAsync(IReadOnlyCollection<Guid> ids, CancellationToken ct)
-    {
-        if (ids.Count == 0)
-            return new Dictionary<Guid, string>();
-
-        var docs = await _bundles.Find(Builders<ImportedBundleDocument>.Filter.In(b => b.Id, ids))
-            .ToListAsync(ct);
-
-        var result = new Dictionary<Guid, string>();
-        foreach (var doc in docs)
-        {
-            var json = await _bundleContentStore.ReadAsync(doc, ct);
-            if (!string.IsNullOrWhiteSpace(json))
-                result[doc.Id] = json;
-        }
-
-        return result;
-    }
-
     private static TestScenarioDocument ToDocument(
         TestScenarioDefinition model,
         List<ImportedPatientInput> sanitizedBundles,
@@ -447,9 +418,7 @@ public sealed class MongoScenarioStore : IScenarioStore
             UpdatedAt = model.UpdatedAt
         };
 
-    private static TestScenarioDefinition ToModel(
-        TestScenarioDocument doc,
-        IReadOnlyDictionary<Guid, string> bundlesById) => new()
+    private static TestScenarioDefinition ToModel(TestScenarioDocument doc) => new()
         {
             Id = doc.Id,
             Name = doc.Name,
@@ -475,19 +444,16 @@ public sealed class MongoScenarioStore : IScenarioStore
             ReportPeriodStart = doc.ReportPeriodStart.HasValue ? new DateTimeOffset(DateTime.SpecifyKind(doc.ReportPeriodStart.Value, DateTimeKind.Utc)) : null,
             ReportPeriodEnd = doc.ReportPeriodEnd.HasValue ? new DateTimeOffset(DateTime.SpecifyKind(doc.ReportPeriodEnd.Value, DateTimeKind.Utc)) : null,
             ImportedPatientIds = DeserializeImported(doc.ImportedPatientIdsJson),
-            ImportedPatientBundles = HydrateBundles(doc, bundlesById),
+            ImportedPatientBundles = AttachBundleReferences(doc),
             UpdatedAt = doc.UpdatedAt
         };
 
     /// <summary>
-    /// Restores each <see cref="ImportedPatientInput.BundleJson"/> from the externalized
-    /// bundle collection. Falls back to whatever <c>BundleJson</c> is already on the
-    /// deserialized input (legacy inline-embedded layout) when the document carries no
-    /// references &mdash; this keeps pre-migration scenarios readable.
+    /// Attaches each external bundle id to its scenario input without loading raw bundle
+    /// content. Legacy inline payloads remain available for migration compatibility, but
+    /// externally stored content is resolved only by the execution layer.
     /// </summary>
-    private static List<ImportedPatientInput> HydrateBundles(
-        TestScenarioDocument doc,
-        IReadOnlyDictionary<Guid, string> bundlesById)
+    private static List<ImportedPatientInput> AttachBundleReferences(TestScenarioDocument doc)
     {
         var inputs = DeserializeImported(doc.ImportedPatientBundlesJson);
         if (doc.ImportedBundleRefs.Count == 0 || inputs.Count == 0)
@@ -510,16 +476,11 @@ public sealed class MongoScenarioStore : IScenarioStore
 
         foreach (var input in inputs)
         {
-            if (!string.IsNullOrEmpty(input.BundleJson))
-                continue; // already inline (legacy doc) — leave as-is
-
             var key = input.PatientId ?? string.Empty;
             if (refsByPatient.TryGetValue(key, out var queue) && queue.Count > 0)
             {
                 var bundleId = queue.Dequeue();
                 input.UploadedBundleId = bundleId;
-                if (bundlesById.TryGetValue(bundleId, out var json))
-                    input.BundleJson = json;
             }
         }
 

--- a/DotNet/Automation.UI/Services/Persistence/MongoSnapshotStore.cs
+++ b/DotNet/Automation.UI/Services/Persistence/MongoSnapshotStore.cs
@@ -70,7 +70,6 @@ public sealed class MongoSnapshotStore : ISnapshotStore
     {
         var update = Builders<AutomationRunDocument>.Update
             .Set(r => r.IsActive, false)
-            .Set(r => r.CompletedAt, DateTimeOffset.UtcNow)
             .Set(r => r.Duration, duration);
 
         await _runs.UpdateOneAsync(r => r.RunId == runId, update, cancellationToken: ct);
@@ -95,8 +94,11 @@ public sealed class MongoSnapshotStore : ISnapshotStore
             .Set(r => r.Error, summary.Error)
             .Set(r => r.FacilityId, facilityId ?? string.Empty)
             .Set(r => r.ReportId, reportId ?? string.Empty)
+            .Set(r => r.GeneratedTemplateCacheVersionId, summary.GeneratedTemplateCacheVersionId)
+            .Set(r => r.GeneratedTemplateCacheVersionNumber, summary.GeneratedTemplateCacheVersionNumber)
+            .Set(r => r.GeneratedTemplateCacheScenarioKey, summary.GeneratedTemplateCacheScenarioKey)
+            .Set(r => r.GeneratedTemplateSetHash, summary.GeneratedTemplateSetHash)
             .Set(r => r.IsActive, hasIdentifiers && summary.Status is not AutomationRunStatus.Succeeded and not AutomationRunStatus.Failed and not AutomationRunStatus.Cancelled)
-            .Set(r => r.CompletedAt, summary.Status is AutomationRunStatus.Succeeded or AutomationRunStatus.Failed or AutomationRunStatus.Cancelled ? summary.FinishedAt ?? DateTimeOffset.UtcNow : null)
             .SetOnInsert(r => r.RunId, summary.RunId);
 
         await _runs.UpdateOneAsync(r => r.RunId == summary.RunId, update, new UpdateOptions { IsUpsert = true }, ct);
@@ -342,6 +344,10 @@ public sealed class MongoSnapshotStore : ISnapshotStore
             Duration = doc.Duration,
             FacilityId = doc.FacilityId,
             ReportId = doc.ReportId,
+            GeneratedTemplateCacheVersionId = doc.GeneratedTemplateCacheVersionId,
+            GeneratedTemplateCacheVersionNumber = doc.GeneratedTemplateCacheVersionNumber,
+            GeneratedTemplateCacheScenarioKey = doc.GeneratedTemplateCacheScenarioKey,
+            GeneratedTemplateSetHash = doc.GeneratedTemplateSetHash,
             Logs = []
         };
     }

--- a/DotNet/Automation.UI/Services/Persistence/MongoSnapshotStore.cs
+++ b/DotNet/Automation.UI/Services/Persistence/MongoSnapshotStore.cs
@@ -88,26 +88,35 @@ public sealed class MongoSnapshotStore : ISnapshotStore
         var hasIdentifiers = !string.IsNullOrWhiteSpace(facilityId)
             && !string.IsNullOrWhiteSpace(reportId);
 
-        var update = Builders<AutomationRunDocument>.Update
-            .Set(r => r.RunName, summary.RunName)
-            .Set(r => r.Scenario, summary.Scenario.ToString())
-            .Set(r => r.SelectedMeasure, summary.SelectedMeasure)
-            .Set(r => r.PatientCount, summary.PatientCount)
-            .Set(r => r.ResourcesPerPatient, summary.ResourcesPerPatient)
-            .Set(r => r.Seed, summary.Seed)
-            .Set(r => r.Status, summary.Status.ToString())
-            .Set(r => r.CreatedAt, summary.CreatedAt)
-            .Set(r => r.StartedAt, summary.StartedAt ?? summary.CreatedAt)
-            .Set(r => r.FinishedAt, summary.FinishedAt)
-            .Set(r => r.Error, summary.Error)
-            .Set(r => r.FacilityId, facilityId ?? string.Empty)
-            .Set(r => r.ReportId, reportId ?? string.Empty)
-            .Set(r => r.GeneratedTemplateCacheVersionId, summary.GeneratedTemplateCacheVersionId)
-            .Set(r => r.GeneratedTemplateCacheVersionNumber, summary.GeneratedTemplateCacheVersionNumber)
-            .Set(r => r.GeneratedTemplateCacheScenarioKey, summary.GeneratedTemplateCacheScenarioKey)
-            .Set(r => r.GeneratedTemplateSetHash, summary.GeneratedTemplateSetHash)
-            .Set(r => r.IsActive, hasIdentifiers && summary.Status is not AutomationRunStatus.Succeeded and not AutomationRunStatus.Failed and not AutomationRunStatus.Cancelled)
-            .SetOnInsert(r => r.RunId, summary.RunId);
+        var updates = new List<UpdateDefinition<AutomationRunDocument>>
+        {
+            Builders<AutomationRunDocument>.Update.Set(r => r.RunName, summary.RunName),
+            Builders<AutomationRunDocument>.Update.Set(r => r.Scenario, summary.Scenario.ToString()),
+            Builders<AutomationRunDocument>.Update.Set(r => r.SelectedMeasure, summary.SelectedMeasure),
+            Builders<AutomationRunDocument>.Update.Set(r => r.PatientCount, summary.PatientCount),
+            Builders<AutomationRunDocument>.Update.Set(r => r.ResourcesPerPatient, summary.ResourcesPerPatient),
+            Builders<AutomationRunDocument>.Update.Set(r => r.Seed, summary.Seed),
+            Builders<AutomationRunDocument>.Update.Set(r => r.Status, summary.Status.ToString()),
+            Builders<AutomationRunDocument>.Update.Set(r => r.CreatedAt, summary.CreatedAt),
+            Builders<AutomationRunDocument>.Update.Set(r => r.StartedAt, summary.StartedAt ?? summary.CreatedAt),
+            Builders<AutomationRunDocument>.Update.Set(r => r.FinishedAt, summary.FinishedAt),
+            Builders<AutomationRunDocument>.Update.Set(r => r.Error, summary.Error),
+            Builders<AutomationRunDocument>.Update.Set(r => r.FacilityId, facilityId ?? string.Empty),
+            Builders<AutomationRunDocument>.Update.Set(r => r.ReportId, reportId ?? string.Empty),
+            Builders<AutomationRunDocument>.Update.Set(r => r.IsActive, hasIdentifiers && summary.Status is not AutomationRunStatus.Succeeded and not AutomationRunStatus.Failed and not AutomationRunStatus.Cancelled),
+            Builders<AutomationRunDocument>.Update.SetOnInsert(r => r.RunId, summary.RunId)
+        };
+
+        if (summary.GeneratedTemplateCacheVersionId.HasValue)
+            updates.Add(Builders<AutomationRunDocument>.Update.Set(r => r.GeneratedTemplateCacheVersionId, summary.GeneratedTemplateCacheVersionId));
+        if (summary.GeneratedTemplateCacheVersionNumber.HasValue)
+            updates.Add(Builders<AutomationRunDocument>.Update.Set(r => r.GeneratedTemplateCacheVersionNumber, summary.GeneratedTemplateCacheVersionNumber));
+        if (!string.IsNullOrWhiteSpace(summary.GeneratedTemplateCacheScenarioKey))
+            updates.Add(Builders<AutomationRunDocument>.Update.Set(r => r.GeneratedTemplateCacheScenarioKey, summary.GeneratedTemplateCacheScenarioKey));
+        if (!string.IsNullOrWhiteSpace(summary.GeneratedTemplateSetHash))
+            updates.Add(Builders<AutomationRunDocument>.Update.Set(r => r.GeneratedTemplateSetHash, summary.GeneratedTemplateSetHash));
+
+        var update = Builders<AutomationRunDocument>.Update.Combine(updates);
 
         await _runs.UpdateOneAsync(r => r.RunId == summary.RunId, update, new UpdateOptions { IsUpsert = true }, ct);
     }

--- a/DotNet/Automation.UI/Services/Persistence/PatientBundleExternalizationMigrationService.cs
+++ b/DotNet/Automation.UI/Services/Persistence/PatientBundleExternalizationMigrationService.cs
@@ -68,41 +68,107 @@ public sealed class PatientBundleExternalizationMigrationService : IHostedServic
     private async Task<int> MigrateEmbeddedPayloadsAsync(CancellationToken ct)
     {
         var migrated = 0;
-        var scenarios = await _scenarios.Find(FilterDefinition<TestScenarioDocument>.Empty).ToListAsync(ct);
-        foreach (var scenario in scenarios)
+        Guid? lastScenarioId = null;
+        while (!ct.IsCancellationRequested)
         {
-            var result = await ExternalizeBundleJsonAsync(scenario.ImportedPatientBundlesJson, scenario.Id, ct);
-            if (!result.Changed)
-                continue;
+            var scenarioFilter = lastScenarioId.HasValue
+                ? Builders<TestScenarioDocument>.Filter.Gt(s => s.Id, lastScenarioId.Value)
+                : FilterDefinition<TestScenarioDocument>.Empty;
 
-            await _scenarios.UpdateOneAsync(
-                s => s.Id == scenario.Id,
-                Builders<TestScenarioDocument>.Update
-                    .Set(s => s.ImportedPatientBundlesJson, result.Json)
-                    .Set(s => s.ImportedBundleRefs, result.References)
-                    .Set(s => s.UpdatedAt, DateTimeOffset.UtcNow),
-                cancellationToken: ct);
-            migrated += result.MigratedCount;
+            var scenarios = await _scenarios
+                .Find(scenarioFilter)
+                .SortBy(s => s.Id)
+                .Project(s => new ScenarioEmbeddedPayloadProjection
+                {
+                    Id = s.Id,
+                    ImportedPatientBundlesJson = s.ImportedPatientBundlesJson
+                })
+                .Limit(MigrationBatchSize)
+                .ToListAsync(ct);
+
+            if (scenarios.Count == 0)
+                break;
+
+            foreach (var scenario in scenarios)
+            {
+                var result = await ExternalizeBundleJsonAsync(scenario.ImportedPatientBundlesJson, scenario.Id, ct);
+                if (!result.Changed)
+                    continue;
+
+                await _scenarios.UpdateOneAsync(
+                    s => s.Id == scenario.Id,
+                    Builders<TestScenarioDocument>.Update
+                        .Set(s => s.ImportedPatientBundlesJson, result.Json)
+                        .Set(s => s.ImportedBundleRefs, result.References)
+                        .Set(s => s.UpdatedAt, DateTimeOffset.UtcNow),
+                    cancellationToken: ct);
+                migrated += result.MigratedCount;
+            }
+
+            lastScenarioId = scenarios[^1].Id;
+
+            if (scenarios.Count == MigrationBatchSize)
+                await Task.Delay(InterBatchPause, ct);
         }
 
-        var runInputs = await _runInputs.Find(FilterDefinition<AutomationRunInputDocument>.Empty).ToListAsync(ct);
-        foreach (var runInput in runInputs)
+        Guid? lastRunId = null;
+        while (!ct.IsCancellationRequested)
         {
-            var result = await ExternalizeBundleJsonAsync(runInput.RunConfigurationJson, scenarioId: null, ct);
-            if (!result.Changed)
-                continue;
+            var runInputFilter = lastRunId.HasValue
+                ? Builders<AutomationRunInputDocument>.Filter.Gt(r => r.RunId, lastRunId.Value)
+                : FilterDefinition<AutomationRunInputDocument>.Empty;
 
-            await _runInputs.UpdateOneAsync(
-                r => r.RunId == runInput.RunId,
-                Builders<AutomationRunInputDocument>.Update
-                    .Set(r => r.RunConfigurationJson, result.Json)
-                    .Set(r => r.ImportedBundleIds, runInput.ImportedBundleIds.Concat(result.References.Select(reference => reference.BundleId)).Distinct().ToList())
-                    .Set(r => r.UpdatedAt, DateTimeOffset.UtcNow),
-                cancellationToken: ct);
-            migrated += result.MigratedCount;
+            var runInputs = await _runInputs
+                .Find(runInputFilter)
+                .SortBy(r => r.RunId)
+                .Project(r => new RunInputEmbeddedPayloadProjection
+                {
+                    RunId = r.RunId,
+                    RunConfigurationJson = r.RunConfigurationJson,
+                    ImportedBundleIds = r.ImportedBundleIds
+                })
+                .Limit(MigrationBatchSize)
+                .ToListAsync(ct);
+
+            if (runInputs.Count == 0)
+                break;
+
+            foreach (var runInput in runInputs)
+            {
+                var result = await ExternalizeBundleJsonAsync(runInput.RunConfigurationJson, scenarioId: null, ct);
+                if (!result.Changed)
+                    continue;
+
+                await _runInputs.UpdateOneAsync(
+                    r => r.RunId == runInput.RunId,
+                    Builders<AutomationRunInputDocument>.Update
+                        .Set(r => r.RunConfigurationJson, result.Json)
+                        .Set(r => r.ImportedBundleIds, runInput.ImportedBundleIds.Concat(result.References.Select(reference => reference.BundleId)).Distinct().ToList())
+                        .Set(r => r.UpdatedAt, DateTimeOffset.UtcNow),
+                    cancellationToken: ct);
+                migrated += result.MigratedCount;
+            }
+
+            lastRunId = runInputs[^1].RunId;
+
+            if (runInputs.Count == MigrationBatchSize)
+                await Task.Delay(InterBatchPause, ct);
         }
 
         return migrated;
+    }
+
+    private sealed class ScenarioEmbeddedPayloadProjection
+    {
+        public Guid Id { get; init; }
+        public string? ImportedPatientBundlesJson { get; init; }
+    }
+
+    private sealed class RunInputEmbeddedPayloadProjection
+    {
+        public Guid RunId { get; init; }
+        public string? RunConfigurationJson { get; init; }
+        public List<Guid> ImportedBundleIds { get; init; } = [];
     }
 
     private async Task<(bool Changed, string? Json, List<ImportedBundleReference> References, int MigratedCount)> ExternalizeBundleJsonAsync(
@@ -113,7 +179,16 @@ public sealed class PatientBundleExternalizationMigrationService : IHostedServic
         if (string.IsNullOrWhiteSpace(json))
             return (false, json, [], 0);
 
-        var root = JsonNode.Parse(json);
+        JsonNode? root;
+        try
+        {
+            root = JsonNode.Parse(json);
+        }
+        catch
+        {
+            return (false, json, [], 0);
+        }
+
         var bundles = root switch
         {
             JsonArray array => array,

--- a/DotNet/Automation.UI/Services/Persistence/PatientBundleExternalizationMigrationService.cs
+++ b/DotNet/Automation.UI/Services/Persistence/PatientBundleExternalizationMigrationService.cs
@@ -1,31 +1,26 @@
-﻿using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Logging;
-using MongoDB.Driver;
+﻿using MongoDB.Driver;
 using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json.Nodes;
 
 namespace Automation.UI.Services.Persistence;
 
-public sealed class ImportedBundleBlobMigrationService : IHostedService
+public sealed class PatientBundleExternalizationMigrationService : IHostedService
 {
     private readonly IMongoCollection<ImportedBundleDocument> _bundles;
     private readonly IMongoCollection<TestScenarioDocument> _scenarios;
     private readonly IMongoCollection<AutomationRunInputDocument> _runInputs;
     private readonly IImportedBundleContentStore _contentStore;
-    private readonly ILogger<ImportedBundleBlobMigrationService> _logger;
+    private readonly ILogger<PatientBundleExternalizationMigrationService> _logger;
     private readonly IHostApplicationLifetime _applicationLifetime;
     private const int MigrationBatchSize = 25;
-    private static readonly TimeSpan StartupDelay = TimeSpan.FromSeconds(30);
     private static readonly TimeSpan InterBatchPause = TimeSpan.FromMilliseconds(250);
     private const long MaxDocsForDeepDedupPass = 5000;
-    private Task? _backgroundTask;
-    private CancellationTokenSource? _cts;
 
-    public ImportedBundleBlobMigrationService(
+    public PatientBundleExternalizationMigrationService(
         IMongoDatabase database,
         IImportedBundleContentStore contentStore,
-        ILogger<ImportedBundleBlobMigrationService> logger,
+        ILogger<PatientBundleExternalizationMigrationService> logger,
         IHostApplicationLifetime applicationLifetime)
     {
         _bundles = database.GetCollection<ImportedBundleDocument>("automation_imported_bundles");
@@ -36,55 +31,26 @@ public sealed class ImportedBundleBlobMigrationService : IHostedService
         _applicationLifetime = applicationLifetime;
     }
 
-    public Task StartAsync(CancellationToken cancellationToken)
-    {
-        _cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-        _applicationLifetime.ApplicationStarted.Register(() =>
-        {
-            if (_cts?.IsCancellationRequested == true)
-                return;
-
-            _backgroundTask = Task.Run(() => RunMigrationAsync(_cts!.Token), CancellationToken.None);
-        });
-
-        _logger.LogInformation("Imported bundle ABS migration is scheduled to run after app startup.");
-        return Task.CompletedTask;
-    }
+    public Task StartAsync(CancellationToken cancellationToken) => RunMigrationAsync(cancellationToken);
 
     public async Task StopAsync(CancellationToken cancellationToken)
     {
-        if (_cts != null)
-            _cts.Cancel();
-
-        if (_backgroundTask == null)
-            return;
-
-        await Task.WhenAny(_backgroundTask, Task.Delay(Timeout.Infinite, cancellationToken));
+        await Task.CompletedTask;
     }
 
     private async Task RunMigrationAsync(CancellationToken stoppingToken)
     {
-        // Non-blocking startup: run migration in the background after app is already serving.
-        await Task.Yield();
-
         try
         {
-            await Task.Delay(StartupDelay, stoppingToken);
-        }
-        catch (OperationCanceledException)
-        {
-            return;
-        }
+            _logger.LogInformation("Starting required migration of imported bundles to Azure Blob Storage.");
 
-        try
-        {
-            _logger.LogInformation("Starting background migration of imported bundles to Azure Blob Storage.");
-
+            var migratedEmbeddedPayloads = await MigrateEmbeddedPayloadsAsync(stoppingToken);
             var migratedPayloadDocs = await MigrateInlinePayloadsToAbsAsync(stoppingToken);
             var deduplicatedDocs = await DeduplicateBundleDocumentsAsync(stoppingToken);
 
             _logger.LogInformation(
-                "Imported bundle ABS migration completed. Payload docs migrated: {MigratedPayloadDocs}. Duplicate bundle docs removed: {DeduplicatedDocs}.",
+                "Imported bundle ABS migration completed. Embedded payloads migrated: {MigratedEmbeddedPayloads}. Payload docs migrated: {MigratedPayloadDocs}. Duplicate bundle docs removed: {DeduplicatedDocs}.",
+                migratedEmbeddedPayloads,
                 migratedPayloadDocs,
                 deduplicatedDocs);
         }
@@ -94,8 +60,110 @@ public sealed class ImportedBundleBlobMigrationService : IHostedService
         }
         catch (Exception ex)
         {
-            _logger.LogWarning(ex, "Imported bundle ABS migration encountered an error. Existing data remains usable; migration will retry on next startup.");
+            _logger.LogCritical(ex, "Imported bundle ABS migration failed. Application startup is blocked to prevent execution against inline bundle payloads.");
+            throw;
         }
+    }
+
+    private async Task<int> MigrateEmbeddedPayloadsAsync(CancellationToken ct)
+    {
+        var migrated = 0;
+        var scenarios = await _scenarios.Find(FilterDefinition<TestScenarioDocument>.Empty).ToListAsync(ct);
+        foreach (var scenario in scenarios)
+        {
+            var result = await ExternalizeBundleJsonAsync(scenario.ImportedPatientBundlesJson, scenario.Id, ct);
+            if (!result.Changed)
+                continue;
+
+            await _scenarios.UpdateOneAsync(
+                s => s.Id == scenario.Id,
+                Builders<TestScenarioDocument>.Update
+                    .Set(s => s.ImportedPatientBundlesJson, result.Json)
+                    .Set(s => s.ImportedBundleRefs, result.References)
+                    .Set(s => s.UpdatedAt, DateTimeOffset.UtcNow),
+                cancellationToken: ct);
+            migrated += result.MigratedCount;
+        }
+
+        var runInputs = await _runInputs.Find(FilterDefinition<AutomationRunInputDocument>.Empty).ToListAsync(ct);
+        foreach (var runInput in runInputs)
+        {
+            var result = await ExternalizeBundleJsonAsync(runInput.RunConfigurationJson, scenarioId: null, ct);
+            if (!result.Changed)
+                continue;
+
+            await _runInputs.UpdateOneAsync(
+                r => r.RunId == runInput.RunId,
+                Builders<AutomationRunInputDocument>.Update
+                    .Set(r => r.RunConfigurationJson, result.Json)
+                    .Set(r => r.ImportedBundleIds, runInput.ImportedBundleIds.Concat(result.References.Select(reference => reference.BundleId)).Distinct().ToList())
+                    .Set(r => r.UpdatedAt, DateTimeOffset.UtcNow),
+                cancellationToken: ct);
+            migrated += result.MigratedCount;
+        }
+
+        return migrated;
+    }
+
+    private async Task<(bool Changed, string? Json, List<ImportedBundleReference> References, int MigratedCount)> ExternalizeBundleJsonAsync(
+        string? json,
+        Guid? scenarioId,
+        CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(json))
+            return (false, json, [], 0);
+
+        var root = JsonNode.Parse(json);
+        var bundles = root switch
+        {
+            JsonArray array => array,
+            JsonObject obj when obj["importedPatientBundles"] is JsonArray array => array,
+            _ => null
+        };
+        if (bundles == null)
+            return (false, json, [], 0);
+
+        var references = new List<ImportedBundleReference>();
+        var migrated = 0;
+        foreach (var bundle in bundles.OfType<JsonObject>())
+        {
+            var rawJson = bundle["bundleJson"]?.GetValue<string>();
+            if (string.IsNullOrWhiteSpace(rawJson))
+                continue;
+
+            var contentHash = ComputeContentHash(rawJson);
+            var now = DateTimeOffset.UtcNow;
+            var document = await _bundles.FindOneAndUpdateAsync(
+                b => b.ContentHash == contentHash,
+                Builders<ImportedBundleDocument>.Update
+                    .SetOnInsert(b => b.Id, Guid.NewGuid())
+                    .SetOnInsert(b => b.ContentHash, contentHash)
+                    .SetOnInsert(b => b.CreatedAt, now)
+                    .SetOnInsert(b => b.IsLibraryEntry, false)
+                    .Set(b => b.PatientId, bundle["patientId"]?.GetValue<string>() ?? string.Empty)
+                    .Set(b => b.FileName, bundle["fileName"]?.GetValue<string>())
+                    .Set(b => b.UpdatedAt, now)
+                    .AddToSetEach(b => b.ScenarioIds, scenarioId.HasValue ? [scenarioId.Value] : []),
+                new FindOneAndUpdateOptions<ImportedBundleDocument> { IsUpsert = true, ReturnDocument = ReturnDocument.After },
+                ct);
+
+            var stored = await _contentStore.StoreAsync(document.Id, document.ContentHash, rawJson, ct);
+            await _bundles.UpdateOneAsync(
+                b => b.Id == document.Id,
+                Builders<ImportedBundleDocument>.Update
+                    .Set(b => b.BundleBlobName, stored.BlobName)
+                    .Set(b => b.ByteCount, stored.ByteCount)
+                    .Set(b => b.BundleJson, null)
+                    .Set(b => b.UpdatedAt, now),
+                cancellationToken: ct);
+
+            bundle["uploadedBundleId"] = document.Id.ToString();
+            bundle.Remove("bundleJson");
+            references.Add(new ImportedBundleReference { BundleId = document.Id, PatientId = bundle["patientId"]?.GetValue<string>() ?? string.Empty });
+            migrated++;
+        }
+
+        return migrated == 0 ? (false, json, references, 0) : (true, root!.ToJsonString(), references, migrated);
     }
 
     private async Task<int> MigrateInlinePayloadsToAbsAsync(CancellationToken ct)

--- a/DotNet/Automation.UI/Services/Persistence/TestScenarioDocument.cs
+++ b/DotNet/Automation.UI/Services/Persistence/TestScenarioDocument.cs
@@ -62,10 +62,10 @@ public sealed class TestScenarioDocument
     /// stored as <c>null</c> here and the raw bundle payload lives in the
     /// <c>automation_imported_bundles</c> collection (one document per bundle, keyed by
     /// <see cref="ImportedBundleReference.BundleId"/>). <see cref="MongoScenarioStore"/>
-    /// hydrates <c>BundleJson</c> on read using <see cref="ImportedBundleRefs"/>. Legacy
-    /// documents written before the migration may still contain inline bundle JSON;
-    /// those are accepted on read and converted to the externalized layout on the next
-    /// upsert.
+    /// attaches the external bundle IDs on read; execution resolves raw content through
+    /// the imported bundle content store. Legacy documents written before the migration
+    /// may still contain inline bundle JSON; those are accepted on read and converted to
+    /// the externalized layout on the next upsert.
     /// </para>
     /// </summary>
     public string ImportedPatientBundlesJson { get; set; } = "[]";

--- a/DotNet/Automation.UI/Services/QueryPlanTemplateSeedService.cs
+++ b/DotNet/Automation.UI/Services/QueryPlanTemplateSeedService.cs
@@ -1,5 +1,4 @@
 ﻿using Automation.UI.Models;
-using Automation.UI.Models;
 using Automation.UI.Services.Persistence;
 
 namespace Automation.UI.Services;

--- a/DotNet/Automation.UI/Services/RunExecutor.cs
+++ b/DotNet/Automation.UI/Services/RunExecutor.cs
@@ -1,6 +1,8 @@
 ﻿using Automation.UI.Models;
+using Automation.UI.Services.Persistence;
 using LantanaGroup.Automation;
-using Automation.UI.Models;
+using LantanaGroup.Automation.Generation;
+using LantanaGroup.Automation.Helpers;
 using LantanaGroup.Link.Automation.Link;
 using LantanaGroup.Link.Automation.Link.Configuration;
 using LantanaGroup.Link.Automation.Link.Helpers;
@@ -43,6 +45,9 @@ internal sealed class RunExecutor
     private readonly QueryPlanTemplateResolver _queryPlanResolver;
     private readonly NormalizationSuiteResolver _normalizationSuiteResolver;
     private readonly OrganizationResourceMapTemplateResolver _organizationResourceMapResolver;
+    private readonly ImportedBundleExecutionResolver _importedBundleResolver;
+    private readonly IGeneratedPatientTemplateCache _generatedTemplateCache;
+    private readonly GeneratedTemplateCacheVersionStore _generatedTemplateVersionStore;
     private readonly bool _suppressExternalManifest;
     private readonly bool _includePatientAggregatorOrganizationResource;
     private readonly string _includePatientAggregatorOrganizationResourceSource;
@@ -58,6 +63,9 @@ internal sealed class RunExecutor
         QueryPlanTemplateResolver queryPlanResolver,
         NormalizationSuiteResolver normalizationSuiteResolver,
         OrganizationResourceMapTemplateResolver organizationResourceMapResolver,
+        ImportedBundleExecutionResolver importedBundleResolver,
+        IGeneratedPatientTemplateCache generatedTemplateCache,
+        GeneratedTemplateCacheVersionStore generatedTemplateVersionStore,
         IConfiguration configuration,
         ILogger logger)
     {
@@ -68,6 +76,9 @@ internal sealed class RunExecutor
         _queryPlanResolver = queryPlanResolver;
         _normalizationSuiteResolver = normalizationSuiteResolver;
         _organizationResourceMapResolver = organizationResourceMapResolver;
+        _importedBundleResolver = importedBundleResolver;
+        _generatedTemplateCache = generatedTemplateCache;
+        _generatedTemplateVersionStore = generatedTemplateVersionStore;
         _suppressExternalManifest = configuration.GetValue<bool>("ExternalBlobStorage:SuppressManifest");
         var includeOrg = ResolveIncludePatientAggregatorOrganizationResource(configuration);
         _includePatientAggregatorOrganizationResource = includeOrg.Value;
@@ -274,7 +285,9 @@ internal sealed class RunExecutor
                 var importedPatients = new List<ImportedPatientInput>(
                     state.Options.ImportedPatientIds.Count + state.Options.ImportedPatientBundles.Count);
                 importedPatients.AddRange(state.Options.ImportedPatientIds);
-                importedPatients.AddRange(state.Options.ImportedPatientBundles);
+                importedPatients.AddRange(await _importedBundleResolver.ResolveAsync(
+                    state.Options.ImportedPatientBundles,
+                    state.RunCancellation.Token));
 
                 // Pre-load imported patient FHIR data so the pipeline can reuse it without
                 // re-fetching, and surface — but do NOT enforce — whether each imported
@@ -340,10 +353,30 @@ internal sealed class RunExecutor
                         // date is outside the reporting window.
                         AllowEncounterAnchoredDateOverrideForOutOfRange = false
                     },
-                    importedPatients: importedPatients.Count > 0 ? importedPatients : null);
+                    importedPatients: importedPatients.Count > 0 ? importedPatients : null,
+                    generatedTemplateCache: _generatedTemplateCache);
 
                 patientIds = pipelineResult.PatientIds;
                 generationManifest = pipelineResult.Manifest;
+
+                var cacheBinding = await _generatedTemplateVersionStore.BindRunAsync(
+                    state.RunId,
+                    state.ScenarioId,
+                    state.RunNameOverride,
+                    pipelineResult.GeneratedTemplateKeys,
+                    state.RunCancellation.Token);
+                if (cacheBinding != null)
+                {
+                    lock (state.Sync)
+                    {
+                        state.GeneratedTemplateCacheVersionId = cacheBinding.VersionId;
+                        state.GeneratedTemplateCacheVersionNumber = cacheBinding.VersionNumber;
+                        state.GeneratedTemplateCacheScenarioKey = cacheBinding.ScenarioKey;
+                        state.GeneratedTemplateSetHash = cacheBinding.TemplateSetHash;
+                    }
+
+                    output.WriteLine($"[cache-version] Bound run to {cacheBinding.ScenarioKey} v{cacheBinding.VersionNumber} ({cacheBinding.VersionId}).");
+                }
 
                 // Manifest carries explicit patient/profile pairs. Build the initial expected
                 // submitted set from those pairs; scheduled runs are recomputed later after
@@ -1355,15 +1388,6 @@ internal sealed class RunExecutor
                 .OrderBy(r => r, StringComparer.OrdinalIgnoreCase)
                 .ToArray();
 
-        static List<NormalizationOperationApiModel> BuildKeyedOperationPool(
-            List<NormalizationOperationApiModel> operations,
-            string name,
-            string operationType)
-            => operations
-                .Where(op => string.Equals(op.Name ?? string.Empty, name, StringComparison.Ordinal)
-                             && string.Equals(op.OperationType ?? string.Empty, operationType, StringComparison.Ordinal))
-                .ToList();
-
         static bool TryTakeMatchingOperation(
             List<NormalizationOperationApiModel> candidates,
             string[] plannedResourceTypes,
@@ -1451,8 +1475,8 @@ internal sealed class RunExecutor
 
             var apiOp = new CreateNormalizationOperationDetailsApiModel
             {
-                OperationType = opDef.OperationType,
-                Name = opDef.Name,
+                OperationType = opDef.OperationType ?? string.Empty,
+                Name = opDef.Name ?? string.Empty,
                 Description = opDef.Description ?? string.Empty,
                 SourceFhirPath = opDef.SourceFhirPath ?? string.Empty,
                 TargetFhirPath = opDef.TargetFhirPath ?? string.Empty

--- a/DotNet/Automation.UI/Services/RunHub.cs
+++ b/DotNet/Automation.UI/Services/RunHub.cs
@@ -1,5 +1,4 @@
 ﻿using Microsoft.AspNetCore.Authorization;
-using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.SignalR;
 
 namespace Automation.UI.Services;

--- a/DotNet/Automation.UI/Services/RunSnapshotOrchestrator.cs
+++ b/DotNet/Automation.UI/Services/RunSnapshotOrchestrator.cs
@@ -255,7 +255,7 @@ public sealed class RunSnapshotOrchestrator : BackgroundService
         }
     }
 
-    private static async Task DisposeUnregisteredPollerAsync(Task task, CancellationTokenSource cts, IServiceScope scope)
+    private async Task DisposeUnregisteredPollerAsync(Task task, CancellationTokenSource cts, IServiceScope scope)
     {
         try
         {
@@ -264,6 +264,10 @@ public sealed class RunSnapshotOrchestrator : BackgroundService
         catch (OperationCanceledException)
         {
             // Expected after cancellation because another poller is already registered.
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Unexpected error while disposing unregistered poller task.");
         }
         finally
         {

--- a/DotNet/Automation.UI/Services/RunSnapshotOrchestrator.cs
+++ b/DotNet/Automation.UI/Services/RunSnapshotOrchestrator.cs
@@ -8,7 +8,7 @@ namespace Automation.UI.Services;
 /// Periodically checks for active runs and ensures each one has a poller.
 /// When a run completes, its poller is stopped and removed.
 ///
-/// This is the single place that does API polling — the UI controllers
+/// This is the single place that does API polling ï¿½ the UI controllers
 /// only read from <see cref="ISnapshotStore"/>.
 /// </summary>
 public sealed class RunSnapshotOrchestrator : BackgroundService
@@ -98,7 +98,7 @@ public sealed class RunSnapshotOrchestrator : BackgroundService
             _logger.LogInformation("Stopped existing poller for run {RunId} before context switch", runId);
         }
 
-        // 2. Now safe to update meta and clear stale domain snapshots — no writer
+        // 2. Now safe to update meta and clear stale domain snapshots ï¿½ no writer
         //    can re-populate them with old-report data.
         await _store.UpdateRunMetaAsync(runId, facilityId, reportId, ct);
 
@@ -141,9 +141,11 @@ public sealed class RunSnapshotOrchestrator : BackgroundService
         try
         {
             var schedule = await _store.GetDomainAsync<PipelineDataReader.ReportScheduleInfo>(runId, "schedule");
-            if (schedule?.Data is { CreateDate: not null, SubmitReportDateTime: not null })
+            var createDate = schedule?.Data?.CreateDate;
+            var submitReportDateTime = schedule?.Data?.SubmitReportDateTime;
+            if (createDate.HasValue && submitReportDateTime.HasValue)
             {
-                var span = schedule.Data.SubmitReportDateTime.Value - schedule.Data.CreateDate.Value;
+                var span = submitReportDateTime.Value - createDate.Value;
                 if (span.TotalSeconds >= 1)
                     duration = span.TotalHours >= 1
                         ? $"{(int)span.TotalHours}h {span.Minutes}m {span.Seconds}s"
@@ -249,7 +251,24 @@ public sealed class RunSnapshotOrchestrator : BackgroundService
         else
         {
             cts.Cancel();
+            _ = DisposeUnregisteredPollerAsync(task, cts, scope);
+        }
+    }
+
+    private static async Task DisposeUnregisteredPollerAsync(Task task, CancellationTokenSource cts, IServiceScope scope)
+    {
+        try
+        {
+            await task;
+        }
+        catch (OperationCanceledException)
+        {
+            // Expected after cancellation because another poller is already registered.
+        }
+        finally
+        {
             scope.Dispose();
+            cts.Dispose();
         }
     }
 

--- a/DotNet/Automation.UI/Services/StartScenarioRequestResolver.cs
+++ b/DotNet/Automation.UI/Services/StartScenarioRequestResolver.cs
@@ -40,7 +40,7 @@ public static class StartScenarioRequestResolver
             {
                 NhsnOrganizationId = MegaPatientTestNhsnOrganizationId
             },
-            AutomationScenarioKind.Custom => new ResolvedRunOptions(10, 250, 20260329, 3, 0, 30, false, true, defaultMeasures, [], [])
+            AutomationScenarioKind.Custom => new ResolvedRunOptions(10, 250, 20260329, 3, 30, 30, false, true, defaultMeasures, [], [])
             {
                 NhsnOrganizationId = GenerateRandomNhsnOrganizationId()
             },

--- a/DotNet/Automation.UI/Views/Shared/_ScenarioEditorModal.cshtml
+++ b/DotNet/Automation.UI/Views/Shared/_ScenarioEditorModal.cshtml
@@ -213,7 +213,7 @@
                                             <i class="bi bi-upload me-1"></i>Upload Bundle JSON
                                             <input type="file" id="importedBundleFile" accept="application/json,.json" multiple hidden />
                                         </label>
-                                        <span id="importedUploadStatus" class="small text-muted" style="display:none;"></span>
+                                        <span id="importedUploadStatus" class="small text-muted" style="display:none;" role="status" aria-live="polite"></span>
                                     </div>
                                 </div>
                             </div>
@@ -303,6 +303,8 @@
         var btnUseServerData = document.getElementById('btnUseServerData');
         var btnReplaceFhirCancel = document.getElementById('btnReplaceFhirCancel');
         var btnReplaceFhirClose = document.getElementById('btnReplaceFhirClose');
+        var activePatientReplacementPollController = null;
+        var patientReplacementPollTimeoutMs = 2 * 60 * 1000;
 
         function notifyChanged(action, id, name) {
             document.dispatchEvent(new CustomEvent('scenario-editor:changed', {
@@ -330,8 +332,21 @@
                 .replace(/"/g, '&quot;')
                 .replace(/'/g, '&#39;');
         }
+        function cancelPatientReplacementPolling() {
+            if (activePatientReplacementPollController) {
+                activePatientReplacementPollController.abort();
+                activePatientReplacementPollController = null;
+            }
+        }
+        function isScenarioEditorModalOpen() {
+            return !!modal && modal.style.display !== 'none';
+        }
         function openModal() { modal.style.display = ''; backdrop.style.display = ''; }
-        function closeModal() { modal.style.display = 'none'; backdrop.style.display = 'none'; }
+        function closeModal() {
+            cancelPatientReplacementPolling();
+            modal.style.display = 'none';
+            backdrop.style.display = 'none';
+        }
         function ensureScenarioId() {
             if (!idInput.value) idInput.value = crypto.randomUUID();
             return idInput.value;
@@ -600,27 +615,84 @@
         }
 
         async function waitForPatientReplacement(statusUrl, patientId) {
-            while (true) {
-                var response = await fetch(statusUrl, { headers: { 'Accept': 'application/json' } });
-                if (!response.ok) {
-                    throw new Error(await response.text() || 'Could not retrieve replacement status.');
-                }
+            var startedAt = Date.now();
+            var controller = new AbortController();
+            activePatientReplacementPollController = controller;
 
-                var status = await response.json();
-                setImportedUploadStatus(
-                    status.message || 'Replacing FHIR-server data for Patient/' + patientId + '...',
-                    !status.isComplete);
-
-                if (status.isComplete) {
-                    if (!status.succeeded) {
-                        throw new Error(status.message || 'FHIR-server replacement failed.');
+            function delayWithSignal(ms, signal) {
+                return new Promise(function (resolve, reject) {
+                    if (signal.aborted) {
+                        reject(new DOMException('Polling canceled.', 'AbortError'));
+                        return;
                     }
 
-                    return status;
+                    var timeoutId = window.setTimeout(function () {
+                        signal.removeEventListener('abort', onAbort);
+                        resolve();
+                    }, ms);
+
+                    function onAbort() {
+                        window.clearTimeout(timeoutId);
+                        signal.removeEventListener('abort', onAbort);
+                        reject(new DOMException('Polling canceled.', 'AbortError'));
+                    }
+
+                    signal.addEventListener('abort', onAbort);
+                });
+            }
+
+            try {
+                while (Date.now() - startedAt < patientReplacementPollTimeoutMs) {
+                    if (!isScenarioEditorModalOpen()) {
+                        throw new DOMException('Scenario editor modal closed.', 'AbortError');
+                    }
+
+                    var response = await fetch(statusUrl, {
+                        headers: { 'Accept': 'application/json' },
+                        signal: controller.signal
+                    });
+                    if (!response.ok) {
+                        throw new Error(await response.text() || 'Could not retrieve replacement status.');
+                    }
+
+                    var status = await response.json();
+                    setImportedUploadStatus(
+                        status.message || 'Replacing FHIR-server data for Patient/' + patientId + '...',
+                        !status.isComplete);
+
+                    if (status.isComplete) {
+                        if (!status.succeeded) {
+                            throw new Error(status.message || 'FHIR-server replacement failed.');
+                        }
+
+                        return status;
+                    }
+
+                    var elapsed = Date.now() - startedAt;
+                    var remaining = patientReplacementPollTimeoutMs - elapsed;
+                    if (remaining <= 0) {
+                        break;
+                    }
+
+                    if (!isScenarioEditorModalOpen()) {
+                        throw new DOMException('Scenario editor modal closed.', 'AbortError');
+                    }
+
+                    await delayWithSignal(Math.min(2000, remaining), controller.signal);
+                }
+            } catch (err) {
+                if (err && err.name === 'AbortError') {
+                    throw new Error('FHIR-server replacement status polling was canceled.');
                 }
 
-                await new Promise(function (resolve) { window.setTimeout(resolve, 2000); });
+                throw err;
+            } finally {
+                if (activePatientReplacementPollController === controller) {
+                    activePatientReplacementPollController = null;
+                }
             }
+
+            throw new Error('Timed out waiting for FHIR-server replacement status for Patient/' + patientId + '.');
         }
 
         async function postForm(url, formData) {

--- a/DotNet/Automation.UI/Views/Shared/_ScenarioEditorModal.cshtml
+++ b/DotNet/Automation.UI/Views/Shared/_ScenarioEditorModal.cshtml
@@ -598,6 +598,31 @@
             var ct = res.headers.get('content-type') || '';
             return ct.indexOf('json') >= 0 ? res.json() : null;
         }
+
+        async function waitForPatientReplacement(statusUrl, patientId) {
+            while (true) {
+                var response = await fetch(statusUrl, { headers: { 'Accept': 'application/json' } });
+                if (!response.ok) {
+                    throw new Error(await response.text() || 'Could not retrieve replacement status.');
+                }
+
+                var status = await response.json();
+                setImportedUploadStatus(
+                    status.message || 'Replacing FHIR-server data for Patient/' + patientId + '...',
+                    !status.isComplete);
+
+                if (status.isComplete) {
+                    if (!status.succeeded) {
+                        throw new Error(status.message || 'FHIR-server replacement failed.');
+                    }
+
+                    return status;
+                }
+
+                await new Promise(function (resolve) { window.setTimeout(resolve, 2000); });
+            }
+        }
+
         async function postForm(url, formData) {
             var res = await fetch(url, {
                 method: 'POST',
@@ -1261,8 +1286,16 @@
                                     uploadedBundleId: uploaded.bundleId,
                                     patientId: uploaded.patientId
                                 });
-                                if (replaceRes && replaceRes.message) {
-                                    lastSpecialOutcomeMessage = replaceRes.message;
+                                if (!replaceRes || !replaceRes.statusUrl) {
+                                    throw new Error('FHIR-server replacement did not return a status endpoint.');
+                                }
+
+                                var replacementStatus = await waitForPatientReplacement(replaceRes.statusUrl, uploaded.patientId);
+                                lastSpecialOutcomeMessage = replacementStatus.message || 'Successfully replaced FHIR-server data for Patient/' + uploaded.patientId + '.';
+                                if (replacementStatus.deletedFailed > 0) {
+                                    showWarning('FHIR purge completed with ' + replacementStatus.deletedFailed + ' failed delete request(s).');
+                                }
+                                if (lastSpecialOutcomeMessage) {
                                     setImportedUploadStatus(lastSpecialOutcomeMessage, false);
                                 }
                             } catch (replaceErr) {

--- a/DotNet/Automation.UI/appsettings.Docker.json
+++ b/DotNet/Automation.UI/appsettings.Docker.json
@@ -89,7 +89,8 @@
   "InternalBlobStorage": {
     "ConnectionString": "UseDevelopmentStorage=true",
     "BlobContainerName": "link-automation-ui",
-    "BlobRoot": "automation/imported-bundles"
+    "BlobRoot": "automation/imported-bundles",
+    "GeneratedTemplateBlobRoot": "automation/generated-bundles"
   },
   "Kestrel": {
     "Endpoints": {

--- a/DotNet/Automation.UI/appsettings.json
+++ b/DotNet/Automation.UI/appsettings.json
@@ -96,6 +96,7 @@
   "InternalBlobStorage": {
     "ConnectionString": "UseDevelopmentStorage=true",
     "BlobContainerName": "link-automation-ui",
-    "BlobRoot": "automation/imported-bundles"
+    "BlobRoot": "automation/imported-bundles",
+    "GeneratedTemplateBlobRoot": "automation/generated-bundles"
   }
 }

--- a/DotNet/Automation/FhirDataLoader.cs
+++ b/DotNet/Automation/FhirDataLoader.cs
@@ -99,6 +99,41 @@ public class FhirDataLoader
             $"FHIR server returned {(int)response.StatusCode} {response.StatusCode} for Patient/{patientId}. Response body: {response.Content}");
     }
 
+    /// <summary>
+    /// Waits until a Patient is no longer available from the FHIR server. This is used
+    /// after requesting an expunge, which can complete asynchronously on deployed servers.
+    /// </summary>
+    public async Task WaitForPatientDeletionAsync(
+        string patientId,
+        Action<string>? progress = null,
+        CancellationToken ct = default)
+    {
+        var attempt = 0;
+
+        while (true)
+        {
+            ct.ThrowIfCancellationRequested();
+            attempt++;
+
+            try
+            {
+                if (!await PatientExistsAsync(patientId, ct))
+                {
+                    progress?.Invoke($"FHIR purge completed for patient '{patientId}'.");
+                    return;
+                }
+
+                progress?.Invoke($"Waiting for FHIR purge to complete for patient '{patientId}' (check {attempt}).");
+            }
+            catch (Exception ex) when (!ct.IsCancellationRequested)
+            {
+                progress?.Invoke($"Could not verify FHIR purge completion for patient '{patientId}' (check {attempt}): {ex.Message}");
+            }
+
+            await Task.Delay(TimeSpan.FromSeconds(2), ct);
+        }
+    }
+
     private void GetAuthorization()
     {
         if (_oauthConfig?.ShouldAuthenticate != true &&

--- a/DotNet/Automation/FhirDataLoader.cs
+++ b/DotNet/Automation/FhirDataLoader.cs
@@ -106,11 +106,16 @@ public class FhirDataLoader
     public async Task WaitForPatientDeletionAsync(
         string patientId,
         Action<string>? progress = null,
+        TimeSpan? timeout = null,
         CancellationToken ct = default)
     {
+        var maxWait = timeout ?? TimeSpan.FromSeconds(60);
+        var started = DateTime.UtcNow;
         var attempt = 0;
+        var delay = TimeSpan.FromSeconds(1);
+        var maxDelay = TimeSpan.FromSeconds(5);
 
-        while (true)
+        while (DateTime.UtcNow - started < maxWait)
         {
             ct.ThrowIfCancellationRequested();
             attempt++;
@@ -123,15 +128,23 @@ public class FhirDataLoader
                     return;
                 }
 
-                progress?.Invoke($"Waiting for FHIR purge to complete for patient '{patientId}' (check {attempt}).");
+                progress?.Invoke($"Waiting for FHIR purge to complete for patient '{patientId}' (check {attempt}, elapsed {(DateTime.UtcNow - started).TotalSeconds:F1}s).");
             }
             catch (Exception ex) when (!ct.IsCancellationRequested)
             {
                 progress?.Invoke($"Could not verify FHIR purge completion for patient '{patientId}' (check {attempt}): {ex.Message}");
             }
 
-            await Task.Delay(TimeSpan.FromSeconds(2), ct);
+            var remaining = maxWait - (DateTime.UtcNow - started);
+            if (remaining <= TimeSpan.Zero)
+                break;
+
+            var nextDelay = delay <= remaining ? delay : remaining;
+            await Task.Delay(nextDelay, ct);
+            delay = delay + TimeSpan.FromSeconds(1) <= maxDelay ? delay + TimeSpan.FromSeconds(1) : maxDelay;
         }
+
+        throw new TimeoutException($"Timed out waiting for FHIR purge to complete for patient '{patientId}' after {maxWait.TotalSeconds:F0}s.");
     }
 
     private void GetAuthorization()

--- a/DotNet/Automation/Generation/FhirBundleGenerator.cs
+++ b/DotNet/Automation/Generation/FhirBundleGenerator.cs
@@ -1,7 +1,6 @@
 ﻿using Hl7.Fhir.Model;
 using LantanaGroup.Automation.Generation.ResourceFactories;
 using LantanaGroup.Automation.Helpers;
-using System.Text.Json;
 
 namespace LantanaGroup.Automation.Generation;
 
@@ -41,10 +40,12 @@ public static class FhirBundleGenerator
     /// Run-scoped shared infrastructure IDs. A short GUID tag (RunTag) ensures concurrent
     /// test runs against the same FHIR server don't conflict on infrastructure resources.
     /// </summary>
-    public sealed record SharedIds()
+    public sealed record SharedIds(string? RunTagOverride = null)
     {
         /// <summary>Short unique tag for this generation run (8 hex chars from a GUID).</summary>
-        public string RunTag { get; } = Guid.NewGuid().ToString("N")[..8];
+        public string RunTag { get; } = string.IsNullOrWhiteSpace(RunTagOverride)
+            ? Guid.NewGuid().ToString("N")[..8]
+            : RunTagOverride.Trim();
 
         public string HospitalLocation => $"{RunTag}-Loc-Hospital";
         public string IcuLocation => $"{RunTag}-Loc-ICU";

--- a/DotNet/Automation/Generation/FhirGenerationPipeline.cs
+++ b/DotNet/Automation/Generation/FhirGenerationPipeline.cs
@@ -172,6 +172,12 @@ public static class FhirGenerationPipeline
         // ------------------------------------------------------------------
         var (sharedEntries, sharedPractitionerIds, sharedMedicationIds, ids) = GenerateSharedInfrastructure(generationRequirementsPlan, effectiveRunId);
 
+        if (generatedTemplateCache != null && !IsSafeRunTagForTemplateCache(ids.RunTag))
+        {
+            output.WriteLine($"[Pipeline] Run tag '{ids.RunTag}' is not in the expected generated format; skipping generated template cache for this run.");
+            generatedTemplateCache = null;
+        }
+
         // Upload shared infrastructure first
         var sharedBundles = ChunkEntries(sharedEntries, "shared", 0);
         output.WriteLine($"[Pipeline] Uploading {sharedBundles.Count} shared infrastructure bundle(s)...");
@@ -877,10 +883,33 @@ public static class FhirGenerationPipeline
 
     private static string ReplaceRunTag(string json, string sourceRunTag, string targetRunTag)
     {
+        if (!IsAllowedTemplateReplacementTag(sourceRunTag) || !IsAllowedTemplateReplacementTag(targetRunTag))
+            return json;
+
         if (string.Equals(sourceRunTag, targetRunTag, StringComparison.Ordinal))
             return json;
 
         return json.Replace(sourceRunTag, targetRunTag, StringComparison.Ordinal);
+    }
+
+    private static bool IsAllowedTemplateReplacementTag(string runTag)
+    {
+        return string.Equals(runTag, TemplateRunTag, StringComparison.Ordinal)
+            || IsSafeRunTagForTemplateCache(runTag);
+    }
+
+    private static bool IsSafeRunTagForTemplateCache(string? runTag)
+    {
+        if (string.IsNullOrWhiteSpace(runTag) || runTag.Length != 8)
+            return false;
+
+        foreach (var ch in runTag)
+        {
+            if (!Uri.IsHexDigit(ch))
+                return false;
+        }
+
+        return true;
     }
 
     private static List<Bundle.EntryComponent> ParseBundleEntriesFromJson(IReadOnlyList<string> bundleJson)

--- a/DotNet/Automation/Generation/FhirGenerationPipeline.cs
+++ b/DotNet/Automation/Generation/FhirGenerationPipeline.cs
@@ -1,7 +1,11 @@
 ﻿using Hl7.Fhir.Model;
+using Hl7.Fhir.Serialization;
 using LantanaGroup.Automation.Generation.ResourceFactories;
 using LantanaGroup.Automation.Helpers;
+using System.Reflection;
 using System.Globalization;
+using System.Security.Cryptography;
+using System.Text;
 using System.Text.Json;
 
 namespace LantanaGroup.Automation.Generation;
@@ -27,6 +31,8 @@ public static class FhirGenerationPipeline
 {
     private const int MaxEntriesPerBundle = 500;
     private const int MaxConcurrentPatients = 4;
+    private const string TemplateRunTag = "template-run";
+    private static readonly Lazy<string> GeneratorDependencyFingerprint = new(ComputeGeneratorDependencyFingerprint);
 
     /// <summary>
     /// Result of a pipeline run. Contains all metadata needed by validators and the
@@ -47,6 +53,12 @@ public static class FhirGenerationPipeline
 
         /// <summary>Total number of transaction bundle chunks uploaded.</summary>
         public int TotalBundlesUploaded { get; init; }
+
+        /// <summary>
+        /// Deterministic template cache keys used for generated patients, ordered by
+        /// generated patient ordinal. Used for immutable cache-version pinning.
+        /// </summary>
+        public IReadOnlyList<string> GeneratedTemplateKeys { get; init; } = [];
     }
 
     /// <summary>
@@ -92,7 +104,8 @@ public static class FhirGenerationPipeline
         GenerationRequirementsPlan? generationRequirementsPlan = null,
         AcquisitionSimulationConfig? acquisitionSimulation = null,
         string? runId = null,
-        IReadOnlyList<ImportedPatientInput>? importedPatients = null)
+        IReadOnlyList<ImportedPatientInput>? importedPatients = null,
+        IGeneratedPatientTemplateCache? generatedTemplateCache = null)
     {
         if (measures == null || measures.Count == 0)
             throw new ArgumentException("At least one measure is required.", nameof(measures));
@@ -157,7 +170,7 @@ public static class FhirGenerationPipeline
         // ------------------------------------------------------------------
         // Shared infrastructure — generated once, uploaded first
         // ------------------------------------------------------------------
-        var (sharedEntries, sharedPractitionerIds, sharedMedicationIds, ids) = GenerateSharedInfrastructure(generationRequirementsPlan);
+        var (sharedEntries, sharedPractitionerIds, sharedMedicationIds, ids) = GenerateSharedInfrastructure(generationRequirementsPlan, effectiveRunId);
 
         // Upload shared infrastructure first
         var sharedBundles = ChunkEntries(sharedEntries, "shared", 0);
@@ -179,6 +192,7 @@ public static class FhirGenerationPipeline
         // sequential within each patient's chunk sequence)
         // ------------------------------------------------------------------
         var patientIds = new string[profiles.Count];
+        var generatedTemplateKeys = new string[profiles.Count];
         var totalBundlesUploaded = sharedBundles.Count;
         var completedPatients = 0;
         var semaphore = new SemaphoreSlim(MaxConcurrentPatients, MaxConcurrentPatients);
@@ -192,7 +206,7 @@ public static class FhirGenerationPipeline
                 await semaphore.WaitAsync();
                 try
                 {
-                    var (patientId, profile, bundleCount) = await GenerateAndUploadSinglePatientAsync(
+                    var (patientId, profile, bundleCount, templateKey) = await GenerateAndUploadSinglePatientAsync(
                         output,
                         fhirDataLoader,
                         manifestBuilder,
@@ -209,9 +223,11 @@ public static class FhirGenerationPipeline
                         generationClinicalPeriodEnd,
                         config,
                         generationRequirementsPlan,
-                        ids);
+                        ids,
+                        generatedTemplateCache);
 
                     patientIds[patientIndex] = patientId;
+                    generatedTemplateKeys[patientIndex] = templateKey;
                     Interlocked.Add(ref totalBundlesUploaded, bundleCount);
 
                     var done = Interlocked.Increment(ref completedPatients);
@@ -267,7 +283,8 @@ public static class FhirGenerationPipeline
         {
             PatientIds = allPatientIds,
             Manifest = manifest,
-            TotalBundlesUploaded = totalBundlesUploaded
+            TotalBundlesUploaded = totalBundlesUploaded,
+            GeneratedTemplateKeys = generatedTemplateKeys.Where(k => !string.IsNullOrWhiteSpace(k)).ToList()
         };
     }
 
@@ -275,7 +292,7 @@ public static class FhirGenerationPipeline
     /// Generates a single patient's FHIR resources, uploads them, accumulates manifest
     /// metadata, optionally runs acquisition simulation, then discards all FHIR data.
     /// </summary>
-    private static async Task<(string PatientId, PatientProfile Profile, int BundleCount)> GenerateAndUploadSinglePatientAsync(
+    private static async Task<(string PatientId, PatientProfile Profile, int BundleCount, string TemplateKey)> GenerateAndUploadSinglePatientAsync(
         IAutomationOutput output,
         FhirDataLoader fhirDataLoader,
         GenerationManifest.IncrementalBuilder manifestBuilder,
@@ -292,7 +309,8 @@ public static class FhirGenerationPipeline
         DateTime? generationClinicalPeriodEnd,
         FhirGenerationConfig? config,
         GenerationRequirementsPlan? generationRequirementsPlan,
-        FhirBundleGenerator.SharedIds ids)
+        FhirBundleGenerator.SharedIds ids,
+        IGeneratedPatientTemplateCache? generatedTemplateCache)
     {
         var patientSeed = baseSeed + (profile.SeedOffset ?? patientIndex);
         var patientId = ids.PatientId(patientIndex);
@@ -301,11 +319,54 @@ public static class FhirGenerationPipeline
         // Falls back to run-level default for profiles that do not specify a concrete target.
         var effectiveResourcesPerPatient = profile.ResourcesPerPatient ?? totalResourcesPerPatient;
 
-        // Generate entries using the same per-patient logic shared with FhirBundleGenerator.
-        var entries = GeneratePatientEntries(
-            profile, patientIndex, baseSeed, effectiveResourcesPerPatient,
-            sharedPractitionerIds, sharedMedicationIds, measures,
-            generationClinicalPeriodStart, generationClinicalPeriodEnd, config, generationRequirementsPlan, ids);
+        var templateCacheKey = ComputeTemplateCacheKey(
+            profile,
+            patientIndex,
+            baseSeed,
+            effectiveResourcesPerPatient,
+            measures,
+            generationClinicalPeriodStart,
+            generationClinicalPeriodEnd,
+            config,
+            generationRequirementsPlan);
+
+        List<Bundle.EntryComponent> entries;
+        List<(string Name, string Json)> bundles;
+
+        var cachedTemplate = generatedTemplateCache == null
+            ? null
+            : await generatedTemplateCache.GetAsync(templateCacheKey);
+
+        if (cachedTemplate == null)
+        {
+            // Generate entries using the same per-patient logic shared with FhirBundleGenerator.
+            entries = GeneratePatientEntries(
+                profile, patientIndex, baseSeed, effectiveResourcesPerPatient,
+                sharedPractitionerIds, sharedMedicationIds, measures,
+                generationClinicalPeriodStart, generationClinicalPeriodEnd, config, generationRequirementsPlan, ids);
+
+            bundles = ChunkEntries(entries, patientId, 0);
+
+            if (generatedTemplateCache != null)
+            {
+                var templateBundles = bundles.Select(b => ReplaceRunTag(b.Json, ids.RunTag, TemplateRunTag)).ToList();
+                await generatedTemplateCache.StoreAsync(templateCacheKey, new GeneratedPatientTemplate(TemplateRunTag, templateBundles));
+                output.WriteLine($"  [cache] Miss for {patientId}; stored template key={templateCacheKey}.");
+            }
+        }
+        else
+        {
+            var materialized = cachedTemplate.BundleJson
+                .Select(json => ReplaceRunTag(json, cachedTemplate.TemplateRunTag, ids.RunTag))
+                .ToList();
+
+            bundles = materialized
+                .Select((json, idx) => (Name: $"{patientId}-bundle-{idx + 1:D3}", Json: json))
+                .ToList();
+
+            entries = ParseBundleEntriesFromJson(materialized);
+            output.WriteLine($"  [cache] Hit for {patientId}; reused template key={templateCacheKey}.");
+        }
 
         var scenario = FhirGenerationCodes.GetScenarioById(profile.ClinicalScenarioId)
                        ?? FhirGenerationCodes.GetScenarioBySeed(patientSeed);
@@ -389,9 +450,6 @@ public static class FhirGenerationPipeline
             // patientSimEntries (JsonElement clones) are now eligible for GC
         }
 
-        // Serialize into chunks, upload sequentially, then discard
-        var bundles = ChunkEntries(entries, patientId, 0);
-
         // Entries list is no longer needed — allow GC before upload
         entries.Clear();
 
@@ -403,7 +461,7 @@ public static class FhirGenerationPipeline
         // Bundles are no longer needed — allow GC
         bundles.Clear();
 
-        return (patientId, profile, bundleCount);
+        return (patientId, profile, bundleCount, templateCacheKey);
     }
 
     /// <summary>
@@ -709,14 +767,137 @@ public static class FhirGenerationPipeline
     // ------------------------------------------------------------------
 
     private static (List<Bundle.EntryComponent> Entries, List<string> PractitionerIds, List<string> MedicationIds, FhirBundleGenerator.SharedIds Ids)
-        GenerateSharedInfrastructure(GenerationRequirementsPlan? generationRequirementsPlan)
+        GenerateSharedInfrastructure(GenerationRequirementsPlan? generationRequirementsPlan, string runTag)
     {
         // All shared-infrastructure construction lives in ScenarioResourceGeneration so
         // FhirBundleGenerator (bulk path) and FhirGenerationPipeline (streaming path)
         // can never drift on shared-resource shape, IDs, or order.
-        var ids = new FhirBundleGenerator.SharedIds();
+        var ids = new FhirBundleGenerator.SharedIds(runTag);
         var (entries, practitionerIds, medicationIds) = ScenarioResourceGeneration.BuildSharedInfrastructure(ids, generationRequirementsPlan);
         return (entries, practitionerIds, medicationIds, ids);
+    }
+
+    private static string ComputeTemplateCacheKey(
+        PatientProfile profile,
+        int patientIndex,
+        int baseSeed,
+        int resourcesPerPatient,
+        IReadOnlyList<ProfiledMeasureType> measures,
+        DateTime? periodStart,
+        DateTime? periodEnd,
+        FhirGenerationConfig? config,
+        GenerationRequirementsPlan? requirements)
+    {
+        var keyPayload = JsonSerializer.Serialize(new
+        {
+            PatientProfile = profile,
+            PatientIndex = patientIndex,
+            BaseSeed = baseSeed,
+            ResourcesPerPatient = resourcesPerPatient,
+            Measures = measures.Select(m => m.ToString()).ToArray(),
+            PeriodStart = periodStart,
+            PeriodEnd = periodEnd,
+            Config = config,
+            Requirements = requirements,
+            GeneratorDependencyFingerprint = GeneratorDependencyFingerprint.Value
+        });
+
+        var hash = SHA256.HashData(Encoding.UTF8.GetBytes(keyPayload));
+        return Convert.ToHexString(hash);
+    }
+
+    private static string ComputeGeneratorDependencyFingerprint()
+    {
+        var assembly = typeof(FhirGenerationPipeline).Assembly;
+        var dependencyNames = new[]
+        {
+            "Automation",
+            "Hl7.Fhir.Base",
+            "Hl7.Fhir.Support"
+        };
+
+        var dependencies = assembly
+            .GetReferencedAssemblies()
+            .Where(reference => dependencyNames.Contains(reference.Name, StringComparer.OrdinalIgnoreCase))
+            .OrderBy(reference => reference.Name, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        var payload = new StringBuilder();
+        payload.Append("pipeline=").Append(GetAssemblyIdentityHash(assembly));
+
+        foreach (var dependency in dependencies)
+        {
+            payload.Append('|')
+                .Append(dependency.Name)
+                .Append('=')
+                .Append(dependency.Version?.ToString() ?? "none")
+                .Append(':')
+                .Append(GetLoadedAssemblyHash(dependency.Name ?? string.Empty));
+        }
+
+        var hash = SHA256.HashData(Encoding.UTF8.GetBytes(payload.ToString()));
+        return Convert.ToHexString(hash);
+    }
+
+    private static string GetLoadedAssemblyHash(string assemblyName)
+    {
+        if (string.IsNullOrWhiteSpace(assemblyName))
+            return "none";
+
+        var loaded = AppDomain.CurrentDomain
+            .GetAssemblies()
+            .FirstOrDefault(a => string.Equals(a.GetName().Name, assemblyName, StringComparison.OrdinalIgnoreCase));
+
+        return loaded == null ? "unloaded" : GetAssemblyIdentityHash(loaded);
+    }
+
+    private static string GetAssemblyIdentityHash(Assembly assembly)
+    {
+        var version = assembly.GetName().Version?.ToString() ?? "none";
+        var moduleVersion = assembly.ManifestModule.ModuleVersionId.ToString("N");
+        var locationHash = string.Empty;
+
+        if (!string.IsNullOrWhiteSpace(assembly.Location) && File.Exists(assembly.Location))
+        {
+            try
+            {
+                using var stream = File.OpenRead(assembly.Location);
+                var bytes = SHA256.HashData(stream);
+                locationHash = Convert.ToHexString(bytes);
+            }
+            catch
+            {
+                locationHash = "io-error";
+            }
+        }
+
+        var payload = $"{assembly.GetName().Name}:{version}:{moduleVersion}:{locationHash}";
+        return Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(payload)));
+    }
+
+    private static string ReplaceRunTag(string json, string sourceRunTag, string targetRunTag)
+    {
+        if (string.Equals(sourceRunTag, targetRunTag, StringComparison.Ordinal))
+            return json;
+
+        return json.Replace(sourceRunTag, targetRunTag, StringComparison.Ordinal);
+    }
+
+    private static List<Bundle.EntryComponent> ParseBundleEntriesFromJson(IReadOnlyList<string> bundleJson)
+    {
+        var parser = new FhirJsonParser();
+        var entries = new List<Bundle.EntryComponent>();
+
+        foreach (var json in bundleJson)
+        {
+            var bundle = parser.Parse<Bundle>(json);
+            if (bundle?.Entry is { Count: > 0 })
+            {
+                entries.AddRange(bundle.Entry.Where(entry => entry?.Resource != null));
+            }
+        }
+
+        return entries;
     }
 
     private static (DateTime Start, DateTime End) DeriveEncounterWindowForProfile(

--- a/DotNet/Automation/Generation/IGeneratedPatientTemplateCache.cs
+++ b/DotNet/Automation/Generation/IGeneratedPatientTemplateCache.cs
@@ -1,0 +1,14 @@
+﻿namespace LantanaGroup.Automation.Generation;
+
+/// <summary>
+/// Cache for generated patient-bundle templates keyed by deterministic generation inputs.
+/// Templates must carry a placeholder run tag so callers can materialize run-scoped IDs
+/// without persisting per-run payloads.
+/// </summary>
+public interface IGeneratedPatientTemplateCache
+{
+    Task<GeneratedPatientTemplate?> GetAsync(string key, CancellationToken ct = default);
+    Task StoreAsync(string key, GeneratedPatientTemplate template, CancellationToken ct = default);
+}
+
+public sealed record GeneratedPatientTemplate(string TemplateRunTag, IReadOnlyList<string> BundleJson);

--- a/DotNet/Automation/Generation/ImportedPatientInput.cs
+++ b/DotNet/Automation/Generation/ImportedPatientInput.cs
@@ -1,4 +1,4 @@
-namespace LantanaGroup.Automation.Generation;
+﻿namespace LantanaGroup.Automation.Generation;
 
 using Hl7.Fhir.Model;
 using System.Text.Json.Serialization;
@@ -18,7 +18,9 @@ public enum ImportedPatientSource
 /// <summary>
 /// Describes a single imported patient as configured on a scenario.
 /// One of <see cref="PatientId"/> (for <see cref="ImportedPatientSource.ExistingId"/>)
-/// or <see cref="BundleJson"/> (for <see cref="ImportedPatientSource.Bundle"/>) is required.
+/// or <see cref="UploadedBundleId"/> (for <see cref="ImportedPatientSource.Bundle"/>) is required.
+/// Raw <see cref="BundleJson"/> is an execution-only value populated after resolving the
+/// external bundle reference, with support retained for legacy inline inputs.
 /// </summary>
 public sealed class ImportedPatientInput
 {
@@ -38,7 +40,11 @@ public sealed class ImportedPatientInput
     /// </summary>
     public Guid? UploadedBundleId { get; set; }
 
-    /// <summary>For <see cref="ImportedPatientSource.Bundle"/>: the raw FHIR Bundle JSON.</summary>
+    /// <summary>
+    /// For <see cref="ImportedPatientSource.Bundle"/>: the raw FHIR Bundle JSON available
+    /// only to execution-time processing. New persisted models use <see cref="UploadedBundleId"/>
+    /// instead; this remains for legacy inline inputs and hydrated execution copies.
+    /// </summary>
     public string? BundleJson { get; set; }
 
     /// <summary>

--- a/DotNet/DMRP/packages.lock.json
+++ b/DotNet/DMRP/packages.lock.json
@@ -246,10 +246,10 @@
       },
       "Microsoft.Extensions.Caching.Abstractions": {
         "type": "Transitive",
-        "resolved": "8.0.0",
-        "contentHash": "3KuSxeHoNYdxVYfg2IRZCThcrlJ1XJqIXkAWikCsbm5C/bCjv7G0WoKDyuR98Q+T607QT2Zl5GsbGRkENcV2yQ==",
+        "resolved": "10.0.10",
+        "contentHash": "4ZFBNE+jzR+CrWWlhOesnmywCW7pYKT0dxyAQRdL11yJwxe4jvcAu31eorFtEkoFeCDcUTeNssgPv2yaRRptaQ==",
         "dependencies": {
-          "Microsoft.Extensions.Primitives": "8.0.0"
+          "Microsoft.Extensions.Primitives": "10.0.10"
         }
       },
       "Microsoft.Extensions.Compliance.Abstractions": {
@@ -377,11 +377,11 @@
       },
       "Microsoft.Extensions.Logging.Abstractions": {
         "type": "Transitive",
-        "resolved": "10.0.3",
-        "contentHash": "lxl0WLk7ROgBFAsjcOYjQ8/DVK+VMszxGBzUhgtQmAsTNldLL5pk9NG/cWTsXHq0lUhUEAtZkEE7jOGOA8bGKQ==",
+        "resolved": "10.0.10",
+        "contentHash": "zkFxGYUvdxAvIKTyXHrmW+Sux53D4SezD9dMyZ6hrwwzPQJNuwCRy1f5W7AvYTqacEGhWF2XderRQG1OvbV8og==",
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.3",
-          "System.Diagnostics.DiagnosticSource": "10.0.3"
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.10",
+          "System.Diagnostics.DiagnosticSource": "10.0.10"
         }
       },
       "Microsoft.Extensions.Logging.Configuration": {
@@ -641,12 +641,12 @@
           "OpenTelemetry.PersistentStorage.Abstractions": "1.0.2"
         }
       },
-      "Pipelines.Sockets.Unofficial": {
+      "RESPite": {
         "type": "Transitive",
-        "resolved": "2.2.16",
-        "contentHash": "nonu9l0YrZH6krVYbskBjE7uG0VMAnvOQ9PU+RmzUsy+++vHkqzzCkHRoP877OiA3iRTxJyNDLfpcU8hrJ3/YQ==",
+        "resolved": "3.1.11",
+        "contentHash": "jkm3/wiiYN2zRPjR9Yyu5NNVDBxgCYmrqC/u5ZPwJpOHTaT/7OOIU6pqDTHOqvOg5snzPuxPJYS1HOVeRZPpTA==",
         "dependencies": {
-          "System.IO.Pipelines": "8.0.0"
+          "System.IO.Pipelines": "10.0.5"
         }
       },
       "runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl": {
@@ -968,8 +968,8 @@
       },
       "System.Diagnostics.DiagnosticSource": {
         "type": "Transitive",
-        "resolved": "10.0.3",
-        "contentHash": "IuZXyF3K5X+mCsBKIQ87Cn/V4Nyb39vyCbzfH/AkoneSWNV/ExGQ/I0m4CEaVAeFh9fW6kp2NVObkmevd1Ys7A=="
+        "resolved": "10.0.10",
+        "contentHash": "cjtKi6ERMYWp6b9UTVPcwDT29PjKDtlM3W9OwnWL5abRsI8ku42Q2wqZoLIIXJnT/XF2s2CjuK8Nl4a3mmTxQQ=="
       },
       "System.Diagnostics.Tools": {
         "type": "Transitive",
@@ -1113,13 +1113,13 @@
       },
       "System.IO.Hashing": {
         "type": "Transitive",
-        "resolved": "10.0.3",
-        "contentHash": "La6ICwsdTKhVX+LKN+pvFjQRR3LhLwq3uKdi2knjLzRyPYBSydF4cjXidYxIiTcDD6XVYdsBWQEI8ZxiZ/OdIg=="
+        "resolved": "10.0.5",
+        "contentHash": "8IBJWcCT9+e4Bmevm4T7+fQEiAh133KGiz4oiVTgJckd3Q76OFdR1falgn9lpz7+C4HJvogCDJeAa2QmvbeVtg=="
       },
       "System.IO.Pipelines": {
         "type": "Transitive",
-        "resolved": "10.0.3",
-        "contentHash": "WMxiA2jGdHnRBmoVK55YUq5VPaxW0Sg2frPtXV+urUMvpqHIga6lleV/YuryHIuGsAKVjQAjv6PrQ6IJpoLohQ=="
+        "resolved": "10.0.5",
+        "contentHash": "8/ZHN/j2y1t+7McdCf1wXku2/c7wtrGLz3WQabIoPuLAn3bHDWT6YOJYreJq8sCMPSo6c8iVYXUdLlFGX5PEqw=="
       },
       "System.Linq": {
         "type": "Transitive",
@@ -1752,10 +1752,10 @@
           "Microsoft.EntityFrameworkCore.SqlServer": "[8.0.27, )",
           "Microsoft.EntityFrameworkCore.Sqlite": "[8.0.27, )",
           "Microsoft.EntityFrameworkCore.Sqlite.Core": "[8.0.27, )",
-          "Microsoft.Extensions.Caching.StackExchangeRedis": "[8.0.27, )",
+          "Microsoft.Extensions.Caching.StackExchangeRedis": "[10.0.10, )",
           "Microsoft.Extensions.Configuration.AzureAppConfiguration": "[7.3.0, )",
           "Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore": "[8.0.27, )",
-          "Microsoft.Extensions.Options": "[10.0.3, )",
+          "Microsoft.Extensions.Options": "[10.0.10, )",
           "Microsoft.Extensions.Telemetry": "[10.1.0, )",
           "MongoDB.Driver": "[3.9.0, )",
           "OpenTelemetry": "[1.15.3, )",
@@ -1774,7 +1774,10 @@
           "Quartz.Plugins.TimeZoneConverter": "[3.18.1, )",
           "Quartz.Serialization.Json": "[3.18.1, )",
           "Quartz.Serialization.SystemTextJson": "[3.18.1, )",
-          "StackExchange.Redis": "[2.13.17, )",
+          "StackExchange.Redis": "[3.1.11, )",
+          "StackExchange.Redis.Extensions.AspNetCore": "[13.0.1, )",
+          "StackExchange.Redis.Extensions.Core": "[13.0.1, )",
+          "StackExchange.Redis.Extensions.System.Text.Json": "[13.0.1, )",
           "Swashbuckle.AspNetCore.SwaggerGen": "[9.0.6, )",
           "Swashbuckle.AspNetCore.SwaggerUI": "[6.9.0, )",
           "System.Text.Encodings.Web": "[10.0.3, )",
@@ -2102,13 +2105,13 @@
       },
       "Microsoft.Extensions.Caching.StackExchangeRedis": {
         "type": "CentralTransitive",
-        "requested": "[8.0.27, )",
-        "resolved": "8.0.27",
-        "contentHash": "8H+885iKNAAqx66D7gO0lZJ12Lu/QUg1jhb7JGTICxdYUmDArnmumWbhugx/TsvmaoVlziAuIWCIr4bNU/v7og==",
+        "requested": "[10.0.10, )",
+        "resolved": "10.0.10",
+        "contentHash": "E+3pfEY68WQh1ZVFTGDNK0JCoayzL3aIDgVHHM85HIbQO7MiABG14A7+ajHH2P/y3a4W2Rla5p2nzut3+mzoyQ==",
         "dependencies": {
-          "Microsoft.Extensions.Caching.Abstractions": "8.0.0",
-          "Microsoft.Extensions.Logging.Abstractions": "8.0.3",
-          "Microsoft.Extensions.Options": "8.0.2",
+          "Microsoft.Extensions.Caching.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Options": "10.0.10",
           "StackExchange.Redis": "2.7.27"
         }
       },
@@ -2129,7 +2132,7 @@
       },
       "Microsoft.Extensions.DependencyInjection": {
         "type": "CentralTransitive",
-        "requested": "[10.0.3, )",
+        "requested": "[10.0.10, )",
         "resolved": "8.0.1",
         "contentHash": "BmANAnR5Xd4Oqw7yQ75xOAYODybZQRzdeNucg7kS5wWKd2PNnMdYtJ2Vciy0QLylRmv42DGl5+AFL9izA6F1Rw==",
         "dependencies": {
@@ -2138,9 +2141,9 @@
       },
       "Microsoft.Extensions.DependencyInjection.Abstractions": {
         "type": "CentralTransitive",
-        "requested": "[10.0.3, )",
-        "resolved": "10.0.3",
-        "contentHash": "bwGMrRcAMWx2s/RDgja97p27rxSz2pEQW0+rX5cWAUWVETVJ/eyxGfjAl8vuG5a+lckWmPIE+vcuaZNVB5YDdw=="
+        "requested": "[10.0.10, )",
+        "resolved": "10.0.10",
+        "contentHash": "z/2xXlFw2aLGjHyEm6E0tQ+In6VfzQzTrtArbQ2c0TQE16ZbyDCMGPvaUT9I0s8rgy9sRWlU2P9waW37qV04qA=="
       },
       "Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore": {
         "type": "CentralTransitive",
@@ -2155,19 +2158,19 @@
       },
       "Microsoft.Extensions.Options": {
         "type": "CentralTransitive",
-        "requested": "[10.0.3, )",
-        "resolved": "10.0.3",
-        "contentHash": "hU6WzGTPvPoLA2ng1ILvWQb3g0qORdlHNsxI8IcPLumJb3suimYUl+bbDzdo1V4KFsvVhnMWzysHpKbZaoDQPQ==",
+        "requested": "[10.0.10, )",
+        "resolved": "10.0.10",
+        "contentHash": "srnhnk7nE8krBiIXp71LvBmKBtraBONWSRzdjJgRv1Ko9Mp8IVNqv4vIS9hGeVteBig8aQkva9ZG+sC+o5sVcA==",
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.3",
-          "Microsoft.Extensions.Primitives": "10.0.3"
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Primitives": "10.0.10"
         }
       },
       "Microsoft.Extensions.Primitives": {
         "type": "CentralTransitive",
-        "requested": "[10.0.3, )",
-        "resolved": "10.0.3",
-        "contentHash": "GEcpTwo7sUoLGGNTqV1FZEuL+tTD9m81NX/mh099dqGNna07/UGZShKQNZRw4hv6nlliSUwYQgSYc7OR99Jufg=="
+        "requested": "[10.0.10, )",
+        "resolved": "10.0.10",
+        "contentHash": "5wu/GrYVd8mG2DVUw3vFJzF+O336TyTGg/Kmcgw9bfwYhCoFiV5lR5QeEmKecJyrW4W54nMfD3p3589E8a7czQ=="
       },
       "Microsoft.Extensions.Telemetry": {
         "type": "CentralTransitive",
@@ -2376,13 +2379,41 @@
       },
       "StackExchange.Redis": {
         "type": "CentralTransitive",
-        "requested": "[2.13.17, )",
-        "resolved": "2.13.17",
-        "contentHash": "P7o7ZDBAmBrOLQEw8Pt44iIA08ioj48smRxn4Jp6yzCu6P3DOSU6lj7f+IOtN3pPvSgC9YufvM92ycukEEBCYQ==",
+        "requested": "[3.1.11, )",
+        "resolved": "3.1.11",
+        "contentHash": "E+HnHo9rw8OZEz0QAoMEup8lwRi6DbQh/nTBGPrCpJLS+L/JrtbPSURgpYjI7TnAvtUsfo9AMYNlqfU1awYPLg==",
         "dependencies": {
-          "Microsoft.Extensions.Logging.Abstractions": "8.0.0",
-          "Pipelines.Sockets.Unofficial": "2.2.16",
-          "System.IO.Hashing": "10.0.2"
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.5",
+          "RESPite": "3.1.11",
+          "System.IO.Hashing": "10.0.5",
+          "System.IO.Pipelines": "10.0.5"
+        }
+      },
+      "StackExchange.Redis.Extensions.AspNetCore": {
+        "type": "CentralTransitive",
+        "requested": "[13.0.1, )",
+        "resolved": "13.0.1",
+        "contentHash": "sxM+jTOqtgWY7UAS71y4O4sv6B5HB8JhdAZRIMS9P7hTtwHZ6Gt0ln9lAzlUf0VdCOtIL2dceRNAeA772grA+Q==",
+        "dependencies": {
+          "StackExchange.Redis.Extensions.Core": "13.0.1"
+        }
+      },
+      "StackExchange.Redis.Extensions.Core": {
+        "type": "CentralTransitive",
+        "requested": "[13.0.1, )",
+        "resolved": "13.0.1",
+        "contentHash": "kN4bLpJ/Ifhjp0zoO6jiq4d8CMYM1Zx2vwIDDbWYZlALdFf/saikUCIxVk3nTwdpQz/+X17AtVMllSvYCigQPg==",
+        "dependencies": {
+          "StackExchange.Redis": "[2.12.14, 4.0.0)"
+        }
+      },
+      "StackExchange.Redis.Extensions.System.Text.Json": {
+        "type": "CentralTransitive",
+        "requested": "[13.0.1, )",
+        "resolved": "13.0.1",
+        "contentHash": "9jZ5mSnd0gaGgWVKQSO1KCd1wts4wPAuBCPdSQnO1NOld9FJXWOeapv53TQE/FMs7lC8LdVqxmG4RG+2bF4lng==",
+        "dependencies": {
+          "StackExchange.Redis.Extensions.Core": "13.0.1"
         }
       },
       "Swashbuckle.AspNetCore.SwaggerGen": {

--- a/DotNet/ServiceTests/IntegrationTests/Automation.UI/AutomationUIIntegrationTestFixture.cs
+++ b/DotNet/ServiceTests/IntegrationTests/Automation.UI/AutomationUIIntegrationTestFixture.cs
@@ -1,5 +1,6 @@
 ﻿using Automation.UI.Services;
 using Automation.UI.Services.Persistence;
+using LantanaGroup.Automation.Generation;
 using LantanaGroup.Link.Automation.Link.Configuration;
 using Microsoft.AspNetCore.SignalR;
 using Microsoft.Extensions.Configuration;
@@ -79,7 +80,10 @@ public sealed class AutomationUIIntegrationTestFixture : IAsyncLifetime, IDispos
             store,
             Mock.Of<IQueryPlanTemplateStore>(),
             Mock.Of<INormalizationStore>(),
-            Mock.Of<IOrganizationResourceMapTemplateStore>());
+            Mock.Of<IOrganizationResourceMapTemplateStore>(),
+            new ImportedBundleExecutionResolver(Database, Mock.Of<IImportedBundleContentStore>()),
+            Mock.Of<IGeneratedPatientTemplateCache>(),
+            new GeneratedTemplateCacheVersionStore(Database));
     }
 
     public async Task InitializeAsync()

--- a/DotNet/ServiceTests/UnitTests/AutomationUI/ImportedBundleBlobMigrationServiceTests.cs
+++ b/DotNet/ServiceTests/UnitTests/AutomationUI/ImportedBundleBlobMigrationServiceTests.cs
@@ -140,7 +140,7 @@ public class ImportedBundleBlobMigrationServiceTests
             ]
             """;
 
-        var remapped = ImportedBundleBlobMigrationService.RemapUploadedBundleIdsInJson(
+        var remapped = PatientBundleExternalizationMigrationService.RemapUploadedBundleIdsInJson(
             json,
             new Dictionary<Guid, Guid> { [sourceId] = replacementId });
 
@@ -165,7 +165,7 @@ public class ImportedBundleBlobMigrationServiceTests
             }
             """;
 
-        var remapped = ImportedBundleBlobMigrationService.RemapUploadedBundleIdsInJson(
+        var remapped = PatientBundleExternalizationMigrationService.RemapUploadedBundleIdsInJson(
             json,
             new Dictionary<Guid, Guid> { [sourceId] = replacementId });
 
@@ -181,20 +181,20 @@ public class ImportedBundleBlobMigrationServiceTests
     {
         const string malformed = "{not valid json";
 
-        var remapped = ImportedBundleBlobMigrationService.RemapUploadedBundleIdsInJson(
+        var remapped = PatientBundleExternalizationMigrationService.RemapUploadedBundleIdsInJson(
             malformed,
             new Dictionary<Guid, Guid>());
 
         Assert.Equal(malformed, remapped);
     }
 
-    private static (ImportedBundleBlobMigrationService Service, Mock<IMongoCollection<ImportedBundleDocument>> BundlesMock, Mock<IImportedBundleContentStore> ContentStoreMock) CreateService()
+    private static (PatientBundleExternalizationMigrationService Service, Mock<IMongoCollection<ImportedBundleDocument>> BundlesMock, Mock<IImportedBundleContentStore> ContentStoreMock) CreateService()
     {
         var bundlesMock = new Mock<IMongoCollection<ImportedBundleDocument>>();
         var scenariosMock = new Mock<IMongoCollection<TestScenarioDocument>>();
         var runInputsMock = new Mock<IMongoCollection<AutomationRunInputDocument>>();
         var contentStoreMock = new Mock<IImportedBundleContentStore>();
-        var loggerMock = new Mock<ILogger<ImportedBundleBlobMigrationService>>();
+        var loggerMock = new Mock<ILogger<PatientBundleExternalizationMigrationService>>();
         var lifetimeMock = new Mock<IHostApplicationLifetime>();
         var dbMock = new Mock<IMongoDatabase>();
 
@@ -205,7 +205,7 @@ public class ImportedBundleBlobMigrationServiceTests
         dbMock.Setup(d => d.GetCollection<AutomationRunInputDocument>("automation_run_inputs", null))
             .Returns(runInputsMock.Object);
 
-        var service = new ImportedBundleBlobMigrationService(
+        var service = new PatientBundleExternalizationMigrationService(
             dbMock.Object,
             contentStoreMock.Object,
             loggerMock.Object,

--- a/DotNet/ServiceTests/UnitTests/AutomationUI/StartScenarioRequestResolverTests.cs
+++ b/DotNet/ServiceTests/UnitTests/AutomationUI/StartScenarioRequestResolverTests.cs
@@ -12,10 +12,10 @@ public class StartScenarioRequestResolverTests
     // ---------- Non-Custom scenarios use scenario-kind defaults outright ----------
 
     [Theory]
-    [InlineData(AutomationScenarioKind.AdhocReportTest, 1, 1000, 20260326)]
-    [InlineData(AutomationScenarioKind.MultiPatientTest, 1000, 100, 20260328)]
+    [InlineData(AutomationScenarioKind.AdhocReportTest, 1, 1000, 20260326, 0)]
+    [InlineData(AutomationScenarioKind.MultiPatientTest, 1000, 100, 20260328, 0)]
     public void Non_custom_scenarios_use_scenario_kind_defaults(
-        AutomationScenarioKind scenario, int expectedPatientCount, int expectedResources, int expectedSeed)
+        AutomationScenarioKind scenario, int expectedPatientCount, int expectedResources, int expectedSeed, int expectedMaxPollingDurationMinutes)
     {
         var request = new StartScenarioRequest
         {
@@ -31,6 +31,7 @@ public class StartScenarioRequestResolverTests
         options.PatientCount.Should().Be(expectedPatientCount);
         options.ResourcesPerPatient.Should().Be(expectedResources);
         options.Seed.Should().Be(expectedSeed);
+        options.MaxPollingDurationMinutes.Should().Be(expectedMaxPollingDurationMinutes);
     }
 
     [Fact]
@@ -76,6 +77,7 @@ public class StartScenarioRequestResolverTests
         options.PatientCount.Should().Be(7);
         options.ResourcesPerPatient.Should().Be(250);
         options.Seed.Should().Be(12345);
+        options.MaxPollingDurationMinutes.Should().Be(30);
         options.CleanupServiceData.Should().BeTrue();
         options.CleanupFhirData.Should().BeFalse();
         options.ReportMethod.Should().Be(ReportMethod.RegenerateReport);

--- a/app-config.yaml
+++ b/app-config.yaml
@@ -293,6 +293,11 @@ global:
     required: false
     defaultValue: "automation/imported-bundles"
     consumers: ["Report", "Submission", "AutomationUI"]
+  - key: "InternalBlobStorage:GeneratedTemplateBlobRoot"
+    description: "Optional blob-path prefix used by Automation.UI for generated template cache blobs. When unset, generated templates are written at the container root under generated-patient-templates."
+    required: false
+    defaultValue: "automation/generated-bundles"
+    consumers: ["AutomationUI"]
   - key: "ServiceRegistry:TenantService:TenantServiceUrl"
     description: "The base URL for the Tenant Service."
     required: true
@@ -488,6 +493,10 @@ services:
       description: "The Slack webhook the Automation.UI test pipeline posts consolidated results to. Consumed by Tests/AutomationUI.Pipeline/azure-pipelines.yml at runtime, not by any service, which is why it does not appear in the code-derived inventory."
       required: true
       sensitive: true
+    - key: "InternalBlobStorage:GeneratedTemplateBlobRoot"
+      description: "Optional blob-path prefix for generated template cache blobs in Automation.UI. Defaults to automation/generated-bundles."
+      required: false
+      defaultValue: "automation/generated-bundles"
     - key: "DataProtection:ApplicationName"
       description: "The Data Protection application name isolating Automation.UI's key ring from other services sharing the store. Falls back to 'Link.Automation.UI:{Environment}' when unset (Automation.UI/Program.cs:208), so it is only provisioned where that default is not wanted - currently dev alone."
       required: false

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -712,6 +712,7 @@ services:
       PatientAggregator__IncludeOrganizationResource: ${PATIENT_AGGREGATOR_INCLUDE_ORGANIZATION_RESOURCE:-true}
       PreQualification__WritePreQualOperationOutcome: ${VALIDATION_WRITE_PREQUAL_OO:-false}
       pre-qualification.write-pre-qual-operation-outcome: ${VALIDATION_WRITE_PREQUAL_OO:-false}
+      InternalBlobStorage__GeneratedTemplateBlobRoot: ${INTERNAL_BLOB_GENERATED_TEMPLATE_BLOB_ROOT:-automation/generated-bundles}
     volumes:
       - automation_ui_keys:/keys/dataprotection
     ports:


### PR DESCRIPTION
### 🛠️ Description of Changes

Generated patient bundles are now stored in ABS to avoid cosmosdb size limits
Generated patient bundles now use a caching/versioning system to reduce repetitive bundle saves (Each scenario will maintain a versioned cache of the generated data that is then uniquified per run, and the run is tied to that cache version).

Made Expunging patients and uploading their data to the fhir server for large patient bundle uploads when creating a scenario a background process that is monitored to avoid timeouts.

### 🧪 Testing Performed

Please describe the testing that was performed on the changes included in this PR.

### 🧑‍🔬 Unit Testing

- [ ] I have written or updated unit tests to cover my changes
- Coverage: 8.3%

### 📓 Documentation Updated

Please update any relevant sections in the project documentation that were impacted by the changes in the PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Patient replacement now runs asynchronously with progress tracking and a status endpoint.
  * Generated patient templates are cached and reused across runs for more consistent results.
  * Imported patient bundles are resolved automatically during execution.
* **Bug Fixes**
  * Added validation to detect missing imported bundle content before processing.
  * Improved confirmation that patient data has been fully deleted before replaying bundles.
* **Improvements**
  * Run summaries now include generated-template version details for improved traceability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


