### PR TITLE
LEGLINK-864: Enhance Org Resource Map Filtering + Prediction Engine Interplay

### DIFF
--- a/DotNet/Automation/Generation/FhirGenerationPipeline.cs
+++ b/DotNet/Automation/Generation/FhirGenerationPipeline.cs
@@ -402,6 +402,7 @@ public static class FhirGenerationPipeline
         // measure's MeasureReport does not contain the patient's resources, so its SDE
         // semantics do not contribute to the intersection of exclusions that determines
         // whether a resource reaches ABS.
+        HashSet<string>? cqlFilteredKeys = null;
         var cqlInput = CqlFilterInputExtractor.ExtractFromEntries(patientId, entries);
         var effectiveProfile = profile;
 
@@ -419,7 +420,7 @@ public static class FhirGenerationPipeline
             var qualifyingMeasures = measures.Where(effectiveProfile.QualifiesFor).ToList();
             if (qualifyingMeasures.Count > 0)
             {
-                var cqlFilteredKeys = CqlFilterSimulator.ComputeFilteredKeys(qualifyingMeasures, cqlInput);
+                cqlFilteredKeys = CqlFilterSimulator.ComputeFilteredKeys(qualifyingMeasures, cqlInput);
                 manifestBuilder.SetCqlFilteredKeys(patientId, cqlFilteredKeys);
             }
         }
@@ -464,7 +465,8 @@ public static class FhirGenerationPipeline
                 acquiredKeys,
                 patientSimEntries,
                 sharedSimEntries,
-                acquisitionSimulation.OrganizationLocationConditionFhirPaths);
+                acquisitionSimulation.OrganizationLocationConditionFhirPaths,
+                cqlFilteredKeys);
             manifestBuilder.SetSimulatedAcquiredKeys(patientId, acquiredKeys);
             // patientSimEntries (JsonElement clones) are now eligible for GC
         }
@@ -562,6 +564,7 @@ public static class FhirGenerationPipeline
         var profile = new PatientProfile(eligibilities, ClinicalScenarioId: imported.DetectedClinicalScenarioId);
 
         // 3. CQL filter simulation + period-aware eligibility prediction
+        HashSet<string>? cqlFilteredKeys = null;
         var cqlInput = CqlFilterInputExtractor.ExtractFromEntries(patientId, entries);
         var effectiveProfile = profile;
         if (cqlInput != null)
@@ -578,7 +581,7 @@ public static class FhirGenerationPipeline
             var qualifyingMeasures = measures.Where(effectiveProfile.QualifiesFor).ToList();
             if (qualifyingMeasures.Count > 0)
             {
-                var cqlFilteredKeys = CqlFilterSimulator.ComputeFilteredKeys(qualifyingMeasures, cqlInput);
+                cqlFilteredKeys = CqlFilterSimulator.ComputeFilteredKeys(qualifyingMeasures, cqlInput);
                 manifestBuilder.SetCqlFilteredKeys(patientId, cqlFilteredKeys);
             }
         }
@@ -617,7 +620,8 @@ public static class FhirGenerationPipeline
                 acquiredKeys,
                 patientSimEntries,
                 sharedSimEntries,
-                acquisitionSimulation.OrganizationLocationConditionFhirPaths);
+                acquisitionSimulation.OrganizationLocationConditionFhirPaths,
+                cqlFilteredKeys);
             manifestBuilder.SetSimulatedAcquiredKeys(patientId, acquiredKeys);
         }
 

--- a/DotNet/Automation/Generation/GenerationManifest.cs
+++ b/DotNet/Automation/Generation/GenerationManifest.cs
@@ -284,7 +284,7 @@ public sealed class GenerationManifest
 
         HashSet<string>? sourceKeys = null;
 
-        if (SimulatedAcquiredResourceKeysByPatient.TryGetValue(patientId, out var simulated) && simulated.Count > 0)
+        if (SimulatedAcquiredResourceKeysByPatient.TryGetValue(patientId, out var simulated))
             sourceKeys = simulated;
         else if (ResourceKeysByPatient.TryGetValue(patientId, out var generated) && generated.Count > 0)
             sourceKeys = generated;

