### PR TITLE
Fix publish/retire race and empty-bundle phantom findings

### DIFF
--- a/Java/validation/src/main/java/com/lantanagroup/link/validation/repositories/RubricVersionRepository.java
+++ b/Java/validation/src/main/java/com/lantanagroup/link/validation/repositories/RubricVersionRepository.java
@@ -39,4 +39,28 @@ public interface RubricVersionRepository extends JpaRepository<RubricVersion, UU
     int recordDryRun(@Param("rubricVersionId") UUID rubricVersionId,
                      @Param("status") RubricResultStatus status,
                      @Param("completedAt") OffsetDateTime completedAt);
+
+    // guarded DRAFT->PUBLISHED: keep the status check in the WHERE so it runs under the update's
+    // row lock. two concurrent publishes can't both win — the first flips the row (1), the rest
+    // see it's no longer DRAFT and touch nothing (0). returns rows affected.
+    @Transactional
+    @Modifying(flushAutomatically = true, clearAutomatically = true)
+    @Query("update RubricVersion v set v.status = :target, v.publishedAt = :publishedAt, v.publishedBy = :publishedBy "
+            + "where v.rubricVersionId = :rubricVersionId and v.status = :expected")
+    int publishIfStatus(@Param("rubricVersionId") UUID rubricVersionId,
+                        @Param("expected") RubricVersionStatus expected,
+                        @Param("target") RubricVersionStatus target,
+                        @Param("publishedAt") OffsetDateTime publishedAt,
+                        @Param("publishedBy") String publishedBy);
+
+    // same trick for retire: status <> RETIRED makes a double retire a no-op (0 rows) so we don't
+    // overwrite retiredAt/retiredBy or record a second event
+    @Transactional
+    @Modifying(flushAutomatically = true, clearAutomatically = true)
+    @Query("update RubricVersion v set v.status = :retired, v.retiredAt = :retiredAt, v.retiredBy = :retiredBy "
+            + "where v.rubricVersionId = :rubricVersionId and v.status <> :retired")
+    int retireIfNotRetired(@Param("rubricVersionId") UUID rubricVersionId,
+                           @Param("retired") RubricVersionStatus retired,
+                           @Param("retiredAt") OffsetDateTime retiredAt,
+                           @Param("retiredBy") String retiredBy);
 }

--- a/Java/validation/src/main/java/com/lantanagroup/link/validation/services/RubricRegistryService.java
+++ b/Java/validation/src/main/java/com/lantanagroup/link/validation/services/RubricRegistryService.java
@@ -171,10 +171,21 @@ public class RubricRegistryService {
                 throw new RubricDryRunRequiredException(rubricId, semver, v.getDryRunStatus());
             }
         }
+        // the status check above can go stale before we write, so flip it with a guarded update
+        // instead of setStatus + save. only one concurrent publish gets a row back.
+        OffsetDateTime publishedAt = OffsetDateTime.now();
+        int updated = rubricVersionRepository.publishIfStatus(
+                v.getRubricVersionId(), RubricVersionStatus.DRAFT, RubricVersionStatus.PUBLISHED, publishedAt, publishedBy);
+        if (updated == 0) {
+            // someone else transitioned it first — re-read so the 409 reports the real status
+            RubricVersion current = rubricVersionRepository.findByRubricIdAndSemver(rubricId, semver)
+                    .orElseThrow(() -> new RubricVersionNotFoundException(rubricId, semver));
+            throw new RubricLifecycleException(rubricId, semver, current.getStatus(), "publish");
+        }
+        // the update cleared the persistence context; patch the fields on the entity we return
         v.setStatus(RubricVersionStatus.PUBLISHED);
-        v.setPublishedAt(OffsetDateTime.now());
+        v.setPublishedAt(publishedAt);
         v.setPublishedBy(publishedBy);
-        v = rubricVersionRepository.save(v);
         // drop the stale DRAFT snapshot and the latest pointer — this may be the new latest
         rubricCacheService.evictVersion(rubricId, semver);
         recordEvent(rubricId, semver, RubricLifecycleAction.PUBLISHED, publishedBy, v.getChecksum());
