### PR TITLE
LEGLINK-956: Return proper ProblemDetails payloads from Reporting Plan APIs

### DIFF
--- a/DotNet/DMRP/Controllers/FacilityReportingPlansController.cs
+++ b/DotNet/DMRP/Controllers/FacilityReportingPlansController.cs
@@ -53,7 +53,7 @@ namespace LantanaGroup.Link.DMRP.Controllers
         /// Get a paged list of facility reporting plans.
         /// </summary>
         [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(PagedFacilityReportingPlanDto))]
-        [ProducesResponseType(StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest, Type = typeof(ProblemDetails))]
         [ProducesResponseType(StatusCodes.Status500InternalServerError)]
         [HttpGet(Name = "GetFacilityReportingPlans")]
         public Task<IActionResult> GetFacilityReportingPlans(string? sortBy, SortOrder? sortOrder,
@@ -66,7 +66,7 @@ namespace LantanaGroup.Link.DMRP.Controllers
         /// period and reporting state.
         /// </summary>
         [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(PagedFacilityReportingPlanDto))]
-        [ProducesResponseType(StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest, Type = typeof(ProblemDetails))]
         [ProducesResponseType(StatusCodes.Status500InternalServerError)]
         [HttpGet("search", Name = "SearchFacilityReportingPlans")]
         public async Task<IActionResult> SearchFacilityReportingPlans([FromQuery] FacilityReportingPlanSearchFilters filters,
@@ -81,18 +81,18 @@ namespace LantanaGroup.Link.DMRP.Controllers
             var periodError = ValidatePeriodFilters(filters.Month, filters.Year);
             if (periodError is not null)
             {
-                return BadRequest(periodError);
+                return BadRequestProblem(periodError);
             }
 
             if (sortBy is not null && !SortableColumns.Contains(sortBy))
             {
-                return BadRequest($"Cannot sort by '{sortBy}'.");
+                return BadRequestProblem($"Cannot sort by '{sortBy}'.");
             }
 
             var pagingError = ValidatePaging(pageSize, pageNumber);
             if (pagingError is not null)
             {
-                return BadRequest(pagingError);
+                return BadRequestProblem(pagingError);
             }
 
             using Activity? activity = ServiceActivitySource.Instance.StartActivity("Search Facility Reporting Plans");
@@ -109,7 +109,7 @@ namespace LantanaGroup.Link.DMRP.Controllers
         /// reporting state.
         /// </summary>
         [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(List<FacilityReportingPlanModel>))]
-        [ProducesResponseType(StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest, Type = typeof(ProblemDetails))]
         [ProducesResponseType(StatusCodes.Status500InternalServerError)]
         [HttpGet("facilities/{facilityId}")]
         public async Task<IActionResult> GetFacilityReportingPlansForFacility(string facilityId, int? month, int? year,
@@ -120,7 +120,7 @@ namespace LantanaGroup.Link.DMRP.Controllers
             var periodError = ValidatePeriodFilters(month, year);
             if (periodError is not null)
             {
-                return BadRequest(periodError);
+                return BadRequestProblem(periodError);
             }
 
             using Activity? activity = ServiceActivitySource.Instance.StartActivity("Get Facility Reporting Plans For Facility");
@@ -134,7 +134,7 @@ namespace LantanaGroup.Link.DMRP.Controllers
         /// Gets a facility reporting plan by Id.
         /// </summary>
         [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(FacilityReportingPlanModel))]
-        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        [ProducesResponseType(StatusCodes.Status404NotFound, Type = typeof(ProblemDetails))]
         [ProducesResponseType(StatusCodes.Status500InternalServerError)]
         [HttpGet("{id}")]
         public async Task<IActionResult> GetFacilityReportingPlan(string id, CancellationToken cancellationToken)
@@ -145,7 +145,7 @@ namespace LantanaGroup.Link.DMRP.Controllers
 
             if (model == null)
             {
-                return NotFound();
+                return NotFoundProblem($"Facility reporting plan with Id: {id} not found.");
             }
 
             return Ok(model);
@@ -155,8 +155,8 @@ namespace LantanaGroup.Link.DMRP.Controllers
         /// Creates a facility reporting plan.
         /// </summary>
         [ProducesResponseType(StatusCodes.Status201Created, Type = typeof(FacilityReportingPlanModel))]