--- a/DotNet/Automation/Generation/OrgResourceMapPredictionFilter.cs
+++ b/DotNet/Automation/Generation/OrgResourceMapPredictionFilter.cs
@@ -1,5 +1,7 @@
-﻿using System.Text.Json;
-using System.Text.RegularExpressions;
+﻿using Hl7.Fhir.ElementModel;
+using Hl7.Fhir.Model;
+using Hl7.FhirPath;
+using System.Text.Json;
 
 namespace LantanaGroup.Automation.Generation;
 
@@ -19,7 +21,8 @@ public static class OrgResourceMapPredictionFilter
         HashSet<string> acquiredKeys,
         IReadOnlyList<(string ResourceType, string ResourceId, string Key, JsonElement Resource)> patientResourceEntries,
         IReadOnlyList<(string ResourceType, string ResourceId, string Key, JsonElement Resource)>? sharedResourceEntries,
-        IReadOnlyList<string>? organizationLocationConditionFhirPaths)
+        IReadOnlyList<string>? organizationLocationConditionFhirPaths,
+        IReadOnlySet<string>? cqlFilteredKeys = null)
     {
         if (acquiredKeys.Count == 0
             || organizationLocationConditionFhirPaths == null
@@ -115,12 +118,13 @@ public static class OrgResourceMapPredictionFilter
                 filtered.Add(key);
         }
 
-        return PruneUnreferencedReferenceResources(filtered, entriesByKey);
+        return PruneUnreferencedReferenceResources(filtered, entriesByKey, cqlFilteredKeys);
     }
 
     private static HashSet<string> PruneUnreferencedReferenceResources(
         HashSet<string> keptKeys,
-        Dictionary<string, ResourceEntry> entriesByKey)
+        Dictionary<string, ResourceEntry> entriesByKey,
+        IReadOnlySet<string>? cqlFilteredKeys)
     {
         if (keptKeys.Count == 0)
             return keptKeys;
@@ -129,6 +133,7 @@ public static class OrgResourceMapPredictionFilter
         // prediction if still referenced by kept resources after org-scope filtering.
         var pruneTypes = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
         {
+            "Location",
             "Medication",
             "Specimen",
             "Device"
@@ -142,6 +147,9 @@ public static class OrgResourceMapPredictionFilter
             var referencedKeys = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             foreach (var key in keptKeys)
             {
+                if (cqlFilteredKeys?.Contains(key) == true)
+                    continue;
+
                 if (!entriesByKey.TryGetValue(key, out var entry))
                     continue;
 
@@ -196,86 +204,46 @@ public static class OrgResourceMapPredictionFilter
         if (string.IsNullOrWhiteSpace(fhirPath))
             return false;
 
-        var path = fhirPath.Trim();
-        if (path.StartsWith("Location.", StringComparison.OrdinalIgnoreCase))
-            path = path["Location.".Length..];
-
-        var system = ExtractQuotedValue(path, "system");
-        var value = ExtractQuotedValue(path, "value");
-        var code = ExtractQuotedValue(path, "code");
-
-        if (path.Contains("identifier", StringComparison.OrdinalIgnoreCase)
-            && !string.IsNullOrWhiteSpace(system)
-            && locationResource.TryGetProperty("identifier", out var identifiers)
-            && identifiers.ValueKind == JsonValueKind.Array)
+        try
         {
-            foreach (var identifier in identifiers.EnumerateArray())
-            {
-                if (!identifier.TryGetProperty("system", out var sysProp) || sysProp.ValueKind != JsonValueKind.String)
-                    continue;
+            var path = fhirPath.Trim();
+            if (path.StartsWith("Location.", StringComparison.OrdinalIgnoreCase))
+                path = path["Location.".Length..];
 
-                var identifierSystem = sysProp.GetString();
-                if (!string.Equals(identifierSystem, system, StringComparison.OrdinalIgnoreCase))
-                    continue;
+            var location = JsonSerializer.Deserialize<Location>(
+                locationResource.GetRawText(),
+                FhirSerializerOptions.ForFhirWithoutValidation());
 
-                if (string.IsNullOrWhiteSpace(value))
-                    return true;
+            if (location is null)
+                return false;
 
-                if (identifier.TryGetProperty("value", out var valueProp)
-                    && valueProp.ValueKind == JsonValueKind.String
-                    && string.Equals(valueProp.GetString(), value, StringComparison.OrdinalIgnoreCase))
-                {
-                    return true;
-                }
-            }
+            var element = location.ToTypedElement();
+            var compiled = new FhirPathCompiler().Compile(path);
+            var results = compiled(element, new EvaluationContext()).ToList();
+
+            if (results.Count == 0)
+                return false;
+
+            if (results.Count == 1 && results[0].Value is bool isMatch)
+                return isMatch;
+
+            return true;
         }
-
-        if (path.Contains("type.coding", StringComparison.OrdinalIgnoreCase)
-            && !string.IsNullOrWhiteSpace(system)
-            && locationResource.TryGetProperty("type", out var types)
-            && types.ValueKind == JsonValueKind.Array)
+        catch
         {
-            foreach (var type in types.EnumerateArray())
-            {
-                if (!type.TryGetProperty("coding", out var codingArray) || codingArray.ValueKind != JsonValueKind.Array)
-                    continue;
-
-                foreach (var coding in codingArray.EnumerateArray())
-                {
-                    if (!coding.TryGetProperty("system", out var sysProp) || sysProp.ValueKind != JsonValueKind.String)
-                        continue;
-
-                    if (!string.Equals(sysProp.GetString(), system, StringComparison.OrdinalIgnoreCase))
-                        continue;
-
-                    if (string.IsNullOrWhiteSpace(code))
-                        return true;
-
-                    if (coding.TryGetProperty("code", out var codeProp)
-                        && codeProp.ValueKind == JsonValueKind.String
-                        && string.Equals(codeProp.GetString(), code, StringComparison.OrdinalIgnoreCase))
-                    {
-                        return true;
-                    }
-                }
-            }
+            return false;
         }
-
-        return false;
-    }
-
-    private static string? ExtractQuotedValue(string source, string key)
-    {
-        var match = Regex.Match(source, $@"\b{Regex.Escape(key)}\s*=\s*'([^']+)'", RegexOptions.IgnoreCase);
-        return match.Success ? match.Groups[1].Value : null;
     }
 
     private static bool TryGetReferencedResourceIds(JsonElement resource, string resourceType, out List<string> ids)
     {
         ids = EnumerateReferences(resource)
-            .Where(reference => reference.StartsWith(resourceType + "/", StringComparison.OrdinalIgnoreCase))
-            .Select(reference => reference[(resourceType.Length + 1)..])
-            .Where(id => !string.IsNullOrWhiteSpace(id))
+            .Select(reference => TryParseReference(reference, out var type, out var id)
+                ? (Type: type, Id: id)
+                : (Type: string.Empty, Id: string.Empty))
+            .Where(parsed => string.Equals(parsed.Type, resourceType, StringComparison.OrdinalIgnoreCase)
+                             && !string.IsNullOrWhiteSpace(parsed.Id))
+            .Select(parsed => parsed.Id)
             .Distinct(StringComparer.OrdinalIgnoreCase)
             .ToList();
 

--- a/DotNet/ServiceTests/UnitTests/Automation/GenerationManifestExpectedAbsTests.cs
+++ b/DotNet/ServiceTests/UnitTests/Automation/GenerationManifestExpectedAbsTests.cs
@@ -168,6 +168,29 @@ public class GenerationManifestExpectedAbsTests
     }
 
     [Fact]
+    public void Empty_simulated_acquired_set_does_not_fallback_to_generated_keys()
+    {
+        var manifest = new GenerationManifest
+        {
+            PatientIds = ["p-q"],
+            Profiles = [QualifyingProfile()],
+            SelectedMeasures = [Ach],
+            ResourceKeysByPatient = new Dictionary<string, HashSet<string>>(StringComparer.Ordinal)
+            {
+                ["p-q"] = new(StringComparer.OrdinalIgnoreCase) { "Encounter/Egen", "Condition/Cgen" },
+            },
+            SimulatedAcquiredResourceKeysByPatient = new Dictionary<string, HashSet<string>>(StringComparer.Ordinal)
+            {
+                ["p-q"] = new(StringComparer.OrdinalIgnoreCase)
+            },
+        };
+
+        var keys = manifest.GetExpectedAbsKeysForPatient("p-q");
+
+        keys.Should().BeEquivalentTo(["Patient/p-q"]);
+    }
+
+    [Fact]
     public void Expected_abs_counts_do_not_include_organization_when_include_setting_is_false()
     {
         var manifest = new GenerationManifest

--- a/DotNet/ServiceTests/UnitTests/Automation/OrgResourceMapPredictionFilterTests.cs
+++ b/DotNet/ServiceTests/UnitTests/Automation/OrgResourceMapPredictionFilterTests.cs
@@ -1,0 +1,198 @@
+﻿using FluentAssertions;
+using LantanaGroup.Automation.Generation;
+using System.Text.Json;
+
+namespace UnitTests.Automation;
+
+[Trait("Category", "UnitTests")]
+public class OrgResourceMapPredictionFilterTests
+{
+    [Fact]
+    public void Apply_honors_managingOrganization_fhirpath_condition()
+    {
+        const string orgCondition = "Location.managingOrganization.reference = 'Organization/ORG-1'";
+
+        var entries = new List<(string ResourceType, string ResourceId, string Key, JsonElement Resource)>
+        {
+            Entry("Location", "L-ROOT", "Location/L-ROOT", """
+                {
+                  "resourceType":"Location",
+                  "id":"L-ROOT",
+                  "managingOrganization":{"reference":"Organization/ORG-1"}
+                }
+                """),
+            Entry("Location", "L-ROOM", "Location/L-ROOM", """
+                {
+                  "resourceType":"Location",
+                  "id":"L-ROOM",
+                  "partOf":{"reference":"Location/L-ROOT"}
+                }
+                """),
+            Entry("Encounter", "E-1", "Encounter/E-1", """
+                {
+                  "resourceType":"Encounter",
+                  "id":"E-1",
+                  "location":[{"location":{"reference":"Location/L-ROOM"}}]
+                }
+                """)
+        };
+
+        var acquired = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            "Encounter/E-1",
+            "Location/L-ROOT",
+            "Location/L-ROOM"
+        };
+
+        var filtered = OrgResourceMapPredictionFilter.Apply(
+            acquired,
+            entries,
+            sharedResourceEntries: null,
+            organizationLocationConditionFhirPaths: [orgCondition]);
+
+        filtered.Should().Contain(["Encounter/E-1", "Location/L-ROOM"]);
+        filtered.Should().NotContain("Location/L-ROOT");
+    }
+
+    [Fact]
+    public void Apply_prunes_unreferenced_location_from_org_scoped_keys()
+    {
+        const string orgCondition = "Location.identifier.where(system='urn:test:loc' and value='org-root').exists()";
+
+        var entries = new List<(string ResourceType, string ResourceId, string Key, JsonElement Resource)>
+        {
+            Entry("Location", "L-ROOT", "Location/L-ROOT", """
+                {
+                  "resourceType":"Location",
+                  "id":"L-ROOT",
+                  "identifier":[{"system":"urn:test:loc","value":"org-root"}]
+                }
+                """),
+            Entry("Location", "L-ROOM", "Location/L-ROOM", """
+                {
+                  "resourceType":"Location",
+                  "id":"L-ROOM",
+                  "partOf":{"reference":"Location/L-ROOT"}
+                }
+                """),
+            Entry("Location", "L-UNUSED", "Location/L-UNUSED", """
+                {
+                  "resourceType":"Location",
+                  "id":"L-UNUSED",
+                  "partOf":{"reference":"Location/L-ROOT"}
+                }
+                """),
+            Entry("Encounter", "E-1", "Encounter/E-1", """
+                {
+                  "resourceType":"Encounter",
+                  "id":"E-1",
+                  "location":[{"location":{"reference":"Location/L-ROOM"}}]
+                }
+                """)
+        };
+
+        var acquired = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            "Encounter/E-1",
+            "Location/L-ROOT",
+            "Location/L-ROOM",
+            "Location/L-UNUSED"
+        };
+
+        var filtered = OrgResourceMapPredictionFilter.Apply(
+            acquired,
+            entries,
+            sharedResourceEntries: null,
+            organizationLocationConditionFhirPaths: [orgCondition]);
+
+        filtered.Should().Contain(["Encounter/E-1", "Location/L-ROOM"]);
+        filtered.Should().NotContain(["Location/L-ROOT", "Location/L-UNUSED"]);
+    }
+
+    [Fact]
+    public void Apply_does_not_keep_medication_referenced_only_by_cql_filtered_resource()
+    {
+        const string orgCondition = "Location.identifier.where(system='urn:test:loc' and value='org-root').exists()";
+
+        var entries = new List<(string ResourceType, string ResourceId, string Key, JsonElement Resource)>
+        {
+            Entry("Location", "L-ROOT", "Location/L-ROOT", """
+                {
+                  "resourceType":"Location",
+                  "id":"L-ROOT",
+                  "identifier":[{"system":"urn:test:loc","value":"org-root"}]
+                }
+                """),
+            Entry("Encounter", "E-1", "Encounter/E-1", """
+                {
+                  "resourceType":"Encounter",
+                  "id":"E-1",
+                  "location":[{"location":{"reference":"Location/L-ROOT"}}]
+                }
+                """),
+            Entry("MedicationRequest", "MR-1", "MedicationRequest/MR-1", """
+                {
+                  "resourceType":"MedicationRequest",
+                  "id":"MR-1",
+                  "encounter":{"reference":"Encounter/E-1"},
+                  "medicationReference":{"reference":"Medication/M-1"}
+                }
+                """),
+            Entry("MedicationRequest", "MR-2", "MedicationRequest/MR-2", """
+                {
+                  "resourceType":"MedicationRequest",
+                  "id":"MR-2",
+                  "encounter":{"reference":"Encounter/E-1"},
+                  "medicationReference":{"reference":"Medication/M-2"}
+                }
+                """),
+            Entry("Medication", "M-1", "Medication/M-1", """
+                {
+                  "resourceType":"Medication",
+                  "id":"M-1"
+                }
+                """),
+            Entry("Medication", "M-2", "Medication/M-2", """
+                {
+                  "resourceType":"Medication",
+                  "id":"M-2"
+                }
+                """)
+        };
+
+        var acquired = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            "Location/L-ROOT",
+            "Encounter/E-1",
+            "MedicationRequest/MR-1",
+            "MedicationRequest/MR-2",
+            "Medication/M-1",
+            "Medication/M-2"
+        };
+
+        var cqlFiltered = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            "MedicationRequest/MR-2"
+        };
+
+        var filtered = OrgResourceMapPredictionFilter.Apply(
+            acquired,
+            entries,
+            sharedResourceEntries: null,
+            organizationLocationConditionFhirPaths: [orgCondition],
+            cqlFilteredKeys: cqlFiltered);
+
+        filtered.Should().Contain(["Medication/M-1", "MedicationRequest/MR-2"]);
+        filtered.Should().NotContain("Medication/M-2");
+    }
+
+    private static (string ResourceType, string ResourceId, string Key, JsonElement Resource) Entry(
+        string resourceType,
+        string resourceId,
+        string key,
+        string json)
+    {
+        using var doc = JsonDocument.Parse(json);
+        return (resourceType, resourceId, key, doc.RootElement.Clone());
+    }
+}


### PR DESCRIPTION
### 🛠️ Description of Changes

Layer Org Resource Map Filtering over Query Plan/CQL filtering to arrive at final prediction

### 🧪 Testing Performed

Please describe the testing that was performed on the changes included in this PR.

### 🧑‍🔬 Unit Testing

- [ ] I have written or updated unit tests to cover my changes
- Coverage: 66.7%

### 📓 Documentation Updated

Please update any relevant sections in the project documentation that were impacted by the changes in the PR.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CQL-based filtering during resource acquisition simulation.
  * Organization, location, and condition predictions now correctly honor CQL exclusions.
  * Preserved explicitly filtered resource keys, including when no simulated resources are acquired.
  * Improved organization and location condition matching and reference handling.
  * Removed unreferenced locations and resources more accurately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->