@@ -192,10 +203,18 @@ public class RubricRegistryService {
         if (v.getStatus() == RubricVersionStatus.RETIRED) {
             throw new RubricLifecycleException(rubricId, semver, v.getStatus(), "retire");
         }
+        // guarded update like publish — if it was retired between our read and here we get 0 rows
+        OffsetDateTime retiredAt = OffsetDateTime.now();
+        int updated = rubricVersionRepository.retireIfNotRetired(
+                v.getRubricVersionId(), RubricVersionStatus.RETIRED, retiredAt, retiredBy);
+        if (updated == 0) {
+            RubricVersion current = rubricVersionRepository.findByRubricIdAndSemver(rubricId, semver)
+                    .orElseThrow(() -> new RubricVersionNotFoundException(rubricId, semver));
+            throw new RubricLifecycleException(rubricId, semver, current.getStatus(), "retire");
+        }
         v.setStatus(RubricVersionStatus.RETIRED);
-        v.setRetiredAt(OffsetDateTime.now());
+        v.setRetiredAt(retiredAt);
         v.setRetiredBy(retiredBy);
-        v = rubricVersionRepository.save(v);
         // drop the cached entry and the latest pointer so nothing keeps evaluating this version
         rubricCacheService.evictVersion(rubricId, semver);
         recordEvent(rubricId, semver, RubricLifecycleAction.RETIRED, retiredBy, v.getChecksum());

--- a/Java/validation/src/main/java/com/lantanagroup/link/validation/services/execution/executors/FhirPathCheckExecutor.java
+++ b/Java/validation/src/main/java/com/lantanagroup/link/validation/services/execution/executors/FhirPathCheckExecutor.java
@@ -97,7 +97,17 @@ public class FhirPathCheckExecutor implements CheckExecutor {
 
     private List<IBaseResource> resolveTargets(ExecutionContext context, String expression) {
         if (context.getBundleEntries().isEmpty()) {
-            return List.of(context.getResource());
+            IBaseResource root = context.getResource();
+            // an empty bundle and a bare single-resource payload both have no entries, but they
+            // mean opposite things. don't run Patient.*/Observation.* checks against an empty
+            // bundle's envelope — that just invents findings. a real Bundle.* expression still
+            // evaluates against it (e.g. "Bundle.entry.count() >= 1" to flag an empty bundle).
+            if (root != null && "Bundle".equals(root.fhirType())) {
+                return "Bundle".equals(leadingResourceType(expression))
+                        ? List.of(root)
+                        : Collections.emptyList();
+            }
+            return List.of(root);
         }
         String resourceType = leadingResourceType(expression);
         if (resourceType == null) {

--- a/Java/validation/src/test/java/com/lantanagroup/link/validation/services/RubricRegistryServiceTest.java
+++ b/Java/validation/src/test/java/com/lantanagroup/link/validation/services/RubricRegistryServiceTest.java
@@ -69,6 +69,9 @@ class RubricRegistryServiceTest {
         when(versionRepository.findByRubricIdAndSemver("piqi.core", "1.0.0"))
                 .thenReturn(Optional.of(version));
         when(versionRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+        // atomic guarded transitions win by default (1 row affected)
+        when(versionRepository.publishIfStatus(any(), any(), any(), any(), any())).thenReturn(1);
+        when(versionRepository.retireIfNotRetired(any(), any(), any(), any())).thenReturn(1);
     }
 
     @Test
@@ -305,6 +308,51 @@ class RubricRegistryServiceTest {
 
         assertThatThrownBy(() -> service().publish("piqi.core", "1.0.0", "qa"))
                 .isInstanceOf(RubricLifecycleException.class);
+    }
+
+    @Test
+    @DisplayName("publish that loses the atomic transition (0 rows) -> 409, no duplicate event, no evict")
+    void publish_losesAtomicRace() {
+        // read sees DRAFT and passes the guard, but the guarded UPDATE affects 0 rows because a
+        // concurrent publish already flipped the row to PUBLISHED — the loser must 409, not double-publish
+        when(versionRepository.findByRubricIdAndSemver("piqi.core", "1.0.0"))
+                .thenReturn(Optional.of(draftVersion()))
+                .thenReturn(Optional.of(versionOf("piqi.core", "1.0.0", RubricVersionStatus.PUBLISHED)));
+        when(versionRepository.publishIfStatus(any(), any(), any(), any(), any())).thenReturn(0);
+
+        assertThatThrownBy(() -> service().publish("piqi.core", "1.0.0", "qa"))
+                .isInstanceOf(RubricLifecycleException.class);
+        verify(eventRepository, never()).save(any());
+        verify(cacheService, never()).evictVersion(any(), any());
+    }
+
+    @Test
+    @DisplayName("retire that loses the atomic transition (0 rows) -> 409, no duplicate event, no evict")
+    void retire_losesAtomicRace() {
+        RubricVersion published = draftVersion();
+        published.setStatus(RubricVersionStatus.PUBLISHED);
+        when(versionRepository.findByRubricIdAndSemver("piqi.core", "1.0.0"))
+                .thenReturn(Optional.of(published))
+                .thenReturn(Optional.of(versionOf("piqi.core", "1.0.0", RubricVersionStatus.RETIRED)));
+        when(versionRepository.retireIfNotRetired(any(), any(), any(), any())).thenReturn(0);
+
+        assertThatThrownBy(() -> service().retire("piqi.core", "1.0.0", "qa"))
+                .isInstanceOf(RubricLifecycleException.class);
+        verify(eventRepository, never()).save(any());
+        verify(cacheService, never()).evictVersion(any(), any());
+    }
+
+    @Test
+    @DisplayName("publish performs the transition atomically (guarded UPDATE), not a read-modify-save")
+    void publish_usesAtomicGuardedUpdate() {
+        stubVersion(draftVersion());
+
+        service().publish("piqi.core", "1.0.0", "qa");
+
+        verify(versionRepository).publishIfStatus(any(),
+                org.mockito.ArgumentMatchers.eq(RubricVersionStatus.DRAFT),
+                org.mockito.ArgumentMatchers.eq(RubricVersionStatus.PUBLISHED), any(), org.mockito.ArgumentMatchers.eq("qa"));
+        verify(versionRepository, never()).save(any());
     }
 
     @Test

--- a/Java/validation/src/test/java/com/lantanagroup/link/validation/services/execution/executors/FhirPathCheckExecutorTest.java
+++ b/Java/validation/src/test/java/com/lantanagroup/link/validation/services/execution/executors/FhirPathCheckExecutorTest.java
@@ -9,6 +9,7 @@ import com.lantanagroup.link.validation.enums.PiqiDimension;
 import com.lantanagroup.link.validation.enums.Severity;
 import com.lantanagroup.link.validation.models.ExecutionContext;
 import com.lantanagroup.link.validation.models.RawFinding;
+import org.hl7.fhir.r4.model.Bundle;
 import org.hl7.fhir.r4.model.Patient;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -108,5 +109,58 @@ class FhirPathCheckExecutorTest {
     @DisplayName("missing expression -> no findings")
     void missingExpression() {
         assertThat(executor.execute(check("{}", null), context(new Patient()))).isEmpty();
+    }
+
+    // empty-Bundle payload: resource is the Bundle, bundleEntries is empty. Must NOT be treated
+    // like a bare single resource (which would run resource-typed checks against the envelope).
+    private static ExecutionContext emptyBundleContext() {
+        return ExecutionContext.builder()
+                .resource(new Bundle())
+                .bundleEntries(List.of())
+                .build();
+    }
+
+    @Test
+    @DisplayName("empty bundle: a resource-typed check produces NO findings (not phantom findings against the Bundle)")
+    void emptyBundleResourceTypedCheckHasNoFindings() {
+        List<RawFinding> findings = executor.execute(
+                check("{\"expression\":\"Patient.name.exists()\"}", null), emptyBundleContext());
+
+        assertThat(findings).isEmpty();
+    }
+
+    @Test
+    @DisplayName("empty bundle: a Bundle-level expression still evaluates against the Bundle so it can be flagged")
+    void emptyBundleBundleLevelExpressionStillEvaluated() {
+        List<RawFinding> findings = executor.execute(
+                check("{\"expression\":\"Bundle.entry.count() >= 1\",\"code\":\"bundle-empty\"}", null),
+                emptyBundleContext());
+
+        assertThat(findings).hasSize(1);
+        assertThat(findings.get(0).getCode()).isEqualTo("bundle-empty");
+        assertThat(findings.get(0).getLocation()).isEqualTo("Bundle");
+    }
+
+    @Test
+    @DisplayName("non-empty bundle: a resource-typed check runs once per matching entry")
+    void nonEmptyBundleTargetsMatchingEntries() {
+        Patient withName = new Patient();
+        withName.setId("with");
+        withName.addName().setFamily("Doe");
+        Patient withoutName = new Patient();
+        withoutName.setId("without");
+        Bundle bundle = new Bundle();
+        bundle.addEntry().setResource(withName);
+        bundle.addEntry().setResource(withoutName);
+        ExecutionContext ctx = ExecutionContext.builder()
+                .resource(bundle)
+                .bundleEntries(List.of(withName, withoutName))
+                .build();
+
+        List<RawFinding> findings = executor.execute(
+                check("{\"expression\":\"Patient.name.exists()\"}", null), ctx);
+
+        assertThat(findings).hasSize(1);
+        assertThat(findings.get(0).getLocation()).isEqualTo("Patient/without");
     }
 }


### PR DESCRIPTION
publish()/retire() did read -> check status -> save, which races under load: concurrent publishes all read DRAFT, all passed the guard and all committed, leaving duplicate PUBLISHED events and last-writer-wins on publishedBy. Swapped in guarded conditional updates (status check in the WHERE clause) so one caller wins and the rest get a clean 409 - same pattern as recordDryRun.

Also, resolveTargets treated an empty bundle like a bare resource and ran Patient.*/Observation.* checks against the Bundle envelope, inventing findings. Empty bundles now target nothing; real Bundle.* expressions still run.

Adds tests for the lost-race path and the empty-bundle handling.

### 🛠️ Description of Changes

Please provide a high-level overview of the changes included in this PR.

### 🧪 Testing Performed

Please describe the testing that was performed on the changes included in this PR.

### 🧑‍🔬 Unit Testing

- [ ] I have written or updated unit tests to cover my changes
- Coverage: 

### 📓 Documentation Updated

Please update any relevant sections in the project documentation that were impacted by the changes in the PR.