-        [ProducesResponseType(StatusCodes.Status400BadRequest)]
-        [ProducesResponseType(StatusCodes.Status409Conflict)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest, Type = typeof(ProblemDetails))]
+        [ProducesResponseType(StatusCodes.Status409Conflict, Type = typeof(ProblemDetails))]
         [ProducesResponseType(StatusCodes.Status500InternalServerError)]
         [HttpPost]
         public async Task<IActionResult> CreateFacilityReportingPlan(FacilityReportingPlanRequest request, CancellationToken cancellationToken)
@@ -169,11 +169,11 @@ namespace LantanaGroup.Link.DMRP.Controllers
             }
             catch (DuplicateReportingPlanException ex)
             {
-                return Conflict(ex.Message);
+                return Problem(ex.Message, statusCode: StatusCodes.Status409Conflict, title: "Conflict");
             }
             catch (ReportingPlanValidationException ex)
             {
-                return BadRequest(ex.Message);
+                return BadRequestProblem(ex.Message);
             }
             catch (Exception ex)
             {
@@ -190,9 +190,9 @@ namespace LantanaGroup.Link.DMRP.Controllers
         /// Updates a facility reporting plan.
         /// </summary>
         [ProducesResponseType(StatusCodes.Status202Accepted, Type = typeof(FacilityReportingPlanModel))]
-        [ProducesResponseType(StatusCodes.Status400BadRequest)]
-        [ProducesResponseType(StatusCodes.Status404NotFound)]
-        [ProducesResponseType(StatusCodes.Status409Conflict)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest, Type = typeof(ProblemDetails))]
+        [ProducesResponseType(StatusCodes.Status404NotFound, Type = typeof(ProblemDetails))]
+        [ProducesResponseType(StatusCodes.Status409Conflict, Type = typeof(ProblemDetails))]
         [ProducesResponseType(StatusCodes.Status500InternalServerError)]
         [HttpPut("{id}")]
         public async Task<IActionResult> UpdateFacilityReportingPlan(string id, FacilityReportingPlanUpdateRequest request, CancellationToken cancellationToken)
@@ -203,12 +203,12 @@ namespace LantanaGroup.Link.DMRP.Controllers
 
             if (string.IsNullOrWhiteSpace(requestId))
             {
-                return BadRequest("Id is required in the request body.");
+                return BadRequestProblem("Id is required in the request body.");
             }
 
             if (requestId != id)
             {
-                return BadRequest("Id in the URL must match the Id in the request body.");
+                return BadRequestProblem("Id in the URL must match the Id in the request body.");
             }
 
             try
@@ -217,15 +217,15 @@ namespace LantanaGroup.Link.DMRP.Controllers
             }
             catch (KeyNotFoundException ex)
             {
-                return NotFound(ex.Message);
+                return NotFoundProblem(ex.Message);
             }
             catch (DuplicateReportingPlanException ex)
             {
-                return Conflict(ex.Message);
+                return Problem(ex.Message, statusCode: StatusCodes.Status409Conflict, title: "Conflict");
             }
             catch (ReportingPlanValidationException ex)
             {
-                return BadRequest(ex.Message);
+                return BadRequestProblem(ex.Message);
             }
             catch (Exception ex)
             {
@@ -265,7 +265,7 @@ namespace LantanaGroup.Link.DMRP.Controllers
         /// Deletes a facility reporting plan.
         /// </summary>
         [ProducesResponseType(StatusCodes.Status204NoContent)]
-        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        [ProducesResponseType(StatusCodes.Status404NotFound, Type = typeof(ProblemDetails))]
         [ProducesResponseType(StatusCodes.Status500InternalServerError)]
         [HttpDelete("{id}")]
         public async Task<IActionResult> DeleteFacilityReportingPlan(string id, CancellationToken cancellationToken)
@@ -278,7 +278,7 @@ namespace LantanaGroup.Link.DMRP.Controllers
             }
             catch (KeyNotFoundException ex)
             {
-                return NotFound(ex.Message);
+                return NotFoundProblem(ex.Message);
             }
             catch (Exception ex)
             {
@@ -293,7 +293,7 @@ namespace LantanaGroup.Link.DMRP.Controllers
         /// Deletes every reporting plan belonging to a facility.
         /// </summary>
         [ProducesResponseType(StatusCodes.Status204NoContent)]
-        [ProducesResponseType(StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest, Type = typeof(ProblemDetails))]
         [ProducesResponseType(StatusCodes.Status500InternalServerError)]
         [HttpDelete("facilities/{facilityId}")]
         public async Task<IActionResult> DeleteFacilityReportingPlansForFacility(string facilityId, CancellationToken cancellationToken)
@@ -302,7 +302,7 @@ namespace LantanaGroup.Link.DMRP.Controllers
 
             if (facilityId is null)
             {
-                return BadRequest("FacilityId is required.");
+                return BadRequestProblem("FacilityId is required.");
             }
 
             try
@@ -356,6 +356,12 @@ namespace LantanaGroup.Link.DMRP.Controllers
 
             return null;
         }
