### PR TITLE
Fix rubric version snapshot dropping scoringPolicyJson on the evaluat…

### DIFF
--- a/Java/validation/src/main/java/com/lantanagroup/link/validation/models/RubricVersionSnapshot.java
+++ b/Java/validation/src/main/java/com/lantanagroup/link/validation/models/RubricVersionSnapshot.java
@@ -17,9 +17,11 @@ import java.util.UUID;
 /**
  * Cached form of a rubric version + its live checks, so one cache hit covers everything the
  * evaluate path reads. The entities themselves can't be cached: their lazy associations
- * don't survive serialization. LOB/dry-run/audit columns are left out on purpose — the
- * evaluate path never touches them, and no dry-run fields means recordDryRun doesn't have
- * to evict.
+ * don't survive serialization. Only columns the evaluate path never reads are left out
+ * (definition/dimensions/applicable-context LOBs, dry-run and audit fields) — scoringPolicyJson
+ * IS carried because the assembler scores with it; dropping a field the evaluate path reads
+ * silently falls back to defaults (see ResultEnvelopeAssembler). No dry-run fields means
+ * recordDryRun doesn't have to evict.
  *
  * Has to stay a plain non-final class (same for CheckSnapshot) — the redis serializer uses
  * NON_FINAL default typing, so a record would come back as a LinkedHashMap.
@@ -35,6 +37,7 @@ public class RubricVersionSnapshot {
     private String semver;
     private RubricVersionStatus status;
     private String checksum;
+    private String scoringPolicyJson;
     private List<CheckSnapshot> checks;
 
     @Data
@@ -60,6 +63,7 @@ public class RubricVersionSnapshot {
                 .semver(version.getSemver())
                 .status(version.getStatus())
                 .checksum(version.getChecksum())
+                .scoringPolicyJson(version.getScoringPolicyJson())
                 .checks(checks.stream()
                         .map(c -> CheckSnapshot.builder()
                                 .checkId(c.getCheckId())
@@ -84,6 +88,7 @@ public class RubricVersionSnapshot {
                 .semver(semver)
                 .status(status)
                 .checksum(checksum)
+                .scoringPolicyJson(scoringPolicyJson)
                 .build();
     }
 

--- a/Java/validation/src/test/java/com/lantanagroup/link/validation/models/RubricVersionSnapshotTest.java
+++ b/Java/validation/src/test/java/com/lantanagroup/link/validation/models/RubricVersionSnapshotTest.java
@@ -1,0 +1,81 @@
+package com.lantanagroup.link.validation.models;
+
+import com.lantanagroup.link.validation.entities.RubricCheck;
+import com.lantanagroup.link.validation.entities.RubricVersion;
+import com.lantanagroup.link.validation.enums.CheckType;
+import com.lantanagroup.link.validation.enums.PiqiDimension;
+import com.lantanagroup.link.validation.enums.RubricVersionStatus;
+import com.lantanagroup.link.validation.enums.Severity;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class RubricVersionSnapshotTest {
+
+    private static final String POLICY_JSON = "{\"type\":\"piqi-check-scorecard\",\"rollup\":\"worst-of\"}";
+
+    private final UUID versionId = UUID.randomUUID();
+    private final UUID checkId = UUID.randomUUID();
+
+    private RubricVersion version() {
+        return RubricVersion.builder()
+                .rubricVersionId(versionId)
+                .rubricId("piqi.core")
+                .semver("1.2.0")
+                .status(RubricVersionStatus.PUBLISHED)
+                .checksum("abc123")
+                .scoringPolicyJson(POLICY_JSON)
+                .build();
+    }
+
+    private RubricCheck check() {
+        return RubricCheck.builder()
+                .checkId(checkId)
+                .rubricVersionId(versionId)
+                .checkLocalId("c1")
+                .type(CheckType.FHIRPATH)
+                .dimension(PiqiDimension.CONFORMANCE)
+                .parametersJson("{\"expression\":\"Patient.name.exists()\"}")
+                .severityOverride(Severity.ERROR)
+                .ordinal(0)
+                .enabled(true)
+                .build();
+    }
+
+    @Test
+    @DisplayName("from() + toVersionEntity() carries every field the evaluate path reads, including scoringPolicyJson")
+    void versionRoundTripCarriesEvaluateFields() {
+        RubricVersion restored = RubricVersionSnapshot.from(version(), List.of(check())).toVersionEntity();
+
+        assertThat(restored.getRubricVersionId()).isEqualTo(versionId);
+        assertThat(restored.getRubricId()).isEqualTo("piqi.core");
+        assertThat(restored.getSemver()).isEqualTo("1.2.0");
+        assertThat(restored.getStatus()).isEqualTo(RubricVersionStatus.PUBLISHED);
+        assertThat(restored.getChecksum()).isEqualTo("abc123");
+        // the assembler scores with this — a snapshot that drops it silently falls back
+        // to the default dimension/worst-of policy for every rubric
+        assertThat(restored.getScoringPolicyJson()).isEqualTo(POLICY_JSON);
+    }
+
+    @Test
+    @DisplayName("from() + toCheckEntities() carries every check field the executors read")
+    void checkRoundTripCarriesAllFields() {
+        List<RubricCheck> restored = RubricVersionSnapshot.from(version(), List.of(check())).toCheckEntities();
+
+        assertThat(restored).hasSize(1);
+        RubricCheck c = restored.get(0);
+        assertThat(c.getCheckId()).isEqualTo(checkId);
+        assertThat(c.getRubricVersionId()).isEqualTo(versionId);
+        assertThat(c.getCheckLocalId()).isEqualTo("c1");
+        assertThat(c.getType()).isEqualTo(CheckType.FHIRPATH);
+        assertThat(c.getDimension()).isEqualTo(PiqiDimension.CONFORMANCE);
+        assertThat(c.getParametersJson()).isEqualTo("{\"expression\":\"Patient.name.exists()\"}");
+        assertThat(c.getSeverityOverride()).isEqualTo(Severity.ERROR);
+        assertThat(c.getOrdinal()).isZero();
+        assertThat(c.isEnabled()).isTrue();
+    }
+}

--- a/Java/validation/src/test/java/com/lantanagroup/link/validation/services/RubricExecutionServiceScoringPolicyTest.java
+++ b/Java/validation/src/test/java/com/lantanagroup/link/validation/services/RubricExecutionServiceScoringPolicyTest.java
@@ -1,0 +1,104 @@
+package com.lantanagroup.link.validation.services;
+
+import ca.uhn.fhir.context.FhirContext;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.lantanagroup.link.validation.entities.RubricCheck;
+import com.lantanagroup.link.validation.entities.RubricVersion;
+import com.lantanagroup.link.validation.enums.CheckType;
+import com.lantanagroup.link.validation.enums.PiqiDimension;
+import com.lantanagroup.link.validation.enums.RubricResultStatus;
+import com.lantanagroup.link.validation.enums.RubricVersionStatus;
+import com.lantanagroup.link.validation.models.EvaluateRequestDto;
+import com.lantanagroup.link.validation.models.ExecutionContext;
+import com.lantanagroup.link.validation.models.RubricVersionSnapshot;
+import com.lantanagroup.link.validation.models.SubjectDto;
+import com.lantanagroup.link.validation.models.ValidationResultEnvelope;
+import com.lantanagroup.link.validation.repositories.RubricVersionRepository;
+import com.lantanagroup.link.validation.services.execution.CheckExecutor;
+import com.lantanagroup.link.validation.services.execution.CheckExecutorRegistry;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Regression test for the scoring↔cache interaction: the resolver hands the evaluate path a
+ * version rebuilt from {@link RubricVersionSnapshot} (the cached form), not the JPA entity.
+ * If the snapshot drops scoringPolicyJson, the real assembler silently scores every rubric
+ * with the default dimension/worst-of policy — so this test wires the REAL assembler and
+ * aggregator and stubs the resolver exactly the way production builds it.
+ */
+class RubricExecutionServiceScoringPolicyTest {
+
+    private final RubricVersionResolver resolver = mock(RubricVersionResolver.class);
+    private final RubricVersionRepository versionRepository = mock(RubricVersionRepository.class);
+    private final CheckExecutorRegistry registry = mock(CheckExecutorRegistry.class);
+    private final RubricResultPersister resultPersister = mock(RubricResultPersister.class);
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final ScoreAggregator scoreAggregator = new ScoreAggregator();
+    private final ResultEnvelopeAssembler assembler = new ResultEnvelopeAssembler(objectMapper, scoreAggregator);
+
+    private final RubricExecutionService service = new RubricExecutionService(
+            resolver, versionRepository, registry, assembler,
+            scoreAggregator, resultPersister, FhirContext.forR4(), objectMapper,
+            Runnable::run, false);
+
+    @Test
+    @DisplayName("a non-default scoring policy survives snapshot resolution: check-scorecard rubrics score byCheck, not the dimension default")
+    void scoringPolicySurvivesSnapshotResolution() throws Exception {
+        RubricVersion entity = RubricVersion.builder()
+                .rubricVersionId(UUID.randomUUID())
+                .rubricId("piqi.core")
+                .semver("1.0.0")
+                .status(RubricVersionStatus.PUBLISHED)
+                .checksum("abc")
+                .scoringPolicyJson("{\"type\":\"piqi-check-scorecard\",\"rollup\":\"worst-of\"}")
+                .build();
+        RubricCheck check = RubricCheck.builder()
+                .checkId(UUID.randomUUID())
+                .rubricVersionId(entity.getRubricVersionId())
+                .checkLocalId("c1")
+                .type(CheckType.FHIRPATH)
+                .dimension(PiqiDimension.CONFORMANCE)
+                .parametersJson("{\"expression\":\"Patient.name.exists()\"}")
+                .ordinal(0)
+                .enabled(true)
+                .build();
+
+        // resolve() returns snapshot-rebuilt entities in production — mirror that here
+        RubricVersionSnapshot snapshot = RubricVersionSnapshot.from(entity, List.of(check));
+        when(resolver.resolve("piqi.core", "1.0.0", true))
+                .thenReturn(new RubricVersionResolver.ResolvedRubric(
+                        snapshot.toVersionEntity(), snapshot.toCheckEntities()));
+
+        CheckExecutor executor = mock(CheckExecutor.class);
+        when(executor.execute(any(RubricCheck.class), any(ExecutionContext.class))).thenReturn(List.of());
+        when(registry.get(eq(CheckType.FHIRPATH))).thenReturn(executor);
+
+        JsonNode payload = objectMapper.readTree("{\"resourceType\":\"Patient\",\"id\":\"p1\"}");
+        EvaluateRequestDto request = EvaluateRequestDto.builder()
+                .subject(SubjectDto.builder().facilityId("f1").build())
+                .payload(payload)
+                .build();
+
+        ValidationResultEnvelope envelope = service.evaluate("piqi.core", "1.0.0", request, true);
+
+        // check-scorecard policy → per-check scores; the pre-fix behavior fell back to the
+        // default dimension scorecard (byCheck null, byDimension populated)
+        assertThat(envelope.getScore()).isNotNull();
+        assertThat(envelope.getScore().getByCheck())
+                .as("scoring policy was dropped by the snapshot — scored with the default dimension policy")
+                .isNotNull()
+                .containsEntry("c1", RubricResultStatus.ACCEPTABLE);
+        assertThat(envelope.getScore().getByDimension()).isNull();
+        assertThat(envelope.getStatus()).isEqualTo(RubricResultStatus.ACCEPTABLE);
+    }
+}


### PR DESCRIPTION
…e path

The cached RubricVersionSnapshot (introduced with the rubric cache, #1803) omitted scoringPolicyJson, but scoring (#1804) reads it via ResultEnvelopeAssembler. Since the resolver returns snapshot-rebuilt entities on both cache hit and miss, every evaluate/dry-run scored with the default piqi-dimension-scorecard/worst-of policy regardless of the rubric's declared scoringPolicy.

- Carry scoringPolicyJson through RubricVersionSnapshot.from() and toVersionEntity()
- Add snapshot round-trip test covering every field the evaluate path reads
- Add execution-level regression test that resolves through the snapshot (like production) with a real assembler/aggregator, asserting a piqi-check-scorecard policy produces score.byCheck

### 🛠️ Description of Changes

Please provide a high-level overview of the changes included in this PR.

### 🧪 Testing Performed

Please describe the testing that was performed on the changes included in this PR.

### 🧑‍🔬 Unit Testing

- [ ] I have written or updated unit tests to cover my changes
- Coverage: 

### 📓 Documentation Updated

Please update any relevant sections in the project documentation that were impacted by the changes in the PR.
