### PR TITLE
LEGLINK-921: CodeSystem responses report content=not-present for licensed terminologies

### DIFF
--- a/DotNet/ServiceTests/UnitTests/Terminology/Services/FhirServiceTests.cs
+++ b/DotNet/ServiceTests/UnitTests/Terminology/Services/FhirServiceTests.cs
@@ -1402,7 +1402,7 @@ public class FhirServiceTests
         var codeSystem = new CodeSystem
         {
             Id = codeSystemId,
-            Content = CodeSystemContentMode.Fragment
+            Content = CodeSystemContentMode.NotPresent
         };
         var mockCodeGroup = new CodeGroup
         {
@@ -1496,7 +1496,6 @@ public class FhirServiceTests
         // Assert
         var codeSystem = Assert.IsType<CodeSystem>(Assert.Single(result.Entry).Resource);
         var concept = Assert.Single(codeSystem.Concept);
-        Assert.Equal(CodeSystemContentMode.Complete, codeSystem.Content);
         Assert.Equal(code, concept.Code);
         Assert.Equal("last display", concept.Display);
     }

--- a/DotNet/ServiceTests/UnitTests/Terminology/Services/FhirServiceTests.cs
+++ b/DotNet/ServiceTests/UnitTests/Terminology/Services/FhirServiceTests.cs
@@ -1395,6 +1395,69 @@ public class FhirServiceTests
     #region GetCodeSystems Tests
 
     [Fact]
+    public void GetCodeSystemById_WithCachedCodes_SetsContentToComplete()
+    {
+        // Arrange
+        var codeSystemId = "test-code-system";
+        var codeSystem = new CodeSystem
+        {
+            Id = codeSystemId,
+            Content = CodeSystemContentMode.Fragment
+        };
+        var mockCodeGroup = new CodeGroup
+        {
+            Id = codeSystemId,
+            Type = CodeGroup.CodeGroupTypes.CodeSystem,
+            Resource = codeSystem,
+            Codes = new Dictionary<string, List<Code>>
+            {
+                { "http://test.system", new List<Code> { new() { Value = "test-code", Display = "Test Code" } } }
+            }
+        };
+
+        _mockCacheService
+            .Setup(x => x.GetCodeGroupById(CodeGroup.CodeGroupTypes.CodeSystem, codeSystemId, It.IsAny<string>()))
+            .Returns(mockCodeGroup);
+
+        // Act
+        var result = _service.GetCodeSystemById(codeSystemId);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(CodeSystemContentMode.Complete, result.Content);
+    }
+
+    [Fact]
+    public void GetCodeSystemById_WithoutCachedCodes_PreservesContentMode()
+    {
+        // Arrange
+        var codeSystemId = "test-empty-code-system";
+        var codeSystem = new CodeSystem
+        {
+            Id = codeSystemId,
+            Content = CodeSystemContentMode.NotPresent
+        };
+        var mockCodeGroup = new CodeGroup
+        {
+            Id = codeSystemId,
+            Type = CodeGroup.CodeGroupTypes.CodeSystem,
+            Resource = codeSystem,
+            Codes = new Dictionary<string, List<Code>>()
+        };
+
+        _mockCacheService
+            .Setup(x => x.GetCodeGroupById(CodeGroup.CodeGroupTypes.CodeSystem, codeSystemId, It.IsAny<string>()))
+            .Returns(mockCodeGroup);
+
+        // Act
+        var result = _service.GetCodeSystemById(codeSystemId);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(CodeSystemContentMode.NotPresent, result.Content);
+    }
+
+    [Fact]
     public void GetCodeSystems_WithDuplicateCode_EmitsSingleConceptWithLastDisplay()
     {
         // Arrange
@@ -1433,6 +1496,7 @@ public class FhirServiceTests
         // Assert
         var codeSystem = Assert.IsType<CodeSystem>(Assert.Single(result.Entry).Resource);
         var concept = Assert.Single(codeSystem.Concept);
+        Assert.Equal(CodeSystemContentMode.Complete, codeSystem.Content);
         Assert.Equal(code, concept.Code);
         Assert.Equal("last display", concept.Display);
     }

--- a/DotNet/Terminology/Services/FhirService.cs
+++ b/DotNet/Terminology/Services/FhirService.cs
@@ -184,7 +184,7 @@ public class FhirService(ICodeGroupCacheService cacheService, ILogger<FhirServic
         }
 
         var codeSystem = codeGroup.Resource as CodeSystem;
-        if(codeSystem != null && codeGroup.Codes.Values.Any(c => c.Count > 0))
+        if(codeSystem != null && codeSystem.Content == CodeSystemContentMode.NotPresent && codeGroup.Codes.Values.Any(c => c.Count > 0))
             codeSystem.Content = CodeSystemContentMode.Complete;
 
         return codeSystem;
@@ -216,7 +216,7 @@ public class FhirService(ICodeGroupCacheService cacheService, ILogger<FhirServic
                 }
 
                 CodeSystem clone = (CodeSystem)codeGroup.Resource.DeepCopy();
-                if (codeGroup.Codes.Values.Any(c => c.Count > 0))
+                if (clone.Content == CodeSystemContentMode.NotPresent && codeGroup.Codes.Values.Any(c => c.Count > 0))
                     clone.Content = CodeSystemContentMode.Complete;
 
                 if (summary != SummaryType.True)

--- a/DotNet/Terminology/Services/FhirService.cs
+++ b/DotNet/Terminology/Services/FhirService.cs
@@ -183,7 +183,11 @@ public class FhirService(ICodeGroupCacheService cacheService, ILogger<FhirServic
             throw new KeyNotFoundException($"Code system not found with ID {id}");
         }
 
-        return codeGroup.Resource as CodeSystem;
+        var codeSystem = codeGroup.Resource as CodeSystem;
+        if(codeSystem != null && codeGroup.Codes.Values.Any(c => c.Count > 0))
+            codeSystem.Content = CodeSystemContentMode.Complete;
+
+        return codeSystem;
     }
 
     public Bundle GetCodeSystems(string? url, SummaryType? summary)
@@ -212,6 +216,8 @@ public class FhirService(ICodeGroupCacheService cacheService, ILogger<FhirServic
                 }
 
                 CodeSystem clone = (CodeSystem)codeGroup.Resource.DeepCopy();
+                if (codeGroup.Codes.Values.Any(c => c.Count > 0))
+                    clone.Content = CodeSystemContentMode.Complete;
 
                 if (summary != SummaryType.True)
                 {


### PR DESCRIPTION
### 🛠️ Description of Changes

Fixes a bug where the terminology service reports code sets' `content: not-present` despite having codes loaded in the cache.

### 🧪 Testing Performed

Tested with Postman

### 🧑‍🔬 Unit Testing

- [x] I have written or updated unit tests to cover my changes
- Coverage: 83.3%

### 📓 Documentation Updated

Please update any relevant sections in the project documentation that were impacted by the changes in the PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Code systems with cached codes are now correctly marked as **complete** when retrieved.
  * URL-based code system searches now return the correct content status.
  * Code systems without cached codes retain their existing **not present** status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

