### PR TITLE
Add category override for rubric findings

### DIFF
--- a/Java/validation/src/main/java/com/lantanagroup/link/validation/configs/ValidationPolicyConfig.java
+++ b/Java/validation/src/main/java/com/lantanagroup/link/validation/configs/ValidationPolicyConfig.java
@@ -1,0 +1,47 @@
+package com.lantanagroup.link.validation.configs;
+
+import com.lantanagroup.link.validation.enums.CategoryMatchStrategy;
+import com.lantanagroup.link.validation.enums.CategoryOverrideScope;
+import com.lantanagroup.link.validation.enums.RollupStrategy;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ConfigurationProperties("validation")
+@Getter
+@Setter
+public class ValidationPolicyConfig {
+
+    private CategoryOverride categoryOverride = new CategoryOverride();
+    private Scoring scoring = new Scoring();
+    private Response response = new Response();
+
+    @Getter
+    @Setter
+    public static class CategoryOverride {
+
+        private boolean enabled = false;
+
+        private CategoryOverrideScope scope = CategoryOverrideScope.ALL_CHECKS;
+
+        private CategoryMatchStrategy matchStrategy = CategoryMatchStrategy.WORST_OF;
+    }
+
+    @Getter
+    @Setter
+    public static class Scoring {
+
+        private RollupStrategy rollup;
+    }
+
+    @Getter
+    @Setter
+    public static class Response {
+
+        private boolean includeOriginalSeverity = true;
+
+        private boolean includeCategoryIds = true;
+    }
+}

--- a/Java/validation/src/main/java/com/lantanagroup/link/validation/enums/CategoryMatchStrategy.java
+++ b/Java/validation/src/main/java/com/lantanagroup/link/validation/enums/CategoryMatchStrategy.java
@@ -1,0 +1,19 @@
+package com.lantanagroup.link.validation.enums;
+
+public enum CategoryMatchStrategy {
+
+    /**
+     * Combines every matching category, per field, taking the worst value of each:
+     * {@code acceptable=false} beats {@code acceptable=true}, and a higher severity beats a
+     * lower one. The two fields are combined independently, so the resulting pair may be a
+     * combination that no single matching category declares — that is intentional, and is the
+     * conservative reading of "worst of".
+     */
+    WORST_OF,
+
+    /**
+     * Uses only the first matching category in sequence order (see
+     * {@code CategorySequenceProvider}), ignoring any others.
+     */
+    FIRST_MATCH
+}

--- a/Java/validation/src/main/java/com/lantanagroup/link/validation/enums/CategoryOverrideScope.java
+++ b/Java/validation/src/main/java/com/lantanagroup/link/validation/enums/CategoryOverrideScope.java
@@ -1,0 +1,17 @@
+package com.lantanagroup.link.validation.enums;
+
+public enum CategoryOverrideScope {
+
+    /** Every finding, regardless of which check type produced it. */
+    ALL_CHECKS,
+
+    /** Only findings emitted by {@link CheckType#FHIR_CONFORMANCE} checks. */
+    FHIR_ONLY;
+
+    public boolean includes(CheckType checkType) {
+        return switch (this) {
+            case ALL_CHECKS -> true;
+            case FHIR_ONLY -> checkType == CheckType.FHIR_CONFORMANCE;
+        };
+    }
+}

--- a/Java/validation/src/main/java/com/lantanagroup/link/validation/models/FindingDto.java
+++ b/Java/validation/src/main/java/com/lantanagroup/link/validation/models/FindingDto.java
@@ -22,10 +22,25 @@ public class FindingDto {
     private UUID id;
     private String checkId;
     private PiqiDimension dimension;
+
+    /** The effective severity: post-override when a category matched, the finding's own otherwise. */
     private Severity severity;
+
     private String code;
     private String message;
     private String location;
     private String expression;
+
+    /** The severity the check itself emitted, before any category override (diagnostic only). */
+    private Severity originalSeverity;
+
+    /** Present only when a category actually moved this finding's severity. */
+    private Severity overriddenSeverity;
+
+    /** The governing category's acceptability; null when no category matched. */
+    private Boolean acceptable;
+
     private List<String> categoryIds;
+
+    private String governingCategoryId;
 }

