### PR TITLE
TECH_DEBT: Generate the Mock DMRP API schema script in the DB migration pipeline

### DIFF
--- a/Azure_Pipelines/azure-pipelines.db-schema-creation.yaml
+++ b/Azure_Pipelines/azure-pipelines.db-schema-creation.yaml
@@ -34,6 +34,11 @@ parameters:
     - name: data
       artifact: data-db
       file: dataDb.sql
+    # No mock-dmrp entry. The Build stage publishes mock-dmrp-db, but no environment has a
+    # Mock DMRP database yet -- the service has no rows in any App Configuration store, so
+    # the apply stages have nothing to target. Add an entry here once one is provisioned,
+    # and note that ${{ db.name }} becomes a job identifier: it must be a single word with
+    # no hyphen, so 'mockdmrp' rather than 'mock-dmrp'.
     - name: normalization
       artifact: normalization-db
       file: normalizationDb.sql
@@ -101,7 +106,7 @@ stages:
             $changedFiles | Out-File -FilePath $changedFilesFile -Encoding utf8
 
             # List of DotNet services to check
-            $dotnetServices = @("Account", "Audit", "Census", "Normalization", "QueryDispatch", "Report", "Submission", "Tenant" ) 
+            $dotnetServices = @("Account", "Audit", "Census", "MockDmrpApi", "Normalization", "QueryDispatch", "Report", "Submission", "Tenant" )
             $javaServices = @("validation" )
             $dataAcquisition = @("DataAcquisition" )
 
@@ -254,7 +259,30 @@ stages:
          PathtoPublish: '$(Build.ArtifactStagingDirectory)/DatabaseScripts/dataDb.sql'
          ArtifactName: 'data-db'
          publishLocation: 'container'
-        displayName: Publish Data Acquisition SQL Script  
+        displayName: Publish Data Acquisition SQL Script
+  ###
+  # MockDmrpApi
+  - job: MockDmrpApi
+    displayName: "Generate Mock DMRP API Schema Script"
+    steps:
+      - script: |
+          cd DotNet/MockDmrpApi
+          dotnet new tool-manifest --force
+          dotnet tool install dotnet-ef --version 8.0.22
+          dotnet tool restore
+          dotnet tool run dotnet-ef --version
+        displayName: Install dotnet-ef (local pinned)
+      - script: |
+          cd DotNet/MockDmrpApi
+          mkdir -p $(build.artifactstagingdirectory)/DatabaseScripts
+          dotnet tool run dotnet-ef migrations script --idempotent --verbose -c ReportingPlanDbContext -s $(build.sourcesdirectory)/DotNet/MockDmrpApi/MockDmrpApi.csproj -p $(build.sourcesdirectory)/DotNet/MockDmrpApi/MockDmrpApi.csproj -o $(build.artifactstagingdirectory)/DatabaseScripts/mockDmrpDb.sql
+        displayName: Generate Mock DMRP API SQL Script
+      - task: PublishBuildArtifacts@1
+        inputs:
+         PathtoPublish: '$(Build.ArtifactStagingDirectory)/DatabaseScripts/mockDmrpDb.sql'
+         ArtifactName: 'mock-dmrp-db'
+         publishLocation: 'container'
+        displayName: Publish Mock DMRP API SQL Script
   ###
   # Normalization
   - job: Normalization


### PR DESCRIPTION
### 🛠️ Description of Changes

`MockDmrpApi` was the only .NET service with an EF `Migrations/` folder that had no job in the database schema pipeline, so a migration added there produced no SQL script and went unreported in the `changedServices` artifact. This adds the missing Build-stage job.

- Add a `MockDmrpApi` job to `azure-pipelines.db-schema-creation.yaml` that generates an idempotent script for `ReportingPlanDbContext` and publishes it as the `mock-dmrp-db` artifact. Placed between DataAcquisition and Normalization to hold the file's existing ordering, and follows the same pinned `dotnet-ef 8.0.22` local-tool pattern as its siblings.
- Add `MockDmrpApi` to the `$dotnetServices` change-detection list. The existing loop checks `Dotnet/$service/migrations` and PowerShell `-like` is case-insensitive, so it matches the `DotNet/MockDmrpApi/Migrations` path as written.
- Leave the `parameters.databases` list — and therefore the TEST/QA/QA2 apply stages — unchanged, with a comment recording why.

No files were deleted or renamed. One file changed, +30 / -2.

**Why the apply stages are deliberately excluded.** There is no Mock DMRP database in any environment yet: the service has no rows in any of the four App Configuration stores, including no `ConnectionStrings:DatabaseConnection` under a `MockDmrpApi` label, and the global catalog entry's `consumers` list does not include it. `app-config.yaml` already records this ("Marked optional only because no environment has been provisioned yet"). An apply entry would target a database that does not exist.

There is also a structural constraint worth capturing for whoever adds the entry later, which the in-file comment notes: the apply stages interpolate `${{ db.name }}` into a job identifier (`Update_${{ db.name }}_TEST`), and Azure DevOps job identifiers permit only alphanumerics and underscores. A hyphenated `mock-dmrp` would fail the whole pipeline at compile time — every database, not just this one — which is why every existing entry is a single word.

### 🧪 Testing Performed

- Ran the job's exact command locally against the real project: `dotnet tool run dotnet-ef migrations script --idempotent -c ReportingPlanDbContext -s DotNet/MockDmrpApi/MockDmrpApi.csproj -p DotNet/MockDmrpApi/MockDmrpApi.csproj`. Build succeeded and it produced a 1540-byte idempotent script creating the `MockDmrpEntries` table and the `__EFMigrationsHistory` guard.
- Confirmed the pinned `dotnet-ef 8.0.22` local-tool install path used by the sibling jobs works for this project, and removed the generated `dotnet-tools.json` afterwards so nothing extra is committed.
- Parsed the modified YAML to confirm it still loads, that the Build stage now contains the `MockDmrpApi` job, and that all 10 remaining `db.name` values are legal Azure DevOps job identifiers.
- Verified the change-detection path casing against the actual `DotNet/MockDmrpApi/Migrations/` folder.

### 🧑‍🔬 Unit Testing

- [ ] I have written or updated unit tests to cover my changes
- Coverage: 0.0%

### 📓 Documentation Updated

No documentation changes required. The rationale that would otherwise need documenting — why Mock DMRP is present in the Build stage but absent from the apply stages, and the hyphen constraint on `db.name` — is recorded as a comment at the point in the file where the next person would add the entry.

