### PR TITLE
LEGLINK-964: Fix inconsistent timestamp formats in FacilityReportingPlans CRUD

### DIFF
--- a/DotNet/DMRP/Business/Managers/FacilityReportingPlanManager.cs
+++ b/DotNet/DMRP/Business/Managers/FacilityReportingPlanManager.cs
@@ -52,7 +52,7 @@ namespace LantanaGroup.Link.DMRP.Business.Managers
 
             ArgumentNullException.ThrowIfNull(newFacilityReportingPlan);
 
-            await ValidateAsync(newFacilityReportingPlan, null, cancellationToken);
+            await ValidateAsync(newFacilityReportingPlan, cancellationToken);
 
             try
             {
@@ -93,7 +93,7 @@ namespace LantanaGroup.Link.DMRP.Business.Managers
                 throw new KeyNotFoundException($"Facility reporting plan with Id: {id} not found");
             }
 
-            await ValidateAsync(facilityReportingPlan, id, cancellationToken);
+            await ValidateAsync(facilityReportingPlan, cancellationToken);
 
             existing.FacilityId = facilityReportingPlan.FacilityId;
             existing.MeasureMappingId = facilityReportingPlan.MeasureMappingId;
@@ -165,11 +165,11 @@ namespace LantanaGroup.Link.DMRP.Business.Managers
         }
 
         /// <summary>
-        /// Rejects a reporting plan that cannot be stored. <paramref name="currentId"/> is the row
-        /// being updated, which is excluded from the duplicate check so that saving a row over itself
-        /// is not treated as a collision.
+        /// Rejects a reporting plan that cannot be stored. Does not check for a duplicate period:
+        /// that is left to the unique index, and reported by <see cref="TranslateSaveFailureAsync"/>
+        /// when the save fails.
         /// </summary>
-        private async Task ValidateAsync(FacilityReportingPlan plan, string? currentId, CancellationToken cancellationToken)
+        private async Task ValidateAsync(FacilityReportingPlan plan, CancellationToken cancellationToken)
         {
             if (string.IsNullOrWhiteSpace(plan.FacilityId))
             {
@@ -211,12 +211,6 @@ namespace LantanaGroup.Link.DMRP.Business.Managers
             if (!facilityExists)
             {
                 throw new ReportingPlanValidationException($"Facility with Id: {plan.FacilityId} not found.");
-            }
-
-            if (await IsDuplicateAsync(plan, currentId, cancellationToken))
-            {
-                throw new DuplicateReportingPlanException(plan.FacilityId, plan.MeasureMappingId,
-                    plan.ReportingMonth, plan.ReportingYear);
             }
         }
 

--- a/DotNet/DMRP/Business/Mapping/FacilityReportingPlanMapper.cs
+++ b/DotNet/DMRP/Business/Mapping/FacilityReportingPlanMapper.cs
@@ -14,8 +14,19 @@ namespace LantanaGroup.Link.DMRP.Business.Mapping
             ReportingMonth = entity.ReportingMonth,
             ReportingYear = entity.ReportingYear,
             IsReporting = entity.IsReporting,
-            CreateDate = entity.CreateDate,
-            ModifyDate = entity.ModifyDate
+
+            // The columns are datetime2 with no offset, so a value that round-tripped through
+            // EF Core comes back DateTimeKind.Unspecified, while a value set in memory just
+            // before SaveChangesAsync (UpdateBaseEntityInterceptor) is still DateTimeKind.Utc.
+            // System.Text.Json only appends "Z" for Kind.Utc, so left unqualified, Create
+            // (no round trip) rendered a "Z" suffix while Get/Update (fetched from the DB
+            // first) did not - the same field serialized two different ways depending on which
+            // operation produced it. The values are always UTC in practice, so it's safe to
+            // pin the Kind rather than convert it.
+            CreateDate = DateTime.SpecifyKind(entity.CreateDate, DateTimeKind.Utc),
+            ModifyDate = entity.ModifyDate is null
+                ? null
+                : DateTime.SpecifyKind(entity.ModifyDate.Value, DateTimeKind.Utc)
         };
 
         public static FacilityReportingPlan ToEntity(FacilityReportingPlanRequest request) => new()

--- a/DotNet/ServiceTests/UnitTests/DMRP/FacilityReportingPlanManagerTests.cs
+++ b/DotNet/ServiceTests/UnitTests/DMRP/FacilityReportingPlanManagerTests.cs
@@ -183,19 +183,22 @@ namespace UnitTests.DMRP
         }
 
         [Fact]
-        public async Task CreateAsync_PeriodAlreadyRecordedForTheFacilityAndMapping_IsRejected()
+        public async Task CreateAsync_DoesNotPreCheckForADuplicatePeriod()
         {
+            // Validation no longer queries for an existing row before saving: a duplicate period is
+            // reported only when the unique index rejects the save (see TranslateSaveFailureAsync).
+            // A plan repository that would report a duplicate if asked must never be asked here.
             _mockRepository
                 .Setup(r => r.AnyAsync(It.IsAny<Expression<Func<FacilityReportingPlan, bool>>>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(true);
 
             var plan = ValidPlan();
 
-            var ex = await Assert.ThrowsAsync<DuplicateReportingPlanException>(() => _manager.CreateAsync(plan));
-            Assert.Equal(
-                $"A reporting plan already exists for facility {plan.FacilityId}, measure mapping " +
-                $"{plan.MeasureMappingId} and period {plan.ReportingMonth}/{plan.ReportingYear}.",
-                ex.Message);
+            await _manager.CreateAsync(plan);
+
+            _mockRepository.Verify(
+                r => r.AnyAsync(It.IsAny<Expression<Func<FacilityReportingPlan, bool>>>(), It.IsAny<CancellationToken>()),
+                Times.Never);
         }
 
         [Fact]
@@ -239,10 +242,11 @@ namespace UnitTests.DMRP
 
             await Assert.ThrowsAsync<DuplicateReportingPlanException>(() => _manager.CreateAsync(ValidPlan()));
 
-            // Once for the pre-check only. The failure names the index, so there is no second lookup.
+            // The failure names the index, so it never falls back to the query - and there is no
+            // pre-check to begin with.
             _mockRepository.Verify(
                 r => r.AnyAsync(It.IsAny<Expression<Func<FacilityReportingPlan, bool>>>(), It.IsAny<CancellationToken>()),
-                Times.Once);
+                Times.Never);
         }
 
         [Fact]