--- a/Java/validation/src/main/java/com/lantanagroup/link/validation/models/ScoringPolicyDto.java
+++ b/Java/validation/src/main/java/com/lantanagroup/link/validation/models/ScoringPolicyDto.java
@@ -23,21 +23,27 @@ public class ScoringPolicyDto {
     private ScoringPolicyType type;
     private RollupStrategy rollup;
 
+    /**
+     * Parses a persisted scoring policy, preserving absent fields as null so that
+     * {@code ScoringPolicyResolver} can apply its precedence (rubric, then configuration, then
+     * WORST_OF). Defaulting at parse time would silently outrank the configuration fallback.
+     * {@code ScoreAggregator}-side null handling keeps direct callers safe.
+     */
     public static ScoringPolicyDto from(String scoringPolicyJson, ObjectMapper objectMapper) {
         if (scoringPolicyJson == null || scoringPolicyJson.isBlank()) {
-            return defaultPolicy();
+            return ScoringPolicyDto.builder().build();
         }
         try {
             JsonNode node = objectMapper.readTree(scoringPolicyJson);
             ScoringPolicyType type = ScoringPolicyType.fromValue(node.path("type").asText(null))
-                    .orElse(ScoringPolicyType.PIQI_DIMENSION_SCORECARD);
+                    .orElse(null);
             RollupStrategy rollup = RollupStrategy.fromValue(node.path("rollup").asText(null))
-                    .orElse(RollupStrategy.WORST_OF);
+                    .orElse(null);
             return ScoringPolicyDto.builder().type(type).rollup(rollup).build();
         } catch (Exception e) {
             log.warn("Failed to parse scoring policy '{}'; falling back to default: {}",
                     scoringPolicyJson, e.getMessage());
-            return defaultPolicy();
+            return ScoringPolicyDto.builder().build();
         }
     }
 

--- a/Java/validation/src/main/java/com/lantanagroup/link/validation/services/ResultEnvelopeAssembler.java
+++ b/Java/validation/src/main/java/com/lantanagroup/link/validation/services/ResultEnvelopeAssembler.java
@@ -1,12 +1,15 @@
 package com.lantanagroup.link.validation.services;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.lantanagroup.link.validation.configs.ValidationPolicyConfig;
 import com.lantanagroup.link.validation.entities.RubricFinding;
 import com.lantanagroup.link.validation.entities.RubricResult;
 import com.lantanagroup.link.validation.entities.RubricVersion;
 import com.lantanagroup.link.validation.enums.Severity;
 import com.lantanagroup.link.validation.models.*;
 import com.lantanagroup.link.validation.services.execution.CheckExecutionResult;
+import com.lantanagroup.link.validation.services.execution.EvaluatedFinding;
+import com.lantanagroup.link.validation.services.scoring.ScoringPolicyResolver;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -21,11 +24,13 @@ public class ResultEnvelopeAssembler {
 
     private final ObjectMapper objectMapper;
     private final ScoreAggregator scoreAggregator;
+    private final ScoringPolicyResolver scoringPolicyResolver;
+    private final ValidationPolicyConfig policyConfig;
 
     public AssembleOutput assemble(
             ExecutionContext ctx,
             RubricVersion version,
-            List<RawFinding> raw,
+            List<EvaluatedFinding> evaluated,
             List<CheckExecutionResult> checkResults,
             Map<String, Long> checkDurationsMs,
             OffsetDateTime completedAt) {
@@ -35,37 +40,35 @@ public class ResultEnvelopeAssembler {
         long checkWorkMs = checkDurationsMs == null ? 0L
                 : checkDurationsMs.values().stream().filter(Objects::nonNull).mapToLong(Long::longValue).sum();
 
-        ScoringPolicyDto scoringPolicy = ScoringPolicyDto.from(version.getScoringPolicyJson(), objectMapper);
+        ScoringPolicyDto scoringPolicy = scoringPolicyResolver.resolve(version.getScoringPolicyJson());
         ScoreCardDto score = scoreAggregator.aggregate(checkResults, scoringPolicy);
 
+        // Summary counts stay on the pre-override severities so the summary reconciles with what
+        // the checks actually emitted; the override's effect shows in the score and per finding.
         SummaryDto summary = SummaryDto.builder()
-                .errorCount(countBy(raw, Severity.ERROR))
-                .warningCount(countBy(raw, Severity.WARNING))
-                .informationCount(countBy(raw, Severity.INFORMATION))
+                .errorCount(countBy(evaluated, Severity.ERROR))
+                .warningCount(countBy(evaluated, Severity.WARNING))
+                .informationCount(countBy(evaluated, Severity.INFORMATION))
                 .build();
 
         UUID resultId = UUID.randomUUID();
+        ValidationPolicyConfig.Response responseConfig = policyConfig.getResponse();
 
-        List<FindingDto> findingDtos = new ArrayList<>(raw.size());
-        List<RubricFinding> findingEntities = new ArrayList<>(raw.size());
-        for (RawFinding r : raw) {
+        List<FindingDto> findingDtos = new ArrayList<>(evaluated.size());
+        List<RubricFinding> findingEntities = new ArrayList<>(evaluated.size());
+        for (EvaluatedFinding f : evaluated) {
+            RawFinding r = f.raw();
             UUID fid = UUID.randomUUID();
-            findingDtos.add(FindingDto.builder()
-                    .id(fid)
-                    .checkId(r.getCheckLocalId())
-                    .dimension(r.getDimension())
-                    .severity(r.getSeverity())
-                    .code(r.getCode())
-                    .message(r.getMessage())
-                    .location(r.getLocation())
-                    .expression(r.getExpression())
-                    .build());
+            findingDtos.add(toDto(fid, f, r, responseConfig));
             findingEntities.add(RubricFinding.builder()
                     .findingId(fid)
                     .resultId(resultId)
                     .checkId(r.getCheckId())
                     .dimension(r.getDimension())
-                    .severity(r.getSeverity())
+                    // Effective severity, so persisted findings reconcile with the persisted status.
+                    // The pre-override severity is reported in the response but not stored; keeping
+                    // both would need a schema change.
+                    .severity(f.effectiveSeverity())
                     .code(r.getCode())
                     .message(r.getMessage())
                     .location(r.getLocation())
@@ -120,8 +123,37 @@ public class ResultEnvelopeAssembler {
         return new AssembleOutput(envelope, resultEntity, findingEntities);
     }
 
-    private int countBy(List<RawFinding> findings, Severity sev) {
-        return (int) findings.stream().filter(f -> f.getSeverity() == sev).count();
+    private FindingDto toDto(UUID findingId, EvaluatedFinding f, RawFinding r,
+                             ValidationPolicyConfig.Response responseConfig) {
+        FindingDto.FindingDtoBuilder builder = FindingDto.builder()
+                .id(findingId)
+                .checkId(r.getCheckLocalId())
+                .dimension(r.getDimension())
+                .severity(f.effectiveSeverity())
+                .code(r.getCode())
+                .message(r.getMessage())
+                .location(r.getLocation())
+                .expression(r.getExpression());
+
+        if (!f.hasCategories()) {
+            return builder.build();
+        }
+        builder.acceptable(f.acceptable());
+        if (responseConfig.isIncludeOriginalSeverity()) {
+            builder.originalSeverity(f.originalSeverity());
+            if (f.severityWasOverridden()) {
+                builder.overriddenSeverity(f.effectiveSeverity());
+            }
+        }
+        if (responseConfig.isIncludeCategoryIds()) {
+            builder.categoryIds(f.categoryIds());
+            builder.governingCategoryId(f.governingCategoryId());
+        }
+        return builder.build();
+    }
+
+    private int countBy(List<EvaluatedFinding> findings, Severity sev) {
+        return (int) findings.stream().filter(f -> f.originalSeverity() == sev).count();
     }
 
     private String writeJson(Object value) {

--- a/Java/validation/src/main/java/com/lantanagroup/link/validation/services/RubricExecutionService.java
+++ b/Java/validation/src/main/java/com/lantanagroup/link/validation/services/RubricExecutionService.java
@@ -12,9 +12,12 @@ import com.lantanagroup.link.validation.models.RawFinding;
 import com.lantanagroup.link.validation.models.SubjectDto;
 import com.lantanagroup.link.validation.models.ValidationResultEnvelope;
 import com.lantanagroup.link.validation.repositories.RubricVersionRepository;
+import com.lantanagroup.link.validation.services.categoryoverride.CategoryOverrideEngine;
 import com.lantanagroup.link.validation.services.execution.CheckExecutionResult;
 import com.lantanagroup.link.validation.services.execution.CheckExecutorRegistry;
 import com.lantanagroup.link.validation.services.execution.CheckOutcome;
+import com.lantanagroup.link.validation.services.execution.EvaluatedFinding;
+import com.lantanagroup.link.validation.enums.CheckType;
 import com.lantanagroup.link.validation.enums.Severity;
 import com.lantanagroup.link.shared.utils.LogUtils;
 import lombok.extern.slf4j.Slf4j;
@@ -38,6 +41,7 @@ public class RubricExecutionService {
     private final RubricVersionRepository rubricVersionRepository;
     private final CheckExecutorRegistry executorRegistry;
     private final ResultEnvelopeAssembler envelopeAssembler;
+    private final CategoryOverrideEngine categoryOverrideEngine;
     private final ScoreAggregator scoreAggregator;
     private final RubricResultPersister resultPersister;
     private final FhirContext fhirContext;
@@ -50,6 +54,7 @@ public class RubricExecutionService {
                                   RubricVersionRepository rubricVersionRepository,
                                   CheckExecutorRegistry executorRegistry,
                                   ResultEnvelopeAssembler envelopeAssembler,
+                                  CategoryOverrideEngine categoryOverrideEngine,
                                   ScoreAggregator scoreAggregator,
                                   RubricResultPersister resultPersister,
                                   FhirContext fhirContext,
@@ -60,6 +65,7 @@ public class RubricExecutionService {
         this.rubricVersionRepository = rubricVersionRepository;
         this.executorRegistry = executorRegistry;
         this.envelopeAssembler = envelopeAssembler;
+        this.categoryOverrideEngine = categoryOverrideEngine;
         this.scoreAggregator = scoreAggregator;
         this.resultPersister = resultPersister;
         this.fhirContext = fhirContext;
@@ -115,29 +121,48 @@ public class RubricExecutionService {
                 ? runParallel(enabled, ctx, resource)
                 : runSequential(enabled, ctx, resource);
 
+        // Findings are flattened into one list before per-check statuses are derived, because
+        // category override has to see every finding at once -- both so the category rules are
+        // read once per evaluation rather than once per check, and so a check's status is derived
+        // from post-override severities. Slices (index ranges), not groupingBy(checkLocalId): two
+        // checks in one version can share a local id, and grouping would give each of them the
+        // other's findings.
         List<RawFinding> allFindings = new ArrayList<>();
+        List<CheckSlice> slices = new ArrayList<>(outcomes.size());
         Map<String, Long> checkDurations = new LinkedHashMap<>();
         for (CheckOutcome outcome : outcomes) {
+            int from = allFindings.size();
             allFindings.addAll(outcome.findings());
+            slices.add(new CheckSlice(outcome.checkLocalId(), from, allFindings.size()));
             checkDurations.put(outcome.checkLocalId(), outcome.durationMs());
         }
 
-        // per-check results (every check, pass or fail) so check-based scoring policies can score
         Map<String, RubricCheck> checkByLocalId = enabled.stream()
                 .collect(Collectors.toMap(RubricCheck::getCheckLocalId, c -> c, (a, b) -> a, LinkedHashMap::new));
-        List<CheckExecutionResult> checkResults = new ArrayList<>(outcomes.size());
-        for (CheckOutcome outcome : outcomes) {
-            RubricCheck c = checkByLocalId.get(outcome.checkLocalId());
+        Map<String, CheckType> checkTypeByLocalId = new LinkedHashMap<>();
+        checkByLocalId.forEach((localId, c) -> checkTypeByLocalId.put(localId, c.getType()));
+
+        List<EvaluatedFinding> evaluated = categoryOverrideEngine.apply(allFindings, checkTypeByLocalId);
+        if (evaluated.size() != allFindings.size()) {
+            throw new IllegalStateException(String.format(
+                    "Category override returned %d finding(s) for %d input(s); slices would be misaligned",
+                    evaluated.size(), allFindings.size()));
+        }
+
+        // per-check results (every check, pass or fail) so check-based scoring policies can score
+        List<CheckExecutionResult> checkResults = new ArrayList<>(slices.size());
+        for (CheckSlice slice : slices) {
+            RubricCheck c = checkByLocalId.get(slice.checkLocalId());
             checkResults.add(CheckExecutionResult.builder()
-                    .checkLocalId(outcome.checkLocalId())
+                    .checkLocalId(slice.checkLocalId())
                     .dimension(c != null ? c.getDimension() : null)
-                    .status(scoreAggregator.collapseCheckStatus(outcome.findings()))
+                    .status(scoreAggregator.collapseCheckStatus(slice.findingsIn(evaluated)))
                     .build());
         }
 
         OffsetDateTime completedAt = OffsetDateTime.now();
         ResultEnvelopeAssembler.AssembleOutput out =
-                envelopeAssembler.assemble(ctx, version, allFindings, checkResults, checkDurations, completedAt);
+                envelopeAssembler.assemble(ctx, version, evaluated, checkResults, checkDurations, completedAt);
 
         if (persist) {
             resultPersister.persist(out.resultEntity(), out.findingEntities());
@@ -199,6 +224,12 @@ public class RubricExecutionService {
             return fhirContext.newJsonParser().parseResource(objectMapper.writeValueAsString(payload));
         } catch (Exception e) {
             throw new PayloadParseException("Failed to parse FHIR payload: " + e.getMessage(), e);
+        }
+    }
+
+    private record CheckSlice(String checkLocalId, int fromIndex, int toIndex) {
+        List<EvaluatedFinding> findingsIn(List<EvaluatedFinding> evaluated) {
+            return evaluated.subList(fromIndex, toIndex);
         }
     }
 }

--- a/Java/validation/src/main/java/com/lantanagroup/link/validation/services/ScoreAggregator.java
+++ b/Java/validation/src/main/java/com/lantanagroup/link/validation/services/ScoreAggregator.java
@@ -4,11 +4,12 @@ import com.lantanagroup.link.validation.enums.PiqiDimension;
 import com.lantanagroup.link.validation.enums.RollupStrategy;
 import com.lantanagroup.link.validation.enums.RubricResultStatus;
 import com.lantanagroup.link.validation.enums.ScoringPolicyType;
-import com.lantanagroup.link.validation.enums.Severity;
-import com.lantanagroup.link.validation.models.RawFinding;
 import com.lantanagroup.link.validation.models.ScoreCardDto;
 import com.lantanagroup.link.validation.models.ScoringPolicyDto;
 import com.lantanagroup.link.validation.services.execution.CheckExecutionResult;
+import com.lantanagroup.link.validation.services.execution.EvaluatedFinding;
+import com.lantanagroup.link.validation.services.scoring.FindingStatusResolver;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 import java.util.Collection;
@@ -22,7 +23,10 @@ import java.util.stream.Collectors;
 
 
 @Component
+@RequiredArgsConstructor
 public class ScoreAggregator {
+
+    private final FindingStatusResolver statusResolver;
 
     public ScoreCardDto aggregate(List<CheckExecutionResult> checkResults, ScoringPolicyDto policy) {
         List<CheckExecutionResult> safeCheckResults = checkResults != null ? checkResults : List.of();
@@ -75,12 +79,16 @@ public class ScoreAggregator {
                 .build();
     }
 
-    /** Collapse a single check's findings into one status (used to build per-check results). */
-    public RubricResultStatus collapseCheckStatus(List<RawFinding> findings) {
+    /**
+     * Collapse a single check's findings into one status (used to build per-check results).
+     * Findings arrive post category override, so an "acceptable" error no longer fails its check
+     * while an uncategorized error still does — see {@link FindingStatusResolver}.
+     */
+    public RubricResultStatus collapseCheckStatus(List<EvaluatedFinding> findings) {
         RubricResultStatus status = RubricResultStatus.ACCEPTABLE;
         if (findings != null) {
-            for (RawFinding f : findings) {
-                status = upgrade(status, f.getSeverity());
+            for (EvaluatedFinding f : findings) {
+                status = worse(status, statusResolver.statusOf(f));
             }
         }
         return status;
@@ -102,16 +110,6 @@ public class ScoreAggregator {
                 .build();
     }
 
-    private RubricResultStatus upgrade(RubricResultStatus current, Severity severity) {
-        return switch (severity) {
-            case ERROR -> RubricResultStatus.UNACCEPTABLE;
-            case WARNING -> current == RubricResultStatus.UNACCEPTABLE
-                    ? RubricResultStatus.UNACCEPTABLE
-                    : RubricResultStatus.ACCEPTABLE_WITH_WARNINGS;
-            case INFORMATION -> current;
-        };
-    }
-
     /** Keeps whichever of two statuses is worse (higher severity rank). */
     private RubricResultStatus worse(RubricResultStatus current, RubricResultStatus candidate) {
         return severityRank(candidate) > severityRank(current) ? candidate : current;
@@ -120,11 +118,14 @@ public class ScoreAggregator {
     private RubricResultStatus rollUp(Collection<RubricResultStatus> statuses, RollupStrategy rollup) {
         RollupStrategy strategy = rollup != null ? rollup : RollupStrategy.WORST_OF;
         return switch (strategy) {
-            case WORST_OF -> worstOf(statuses);
+            // ALL_MUST_PASS is a documented alias of WORST_OF, not a stricter variant: "every entry
+            // must pass" and "the overall status is the worst status present" are the same rule once
+            // a warning is not treated as a failure. It is retained rather than removed because it
+            // is a persisted value in rubric_version.scoring_policy_json.
+            case WORST_OF, ALL_MUST_PASS -> worstOf(statuses);
             case BEST_OF -> bestOf(statuses);
             case PASS_FAIL -> passFail(statuses);
             case MAJORITY -> majority(statuses);
-            case ALL_MUST_PASS -> allMustPass(statuses);
         };
     }
 
@@ -149,12 +150,6 @@ public class ScoreAggregator {
         return severityRank(status) >= severityRank(RubricResultStatus.UNACCEPTABLE)
                 ? RubricResultStatus.UNACCEPTABLE
                 : RubricResultStatus.ACCEPTABLE;
-    }
-
-    private RubricResultStatus allMustPass(Collection<RubricResultStatus> statuses) {
-        return worstOf(statuses) == RubricResultStatus.ACCEPTABLE
-                ? RubricResultStatus.ACCEPTABLE
-                : RubricResultStatus.UNACCEPTABLE;
     }
 
     private RubricResultStatus majority(Collection<RubricResultStatus> statuses) {

--- a/Java/validation/src/main/java/com/lantanagroup/link/validation/services/categoryoverride/CategoryCombiner.java
+++ b/Java/validation/src/main/java/com/lantanagroup/link/validation/services/categoryoverride/CategoryCombiner.java
@@ -1,0 +1,90 @@
+package com.lantanagroup.link.validation.services.categoryoverride;
+
+import com.lantanagroup.link.validation.entities.Category;
+import com.lantanagroup.link.validation.entities.CategorySeverity;
+import com.lantanagroup.link.validation.enums.CategoryMatchStrategy;
+import com.lantanagroup.link.validation.enums.Severity;
+import com.lantanagroup.link.validation.models.RawFinding;
+import com.lantanagroup.link.validation.services.execution.EvaluatedFinding;
+
+import java.util.List;
+
+public final class CategoryCombiner {
+
+    private CategoryCombiner() {
+    }
+
+    public static EvaluatedFinding combine(RawFinding raw, List<Category> matched, CategoryMatchStrategy strategy) {
+        if (matched == null || matched.isEmpty()) {
+            return EvaluatedFinding.identity(raw);
+        }
+        return switch (strategy) {
+            case FIRST_MATCH -> single(raw, matched.get(0));
+            case WORST_OF -> worstOf(raw, matched);
+        };
+    }
+
+    private static EvaluatedFinding single(RawFinding raw, Category category) {
+        return new EvaluatedFinding(
+                raw,
+                raw.getSeverity(),
+                toSeverity(category.getSeverity(), raw.getSeverity()),
+                category.isAcceptable(),
+                List.of(category.getId()),
+                category.getId());
+    }
+
+    private static EvaluatedFinding worstOf(RawFinding raw, List<Category> matched) {
+        Severity worstSeverity = null;
+        boolean anyUnacceptable = false;
+        Category governing = null;
+
+        for (Category category : matched) {
+            Severity severity = toSeverity(category.getSeverity(), raw.getSeverity());
+            if (worstSeverity == null || rank(severity) > rank(worstSeverity)) {
+                worstSeverity = severity;
+            }
+            anyUnacceptable |= !category.isAcceptable();
+            if (governing == null || isWorse(category, governing)) {
+                governing = category;
+            }
+        }
+
+        return new EvaluatedFinding(
+                raw,
+                raw.getSeverity(),
+                worstSeverity != null ? worstSeverity : raw.getSeverity(),
+                !anyUnacceptable,
+                matched.stream().map(Category::getId).toList(),
+                governing != null ? governing.getId() : null);
+    }
+
+    private static boolean isWorse(Category candidate, Category current) {
+        if (candidate.isAcceptable() != current.isAcceptable()) {
+            return !candidate.isAcceptable();
+        }
+        return rank(toSeverity(candidate.getSeverity(), null)) > rank(toSeverity(current.getSeverity(), null));
+    }
+
+    private static Severity toSeverity(CategorySeverity categorySeverity, Severity fallback) {
+        if (categorySeverity == null) {
+            return fallback;
+        }
+        return switch (categorySeverity) {
+            case ERROR -> Severity.ERROR;
+            case WARNING -> Severity.WARNING;
+            case INFORMATION -> Severity.INFORMATION;
+        };
+    }
+
+    private static int rank(Severity severity) {
+        if (severity == null) {
+            return -1;
+        }
+        return switch (severity) {
+            case INFORMATION -> 0;
+            case WARNING -> 1;
+            case ERROR -> 2;
+        };
+    }
+}

--- a/Java/validation/src/main/java/com/lantanagroup/link/validation/services/categoryoverride/CategoryOverrideEngine.java
+++ b/Java/validation/src/main/java/com/lantanagroup/link/validation/services/categoryoverride/CategoryOverrideEngine.java
@@ -1,0 +1,113 @@
+package com.lantanagroup.link.validation.services.categoryoverride;
+
+import com.lantanagroup.link.validation.configs.ValidationPolicyConfig;
+import com.lantanagroup.link.validation.entities.Category;
+import com.lantanagroup.link.validation.entities.Result;
+import com.lantanagroup.link.validation.enums.CategoryMatchStrategy;
+import com.lantanagroup.link.validation.enums.CategoryOverrideScope;
+import com.lantanagroup.link.validation.enums.CheckType;
+import com.lantanagroup.link.validation.models.RawFinding;
+import com.lantanagroup.link.validation.services.CategorizationService;
+import com.lantanagroup.link.validation.services.execution.EvaluatedFinding;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class CategoryOverrideEngine {
+
+    private final CategorizationService categorizationService;
+    private final CategorySequenceProvider sequenceProvider;
+    private final ValidationPolicyConfig config;
+
+    public List<EvaluatedFinding> apply(List<RawFinding> findings, Map<String, CheckType> checkTypeByLocalId) {
+        if (findings == null || findings.isEmpty()) {
+            return List.of();
+        }
+        ValidationPolicyConfig.CategoryOverride settings = config.getCategoryOverride();
+        if (!settings.isEnabled()) {
+            log.debug("Category override disabled; {} finding(s) keep their own severity", findings.size());
+            return identity(findings);
+        }
+
+        CategoryOverrideScope scope = settings.getScope();
+        Map<String, CheckType> checkTypes = checkTypeByLocalId != null ? checkTypeByLocalId : Map.of();
+
+        // Index-aligned with `findings`; null means the finding is out of scope and stays untouched.
+        List<Result> views = new ArrayList<>(findings.size());
+        List<Result> toCategorize = new ArrayList<>(findings.size());
+        for (RawFinding finding : findings) {
+            if (!inScope(scope, checkTypes.get(finding.getCheckLocalId()))) {
+                views.add(null);
+                continue;
+            }
+            Result view = FindingResultAdapter.toTransientResult(finding);
+            views.add(view);
+            toCategorize.add(view);
+        }
+        if (toCategorize.isEmpty()) {
+            log.debug("Category override enabled but no finding is within scope {}", scope);
+            return identity(findings);
+        }
+
+        try {
+            categorizationService.categorize(toCategorize);
+        } catch (Exception e) {
+            // A single unusable matcher in the category table must not fail the whole evaluation;
+            // falling back to identity scores exactly as the disabled path would.
+            log.error("Categorization failed; findings keep their own severity", e);
+            return identity(findings);
+        }
+
+        CategoryMatchStrategy strategy = settings.getMatchStrategy();
+        List<EvaluatedFinding> evaluated = new ArrayList<>(findings.size());
+        int matchedCount = 0;
+        int overriddenCount = 0;
+        for (int i = 0; i < findings.size(); i++) {
+            Result view = views.get(i);
+            List<Category> matched = view != null ? inSequenceOrder(view.getCategories()) : List.of();
+            EvaluatedFinding decision = CategoryCombiner.combine(findings.get(i), matched, strategy);
+            evaluated.add(decision);
+            if (decision.hasCategories()) {
+                matchedCount++;
+            }
+            if (decision.severityWasOverridden()) {
+                overriddenCount++;
+            }
+        }
+        log.debug("Category override matched {} of {} finding(s) using {}", matchedCount, findings.size(), strategy);
+        if (overriddenCount > 0) {
+            log.info("Category override changed the severity of {} of {} finding(s) (scope {}, strategy {})",
+                    overriddenCount, findings.size(), scope, strategy);
+        }
+        return evaluated;
+    }
+
+    private List<Category> inSequenceOrder(List<Category> matched) {
+        if (matched == null || matched.isEmpty()) {
+            return List.of();
+        }
+        return matched.stream()
+                .sorted(Comparator.comparingInt((Category c) -> sequenceProvider.sequenceOf(c.getId()))
+                        .thenComparing(Category::getId))
+                .toList();
+    }
+
+    private boolean inScope(CategoryOverrideScope scope, CheckType checkType) {
+        if (scope == CategoryOverrideScope.ALL_CHECKS) {
+            return true;
+        }
+        return checkType != null && scope.includes(checkType);
+    }
+
+    private static List<EvaluatedFinding> identity(List<RawFinding> findings) {
+        return findings.stream().map(EvaluatedFinding::identity).toList();
+    }
+}

--- a/Java/validation/src/main/java/com/lantanagroup/link/validation/services/categoryoverride/CategorySequenceProvider.java
+++ b/Java/validation/src/main/java/com/lantanagroup/link/validation/services/categoryoverride/CategorySequenceProvider.java
@@ -1,0 +1,53 @@
+package com.lantanagroup.link.validation.services.categoryoverride;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
+import org.springframework.stereotype.Component;
+
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.Map;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class CategorySequenceProvider {
+
+    static final int UNSEQUENCED = Integer.MAX_VALUE;
+
+    private final ObjectMapper objectMapper;
+
+    private Map<String, Integer> sequenceById = Map.of();
+
+    @PostConstruct
+    void load() {
+        Resource resource = new PathMatchingResourcePatternResolver().getResource("classpath:categories.json");
+        Map<String, Integer> loaded = new HashMap<>();
+        try (InputStream stream = resource.getInputStream()) {
+            JsonNode root = objectMapper.readTree(stream);
+            int sequence = 0;
+            for (JsonNode node : root) {
+                String id = node.path("id").asText(null);
+                if (id != null && !id.isBlank()) {
+                    loaded.putIfAbsent(id, sequence++);
+                }
+            }
+        } catch (Exception e) {
+            // Not fatal: without the file every category is unsequenced and ties fall to id order,
+            // which is still deterministic. Startup must not depend on a tie-break input.
+            log.warn("Could not read category sequence from classpath:categories.json ({}); "
+                    + "category ties will be broken by id", e.getMessage());
+        }
+        sequenceById = Map.copyOf(loaded);
+        log.debug("Loaded sequence for {} categories", sequenceById.size());
+    }
+
+    public int sequenceOf(String categoryId) {
+        return sequenceById.getOrDefault(categoryId, UNSEQUENCED);
+    }
+}

--- a/Java/validation/src/main/java/com/lantanagroup/link/validation/services/categoryoverride/FindingResultAdapter.java
+++ b/Java/validation/src/main/java/com/lantanagroup/link/validation/services/categoryoverride/FindingResultAdapter.java
@@ -1,0 +1,37 @@
+package com.lantanagroup.link.validation.services.categoryoverride;
+
+import com.lantanagroup.link.validation.entities.Result;
+import com.lantanagroup.link.validation.enums.Severity;
+import com.lantanagroup.link.validation.models.RawFinding;
+import org.hl7.fhir.r4.model.OperationOutcome;
+
+public final class FindingResultAdapter {
+
+    private FindingResultAdapter() {
+    }
+
+    public static Result toTransientResult(RawFinding finding) {
+        Result result = new Result();
+        result.setSeverity(toIssueSeverity(finding.getSeverity()));
+        result.setCode(IssueTypes.parseOrNull(finding.getCode()));
+        result.setMessage(finding.getMessage());
+        result.setLocation(finding.getLocation());
+        result.setExpression(finding.getExpression());
+        return result;
+    }
+
+    /**
+     * Exhaustive mapping, deliberately not {@code IssueSeverity.fromCode}: adding a Severity value
+     * becomes a compile error here rather than a runtime throw. Rubric findings cannot be FATAL.
+     */
+    private static OperationOutcome.IssueSeverity toIssueSeverity(Severity severity) {
+        if (severity == null) {
+            return null;
+        }
+        return switch (severity) {
+            case ERROR -> OperationOutcome.IssueSeverity.ERROR;
+            case WARNING -> OperationOutcome.IssueSeverity.WARNING;
+            case INFORMATION -> OperationOutcome.IssueSeverity.INFORMATION;
+        };
+    }
+}

--- a/Java/validation/src/main/java/com/lantanagroup/link/validation/services/categoryoverride/IssueTypes.java
+++ b/Java/validation/src/main/java/com/lantanagroup/link/validation/services/categoryoverride/IssueTypes.java
@@ -1,0 +1,45 @@
+package com.lantanagroup.link.validation.services.categoryoverride;
+
+import lombok.extern.slf4j.Slf4j;
+import org.hl7.fhir.r4.model.OperationOutcome;
+
+import java.util.Map;
+
+@Slf4j
+public final class IssueTypes {
+
+    /**
+     * Rubric-specific codes that have an unambiguous FHIR IssueType equivalent. Without these the
+     * one category rule in categories.json that matches on {@code CODE}
+     * ({@code invalid_code_in_required_valueset}, which requires {@code code-invalid}) could never
+     * match a rubric finding, since no executor emits a FHIR code.
+     */
+    private static final Map<String, OperationOutcome.IssueType> ALIASES = Map.of(
+            "terminology-code-invalid", OperationOutcome.IssueType.CODEINVALID,
+            "valueset-membership-failed", OperationOutcome.IssueType.CODEINVALID,
+            "fhirpath-evaluation-error", OperationOutcome.IssueType.PROCESSING,
+            "check-execution-error", OperationOutcome.IssueType.PROCESSING,
+            "custom-check-error", OperationOutcome.IssueType.PROCESSING,
+            "custom-check-not-found", OperationOutcome.IssueType.NOTFOUND);
+
+    private IssueTypes() {
+    }
+
+    public static OperationOutcome.IssueType parseOrNull(String code) {
+        if (code == null || code.isBlank()) {
+            return null;
+        }
+        OperationOutcome.IssueType alias = ALIASES.get(code);
+        if (alias != null) {
+            return alias;
+        }
+        try {
+            return OperationOutcome.IssueType.fromCode(code);
+        } catch (Exception e) {
+            // Expected for every rubric-native code; category rules keyed on MESSAGE or EXPRESSION
+            // still match fine with a null code.
+            log.trace("Finding code '{}' is not a FHIR IssueType; matching on it will be skipped", code);
+            return null;
+        }
+    }
+}

--- a/Java/validation/src/main/java/com/lantanagroup/link/validation/services/execution/EvaluatedFinding.java
+++ b/Java/validation/src/main/java/com/lantanagroup/link/validation/services/execution/EvaluatedFinding.java
@@ -1,0 +1,38 @@
+package com.lantanagroup.link.validation.services.execution;
+
+import com.lantanagroup.link.validation.enums.PiqiDimension;
+import com.lantanagroup.link.validation.enums.Severity;
+import com.lantanagroup.link.validation.models.RawFinding;
+
+import java.util.List;
+
+public record EvaluatedFinding(
+        RawFinding raw,
+        Severity originalSeverity,
+        Severity effectiveSeverity,
+        Boolean acceptable,
+        List<String> categoryIds,
+        String governingCategoryId) {
+
+    /** No category applied: the finding scores on its own severity, exactly as it did pre-override. */
+    public static EvaluatedFinding identity(RawFinding raw) {
+        return new EvaluatedFinding(raw, raw.getSeverity(), raw.getSeverity(), null, List.of(), null);
+    }
+
+    public String checkLocalId() {
+        return raw.getCheckLocalId();
+    }
+
+    public PiqiDimension dimension() {
+        return raw.getDimension();
+    }
+
+    /** True when a category actually moved this finding's severity. */
+    public boolean severityWasOverridden() {
+        return originalSeverity != effectiveSeverity;
+    }
+
+    public boolean hasCategories() {
+        return categoryIds != null && !categoryIds.isEmpty();
+    }
+}

--- a/Java/validation/src/main/java/com/lantanagroup/link/validation/services/scoring/FindingStatusResolver.java
+++ b/Java/validation/src/main/java/com/lantanagroup/link/validation/services/scoring/FindingStatusResolver.java
@@ -1,0 +1,39 @@
+package com.lantanagroup.link.validation.services.scoring;
+
+import com.lantanagroup.link.validation.enums.RubricResultStatus;
+import com.lantanagroup.link.validation.enums.Severity;
+import com.lantanagroup.link.validation.services.execution.EvaluatedFinding;
+import org.springframework.stereotype.Component;
+
+@Component
+public class FindingStatusResolver {
+
+    public RubricResultStatus statusOf(EvaluatedFinding finding) {
+        Boolean acceptable = finding.acceptable();
+        if (Boolean.FALSE.equals(acceptable)) {
+            return RubricResultStatus.UNACCEPTABLE;
+        }
+        if (Boolean.TRUE.equals(acceptable)) {
+            return atLeastWarning(finding.effectiveSeverity())
+                    ? RubricResultStatus.ACCEPTABLE_WITH_WARNINGS
+                    : RubricResultStatus.ACCEPTABLE;
+        }
+        return bySeverityAlone(finding.effectiveSeverity());
+    }
+
+    /** The pre-override mapping, unchanged: an uncategorized error still fails. */
+    private RubricResultStatus bySeverityAlone(Severity severity) {
+        if (severity == null) {
+            return RubricResultStatus.ACCEPTABLE;
+        }
+        return switch (severity) {
+            case ERROR -> RubricResultStatus.UNACCEPTABLE;
+            case WARNING -> RubricResultStatus.ACCEPTABLE_WITH_WARNINGS;
+            case INFORMATION -> RubricResultStatus.ACCEPTABLE;
+        };
+    }
+
+    private boolean atLeastWarning(Severity severity) {
+        return severity == Severity.WARNING || severity == Severity.ERROR;
+    }
+}

--- a/Java/validation/src/main/java/com/lantanagroup/link/validation/services/scoring/ScoringPolicyResolver.java
+++ b/Java/validation/src/main/java/com/lantanagroup/link/validation/services/scoring/ScoringPolicyResolver.java
@@ -1,0 +1,37 @@
+package com.lantanagroup.link.validation.services.scoring;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.lantanagroup.link.validation.configs.ValidationPolicyConfig;
+import com.lantanagroup.link.validation.enums.RollupStrategy;
+import com.lantanagroup.link.validation.enums.ScoringPolicyType;
+import com.lantanagroup.link.validation.models.ScoringPolicyDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ScoringPolicyResolver {
+
+    private final ValidationPolicyConfig config;
+    private final ObjectMapper objectMapper;
+
+    public ScoringPolicyDto resolve(String scoringPolicyJson) {
+        return resolve(ScoringPolicyDto.from(scoringPolicyJson, objectMapper));
+    }
+
+    public ScoringPolicyDto resolve(ScoringPolicyDto policy) {
+        ScoringPolicyDto safe = policy != null ? policy : ScoringPolicyDto.defaultPolicy();
+        return ScoringPolicyDto.builder()
+                .type(safe.getType() != null ? safe.getType() : ScoringPolicyType.PIQI_DIMENSION_SCORECARD)
+                .rollup(resolveRollup(safe.getRollup()))
+                .build();
+    }
+
+    private RollupStrategy resolveRollup(RollupStrategy fromRubric) {
+        if (fromRubric != null) {
+            return fromRubric;
+        }
+        RollupStrategy fromConfig = config.getScoring().getRollup();
+        return fromConfig != null ? fromConfig : RollupStrategy.WORST_OF;
+    }
+}

--- a/Java/validation/src/main/resources/application.yml
+++ b/Java/validation/src/main/resources/application.yml
@@ -155,3 +155,41 @@ vaas:
     max-pool-size: 8
     queue-capacity: 0
     keep-alive-seconds: 60
+
+validation:
+  # Behavioural knobs for rubric (v2) category override and scoring, bound to ValidationPolicyConfig.
+  # Every key below is stated explicitly rather than left to the code default, so the whole policy is
+  # readable in one place. Values here match the code defaults except categoryOverride.scope.
+  #
+  # NOTE ON ENUM VALUES: these bind via Spring relaxed binding, which uses the enum CONSTANT NAME
+  # (WORST_OF, FHIR_ONLY). The kebab-case forms seen in rubric JSON ("worst-of") come from the
+  # enum's JSON value and apply to Jackson only -- they will NOT bind here.
+  categoryOverride:
+    # Master switch. When false the override engine short-circuits before reading any category, and
+    # every finding keeps its own severity -- i.e. scoring behaves exactly as it did before the
+    # override engine existed.
+    enabled: true
+
+    # Which findings the override engine may touch. ALL_CHECKS | FHIR_ONLY.
+    # FHIR_ONLY restricts it to CheckType.FHIR_CONFORMANCE findings, so COMPLETENESS / PLAUSIBILITY /
+    # TERMINOLOGY errors are filtered out before any category is consulted and can never be
+    # downgraded.
+    scope: FHIR_ONLY
+
+    # How several matching categories collapse into one decision. WORST_OF | FIRST_MATCH.
+    # WORST_OF combines severity and acceptable independently, each taking the worst value:
+    # any acceptable=false wins, and the highest severity wins.
+    matchStrategy: WORST_OF
+
+  scoring:
+    # Fallback rollup, used ONLY when a rubric version's own scoringPolicy.rollup is absent.
+    # A rubric's persisted rollup always wins over this -- see ScoringPolicyResolver.
+    # WORST_OF | BEST_OF | PASS_FAIL | MAJORITY | ALL_MUST_PASS.
+    rollup: WORST_OF
+
+  response:
+    # Diagnostic fields only -- neither of these ever affects a score.
+    # Emit originalSeverity / overriddenSeverity on each finding a category matched.
+    includeOriginalSeverity: true
+    # Emit categoryIds / governingCategoryId on each finding a category matched.
+    includeCategoryIds: true

--- a/Java/validation/src/test/java/com/lantanagroup/link/validation/matchers/NestedMatcherTest.java
+++ b/Java/validation/src/test/java/com/lantanagroup/link/validation/matchers/NestedMatcherTest.java
@@ -1,0 +1,100 @@
+package com.lantanagroup.link.validation.matchers;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.lantanagroup.link.validation.converters.MatcherConverter;
+import com.lantanagroup.link.validation.entities.Result;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The category rules that need "(one of these positives) AND (none of these exclusions)" nest a
+ * CompositeMatcher inside another one. Since {@link Matcher} resolves subtypes with
+ * {@code JsonTypeInfo.Id.DEDUCTION} — no explicit type field to fall back on — this verifies
+ * nesting actually round-trips, through the DB converter as well as plain Jackson, before any
+ * category rule depends on it.
+ */
+class NestedMatcherTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final MatcherConverter converter = new MatcherConverter(objectMapper);
+
+    /** (starts with A OR starts with B) AND NOT containing "skip". */
+    private static final String NESTED_JSON = """
+            {
+              "children": [
+                {
+                  "children": [
+                    { "field": "MESSAGE", "regex": "^Alpha" },
+                    { "field": "MESSAGE", "regex": "^Bravo" }
+                  ],
+                  "requiresAllChildren": false
+                },
+                { "field": "MESSAGE", "regex": "skip", "inverted": true }
+              ],
+              "requiresAllChildren": true
+            }
+            """;
+
+    private static Result withMessage(String message) {
+        Result result = new Result();
+        result.setMessage(message);
+        return result;
+    }
+
+    @Test
+    void deductionResolvesANestedComposite() throws Exception {
+        Matcher matcher = objectMapper.readValue(NESTED_JSON, Matcher.class);
+
+        CompositeMatcher outer = assertInstanceOf(CompositeMatcher.class, matcher);
+        assertTrue(outer.isRequiresAllChildren());
+        assertInstanceOf(CompositeMatcher.class, outer.getChildren().get(0));
+        assertInstanceOf(RegexMatcher.class, outer.getChildren().get(1));
+    }
+
+    @Test
+    void nestedCompositeAppliesInnerOrAndOuterExclusion() throws Exception {
+        Matcher matcher = objectMapper.readValue(NESTED_JSON, Matcher.class);
+
+        assertTrue(matcher.isMatch(withMessage("Alpha happened")));
+        assertTrue(matcher.isMatch(withMessage("Bravo happened")));
+        assertFalse(matcher.isMatch(withMessage("Charlie happened")), "neither positive branch matched");
+        assertFalse(matcher.isMatch(withMessage("Alpha but skip this")), "exclusion must veto a positive match");
+    }
+
+    @Test
+    void nestedCompositeSurvivesTheDatabaseConverterRoundTrip() throws Exception {
+        Matcher original = objectMapper.readValue(NESTED_JSON, Matcher.class);
+
+        Matcher restored = converter.convertToEntityAttribute(converter.convertToDatabaseColumn(original));
+
+        assertInstanceOf(CompositeMatcher.class, restored);
+        assertTrue(restored.isMatch(withMessage("Alpha happened")));
+        assertFalse(restored.isMatch(withMessage("Alpha but skip this")));
+        assertFalse(restored.isMatch(withMessage("Charlie happened")));
+    }
+
+    /**
+     * The defect the structural guard in CategoriesJsonStructureTest exists for: OR-ing an inverted
+     * child makes the matcher a catch-all, because "does not match X" is true for almost every
+     * message.
+     */
+    @Test
+    void orWithAnInvertedChildMatchesEverything() throws Exception {
+        String broken = """
+                {
+                  "children": [
+                    { "field": "MESSAGE", "regex": "^Alpha" },
+                    { "field": "MESSAGE", "regex": "skip", "inverted": true }
+                  ],
+                  "requiresAllChildren": false
+                }
+                """;
+        Matcher matcher = objectMapper.readValue(broken, Matcher.class);
+
+        assertTrue(matcher.isMatch(withMessage("totally unrelated message")),
+                "demonstrates the catch-all; the shipped rules must not behave this way");
+    }
+}

--- a/Java/validation/src/test/java/com/lantanagroup/link/validation/services/CategoriesJsonStructureTest.java
+++ b/Java/validation/src/test/java/com/lantanagroup/link/validation/services/CategoriesJsonStructureTest.java
@@ -1,0 +1,77 @@
+package com.lantanagroup.link.validation.services;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.lantanagroup.link.validation.entities.CategorySnapshot;
+import com.lantanagroup.link.validation.entities.Result;
+import com.lantanagroup.link.validation.matchers.CompositeMatcher;
+import com.lantanagroup.link.validation.matchers.InvertibleMatcher;
+import com.lantanagroup.link.validation.matchers.Matcher;
+import org.junit.jupiter.api.Test;
+
+import java.io.InputStream;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * Structural guards over every shipped category rule, complementing the behavioural cases in
+ * {@link CategoriesJsonMatcherTest}. The defect they prevent from coming back: OR-ing an inverted
+ * child. "Does not match X" is true for almost any message, so a single inverted child inside
+ * {@code requiresAllChildren: false} turns the whole rule into a catch-all — and both historical
+ * offenders were acceptable=true, so they silently marked unrelated findings acceptable. With
+ * category override consuming these rules at evaluation time, a catch-all rule would now also
+ * silently rewrite severities, so the guard matters more, not less.
+ */
+class CategoriesJsonStructureTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    private Map<String, Matcher> matchersById() throws Exception {
+        try (InputStream stream = getClass().getClassLoader().getResourceAsStream("categories.json")) {
+            assertNotNull(stream, "categories.json must be on the classpath");
+            CategorySnapshot[] snapshots = objectMapper.readValue(stream, CategorySnapshot[].class);
+            return Arrays.stream(snapshots)
+                    .collect(Collectors.toMap(CategorySnapshot::getId, CategorySnapshot::getMatcher,
+                            (a, b) -> a, LinkedHashMap::new));
+        }
+    }
+
+    @Test
+    void noRuleOrsAnInvertedChild() throws Exception {
+        matchersById().forEach((id, matcher) -> assertNoOrOverInverted(matcher, id));
+    }
+
+    private void assertNoOrOverInverted(Matcher matcher, String categoryId) {
+        if (!(matcher instanceof CompositeMatcher composite) || composite.getChildren() == null) {
+            return;
+        }
+        if (!composite.isRequiresAllChildren()) {
+            for (Matcher child : composite.getChildren()) {
+                if (child instanceof InvertibleMatcher invertible && invertible.isInverted()) {
+                    fail("Category '" + categoryId + "' ORs an inverted child, which matches nearly "
+                            + "every finding. Wrap the positive alternatives in a nested composite and "
+                            + "AND the exclusions around it.");
+                }
+            }
+        }
+        composite.getChildren().forEach(child -> assertNoOrOverInverted(child, categoryId));
+    }
+
+    @Test
+    void everyRuleIsEvaluableAgainstAnEmptyResult() throws Exception {
+        // Same contract the category endpoints enforce on submitted rules; the override engine
+        // additionally relies on it for findings that carry no code or expression.
+        matchersById().forEach((id, matcher) -> {
+            assertNotNull(matcher, "category '" + id + "' has no matcher");
+            try {
+                matcher.isMatch(new Result());
+            } catch (Exception e) {
+                fail("Category '" + id + "' has an unusable matcher: " + e.getMessage());
+            }
+        });
+    }
+}

--- a/Java/validation/src/test/java/com/lantanagroup/link/validation/services/ResultEnvelopeAssemblerTest.java
+++ b/Java/validation/src/test/java/com/lantanagroup/link/validation/services/ResultEnvelopeAssemblerTest.java
@@ -1,6 +1,7 @@
 package com.lantanagroup.link.validation.services;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.lantanagroup.link.validation.configs.ValidationPolicyConfig;
 import com.lantanagroup.link.validation.entities.RubricFinding;
 import com.lantanagroup.link.validation.entities.RubricVersion;
 import com.lantanagroup.link.validation.enums.PiqiDimension;
@@ -11,6 +12,9 @@ import com.lantanagroup.link.validation.models.FindingDto;
 import com.lantanagroup.link.validation.models.RawFinding;
 import com.lantanagroup.link.validation.models.SubjectDto;
 import com.lantanagroup.link.validation.services.execution.CheckExecutionResult;
+import com.lantanagroup.link.validation.services.execution.EvaluatedFinding;
+import com.lantanagroup.link.validation.services.scoring.FindingStatusResolver;
+import com.lantanagroup.link.validation.services.scoring.ScoringPolicyResolver;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -23,8 +27,19 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class ResultEnvelopeAssemblerTest {
 
-    private final ResultEnvelopeAssembler assembler =
-            new ResultEnvelopeAssembler(new ObjectMapper(), new ScoreAggregator());
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final ValidationPolicyConfig policyConfig = new ValidationPolicyConfig();
+    private final ResultEnvelopeAssembler assembler = new ResultEnvelopeAssembler(
+            objectMapper, new ScoreAggregator(new FindingStatusResolver()),
+            new ScoringPolicyResolver(policyConfig, objectMapper), policyConfig);
+
+    /**
+     * Wraps raw findings as uncategorized, which is what the assembler receives whenever category
+     * override is disabled — so the pre-override envelope shape stays pinned by these cases.
+     */
+    private static List<EvaluatedFinding> identity(List<RawFinding> raw) {
+        return raw.stream().map(EvaluatedFinding::identity).toList();
+    }
 
     private static RawFinding finding(UUID checkId, PiqiDimension dimension, Severity severity, String code) {
         return RawFinding.builder()
@@ -78,7 +93,7 @@ class ResultEnvelopeAssemblerTest {
 
         RubricVersion version = version();
         ResultEnvelopeAssembler.AssembleOutput out =
-                assembler.assemble(ctx, version, raw, checkResults, Map.of("c-e1", 12L), completedAt);
+                assembler.assemble(ctx, version, identity(raw), checkResults, Map.of("c-e1", 12L), completedAt);
 
         // envelope
         assertThat(out.envelope().getRubricId()).isEqualTo("piqi.core");
@@ -122,7 +137,7 @@ class ResultEnvelopeAssemblerTest {
                 .build();
 
         ResultEnvelopeAssembler.AssembleOutput out =
-                assembler.assemble(ctx, version(), List.of(), List.of(), Map.of(), OffsetDateTime.now());
+                assembler.assemble(ctx, version(), identity(List.of()), List.of(), Map.of(), OffsetDateTime.now());
 
         assertThat(out.envelope().getStatus()).isEqualTo(RubricResultStatus.ACCEPTABLE);
         assertThat(out.envelope().getFindings()).isEmpty();
@@ -139,9 +154,90 @@ class ResultEnvelopeAssemblerTest {
                 .build();
 
         ResultEnvelopeAssembler.AssembleOutput out =
-                assembler.assemble(ctx, version(), List.of(), List.of(), Map.of(), OffsetDateTime.now());
+                assembler.assemble(ctx, version(), identity(List.of()), List.of(), Map.of(), OffsetDateTime.now());
 
         assertThat(out.resultEntity().getFacilityId()).isNull();
         assertThat(out.resultEntity().getPatientId()).isNull();
+    }
+
+    // ------------------------------------------------------------------
+    // Category-override decorations
+    // ------------------------------------------------------------------
+
+    private static EvaluatedFinding categorized(RawFinding raw, Severity effective, boolean acceptable) {
+        return new EvaluatedFinding(raw, raw.getSeverity(), effective, acceptable,
+                List.of("cat-1"), "cat-1");
+    }
+
+    private ExecutionContext ctx() {
+        return ExecutionContext.builder()
+                .requestId(UUID.randomUUID())
+                .requestedAt(OffsetDateTime.now())
+                .build();
+    }
+
+    @Test
+    @DisplayName("a categorized finding exposes original/overridden severity, acceptability, and category ids in the DTO")
+    void categorizedFindingCarriesOverrideFields() {
+        RawFinding raw = finding(UUID.randomUUID(), PiqiDimension.CONFORMANCE, Severity.ERROR, "e1");
+
+        ResultEnvelopeAssembler.AssembleOutput out = assembler.assemble(
+                ctx(), version(), List.of(categorized(raw, Severity.WARNING, true)),
+                List.of(), Map.of(), OffsetDateTime.now());
+
+        FindingDto dto = out.envelope().getFindings().get(0);
+        assertThat(dto.getSeverity()).isEqualTo(Severity.WARNING);
+        assertThat(dto.getOriginalSeverity()).isEqualTo(Severity.ERROR);
+        assertThat(dto.getOverriddenSeverity()).isEqualTo(Severity.WARNING);
+        assertThat(dto.getAcceptable()).isTrue();
+        assertThat(dto.getCategoryIds()).containsExactly("cat-1");
+        assertThat(dto.getGoverningCategoryId()).isEqualTo("cat-1");
+    }
+
+    @Test
+    @DisplayName("summary counts stay on the pre-override severities while the persisted finding stores the effective one")
+    void summaryCountsPreOverrideAndEntityStoresEffective() {
+        RawFinding raw = finding(UUID.randomUUID(), PiqiDimension.CONFORMANCE, Severity.ERROR, "e1");
+
+        ResultEnvelopeAssembler.AssembleOutput out = assembler.assemble(
+                ctx(), version(), List.of(categorized(raw, Severity.WARNING, true)),
+                List.of(), Map.of(), OffsetDateTime.now());
+
+        assertThat(out.envelope().getSummary().getErrorCount()).isEqualTo(1);
+        assertThat(out.envelope().getSummary().getWarningCount()).isZero();
+        assertThat(out.findingEntities().get(0).getSeverity()).isEqualTo(Severity.WARNING);
+    }
+
+    @Test
+    @DisplayName("an uncategorized finding emits no override diagnostics at all")
+    void uncategorizedFindingHasNoOverrideFields() {
+        RawFinding raw = finding(UUID.randomUUID(), PiqiDimension.CONFORMANCE, Severity.ERROR, "e1");
+
+        ResultEnvelopeAssembler.AssembleOutput out = assembler.assemble(
+                ctx(), version(), identity(List.of(raw)), List.of(), Map.of(), OffsetDateTime.now());
+
+        FindingDto dto = out.envelope().getFindings().get(0);
+        assertThat(dto.getOriginalSeverity()).isNull();
+        assertThat(dto.getOverriddenSeverity()).isNull();
+        assertThat(dto.getAcceptable()).isNull();
+        assertThat(dto.getGoverningCategoryId()).isNull();
+    }
+
+    @Test
+    @DisplayName("response config can suppress the diagnostic fields without touching the effective severity")
+    void responseConfigSuppressesDiagnostics() {
+        policyConfig.getResponse().setIncludeOriginalSeverity(false);
+        policyConfig.getResponse().setIncludeCategoryIds(false);
+        RawFinding raw = finding(UUID.randomUUID(), PiqiDimension.CONFORMANCE, Severity.ERROR, "e1");
+
+        ResultEnvelopeAssembler.AssembleOutput out = assembler.assemble(
+                ctx(), version(), List.of(categorized(raw, Severity.WARNING, true)),
+                List.of(), Map.of(), OffsetDateTime.now());
+
+        FindingDto dto = out.envelope().getFindings().get(0);
+        assertThat(dto.getSeverity()).isEqualTo(Severity.WARNING);
+        assertThat(dto.getOriginalSeverity()).isNull();
+        assertThat(dto.getCategoryIds()).isNull();
+        assertThat(dto.getAcceptable()).isTrue();
     }
 }

--- a/Java/validation/src/test/java/com/lantanagroup/link/validation/services/RubricExecutionServiceCategoryOverrideTest.java
+++ b/Java/validation/src/test/java/com/lantanagroup/link/validation/services/RubricExecutionServiceCategoryOverrideTest.java
@@ -1,0 +1,167 @@
+package com.lantanagroup.link.validation.services;
+
+import ca.uhn.fhir.context.FhirContext;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.lantanagroup.link.validation.configs.ValidationPolicyConfig;
+import com.lantanagroup.link.validation.entities.Category;
+import com.lantanagroup.link.validation.entities.CategorySeverity;
+import com.lantanagroup.link.validation.entities.Result;
+import com.lantanagroup.link.validation.entities.RubricCheck;
+import com.lantanagroup.link.validation.entities.RubricVersion;
+import com.lantanagroup.link.validation.enums.CategoryMatchStrategy;
+import com.lantanagroup.link.validation.enums.CategoryOverrideScope;
+import com.lantanagroup.link.validation.enums.CheckType;
+import com.lantanagroup.link.validation.enums.PiqiDimension;
+import com.lantanagroup.link.validation.enums.RubricResultStatus;
+import com.lantanagroup.link.validation.enums.Severity;
+import com.lantanagroup.link.validation.models.EvaluateRequestDto;
+import com.lantanagroup.link.validation.models.ExecutionContext;
+import com.lantanagroup.link.validation.models.FindingDto;
+import com.lantanagroup.link.validation.models.RawFinding;
+import com.lantanagroup.link.validation.models.SubjectDto;
+import com.lantanagroup.link.validation.models.ValidationResultEnvelope;
+import com.lantanagroup.link.validation.repositories.RubricVersionRepository;
+import com.lantanagroup.link.validation.services.categoryoverride.CategoryOverrideEngine;
+import com.lantanagroup.link.validation.services.categoryoverride.CategorySequenceProvider;
+import com.lantanagroup.link.validation.services.execution.CheckExecutor;
+import com.lantanagroup.link.validation.services.execution.CheckExecutorRegistry;
+import com.lantanagroup.link.validation.services.scoring.FindingStatusResolver;
+import com.lantanagroup.link.validation.services.scoring.ScoringPolicyResolver;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * End-to-end through the real assembler, aggregator, and override engine: only the category source
+ * (CategorizationService) and the check executor are stubbed. Pins the whole chain the feature
+ * depends on — findings flow through the engine, per-check statuses are derived post-override, and
+ * the envelope carries both the effective severity and the diagnostics.
+ */
+class RubricExecutionServiceCategoryOverrideTest {
+
+    private final RubricVersionResolver resolver = mock(RubricVersionResolver.class);
+    private final CheckExecutorRegistry registry = mock(CheckExecutorRegistry.class);
+    private final CategorizationService categorizationService = mock(CategorizationService.class);
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    private final ValidationPolicyConfig policyConfig = new ValidationPolicyConfig();
+    private final ScoreAggregator scoreAggregator = new ScoreAggregator(new FindingStatusResolver());
+    private final ResultEnvelopeAssembler assembler = new ResultEnvelopeAssembler(
+            objectMapper, scoreAggregator, new ScoringPolicyResolver(policyConfig, objectMapper), policyConfig);
+    private final CategoryOverrideEngine overrideEngine = new CategoryOverrideEngine(
+            categorizationService, new CategorySequenceProvider(objectMapper), policyConfig);
+
+    private final RubricExecutionService service = new RubricExecutionService(
+            resolver, mock(RubricVersionRepository.class), registry, assembler, overrideEngine,
+            scoreAggregator, mock(RubricResultPersister.class), FhirContext.forR4(), objectMapper,
+            Runnable::run, false);
+
+    private final RubricVersion version = RubricVersion.builder()
+            .rubricId("piqi.core").semver("1.0.0").rubricVersionId(UUID.randomUUID()).checksum("abc").build();
+
+    private static Category acceptableWarning(String id) {
+        Category category = new Category();
+        category.setId(id);
+        category.setTitle(id);
+        category.setSeverity(CategorySeverity.WARNING);
+        category.setAcceptable(true);
+        category.setGuidance("guidance");
+        return category;
+    }
+
+    private static RubricCheck conformanceCheck() {
+        return RubricCheck.builder()
+                .checkId(UUID.randomUUID())
+                .checkLocalId("c1")
+                .type(CheckType.FHIR_CONFORMANCE)
+                .dimension(PiqiDimension.CONFORMANCE)
+                .enabled(true)
+                .build();
+    }
+
+    private EvaluateRequestDto request() throws Exception {
+        JsonNode payload = objectMapper.readTree("{\"resourceType\":\"Patient\",\"id\":\"p1\"}");
+        return EvaluateRequestDto.builder()
+                .subject(SubjectDto.builder().facilityId("f1").build())
+                .payload(payload)
+                .build();
+    }
+
+    @Test
+    @DisplayName("an error a category declares acceptable is downgraded end to end: status, score, and finding all reflect the override")
+    void acceptableCategoryDowngradesAnErrorEndToEnd() throws Exception {
+        policyConfig.getCategoryOverride().setEnabled(true);
+        policyConfig.getCategoryOverride().setScope(CategoryOverrideScope.FHIR_ONLY);
+        policyConfig.getCategoryOverride().setMatchStrategy(CategoryMatchStrategy.WORST_OF);
+
+        RubricCheck check = conformanceCheck();
+        when(resolver.resolve("piqi.core", "1.0.0", false))
+                .thenReturn(new RubricVersionResolver.ResolvedRubric(version, List.of(check)));
+        CheckExecutor executor = mock(CheckExecutor.class);
+        when(executor.execute(eq(check), any(ExecutionContext.class)))
+                .thenReturn(List.of(RawFinding.builder()
+                        .checkLocalId("c1").dimension(PiqiDimension.CONFORMANCE)
+                        .severity(Severity.ERROR).code("fhir-conformance")
+                        .message("some validator message").build()));
+        when(registry.get(CheckType.FHIR_CONFORMANCE)).thenReturn(executor);
+        doAnswer(invocation -> {
+            List<Result> results = invocation.getArgument(0);
+            results.forEach(r -> r.setCategories(List.of(acceptableWarning("cat-a"))));
+            return null;
+        }).when(categorizationService).categorize(anyList());
+
+        ValidationResultEnvelope envelope = service.evaluate("piqi.core", "1.0.0", request(), false);
+
+        assertThat(envelope.getStatus()).isEqualTo(RubricResultStatus.ACCEPTABLE_WITH_WARNINGS);
+        FindingDto finding = envelope.getFindings().get(0);
+        assertThat(finding.getSeverity()).isEqualTo(Severity.WARNING);
+        assertThat(finding.getOriginalSeverity()).isEqualTo(Severity.ERROR);
+        assertThat(finding.getOverriddenSeverity()).isEqualTo(Severity.WARNING);
+        assertThat(finding.getAcceptable()).isTrue();
+        assertThat(finding.getGoverningCategoryId()).isEqualTo("cat-a");
+        // the summary still reconciles with what the check emitted
+        assertThat(envelope.getSummary().getErrorCount()).isEqualTo(1);
+        assertThat(envelope.getSummary().getWarningCount()).isZero();
+    }
+
+    @Test
+    @DisplayName("with FHIR_ONLY scope a TERMINOLOGY error is out of reach: nothing is categorized and the result still fails")
+    void outOfScopeErrorStillFails() throws Exception {
+        policyConfig.getCategoryOverride().setEnabled(true);
+        policyConfig.getCategoryOverride().setScope(CategoryOverrideScope.FHIR_ONLY);
+
+        RubricCheck check = RubricCheck.builder()
+                .checkId(UUID.randomUUID())
+                .checkLocalId("c1")
+                .type(CheckType.TERMINOLOGY)
+                .dimension(PiqiDimension.TERMINOLOGY)
+                .enabled(true)
+                .build();
+        when(resolver.resolve("piqi.core", "1.0.0", false))
+                .thenReturn(new RubricVersionResolver.ResolvedRubric(version, List.of(check)));
+        CheckExecutor executor = mock(CheckExecutor.class);
+        when(executor.execute(eq(check), any(ExecutionContext.class)))
+                .thenReturn(List.of(RawFinding.builder()
+                        .checkLocalId("c1").dimension(PiqiDimension.TERMINOLOGY)
+                        .severity(Severity.ERROR).code("terminology-code-invalid")
+                        .message("bad code").build()));
+        when(registry.get(CheckType.TERMINOLOGY)).thenReturn(executor);
+
+        ValidationResultEnvelope envelope = service.evaluate("piqi.core", "1.0.0", request(), false);
+
+        assertThat(envelope.getStatus()).isEqualTo(RubricResultStatus.UNACCEPTABLE);
+        assertThat(envelope.getFindings().get(0).getAcceptable()).isNull();
+        assertThat(envelope.getFindings().get(0).getSeverity()).isEqualTo(Severity.ERROR);
+    }
+}

--- a/Java/validation/src/test/java/com/lantanagroup/link/validation/services/RubricExecutionServiceParallelTest.java
+++ b/Java/validation/src/test/java/com/lantanagroup/link/validation/services/RubricExecutionServiceParallelTest.java
@@ -4,6 +4,7 @@ import ca.uhn.fhir.context.FhirContext;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.lantanagroup.link.validation.configs.CheckExecutionConfig;
+import com.lantanagroup.link.validation.configs.ValidationPolicyConfig;
 import com.lantanagroup.link.validation.enums.CheckType;
 import com.lantanagroup.link.validation.enums.PiqiDimension;
 import com.lantanagroup.link.validation.enums.Severity;
@@ -15,8 +16,12 @@ import com.lantanagroup.link.validation.models.FindingDto;
 import com.lantanagroup.link.validation.models.RawFinding;
 import com.lantanagroup.link.validation.models.ValidationResultEnvelope;
 import com.lantanagroup.link.validation.repositories.RubricVersionRepository;
+import com.lantanagroup.link.validation.services.categoryoverride.CategoryOverrideEngine;
+import com.lantanagroup.link.validation.services.categoryoverride.CategorySequenceProvider;
 import com.lantanagroup.link.validation.services.execution.CheckExecutor;
 import com.lantanagroup.link.validation.services.execution.CheckExecutorRegistry;
+import com.lantanagroup.link.validation.services.scoring.FindingStatusResolver;
+import com.lantanagroup.link.validation.services.scoring.ScoringPolicyResolver;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -268,12 +273,19 @@ class RubricExecutionServiceParallelTest {
         when(versionResolver.resolve(RUBRIC_ID, null, false))
                 .thenReturn(new RubricVersionResolver.ResolvedRubric(version, checks));
         when(executorRegistry.get(any())).thenReturn(executor);
+        ValidationPolicyConfig policyConfig = new ValidationPolicyConfig();
+        ScoreAggregator scoreAggregator = new ScoreAggregator(new FindingStatusResolver());
         return new RubricExecutionService(
                 versionResolver,
                 mock(RubricVersionRepository.class),
                 executorRegistry,
-                new ResultEnvelopeAssembler(objectMapper, new ScoreAggregator()),
-                new ScoreAggregator(),
+                new ResultEnvelopeAssembler(objectMapper, scoreAggregator,
+                        new ScoringPolicyResolver(policyConfig, objectMapper), policyConfig),
+                // default (disabled) override config: parallel-vs-sequential equivalence is about
+                // the fan-out, not the override feature
+                new CategoryOverrideEngine(mock(CategorizationService.class),
+                        new CategorySequenceProvider(objectMapper), policyConfig),
+                scoreAggregator,
                 mock(RubricResultPersister.class),
                 FHIR_CONTEXT,
                 objectMapper,

--- a/Java/validation/src/test/java/com/lantanagroup/link/validation/services/RubricExecutionServiceScoringPolicyTest.java
+++ b/Java/validation/src/test/java/com/lantanagroup/link/validation/services/RubricExecutionServiceScoringPolicyTest.java
@@ -3,6 +3,7 @@ package com.lantanagroup.link.validation.services;
 import ca.uhn.fhir.context.FhirContext;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.lantanagroup.link.validation.configs.ValidationPolicyConfig;
 import com.lantanagroup.link.validation.entities.RubricCheck;
 import com.lantanagroup.link.validation.entities.RubricVersion;
 import com.lantanagroup.link.validation.enums.CheckType;
@@ -15,8 +16,12 @@ import com.lantanagroup.link.validation.models.RubricVersionSnapshot;
 import com.lantanagroup.link.validation.models.SubjectDto;
 import com.lantanagroup.link.validation.models.ValidationResultEnvelope;
 import com.lantanagroup.link.validation.repositories.RubricVersionRepository;
+import com.lantanagroup.link.validation.services.categoryoverride.CategoryOverrideEngine;
+import com.lantanagroup.link.validation.services.categoryoverride.CategorySequenceProvider;
 import com.lantanagroup.link.validation.services.execution.CheckExecutor;
 import com.lantanagroup.link.validation.services.execution.CheckExecutorRegistry;
+import com.lantanagroup.link.validation.services.scoring.FindingStatusResolver;
+import com.lantanagroup.link.validation.services.scoring.ScoringPolicyResolver;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -43,11 +48,18 @@ class RubricExecutionServiceScoringPolicyTest {
     private final CheckExecutorRegistry registry = mock(CheckExecutorRegistry.class);
     private final RubricResultPersister resultPersister = mock(RubricResultPersister.class);
     private final ObjectMapper objectMapper = new ObjectMapper();
-    private final ScoreAggregator scoreAggregator = new ScoreAggregator();
-    private final ResultEnvelopeAssembler assembler = new ResultEnvelopeAssembler(objectMapper, scoreAggregator);
+    private final ValidationPolicyConfig policyConfig = new ValidationPolicyConfig();
+    private final ScoreAggregator scoreAggregator = new ScoreAggregator(new FindingStatusResolver());
+    private final ResultEnvelopeAssembler assembler = new ResultEnvelopeAssembler(
+            objectMapper, scoreAggregator, new ScoringPolicyResolver(policyConfig, objectMapper), policyConfig);
+
+    // Override engine on its default (disabled) configuration: scoring behaviour under test is
+    // exactly the pre-override one.
+    private final CategoryOverrideEngine overrideEngine = new CategoryOverrideEngine(
+            mock(CategorizationService.class), new CategorySequenceProvider(objectMapper), policyConfig);
 
     private final RubricExecutionService service = new RubricExecutionService(
-            resolver, versionRepository, registry, assembler,
+            resolver, versionRepository, registry, assembler, overrideEngine,
             scoreAggregator, resultPersister, FhirContext.forR4(), objectMapper,
             Runnable::run, false);
 

--- a/Java/validation/src/test/java/com/lantanagroup/link/validation/services/RubricExecutionServiceTest.java
+++ b/Java/validation/src/test/java/com/lantanagroup/link/validation/services/RubricExecutionServiceTest.java
@@ -16,9 +16,14 @@ import com.lantanagroup.link.validation.models.ExecutionContext;
 import com.lantanagroup.link.validation.models.RawFinding;
 import com.lantanagroup.link.validation.models.SubjectDto;
 import com.lantanagroup.link.validation.models.ValidationResultEnvelope;
+import com.lantanagroup.link.validation.configs.ValidationPolicyConfig;
 import com.lantanagroup.link.validation.repositories.RubricVersionRepository;
+import com.lantanagroup.link.validation.services.categoryoverride.CategoryOverrideEngine;
+import com.lantanagroup.link.validation.services.categoryoverride.CategorySequenceProvider;
 import com.lantanagroup.link.validation.services.execution.CheckExecutor;
 import com.lantanagroup.link.validation.services.execution.CheckExecutorRegistry;
+import com.lantanagroup.link.validation.services.execution.EvaluatedFinding;
+import com.lantanagroup.link.validation.services.scoring.FindingStatusResolver;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -47,10 +52,16 @@ class RubricExecutionServiceTest {
     private final FhirContext fhirContext = FhirContext.forR4();
     private final ObjectMapper objectMapper = new ObjectMapper();
 
+    // A real override engine on its default (disabled) configuration, so these cases keep
+    // asserting the pre-override behaviour end to end rather than through a mocked engine.
+    private final CategoryOverrideEngine overrideEngine = new CategoryOverrideEngine(
+            mock(CategorizationService.class), new CategorySequenceProvider(objectMapper),
+            new ValidationPolicyConfig());
+
     // Sequential mode (parallel=false), so the pool is never touched — a synchronous executor suffices.
     private final RubricExecutionService service = new RubricExecutionService(
-            resolver, versionRepository, registry, assembler,
-            new ScoreAggregator(), resultPersister, fhirContext, objectMapper,
+            resolver, versionRepository, registry, assembler, overrideEngine,
+            new ScoreAggregator(new FindingStatusResolver()), resultPersister, fhirContext, objectMapper,
             Runnable::run, false);
 
     private final UUID versionId = UUID.randomUUID();
@@ -150,14 +161,14 @@ class RubricExecutionServiceTest {
         service.evaluate("piqi.core", "1.0.0", request(), true);
 
         @SuppressWarnings("unchecked")
-        ArgumentCaptor<List<RawFinding>> captor = ArgumentCaptor.forClass(List.class);
+        ArgumentCaptor<List<EvaluatedFinding>> captor = ArgumentCaptor.forClass(List.class);
         verify(assembler).assemble(any(ExecutionContext.class), eq(version), captor.capture(),
                 anyList(), anyMap(), any(OffsetDateTime.class));
         assertThat(captor.getValue())
-                .anySatisfy(f -> assertThat(f.getCode()).isEqualTo("check-execution-error"));
+                .anySatisfy(f -> assertThat(f.raw().getCode()).isEqualTo("check-execution-error"));
         // the failure finding still carries the originating check_id so it can be persisted
         assertThat(captor.getValue())
-                .anySatisfy(f -> assertThat(f.getCheckId()).isEqualTo(c.getCheckId()));
+                .anySatisfy(f -> assertThat(f.raw().getCheckId()).isEqualTo(c.getCheckId()));
     }
 
     @Test
@@ -177,9 +188,9 @@ class RubricExecutionServiceTest {
         service.evaluate("piqi.core", "1.0.0", request(), true);
 
         @SuppressWarnings("unchecked")
-        ArgumentCaptor<List<RawFinding>> captor = ArgumentCaptor.forClass(List.class);
+        ArgumentCaptor<List<EvaluatedFinding>> captor = ArgumentCaptor.forClass(List.class);
         verify(assembler).assemble(any(ExecutionContext.class), eq(version), captor.capture(),
                 anyList(), anyMap(), any(OffsetDateTime.class));
-        assertThat(captor.getValue()).allSatisfy(f -> assertThat(f.getCheckId()).isEqualTo(c.getCheckId()));
+        assertThat(captor.getValue()).allSatisfy(f -> assertThat(f.raw().getCheckId()).isEqualTo(c.getCheckId()));
     }
 }

--- a/Java/validation/src/test/java/com/lantanagroup/link/validation/services/ScoreAggregatorTest.java
+++ b/Java/validation/src/test/java/com/lantanagroup/link/validation/services/ScoreAggregatorTest.java
@@ -4,9 +4,13 @@ import com.lantanagroup.link.validation.enums.PiqiDimension;
 import com.lantanagroup.link.validation.enums.RollupStrategy;
 import com.lantanagroup.link.validation.enums.RubricResultStatus;
 import com.lantanagroup.link.validation.enums.ScoringPolicyType;
+import com.lantanagroup.link.validation.enums.Severity;
+import com.lantanagroup.link.validation.models.RawFinding;
 import com.lantanagroup.link.validation.models.ScoreCardDto;
 import com.lantanagroup.link.validation.models.ScoringPolicyDto;
 import com.lantanagroup.link.validation.services.execution.CheckExecutionResult;
+import com.lantanagroup.link.validation.services.execution.EvaluatedFinding;
+import com.lantanagroup.link.validation.services.scoring.FindingStatusResolver;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -16,7 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class ScoreAggregatorTest {
 
-    private final ScoreAggregator aggregator = new ScoreAggregator();
+    private final ScoreAggregator aggregator = new ScoreAggregator(new FindingStatusResolver());
 
     /** A per-check result carrying a dimension (what the dimension scorecard scores from). */
     private static CheckExecutionResult dimResult(PiqiDimension dimension, RubricResultStatus status) {
@@ -156,14 +160,43 @@ class ScoreAggregatorTest {
         assertThat(score.getInterpretation()).isEqualTo(RubricResultStatus.ACCEPTABLE);
     }
 
+    /**
+     * ALL_MUST_PASS is an alias of WORST_OF, so warnings alone no longer fail the result — they
+     * surface as ACCEPTABLE_WITH_WARNINGS. It previously collapsed anything short of a clean
+     * ACCEPTABLE to UNACCEPTABLE; that was the stricter reading and is the one behaviour change in
+     * this rollup. PASS_FAIL remains the strategy that erases the distinction, passing warnings as
+     * a plain ACCEPTABLE.
+     */
     @Test
-    @DisplayName("dimension + ALL_MUST_PASS fails overall on a mere WARNING (stricter than a clean pass)")
-    void dimensionAllMustPassFailsOnWarning() {
+    @DisplayName("dimension + ALL_MUST_PASS behaves as WORST_OF: warnings surface, they do not fail")
+    void dimensionAllMustPassIsAnAliasOfWorstOf() {
         ScoreCardDto score = aggregator.aggregate(
                 List.of(dimResult(PiqiDimension.TERMINOLOGY, RubricResultStatus.ACCEPTABLE_WITH_WARNINGS)),
                 policy(ScoringPolicyType.PIQI_DIMENSION_SCORECARD, RollupStrategy.ALL_MUST_PASS));
 
-        assertThat(score.getInterpretation()).isEqualTo(RubricResultStatus.UNACCEPTABLE);
+        assertThat(score.getInterpretation()).isEqualTo(RubricResultStatus.ACCEPTABLE_WITH_WARNINGS);
+    }
+
+    @Test
+    @DisplayName("ALL_MUST_PASS agrees with WORST_OF for every input, not just the warnings-only case")
+    void allMustPassAgreesWithWorstOfAcrossMixedStatuses() {
+        List<List<CheckExecutionResult>> cases = List.of(
+                List.of(),
+                List.of(dimResult(PiqiDimension.CURRENCY, RubricResultStatus.ACCEPTABLE)),
+                List.of(dimResult(PiqiDimension.CURRENCY, RubricResultStatus.ACCEPTABLE_WITH_WARNINGS)),
+                List.of(dimResult(PiqiDimension.CURRENCY, RubricResultStatus.UNACCEPTABLE)),
+                List.of(dimResult(PiqiDimension.CURRENCY, RubricResultStatus.ACCEPTABLE_WITH_WARNINGS),
+                        dimResult(PiqiDimension.COMPLETENESS, RubricResultStatus.UNACCEPTABLE)));
+
+        for (List<CheckExecutionResult> results : cases) {
+            RubricResultStatus worstOf = aggregator.aggregate(results,
+                    policy(ScoringPolicyType.PIQI_DIMENSION_SCORECARD, RollupStrategy.WORST_OF)).getInterpretation();
+            RubricResultStatus allMustPass = aggregator.aggregate(results,
+                    policy(ScoringPolicyType.PIQI_DIMENSION_SCORECARD, RollupStrategy.ALL_MUST_PASS)).getInterpretation();
+            assertThat(allMustPass)
+                    .as("ALL_MUST_PASS diverged from WORST_OF for %d check(s)", results.size())
+                    .isEqualTo(worstOf);
+        }
     }
 
     // ------------------------------------------------------------------
@@ -234,5 +267,52 @@ class ScoreAggregatorTest {
                 policy(ScoringPolicyType.PIQI_PASS_FAIL, null));
 
         assertThat(score.getInterpretation()).isEqualTo(RubricResultStatus.ACCEPTABLE);
+    }
+
+    // ------------------------------------------------------------------
+    // collapseCheckStatus — post-override findings drive per-check status
+    // ------------------------------------------------------------------
+
+    private static EvaluatedFinding uncategorized(Severity severity) {
+        return EvaluatedFinding.identity(RawFinding.builder()
+                .checkLocalId("c1").dimension(PiqiDimension.CONFORMANCE).severity(severity).build());
+    }
+
+    private static EvaluatedFinding categorized(Severity effective, boolean acceptable) {
+        RawFinding raw = RawFinding.builder()
+                .checkLocalId("c1").dimension(PiqiDimension.CONFORMANCE).severity(Severity.ERROR).build();
+        return new EvaluatedFinding(raw, Severity.ERROR, effective, acceptable, List.of("cat-1"), "cat-1");
+    }
+
+    @Test
+    @DisplayName("collapse takes the worst of multiple findings on one check, whatever their order")
+    void collapseTakesTheWorstFinding() {
+        List<EvaluatedFinding> findings = List.of(
+                uncategorized(Severity.WARNING),
+                uncategorized(Severity.ERROR),
+                uncategorized(Severity.INFORMATION));
+
+        assertThat(aggregator.collapseCheckStatus(findings)).isEqualTo(RubricResultStatus.UNACCEPTABLE);
+    }
+
+    @Test
+    @DisplayName("an error a category declared acceptable no longer fails its check")
+    void acceptableErrorDoesNotFailTheCheck() {
+        assertThat(aggregator.collapseCheckStatus(List.of(categorized(Severity.ERROR, true))))
+                .isEqualTo(RubricResultStatus.ACCEPTABLE_WITH_WARNINGS);
+    }
+
+    @Test
+    @DisplayName("an unacceptable category fails its check even at INFORMATION severity")
+    void unacceptableCategoryFailsTheCheck() {
+        assertThat(aggregator.collapseCheckStatus(List.of(categorized(Severity.INFORMATION, false))))
+                .isEqualTo(RubricResultStatus.UNACCEPTABLE);
+    }
+
+    @Test
+    @DisplayName("null or empty findings collapse to ACCEPTABLE")
+    void nullOrEmptyFindingsAreAcceptable() {
+        assertThat(aggregator.collapseCheckStatus(null)).isEqualTo(RubricResultStatus.ACCEPTABLE);
+        assertThat(aggregator.collapseCheckStatus(List.of())).isEqualTo(RubricResultStatus.ACCEPTABLE);
     }
 }

--- a/Java/validation/src/test/java/com/lantanagroup/link/validation/services/categoryoverride/CategoryOverrideEngineTest.java
+++ b/Java/validation/src/test/java/com/lantanagroup/link/validation/services/categoryoverride/CategoryOverrideEngineTest.java
@@ -1,0 +1,269 @@
+package com.lantanagroup.link.validation.services.categoryoverride;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.lantanagroup.link.validation.configs.ValidationPolicyConfig;
+import com.lantanagroup.link.validation.entities.Category;
+import com.lantanagroup.link.validation.entities.CategorySeverity;
+import com.lantanagroup.link.validation.entities.Result;
+import com.lantanagroup.link.validation.enums.CategoryMatchStrategy;
+import com.lantanagroup.link.validation.enums.CategoryOverrideScope;
+import com.lantanagroup.link.validation.enums.CheckType;
+import com.lantanagroup.link.validation.enums.PiqiDimension;
+import com.lantanagroup.link.validation.enums.Severity;
+import com.lantanagroup.link.validation.models.RawFinding;
+import com.lantanagroup.link.validation.services.CategorizationService;
+import com.lantanagroup.link.validation.services.execution.EvaluatedFinding;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+@ExtendWith(MockitoExtension.class)
+class CategoryOverrideEngineTest {
+
+    @Mock private CategorizationService categorizationService;
+
+    private final ValidationPolicyConfig config = new ValidationPolicyConfig();
+
+    private CategoryOverrideEngine engine;
+
+    @BeforeEach
+    void setUp() {
+        engine = new CategoryOverrideEngine(
+                categorizationService, new CategorySequenceProvider(new ObjectMapper()), config);
+    }
+
+    private static Category category(String id, CategorySeverity severity, boolean acceptable) {
+        Category category = new Category();
+        category.setId(id);
+        category.setTitle(id);
+        category.setSeverity(severity);
+        category.setAcceptable(acceptable);
+        category.setGuidance("guidance");
+        return category;
+    }
+
+    private static RawFinding finding(String checkLocalId, Severity severity) {
+        return RawFinding.builder()
+                .checkLocalId(checkLocalId)
+                .dimension(PiqiDimension.CONFORMANCE)
+                .severity(severity)
+                .code("fhir-conformance")
+                .message("some validator message")
+                .build();
+    }
+
+    /** Every Result handed to categorization comes back carrying these categories. */
+    private void categorizeWith(Category... categories) {
+        doAnswer(invocation -> {
+            List<Result> results = invocation.getArgument(0);
+            results.forEach(r -> r.setCategories(List.of(categories)));
+            return null;
+        }).when(categorizationService).categorize(anyList());
+    }
+
+    private void enable(CategoryMatchStrategy strategy) {
+        config.getCategoryOverride().setEnabled(true);
+        config.getCategoryOverride().setMatchStrategy(strategy);
+    }
+
+    // ------------------------------------------------------------------
+    // Feature flag
+    // ------------------------------------------------------------------
+
+    @Test
+    void disabledLeavesEveryFindingUntouchedAndNeverCategorizes() {
+        List<EvaluatedFinding> evaluated = engine.apply(
+                List.of(finding("c1", Severity.ERROR), finding("c2", Severity.WARNING)),
+                Map.of("c1", CheckType.FHIR_CONFORMANCE, "c2", CheckType.TERMINOLOGY));
+
+        assertEquals(2, evaluated.size());
+        assertEquals(Severity.ERROR, evaluated.get(0).effectiveSeverity());
+        assertNull(evaluated.get(0).acceptable(), "acceptable must stay unknown when disabled");
+        assertTrue(evaluated.get(0).categoryIds().isEmpty());
+        // Also a performance guarantee: the disabled path must not read the category table at all.
+        verifyNoInteractions(categorizationService);
+    }
+
+    @Test
+    void enabledWithNoMatchesBehavesExactlyLikeDisabled() {
+        enable(CategoryMatchStrategy.WORST_OF);
+        categorizeWith();
+
+        List<EvaluatedFinding> evaluated = engine.apply(
+                List.of(finding("c1", Severity.ERROR)), Map.of("c1", CheckType.FHIR_CONFORMANCE));
+
+        assertEquals(Severity.ERROR, evaluated.get(0).effectiveSeverity());
+        assertNull(evaluated.get(0).acceptable());
+    }
+
+    @Test
+    void noFindingsProducesNoDecisions() {
+        assertTrue(engine.apply(List.of(), Map.of()).isEmpty());
+    }
+
+    // ------------------------------------------------------------------
+    // WORST_OF
+    // ------------------------------------------------------------------
+
+    @Test
+    void aSingleCategoryAppliesItsSeverityAndAcceptability() {
+        enable(CategoryMatchStrategy.WORST_OF);
+        categorizeWith(category("cat-a", CategorySeverity.WARNING, true));
+
+        EvaluatedFinding evaluated = engine.apply(
+                List.of(finding("c1", Severity.ERROR)), Map.of("c1", CheckType.FHIR_CONFORMANCE)).get(0);
+
+        assertEquals(Severity.ERROR, evaluated.originalSeverity());
+        assertEquals(Severity.WARNING, evaluated.effectiveSeverity());
+        assertEquals(Boolean.TRUE, evaluated.acceptable());
+        assertEquals(List.of("cat-a"), evaluated.categoryIds());
+        assertEquals("cat-a", evaluated.governingCategoryId());
+        assertTrue(evaluated.severityWasOverridden());
+    }
+
+    @Test
+    void unacceptableBeatsAcceptableInEitherDeclarationOrder() {
+        enable(CategoryMatchStrategy.WORST_OF);
+
+        categorizeWith(category("a-yes", CategorySeverity.WARNING, true),
+                category("b-no", CategorySeverity.WARNING, false));
+        assertEquals(Boolean.FALSE, applyOne().acceptable());
+
+        categorizeWith(category("a-no", CategorySeverity.WARNING, false),
+                category("b-yes", CategorySeverity.WARNING, true));
+        assertEquals(Boolean.FALSE, applyOne().acceptable());
+    }
+
+    @Test
+    void theHighestSeverityWins() {
+        enable(CategoryMatchStrategy.WORST_OF);
+        categorizeWith(category("a", CategorySeverity.INFORMATION, true),
+                category("b", CategorySeverity.ERROR, true),
+                category("c", CategorySeverity.WARNING, true));
+
+        assertEquals(Severity.ERROR, applyOne().effectiveSeverity());
+    }
+
+    /**
+     * Severity and acceptable are combined independently, so the outcome can be a pair no single
+     * category declares — ERROR from one, unacceptable from the other.
+     */
+    @Test
+    void severityAndAcceptabilityAreCombinedIndependently() {
+        enable(CategoryMatchStrategy.WORST_OF);
+        categorizeWith(category("a-loud-but-fine", CategorySeverity.ERROR, true),
+                category("b-quiet-but-fatal", CategorySeverity.WARNING, false));
+
+        EvaluatedFinding evaluated = applyOne();
+
+        assertEquals(Severity.ERROR, evaluated.effectiveSeverity());
+        assertEquals(Boolean.FALSE, evaluated.acceptable());
+        assertEquals("b-quiet-but-fatal", evaluated.governingCategoryId(), "unacceptable governs");
+    }
+
+    /**
+     * Neither category is in categories.json here, so both are unsequenced and the documented final
+     * tie-break — category id — decides. Ordering stays total either way.
+     */
+    @Test
+    void tiesFallBackToCategoryIdOrder() {
+        enable(CategoryMatchStrategy.WORST_OF);
+        categorizeWith(category("zulu", CategorySeverity.WARNING, true),
+                category("alpha", CategorySeverity.WARNING, true));
+
+        assertEquals("alpha", applyOne().governingCategoryId());
+    }
+
+    // ------------------------------------------------------------------
+    // FIRST_MATCH
+    // ------------------------------------------------------------------
+
+    @Test
+    void firstMatchUsesOneCategoryOnly() {
+        enable(CategoryMatchStrategy.FIRST_MATCH);
+        categorizeWith(category("zulu", CategorySeverity.ERROR, false),
+                category("alpha", CategorySeverity.INFORMATION, true));
+
+        EvaluatedFinding evaluated = applyOne();
+
+        assertEquals(List.of("alpha"), evaluated.categoryIds(), "lowest sequence, then id");
+        assertEquals(Severity.INFORMATION, evaluated.effectiveSeverity());
+        assertEquals(Boolean.TRUE, evaluated.acceptable());
+    }
+
+    // ------------------------------------------------------------------
+    // Scope
+    // ------------------------------------------------------------------
+
+    @Test
+    void fhirOnlyScopeSkipsFindingsFromOtherCheckTypes() {
+        enable(CategoryMatchStrategy.WORST_OF);
+        config.getCategoryOverride().setScope(CategoryOverrideScope.FHIR_ONLY);
+        categorizeWith(category("cat-a", CategorySeverity.INFORMATION, true));
+
+        List<EvaluatedFinding> evaluated = engine.apply(
+                List.of(finding("c-conformance", Severity.ERROR), finding("c-terminology", Severity.ERROR)),
+                Map.of("c-conformance", CheckType.FHIR_CONFORMANCE, "c-terminology", CheckType.TERMINOLOGY));
+
+        assertEquals(Severity.INFORMATION, evaluated.get(0).effectiveSeverity());
+        assertEquals(Severity.ERROR, evaluated.get(1).effectiveSeverity(), "terminology finding untouched");
+        assertNull(evaluated.get(1).acceptable());
+    }
+
+    @Test
+    void fhirOnlyScopeWithNothingInScopeSkipsCategorizationEntirely() {
+        enable(CategoryMatchStrategy.WORST_OF);
+        config.getCategoryOverride().setScope(CategoryOverrideScope.FHIR_ONLY);
+
+        List<EvaluatedFinding> evaluated = engine.apply(
+                List.of(finding("c-terminology", Severity.ERROR)), Map.of("c-terminology", CheckType.TERMINOLOGY));
+
+        assertNull(evaluated.get(0).acceptable());
+        verifyNoInteractions(categorizationService);
+    }
+
+    // ------------------------------------------------------------------
+    // Resilience
+    // ------------------------------------------------------------------
+
+    /** One unusable rule in the category table must not fail the whole evaluation. */
+    @Test
+    void aCategorizationFailureFallsBackToUntouchedFindings() {
+        enable(CategoryMatchStrategy.WORST_OF);
+        doThrow(new IllegalStateException("No pattern specified"))
+                .when(categorizationService).categorize(anyList());
+
+        List<EvaluatedFinding> evaluated = engine.apply(
+                List.of(finding("c1", Severity.ERROR)), Map.of("c1", CheckType.FHIR_CONFORMANCE));
+
+        assertEquals(Severity.ERROR, evaluated.get(0).effectiveSeverity());
+        assertNull(evaluated.get(0).acceptable());
+    }
+
+    @Test
+    void aNullCheckTypeMapIsToleratedUnderAllChecks() {
+        enable(CategoryMatchStrategy.WORST_OF);
+        categorizeWith(category("cat-a", CategorySeverity.INFORMATION, true));
+
+        List<EvaluatedFinding> evaluated = engine.apply(List.of(finding("c1", Severity.ERROR)), null);
+
+        assertEquals(Severity.INFORMATION, evaluated.get(0).effectiveSeverity());
+    }
+
+    private EvaluatedFinding applyOne() {
+        return engine.apply(List.of(finding("c1", Severity.ERROR)), Map.of("c1", CheckType.FHIR_CONFORMANCE)).get(0);
+    }
+}

--- a/Java/validation/src/test/java/com/lantanagroup/link/validation/services/categoryoverride/FindingResultAdapterTest.java
+++ b/Java/validation/src/test/java/com/lantanagroup/link/validation/services/categoryoverride/FindingResultAdapterTest.java
@@ -1,0 +1,143 @@
+package com.lantanagroup.link.validation.services.categoryoverride;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.lantanagroup.link.validation.entities.Result;
+import com.lantanagroup.link.validation.enums.PiqiDimension;
+import com.lantanagroup.link.validation.enums.Severity;
+import com.lantanagroup.link.validation.matchers.Matcher;
+import com.lantanagroup.link.validation.models.RawFinding;
+import org.hl7.fhir.r4.model.OperationOutcome;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Rubric check executors emit their own codes, none of which are FHIR IssueType codes, and there
+ * are two ways that could turn into an error response: {@code IssueType.fromCode} throwing, and
+ * persisting a Result whose non-nullable code column is null. The adapter closes both — it never
+ * calls fromCode unguarded, and its Result is transient, never persisted.
+ */
+class FindingResultAdapterTest {
+
+    /** Every code any executor in this service actually emits. */
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "fhir-conformance",
+            "check-execution-error",
+            "fhirpath-evaluation-error",
+            "terminology-code-invalid",
+            "valueset-membership-failed",
+            "custom-check-not-found",
+            "custom-check-error",
+            "not-a-fhir-code-at-all",
+            "Rule dom-6",
+    })
+    void noExecutorCodeCanThrow(String code) {
+        assertDoesNotThrow(() -> IssueTypes.parseOrNull(code));
+    }
+
+    @Test
+    void anUnknownCodeBecomesNullRatherThanAnException() {
+        assertNull(IssueTypes.parseOrNull("fhir-conformance"));
+        assertNull(IssueTypes.parseOrNull("not-a-fhir-code-at-all"));
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    @ValueSource(strings = {"   "})
+    void blankCodesBecomeNull(String code) {
+        assertNull(IssueTypes.parseOrNull(code));
+    }
+
+    @Test
+    void aRealFhirCodeStillResolves() {
+        assertEquals(OperationOutcome.IssueType.CODEINVALID, IssueTypes.parseOrNull("code-invalid"));
+    }
+
+    /**
+     * Without these aliases the one rule in categories.json that matches on CODE
+     * (invalid_code_in_required_valueset, requiring code-invalid) could never match a rubric finding.
+     */
+    @Test
+    void rubricCodesWithAnUnambiguousEquivalentAreAliased() {
+        assertEquals(OperationOutcome.IssueType.CODEINVALID, IssueTypes.parseOrNull("terminology-code-invalid"));
+        assertEquals(OperationOutcome.IssueType.CODEINVALID, IssueTypes.parseOrNull("valueset-membership-failed"));
+        assertEquals(OperationOutcome.IssueType.PROCESSING, IssueTypes.parseOrNull("check-execution-error"));
+    }
+
+    /** Confirms the underlying call really does throw, so the try/catch is not decorative. */
+    @Test
+    void theUnguardedFhirCallWouldHaveThrown() {
+        assertThrows(Exception.class, () -> OperationOutcome.IssueType.fromCode("fhir-conformance"));
+    }
+
+    // ------------------------------------------------------------------
+    // Adapter
+    // ------------------------------------------------------------------
+
+    @Test
+    void severityIsMappedWithoutFromCode() {
+        assertEquals(OperationOutcome.IssueSeverity.ERROR, adapt(Severity.ERROR, "x").getSeverity());
+        assertEquals(OperationOutcome.IssueSeverity.WARNING, adapt(Severity.WARNING, "x").getSeverity());
+        assertEquals(OperationOutcome.IssueSeverity.INFORMATION, adapt(Severity.INFORMATION, "x").getSeverity());
+        assertNull(adapt(null, "x").getSeverity());
+    }
+
+    @Test
+    void messageAndExpressionCarryThroughForMatching() {
+        Result result = adapt(Severity.ERROR, "fhir-conformance");
+
+        assertEquals("some validator message", result.getMessage());
+        assertEquals("Patient.name[0]", result.getExpression());
+        assertNull(result.getCode(), "a rubric code has no FHIR IssueType");
+    }
+
+    /**
+     * A null code must not break matching. This is the same contract CategoryController relies on
+     * when it validates a submitted rule against a completely empty Result.
+     */
+    @Test
+    void matchersStillWorkAgainstAnAdaptedFindingWithNoCode() throws Exception {
+        Matcher matcher = new ObjectMapper().readValue("""
+                {
+                  "children": [
+                    { "field": "MESSAGE", "regex": "validator message" },
+                    { "field": "CODE", "regex": "^code-invalid$" }
+                  ],
+                  "requiresAllChildren": false
+                }
+                """, Matcher.class);
+        Result result = adapt(Severity.ERROR, "fhir-conformance");
+
+        assertTrue(assertDoesNotThrow(() -> matcher.isMatch(result)), "MESSAGE branch must still match");
+    }
+
+    @Test
+    void aCodeOnlyRuleSimplyDoesNotMatchAnUnmappedCode() throws Exception {
+        Matcher matcher = new ObjectMapper()
+                .readValue("{ \"field\": \"CODE\", \"regex\": \"^code-invalid$\" }", Matcher.class);
+
+        assertFalse(matcher.isMatch(adapt(Severity.ERROR, "fhir-conformance")));
+        assertTrue(matcher.isMatch(adapt(Severity.ERROR, "terminology-code-invalid")), "via alias");
+    }
+
+    private static Result adapt(Severity severity, String code) {
+        return FindingResultAdapter.toTransientResult(RawFinding.builder()
+                .checkLocalId("c1")
+                .dimension(PiqiDimension.CONFORMANCE)
+                .severity(severity)
+                .code(code)
+                .message("some validator message")
+                .location("Patient.name[0]")
+                .expression("Patient.name[0]")
+                .build());
+    }
+}

--- a/Java/validation/src/test/java/com/lantanagroup/link/validation/services/scoring/FindingStatusResolverTest.java
+++ b/Java/validation/src/test/java/com/lantanagroup/link/validation/services/scoring/FindingStatusResolverTest.java
@@ -1,0 +1,76 @@
+package com.lantanagroup.link.validation.services.scoring;
+
+import com.lantanagroup.link.validation.enums.PiqiDimension;
+import com.lantanagroup.link.validation.enums.RubricResultStatus;
+import com.lantanagroup.link.validation.enums.Severity;
+import com.lantanagroup.link.validation.models.RawFinding;
+import com.lantanagroup.link.validation.services.execution.EvaluatedFinding;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * The precedence rule, exhaustively. The {@code acceptable = null} rows are the important ones:
+ * they are the pre-override severity mapping, so a finding no category matched is never downgraded
+ * just because the override feature exists.
+ */
+class FindingStatusResolverTest {
+
+    private final FindingStatusResolver resolver = new FindingStatusResolver();
+
+    private static EvaluatedFinding finding(Severity effective, Boolean acceptable) {
+        RawFinding raw = RawFinding.builder()
+                .checkLocalId("c1")
+                .dimension(PiqiDimension.CONFORMANCE)
+                .severity(effective)
+                .build();
+        if (acceptable == null) {
+            return EvaluatedFinding.identity(raw);
+        }
+        return new EvaluatedFinding(raw, effective, effective, acceptable, List.of("cat-1"), "cat-1");
+    }
+
+    @ParameterizedTest(name = "acceptable={0}, severity={1} -> {2}")
+    @CsvSource({
+            "false, ERROR,       UNACCEPTABLE",
+            "false, WARNING,     UNACCEPTABLE",
+            "false, INFORMATION, UNACCEPTABLE",
+            "true,  ERROR,       ACCEPTABLE_WITH_WARNINGS",
+            "true,  WARNING,     ACCEPTABLE_WITH_WARNINGS",
+            "true,  INFORMATION, ACCEPTABLE",
+    })
+    void categorizedFindingsFollowAcceptableFirst(boolean acceptable, Severity severity, RubricResultStatus expected) {
+        assertEquals(expected, resolver.statusOf(finding(severity, acceptable)));
+    }
+
+    @ParameterizedTest(name = "uncategorized {0} -> {1}")
+    @CsvSource({
+            "ERROR,       UNACCEPTABLE",
+            "WARNING,     ACCEPTABLE_WITH_WARNINGS",
+            "INFORMATION, ACCEPTABLE",
+    })
+    void uncategorizedFindingsKeepThePreOverrideMapping(Severity severity, RubricResultStatus expected) {
+        assertEquals(expected, resolver.statusOf(finding(severity, null)));
+    }
+
+    /** The regression that matters most: no silent downgrade when acceptable is unknown. */
+    @Test
+    void anUncategorizedErrorIsNeverDowngraded() {
+        assertEquals(RubricResultStatus.UNACCEPTABLE, resolver.statusOf(finding(Severity.ERROR, null)));
+    }
+
+    /** The point of the feature: a category may declare an error acceptable, and that must hold. */
+    @Test
+    void anAcceptableErrorNoLongerFailsTheResult() {
+        assertEquals(RubricResultStatus.ACCEPTABLE_WITH_WARNINGS, resolver.statusOf(finding(Severity.ERROR, true)));
+    }
+
+    @Test
+    void aNullSeverityIsTreatedAsNoSignalRatherThanThrowing() {
+        assertEquals(RubricResultStatus.ACCEPTABLE, resolver.statusOf(finding(null, null)));
+    }
+}

--- a/Java/validation/src/test/java/com/lantanagroup/link/validation/services/scoring/ScoringPolicyResolverTest.java
+++ b/Java/validation/src/test/java/com/lantanagroup/link/validation/services/scoring/ScoringPolicyResolverTest.java
@@ -1,0 +1,78 @@
+package com.lantanagroup.link.validation.services.scoring;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.lantanagroup.link.validation.configs.ValidationPolicyConfig;
+import com.lantanagroup.link.validation.enums.RollupStrategy;
+import com.lantanagroup.link.validation.enums.ScoringPolicyType;
+import com.lantanagroup.link.validation.models.ScoringPolicyDto;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Rollup precedence is rubric version, then configuration, then WORST_OF. A rubric's persisted
+ * scoringPolicy.rollup is a deliberate per-rubric decision, so configuration only fills gaps —
+ * otherwise setting validation.scoring.rollup would silently restate every existing rubric.
+ */
+class ScoringPolicyResolverTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final ValidationPolicyConfig config = new ValidationPolicyConfig();
+    private final ScoringPolicyResolver resolver = new ScoringPolicyResolver(config, objectMapper);
+
+    @Test
+    void theRubricVersionRollupWinsOverConfiguration() {
+        config.getScoring().setRollup(RollupStrategy.MAJORITY);
+
+        ScoringPolicyDto resolved = resolver.resolve(
+                "{\"type\":\"piqi-check-scorecard\",\"rollup\":\"best-of\"}");
+
+        assertEquals(RollupStrategy.BEST_OF, resolved.getRollup());
+        assertEquals(ScoringPolicyType.PIQI_CHECK_SCORECARD, resolved.getType());
+    }
+
+    @Test
+    void configurationFillsInARollupTheRubricDoesNotName() {
+        config.getScoring().setRollup(RollupStrategy.MAJORITY);
+
+        ScoringPolicyDto resolved = resolver.resolve("{\"type\":\"piqi-check-scorecard\"}");
+
+        assertEquals(RollupStrategy.MAJORITY, resolved.getRollup());
+    }
+
+    @Test
+    void worstOfIsTheFallbackWhenNeitherNamesOne() {
+        ScoringPolicyDto resolved = resolver.resolve("{\"type\":\"piqi-check-scorecard\"}");
+
+        assertEquals(RollupStrategy.WORST_OF, resolved.getRollup());
+    }
+
+    @Test
+    void aMissingPolicyFallsBackToTheDimensionScorecard() {
+        ScoringPolicyDto resolved = resolver.resolve((String) null);
+
+        assertEquals(ScoringPolicyType.PIQI_DIMENSION_SCORECARD, resolved.getType());
+        assertEquals(RollupStrategy.WORST_OF, resolved.getRollup());
+    }
+
+    /** The seeded rubrics declare worst-of explicitly, so configuration must not be able to move them. */
+    @Test
+    void configurationCannotOverrideAnExplicitRubricRollup() {
+        config.getScoring().setRollup(RollupStrategy.PASS_FAIL);
+
+        ScoringPolicyDto resolved = resolver.resolve(
+                "{\"type\":\"piqi-dimension-scorecard\",\"rollup\":\"worst-of\"}");
+
+        assertEquals(RollupStrategy.WORST_OF, resolved.getRollup());
+    }
+
+    /** A missing rollup now also respects configuration when the whole policy JSON is absent. */
+    @Test
+    void configurationAppliesWhenThePolicyJsonIsAbsent() {
+        config.getScoring().setRollup(RollupStrategy.MAJORITY);
+
+        ScoringPolicyDto resolved = resolver.resolve((String) null);
+
+        assertEquals(RollupStrategy.MAJORITY, resolved.getRollup());
+    }
+}


### PR DESCRIPTION
- Category rules can now override a finding's severity and acceptability (configurable scope and match strategy via validation.categoryOverride).
- Per-check statuses are derived after the override, so an acceptable error no longer fails its check while uncategorized errors still do.
- Scoring rollup precedence: rubric policy > validation.scoring config >
  WORST_OF; ALL_MUST_PASS now behaves as WORST_OF.
- Findings expose originalSeverity/overriddenSeverity/acceptable/category ids.

### 🛠️ Description of Changes

Please provide a high-level overview of the changes included in this PR.

### 🧪 Testing Performed

Please describe the testing that was performed on the changes included in this PR.

### 🧑‍🔬 Unit Testing

- [ ] I have written or updated unit tests to cover my changes
- Coverage: 

### 📓 Documentation Updated

Please update any relevant sections in the project documentation that were impacted by the changes in the PR.
