### PR TITLE
TECH_DEBT: Remove duplicate index creation

### DIFF
--- a/DotNet/Automation.UI/Services/Persistence/GeneratedTemplateCacheVersionStore.cs
+++ b/DotNet/Automation.UI/Services/Persistence/GeneratedTemplateCacheVersionStore.cs
@@ -34,12 +34,6 @@ public sealed class GeneratedTemplateCacheVersionStore
     public GeneratedTemplateCacheVersionStore(IMongoDatabase database)
     {
         _versions = database.GetCollection<GeneratedTemplateCacheVersionDocument>("automation_generated_template_versions");
-        var uniqueScenarioHashIndex = new CreateIndexModel<GeneratedTemplateCacheVersionDocument>(
-            Builders<GeneratedTemplateCacheVersionDocument>.IndexKeys
-                .Ascending(version => version.ScenarioKey)
-                .Ascending(version => version.TemplateSetHash),
-            new CreateIndexOptions { Unique = true, Name = ScenarioHashUniqueIndexName });
-        _versions.Indexes.CreateOne(uniqueScenarioHashIndex);
     }
 
     public async Task<GeneratedTemplateCacheVersionBinding?> BindRunAsync(


### PR DESCRIPTION
The index created as `ux_generated_template_versions_scenario_hash` in the `GeneratedTemplateCacheVersionStore` constructor is already created as `idx_scenarioKey_templateSetHash` in `MongoIndexManager`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved template cache persistence compatibility by removing automatic creation of a MongoDB index during initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


### 🧑‍🔬 Unit Testing
- Coverage: 0.0%