+
+        private ObjectResult BadRequestProblem(string detail) =>
+            Problem(detail, statusCode: StatusCodes.Status400BadRequest, title: "Bad Request");
+
+        private ObjectResult NotFoundProblem(string detail) =>
+            Problem(detail, statusCode: StatusCodes.Status404NotFound, title: "Not Found");
 
         private static string? NullIfBlank(string? value) => string.IsNullOrWhiteSpace(value) ? null : value;
 

--- a/DotNet/ServiceTests/IntegrationTests/DMRP/FacilityReportingPlansControllerTests.cs
+++ b/DotNet/ServiceTests/IntegrationTests/DMRP/FacilityReportingPlansControllerTests.cs
@@ -110,6 +110,18 @@ public class FacilityReportingPlansControllerTests : IDisposable
         return (FacilityReportingPlanModel)Assert.IsType<CreatedResult>(result).Value!;
     }
 
+    private static ProblemDetails AssertProblem(IActionResult result, int status, string title)
+    {
+        var obj = Assert.IsType<ObjectResult>(result);
+        Assert.Equal(status, obj.StatusCode);
+
+        var problem = Assert.IsType<ProblemDetails>(obj.Value);
+        Assert.Equal(status, problem.Status);
+        Assert.Equal(title, problem.Title);
+
+        return problem;
+    }
+
     [Fact]
     public async Task CreateFacilityReportingPlan_ThenGet_RoundTripsEveryField()
     {
@@ -134,14 +146,18 @@ public class FacilityReportingPlansControllerTests : IDisposable
     }
 
     [Fact]
-    public async Task CreateFacilityReportingPlan_DuplicatePeriod_ReturnsConflict()
+    public async Task CreateFacilityReportingPlan_DuplicatePeriod_ReturnsConflictProblemDetails()
     {
         var request = await ValidRequestAsync();
 
         await _controller.CreateFacilityReportingPlan(request, CancellationToken.None);
-        var second = await _controller.CreateFacilityReportingPlan(request, CancellationToken.None);
+        var secondResult = await _controller.CreateFacilityReportingPlan(request, CancellationToken.None);
 
-        Assert.IsType<ConflictObjectResult>(second);
+        var problem = AssertProblem(secondResult, StatusCodes.Status409Conflict, "Conflict");
+        Assert.Equal(
+            $"A reporting plan already exists for facility {request.FacilityId}, measure mapping " +
+            $"{request.MeasureMappingId} and period {request.ReportingMonth}/{request.ReportingYear}.",
+            problem.Detail);
     }
 
     [Fact]
@@ -152,8 +168,8 @@ public class FacilityReportingPlansControllerTests : IDisposable
 
         var result = await _controller.CreateFacilityReportingPlan(request, CancellationToken.None);
 
-        var badRequest = Assert.IsType<BadRequestObjectResult>(result);
-        Assert.Equal("MeasureMappingId is required.", badRequest.Value);
+        var problem = AssertProblem(result, StatusCodes.Status400BadRequest, "Bad Request");
+        Assert.Equal("MeasureMappingId is required.", problem.Detail);
     }
 
     [Fact]
@@ -164,7 +180,7 @@ public class FacilityReportingPlansControllerTests : IDisposable
 
         var result = await _controller.CreateFacilityReportingPlan(request, CancellationToken.None);
 
-        Assert.IsType<BadRequestObjectResult>(result);
+        AssertProblem(result, StatusCodes.Status400BadRequest, "Bad Request");
     }
 
     [Fact]
