### PR TITLE
LEGLINK-937: Quick Launch – Open Selected Scenario in Edit Mode When Clicking Manage

### DIFF
--- a/DotNet/Automation.UI/Views/Runs/Index.cshtml
+++ b/DotNet/Automation.UI/Views/Runs/Index.cshtml
@@ -1030,6 +1030,7 @@
         refreshRecentRunsCard({ pageSize: sel.value, pageNumber: '1' });
     });
 })();
+
 </script>
 
 @await Html.PartialAsync("_ScenarioEditorModal")

--- a/DotNet/Automation.UI/Views/Runs/Index.cshtml
+++ b/DotNet/Automation.UI/Views/Runs/Index.cshtml
@@ -265,7 +265,10 @@
                     </button>
                 </div>
                 <div class="col-md-2">
-                    <a asp-controller="Scenarios" asp-action="Index" class="btn btn-outline-secondary w-100">
+                    <a asp-controller="Scenarios"
+                       asp-action="Index"
+                       class="btn btn-outline-secondary w-100"
+                       id="btnManageScenario">
                         <i class="bi bi-journal-text me-1"></i> Manage
                     </a>
                 </div>
@@ -302,6 +305,7 @@
     var recentRunsPartialUrl = '@Url.Action("RecentRunsPartial", "Runs")';
     var cancelUrl = '@Url.Action("CancelJson", "Runs")';
     var deleteUrl = '@Url.Action("DeleteJson", "Runs")';
+            var scenariosUrl = '@Url.Action("Index", "Scenarios")';
 
     // --- KPI elements ---
     var kpiActive = document.getElementById('kpiActive');
@@ -612,6 +616,7 @@
     var noResults = document.getElementById('quickLaunchNoResults');
     var quickTypeFilter = document.getElementById('quickLaunchTypeFilter');
     var quickSort = document.getElementById('quickLaunchSort');
+            var manageLink = document.getElementById('btnManageScenario');
 
     function getQuickLaunchOptions() {
         return Array.from(
@@ -688,6 +693,12 @@
         if (dropdownButton) {
             dropdownButton.textContent =
                 label || '-- Select a scenario --';
+        }
+
+        if (manageLink) {
+            manageLink.href = id
+                ? scenariosUrl + '?editScenarioId=' + encodeURIComponent(id)
+                : scenariosUrl;
         }
     }
 

--- a/DotNet/Automation.UI/Views/Scenarios/Index.cshtml
+++ b/DotNet/Automation.UI/Views/Scenarios/Index.cshtml
@@ -247,5 +247,18 @@
         }
 
         applyScenarioView();
+
+        // Open a scenario passed from Quick Launch directly in the editor.
+        var editScenarioId = new URLSearchParams(window.location.search).get('editScenarioId');
+
+        if (editScenarioId && typeof window.openScenarioEditor === 'function') {
+            window.openScenarioEditor(editScenarioId, 'edit');
+
+            // Remove the one-time navigation parameter so saving/reloading the
+            // Scenarios page does not automatically reopen the editor.
+            var url = new URL(window.location.href);
+            url.searchParams.delete('editScenarioId');
+            window.history.replaceState(null, '', url.toString());
+        }
     })();
 </script>


### PR DESCRIPTION
### 🛠️ Description of Changes

Update Quick Launch Manage navigation to pass the currently selected scenario to the Scenarios page and automatically open it using the existing scenario editor. Added one-time scenario ID handling on the Scenarios page while preserving existing behavior when no scenario is selected.

### 🧪 Testing Performed

I used the search in quick launch to select a scenario and then hit the Manage button, it successfully pulled up the edit scenario window

### 🧑‍🔬 Unit Testing

- Coverage: 0.0%

N/A

### 📓 Documentation Updated

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Manage Scenario links now open the selected scenario directly for editing.
  * When no scenario is selected, the link opens the scenario list.
  * Scenario edit links now open automatically and clean up the URL afterward to prevent reopening on refresh.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