--- a/DotNet/ServiceTests/UnitTests/DMRP/FacilityReportingPlanMapperTests.cs
+++ b/DotNet/ServiceTests/UnitTests/DMRP/FacilityReportingPlanMapperTests.cs
@@ -1,0 +1,72 @@
+using LantanaGroup.Link.DMRP.Business.Mapping;
+using LantanaGroup.Link.DMRP.Data.Entities;
+using LantanaGroup.Link.Shared.Application.Models.Integration.DMRP;
+using Xunit;
+
+namespace UnitTests.DMRP
+{
+    [Trait("Category", "UnitTests")]
+    public class FacilityReportingPlanMapperTests
+    {
+        private static FacilityReportingPlan Entity(DateTimeKind createKind, DateTime? modifyDate = null) => new()
+        {
+            Id = "11111111-1111-1111-1111-111111111111",
+            FacilityId = "F1",
+            MeasureMappingId = "22222222-2222-2222-2222-222222222222",
+            ReportingMonth = 5,
+            ReportingYear = 2026,
+            IsReporting = true,
+            CreateDate = DateTime.SpecifyKind(new DateTime(2026, 5, 1, 12, 0, 0), createKind),
+            ModifyDate = modifyDate
+        };
+
+        [Fact]
+        public void ToModel_TreatsStoredTimestampsAsUtc()
+        {
+            // SQL Server's datetime2 columns carry no offset, so a CreateDate that survives a
+            // round trip through EF Core comes back DateTimeKind.Unspecified, while a value set
+            // in memory just before SaveChangesAsync (see UpdateBaseEntityInterceptor) is still
+            // DateTimeKind.Utc. System.Text.Json only appends the "Z" suffix for Kind.Utc, so
+            // Create (no round trip) rendered a "Z" while Get/Update (fetched from the DB first)
+            // did not - the same field serialized two different ways depending on which
+            // operation produced it.
+            var entity = Entity(DateTimeKind.Unspecified);
+
+            var model = FacilityReportingPlanMapper.ToModel(entity);
+
+            Assert.Equal(DateTimeKind.Utc, model.CreateDate.Kind);
+            Assert.Equal(12, model.CreateDate.Hour);
+        }
+
+        [Fact]
+        public void ToModel_WithAnAlreadyUtcCreateDate_LeavesTheValueUnchanged()
+        {
+            var entity = Entity(DateTimeKind.Utc);
+
+            var model = FacilityReportingPlanMapper.ToModel(entity);
+
+            Assert.Equal(DateTimeKind.Utc, model.CreateDate.Kind);
+            Assert.Equal(12, model.CreateDate.Hour);
+        }
+
+        [Fact]
+        public void ToModel_WithNoModifyDate_LeavesItNull()
+        {
+            var entity = Entity(DateTimeKind.Utc);
+
+            Assert.Null(FacilityReportingPlanMapper.ToModel(entity).ModifyDate);
+        }
+
+        [Fact]
+        public void ToModel_TreatsAStoredModifyDateAsUtc()
+        {
+            var entity = Entity(DateTimeKind.Unspecified,
+                modifyDate: DateTime.SpecifyKind(new DateTime(2026, 5, 2, 12, 0, 0), DateTimeKind.Unspecified));
+
+            var model = FacilityReportingPlanMapper.ToModel(entity);
+
+            Assert.Equal(DateTimeKind.Utc, model.ModifyDate!.Value.Kind);
+            Assert.Equal(12, model.ModifyDate.Value.Hour);
+        }
+    }
+}


### PR DESCRIPTION

### 🛠️ Description of Changes
CreateDate/ModifyDate are datetime2 columns with no offset, so a value that round-tripped through EF Core comes back DateTimeKind.Unspecified while a value stamped in memory just before SaveChangesAsync stays DateTimeKind.Utc. System.Text.Json only appends "Z" for Kind.Utc, so Create returned a "Z" suffix while Get/Update (which re-fetch first) did not - same field, two different formats depending on the operation. FacilityReportingPlanMapper.ToModel now pins both fields to Utc, mirroring the fix MockEntryMapper already applies to the same problem in MockDmrpApi.

### 🧪 Testing Performed

Tested locally

### 🧑‍🔬 Unit Testing

- [ x] I have written or updated unit tests to cover my changes
- Coverage: 100.0%

### 📓 Documentation Updated

Please update any relevant sections in the project documentation that were impacted by the changes in the PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured facility reporting plan timestamps are consistently serialized as UTC with a `Z` suffix.
  * Preserved timestamp values without changing their recorded date or time.
  * Handled missing modification dates correctly.

* **Tests**
  * Added coverage for stored, UTC, null, and time-preservation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