@@ -176,7 +192,7 @@ public class FacilityReportingPlansControllerTests : IDisposable
 
         var result = await _controller.CreateFacilityReportingPlan(await ValidRequestAsync(), CancellationToken.None);
 
-        Assert.IsType<BadRequestObjectResult>(result);
+        AssertProblem(result, StatusCodes.Status400BadRequest, "Bad Request");
     }
 
     [Fact]
@@ -184,7 +200,7 @@ public class FacilityReportingPlansControllerTests : IDisposable
     {
         var result = await _controller.CreateFacilityReportingPlan(await ValidRequestAsync(month: 13), CancellationToken.None);
 
-        Assert.IsType<BadRequestObjectResult>(result);
+        AssertProblem(result, StatusCodes.Status400BadRequest, "Bad Request");
     }
 
     [Fact]
@@ -192,7 +208,7 @@ public class FacilityReportingPlansControllerTests : IDisposable
     {
         var result = await _controller.GetFacilityReportingPlan(Guid.NewGuid().ToString(), CancellationToken.None);
 
-        Assert.IsType<NotFoundResult>(result);
+        AssertProblem(result, StatusCodes.Status404NotFound, "Not Found");
     }
 
     [Fact]
@@ -237,7 +253,7 @@ public class FacilityReportingPlansControllerTests : IDisposable
     {
         var result = await _controller.GetFacilityReportingPlansForFacility(FacilityId, 0, null, null, CancellationToken.None);
 
-        Assert.IsType<BadRequestObjectResult>(result);
+        AssertProblem(result, StatusCodes.Status400BadRequest, "Bad Request");
     }
 
     [Fact]
@@ -277,7 +293,7 @@ public class FacilityReportingPlansControllerTests : IDisposable
         var result = await _controller.SearchFacilityReportingPlans(new FacilityReportingPlanSearchFilters(),
             sortBy: "DROP TABLE", sortOrder: null, pageSize: 10, pageNumber: 1, cancellationToken: CancellationToken.None);
 
-        Assert.IsType<BadRequestObjectResult>(result);
+        AssertProblem(result, StatusCodes.Status400BadRequest, "Bad Request");
     }
 
     [Theory]
@@ -315,6 +331,29 @@ public class FacilityReportingPlansControllerTests : IDisposable
     }
 
     [Fact]
+    public async Task UpdateFacilityReportingPlan_MovedOntoAnotherPlansPeriod_ReturnsConflictProblemDetails()
+    {
+        var first = await CreatedPlanAsync(month: 5);
+        var second = await CreatedPlanAsync(month: 6);
+
+        var result = await _controller.UpdateFacilityReportingPlan(second.Id!, new FacilityReportingPlanUpdateRequest
+        {
+            Id = second.Id,
+            FacilityId = first.FacilityId,
+            MeasureMappingId = first.MeasureMappingId,
+            ReportingMonth = first.ReportingMonth,
+            ReportingYear = first.ReportingYear,
+            IsReporting = second.IsReporting
+        }, CancellationToken.None);
+
+        var problem = AssertProblem(result, StatusCodes.Status409Conflict, "Conflict");
+        Assert.Equal(
+            $"A reporting plan already exists for facility {first.FacilityId}, measure mapping " +
+            $"{first.MeasureMappingId} and period {first.ReportingMonth}/{first.ReportingYear}.",
+            problem.Detail);
+    }
+
+    [Fact]
     public async Task UpdateFacilityReportingPlan_MismatchedId_ReturnsBadRequest()
     {
         var created = await CreatedPlanAsync();
@@ -322,7 +361,7 @@ public class FacilityReportingPlansControllerTests : IDisposable
         var result = await _controller.UpdateFacilityReportingPlan(created.Id!,
             new FacilityReportingPlanUpdateRequest { Id = Guid.NewGuid().ToString() }, CancellationToken.None);
 
-        Assert.IsType<BadRequestObjectResult>(result);
+        AssertProblem(result, StatusCodes.Status400BadRequest, "Bad Request");
     }
 
     [Fact]
@@ -333,7 +372,7 @@ public class FacilityReportingPlansControllerTests : IDisposable
 
         var result = await _controller.UpdateFacilityReportingPlan(unknownId, request, CancellationToken.None);
 
