### PR TITLE
LEGLINK-951: Return 404 from DMRP endpoints when the module is disabled

### DIFF
--- a/DotNet/DMRP/DependencyInjection/DmrpModuleExtensions.cs
+++ b/DotNet/DMRP/DependencyInjection/DmrpModuleExtensions.cs
@@ -35,6 +35,16 @@ namespace LantanaGroup.Link.DMRP.DependencyInjection
 
             if (section.Get<DmrpSettings>()?.Enabled != true)
             {
+                // The host's build emits [assembly: ApplicationPart("DMRP")] for the project reference,
+                // so MVC discovers this module's controllers before AddDmrpModule runs. Left in place
+                // without their services, those controllers turn every DMRP request into a 500; strip
+                // the part so a disabled module has no routes at all.
+                var moduleAssemblyName = typeof(DmrpModuleExtensions).Assembly.GetName().Name;
+                foreach (var part in mvcBuilder.PartManager.ApplicationParts.Where(p => p.Name == moduleAssemblyName).ToList())
+                {
+                    mvcBuilder.PartManager.ApplicationParts.Remove(part);
+                }
+
                 return false;
             }
 

--- a/DotNet/ServiceTests/UnitTests/DMRP/DmrpModuleExtensionsTests.cs
+++ b/DotNet/ServiceTests/UnitTests/DMRP/DmrpModuleExtensionsTests.cs
@@ -145,5 +145,30 @@ namespace UnitTests.DMRP
             var dmrpAssembly = typeof(MeasureMapping).Assembly;
             Assert.DoesNotContain(mvcBuilder.PartManager.ApplicationParts, p => p.Name == dmrpAssembly.GetName().Name);
         }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(null)]
+        public void AddDmrpModule_removes_the_hosts_auto_discovered_part_when_disabled(bool? enabled)
+        {
+            var builder = CreateBuilder(enabled);
+            var mvcBuilder = builder.Services.AddControllers();
+
+            // The Tenant build emits [assembly: ApplicationPart("DMRP")] for the project reference, so
+            // in the real host the module's assembly is an application part before AddDmrpModule runs.
+            // Recreate that here: the module must strip the part, or its controllers would be routable
+            // without their services and every DMRP request would 500 instead of 404.
+            var dmrpAssembly = typeof(MeasureMapping).Assembly;
+            mvcBuilder.AddApplicationPart(dmrpAssembly);
+
+            var registered = builder.AddDmrpModule<TenantDbContext>(mvcBuilder);
+
+            Assert.False(registered);
+            Assert.DoesNotContain(mvcBuilder.PartManager.ApplicationParts, p => p.Name == dmrpAssembly.GetName().Name);
+
+            var controllers = new ControllerFeature();
+            mvcBuilder.PartManager.PopulateFeature(controllers);
+            Assert.DoesNotContain(controllers.Controllers, c => c.Assembly == dmrpAssembly);
+        }
     }
 }


### PR DESCRIPTION
The Tenant build emits [assembly: ApplicationPart(DMRP)] for the DMRP project reference, so AddControllers() discovered the module's controllers even when DMRP:Enabled was false or missing. With no DMRP services registered, activating those controllers threw InvalidOperationException and every DMRP request returned 500.

AddDmrpModule now strips the module's application part when the flag is off, so the routes are never mapped and requests fall through to 404.

Claude-Session: https://claude.ai/code/session_01LVVXQjfgjXC4WwHtciJYEJ

### 🛠️ Description of Changes

Please provide a high-level overview of the changes included in this PR.

### 🧪 Testing Performed

Please describe the testing that was performed on the changes included in this PR.

### 🧑‍🔬 Unit Testing

- [ ] I have written or updated unit tests to cover my changes
- Coverage: 100.0%

### 📓 Documentation Updated

Please update any relevant sections in the project documentation that were impacted by the changes in the PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Disabled DMRP modules no longer expose their controllers as application routes.
  * Prevented unintended controller discovery when DMRP is disabled or not configured.

* **Tests**
  * Added coverage verifying that disabled DMRP configuration removes its application routes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