-        Assert.IsType<NotFoundObjectResult>(result);
+        AssertProblem(result, StatusCodes.Status404NotFound, "Not Found");
     }
 
     [Fact]
@@ -344,7 +383,7 @@ public class FacilityReportingPlansControllerTests : IDisposable
         var result = await _controller.UpdateFacilityReportingPlan(created.Id!,
             await ValidUpdateRequestAsync(id: null), CancellationToken.None);
 
-        Assert.IsType<BadRequestObjectResult>(result);
+        AssertProblem(result, StatusCodes.Status400BadRequest, "Bad Request");
     }
 
     [Fact]
@@ -361,7 +400,7 @@ public class FacilityReportingPlansControllerTests : IDisposable
             ReportingYear = created.ReportingYear
         }, CancellationToken.None);
 
-        Assert.IsType<BadRequestObjectResult>(result);
+        AssertProblem(result, StatusCodes.Status400BadRequest, "Bad Request");
     }
 
     [Fact]
@@ -373,7 +412,7 @@ public class FacilityReportingPlansControllerTests : IDisposable
         Assert.IsType<NoContentResult>(deleteResult);
 
         var getResult = await _controller.GetFacilityReportingPlan(created.Id!, CancellationToken.None);
-        Assert.IsType<NotFoundResult>(getResult);
+        AssertProblem(getResult, StatusCodes.Status404NotFound, "Not Found");
     }
 
     [Fact]
@@ -381,7 +420,7 @@ public class FacilityReportingPlansControllerTests : IDisposable
     {
         var result = await _controller.DeleteFacilityReportingPlan(Guid.NewGuid().ToString(), CancellationToken.None);
 
-        Assert.IsType<NotFoundObjectResult>(result);
+        AssertProblem(result, StatusCodes.Status404NotFound, "Not Found");
     }
 
     [Fact]

--- a/DotNet/Tenant/Program.cs
+++ b/DotNet/Tenant/Program.cs
@@ -158,7 +158,18 @@ namespace Tenant
             {
                 options.CustomizeProblemDetails = ctx =>
                 {
-                    ctx.ProblemDetails.Detail = "An error occured in our API. Please use the trace id when requesting assistence.";
+                    var statusCode = ctx.ProblemDetails.Status ?? ctx.HttpContext.Response.StatusCode;
+
+                    // A 500 may carry a raw exception message the caller should not see. Every
+                    // other status is framework- or controller-authored and already safe to show,
+                    // so only fall back to the generic text when nothing more specific was set
+                    // (matches the pattern Terminology and MockDmrpApi already use).
+                    if (statusCode == StatusCodes.Status500InternalServerError
+                        || string.IsNullOrWhiteSpace(ctx.ProblemDetails.Detail))
+                    {
+                        ctx.ProblemDetails.Detail = "An error occured in our API. Please use the trace id when requesting assistence.";
+                    }
+
                     if (!ctx.ProblemDetails.Extensions.ContainsKey("traceId"))
                     {
                         string? traceId = Activity.Current?.Id ?? ctx.HttpContext.TraceIdentifier;


### PR DESCRIPTION


### 🛠️ Description of Changes

Two fixes, both needed together:

- Tenant/Program.cs: CustomizeProblemDetails was unconditionally overwriting ProblemDetails.Detail on every response, discarding any specific message a controller had set. Now only falls back to the generic text for a 500 (which may carry raw exception text) or a genuinely empty detail, matching the pattern Terminology and MockDmrpApi already use.

- FacilityReportingPlansController: every hand-written BadRequest/ NotFound/Conflict call returned a bare string instead of ProblemDetails. Converted them all to Problem(...) via two new helpers (BadRequestProblem/NotFoundProblem), so callers get a structured type/title/status/detail/traceId body instead of raw text.



### 🧪 Testing Performed

Verified against a locally running instance of the service against all 5 test cases from the ticket.

### 🧑‍🔬 Unit Testing

- [x ] I have written or updated unit tests to cover my changes
- Coverage: 46.4%

### 📓 Documentation Updated

Please update any relevant sections in the project documentation that were impacted by the changes in the PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **API Improvements**
  * Standardized validation, not-found, and conflict error responses using RFC 7807 `ProblemDetails`.
  * Added clear response metadata for affected error status codes.
  * Server errors now provide a generic message when specific details are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
