### PR TITLE
LEGLINK-958: Measure Eval: clean up the resource cache when evaluation or normalization fails

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -297,12 +297,23 @@ jobs:
             ${{ runner.os }}-nuget-
 
       # Pulled up-front so the integration fixtures (Testcontainers) don't
-      # spend their per-test pull budget on the cold pull.
+      # spend their per-test pull budget on the cold pull. Retry up to 3 times
+      # to handle transient MCR network timeouts.
       - name: Pull Azurite Docker image
-        run: docker pull mcr.microsoft.com/azure-storage/azurite:latest
+        run: |
+          for i in 1 2 3; do
+            docker pull mcr.microsoft.com/azure-storage/azurite:latest && break
+            echo "Pull attempt $i failed, retrying in 15s..."
+            sleep 15
+          done
 
       - name: Pull SQL Server Docker image
-        run: docker pull mcr.microsoft.com/mssql/server:2022-CU13-ubuntu-22.04
+        run: |
+          for i in 1 2 3; do
+            docker pull mcr.microsoft.com/mssql/server:2022-CU13-ubuntu-22.04 && break
+            echo "Pull attempt $i failed, retrying in 15s..."
+            sleep 15
+          done
 
       - name: Restore dependencies
         run: dotnet restore DotNet/ServiceTests/ServiceTests.csproj

--- a/DotNet/Normalization/Application/Error/ResourcesAcquiredRetryDeadLetterHandler.cs
+++ b/DotNet/Normalization/Application/Error/ResourcesAcquiredRetryDeadLetterHandler.cs
@@ -80,16 +80,10 @@ public class ResourcesAcquiredRetryDeadLetterHandler : DeadLetterExceptionHandle
             return;
         }
 
-        // Retry exhaustion cannot rule out that an earlier attempt already produced
-        // ResourcesNormalized and then failed on the trailing cache delete — the produce precedes
-        // the delete on the success path — in which case Measure Eval is holding {correlationId}
-        // for its SUPPLEMENTAL pass. Deleting it would make that pass read an empty cache and emit
-        // a silent false not-reportable report, so only the acquisition keys are released here.
-        //
         // RetryListener runs its consume callback on a background thread with no synchronization
         // context, so blocking here cannot deadlock. PurgeAsync does not throw.
         _resourceCachePurger
-            .PurgeAsync(value, $"retry count exhausted: {exceptionMessage}", ResourceCachePurgeScope.AcquisitionKeysOnly)
+            .PurgeAsync(value, $"retry count exhausted: {exceptionMessage}")
             .GetAwaiter()
             .GetResult();
     }

--- a/DotNet/Normalization/Application/Error/ResourcesAcquiredRetryDeadLetterHandler.cs
+++ b/DotNet/Normalization/Application/Error/ResourcesAcquiredRetryDeadLetterHandler.cs
@@ -1,0 +1,89 @@
+using Confluent.Kafka;
+using LantanaGroup.Link.Normalization.Application.Models.Messages;
+using LantanaGroup.Link.Normalization.Application.Services;
+using LantanaGroup.Link.Shared.Application.Error.Handlers;
+using LantanaGroup.Link.Shared.Application.Error.Interfaces;
+using LantanaGroup.Link.Shared.Application.Interfaces;
+using LantanaGroup.Link.Shared.Application.Listeners;
+using LantanaGroup.Link.Shared.Application.Models;
+using System.Text.Json;
+
+namespace LantanaGroup.Link.Normalization.Application.Error;
+
+/// <summary>
+/// Dead letter handler for <see cref="RetryListener"/> that also releases the resource cache.
+/// </summary>
+/// <remarks>
+/// A <c>ResourcesAcquired</c> message that fails transiently is republished to
+/// <c>ResourcesAcquired-Retry</c> and redelivered on a schedule. Once the retry count is exhausted,
+/// <see cref="RetryListener"/> — shared, service-agnostic code with no knowledge of the resource
+/// cache — dead-letters it to <c>ResourcesAcquired-Error</c>. That is the second and final terminal
+/// path for the message (the first being a <c>DeadLetterException</c> raised directly in
+/// <c>ResourcesAcquiredListener</c>), so it is where the cached resources have to be released.
+/// <para>
+/// Normalization registers <see cref="RetryListener"/> for <c>ResourcesAcquired-Retry</c> only, so
+/// every message reaching this handler is a <see cref="ResourcesAcquiredValue"/>.
+/// </para>
+/// </remarks>
+public class ResourcesAcquiredRetryDeadLetterHandler : DeadLetterExceptionHandler<RetryListener, string, string>
+{
+    private static readonly JsonSerializerOptions DeserializerOptions = new()
+    {
+        // Mirrors JsonWithFhirMessageDeserializer, which is how the value was read off the topic.
+        PropertyNameCaseInsensitive = true,
+        AllowTrailingCommas = true
+    };
+
+    private readonly IResourceCachePurger _resourceCachePurger;
+    private readonly ILogger<ResourcesAcquiredRetryDeadLetterHandler> _logger;
+
+    public ResourcesAcquiredRetryDeadLetterHandler(
+        IKafkaProducerFactory<string, string> producerFactory,
+        IKafkaProducerFactory<string, string> nullConsumeResultProducerFactory,
+        ServiceInformation serviceInformation,
+        IExceptionLogger<RetryListener> exceptionHandler,
+        IResourceCachePurger resourceCachePurger,
+        ILogger<ResourcesAcquiredRetryDeadLetterHandler> logger)
+        : base(producerFactory, nullConsumeResultProducerFactory, serviceInformation, exceptionHandler)
+    {
+        _resourceCachePurger = resourceCachePurger ?? throw new ArgumentNullException(nameof(resourceCachePurger));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <remarks>
+    /// Both <c>HandleException</c> overloads funnel through here. The dead letter is produced first so
+    /// that the durable record of the failure is never at the mercy of the cache purge.
+    /// </remarks>
+    public override void ProduceDeadLetter(ConsumeResult<string, string> consumeResult, string exceptionMessage)
+    {
+        base.ProduceDeadLetter(consumeResult, exceptionMessage);
+
+        PurgeResourceCache(consumeResult, exceptionMessage);
+    }
+
+    private void PurgeResourceCache(ConsumeResult<string, string> consumeResult, string exceptionMessage)
+    {
+        ResourcesAcquiredValue? value;
+
+        try
+        {
+            value = JsonSerializer.Deserialize<ResourcesAcquiredValue>(
+                consumeResult.Message.Value, DeserializerOptions);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex,
+                "Could not deserialize a retry-exhausted message from {Topic} to determine its resource cache keys. " +
+                "Any cached resources for it will be released by the cache expiration policy instead.",
+                consumeResult.Topic);
+            return;
+        }
+
+        // RetryListener runs its consume callback on a background thread with no synchronization
+        // context, so blocking here cannot deadlock. PurgeAsync does not throw.
+        _resourceCachePurger
+            .PurgeAsync(value, $"retry count exhausted: {exceptionMessage}")
+            .GetAwaiter()
+            .GetResult();
+    }
+}

--- a/DotNet/Normalization/Application/Error/ResourcesAcquiredRetryDeadLetterHandler.cs
+++ b/DotNet/Normalization/Application/Error/ResourcesAcquiredRetryDeadLetterHandler.cs
@@ -80,10 +80,16 @@ public class ResourcesAcquiredRetryDeadLetterHandler : DeadLetterExceptionHandle
             return;
         }
 
+        // Retry exhaustion cannot rule out that an earlier attempt already produced
+        // ResourcesNormalized and then failed on the trailing cache delete — the produce precedes
+        // the delete on the success path — in which case Measure Eval is holding {correlationId}
+        // for its SUPPLEMENTAL pass. Deleting it would make that pass read an empty cache and emit
+        // a silent false not-reportable report, so only the acquisition keys are released here.
+        //
         // RetryListener runs its consume callback on a background thread with no synchronization
         // context, so blocking here cannot deadlock. PurgeAsync does not throw.
         _resourceCachePurger
-            .PurgeAsync(value, $"retry count exhausted: {exceptionMessage}")
+            .PurgeAsync(value, $"retry count exhausted: {exceptionMessage}", ResourceCachePurgeScope.AcquisitionKeysOnly)
             .GetAwaiter()
             .GetResult();
     }

--- a/DotNet/Normalization/Application/Error/ResourcesAcquiredRetryDeadLetterHandler.cs
+++ b/DotNet/Normalization/Application/Error/ResourcesAcquiredRetryDeadLetterHandler.cs
@@ -6,6 +6,7 @@ using LantanaGroup.Link.Shared.Application.Error.Interfaces;
 using LantanaGroup.Link.Shared.Application.Interfaces;
 using LantanaGroup.Link.Shared.Application.Listeners;
 using LantanaGroup.Link.Shared.Application.Models;
+using LantanaGroup.Link.Shared.Application.Services.Security;
 using System.Text.Json;
 
 namespace LantanaGroup.Link.Normalization.Application.Error;
@@ -75,7 +76,7 @@ public class ResourcesAcquiredRetryDeadLetterHandler : DeadLetterExceptionHandle
             _logger.LogError(ex,
                 "Could not deserialize a retry-exhausted message from {Topic} to determine its resource cache keys. " +
                 "Any cached resources for it will be released by the cache expiration policy instead.",
-                consumeResult.Topic);
+                consumeResult.Topic.SanitizeForLog());
             return;
         }
 

--- a/DotNet/Normalization/Application/Services/ResourceCachePurger.cs
+++ b/DotNet/Normalization/Application/Services/ResourceCachePurger.cs
@@ -5,30 +5,6 @@ using LantanaGroup.Link.Shared.Application.Services.Security;
 namespace LantanaGroup.Link.Normalization.Application.Services;
 
 /// <summary>
-/// Which cache keys a terminal-failure purge is allowed to remove. The scope encodes what the
-/// caller can prove about whether <c>ResourcesNormalized</c> was already published for the message.
-/// </summary>
-public enum ResourceCachePurgeScope
-{
-    /// <summary>
-    /// Remove the per-resource-type acquisition keys and the <c>{correlationId}</c> key. Only valid
-    /// where the failure provably occurred before <c>ResourcesNormalized</c> was produced (the
-    /// immediate dead-letter path: validation raises before the processing loop), so nothing
-    /// downstream can be holding the correlation key.
-    /// </summary>
-    All,
-
-    /// <summary>
-    /// Remove only the per-resource-type acquisition keys. For paths that cannot rule out a prior
-    /// publish — retry exhaustion follows attempts that may have produced <c>ResourcesNormalized</c>
-    /// and then failed on the trailing cache delete — where Measure Eval may already be holding
-    /// <c>{correlationId}</c> for its SUPPLEMENTAL pass. The correlation key is left to the cache
-    /// expiration policy.
-    /// </summary>
-    AcquisitionKeysOnly
-}
-
-/// <summary>
 /// Releases the resource cache entries belonging to a <c>ResourcesAcquired</c> message after a
 /// terminal (non-retryable) normalization failure.
 /// </summary>
@@ -37,15 +13,18 @@ public enum ResourceCachePurgeScope
 /// needs its cached resources when it is redelivered, so purging on a transient failure would
 /// guarantee the retry fails too.
 /// <para>
-/// The success path deletes only the per-resource-type acquisition keys and leaves
-/// <c>{correlationId}</c> in place for Measure Eval to read. Whether a terminal failure may also
-/// remove the correlation key depends on what the caller can prove — see
-/// <see cref="ResourceCachePurgeScope"/>.
+/// Only the per-resource-type acquisition keys (<c>{correlationId}:{ResourceType}</c>) are ever
+/// deleted — they are Normalization's input, consumed by this message alone. The
+/// <c>{correlationId}</c> key is Normalization's output and belongs to its reader: Measure Eval
+/// deletes it after evaluation, and the cache expiration policy reclaims it if no reader ever
+/// comes (e.g. the failure occurred before <c>ResourcesNormalized</c> was published). Normalization
+/// never deletes it, on any path — it cannot know whether an earlier attempt already published, or
+/// whether the key still holds kept INITIAL-phase data a SUPPLEMENTAL evaluation needs.
 /// </para>
 /// </remarks>
 public interface IResourceCachePurger
 {
-    Task PurgeAsync(ResourcesAcquiredValue? value, string reason, ResourceCachePurgeScope scope, CancellationToken cancellationToken = default);
+    Task PurgeAsync(ResourcesAcquiredValue? value, string reason, CancellationToken cancellationToken = default);
 }
 
 /// <inheritdoc cref="IResourceCachePurger"/>
@@ -60,7 +39,7 @@ public class ResourceCachePurger : IResourceCachePurger
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
-    public async Task PurgeAsync(ResourcesAcquiredValue? value, string reason, ResourceCachePurgeScope scope, CancellationToken cancellationToken = default)
+    public async Task PurgeAsync(ResourcesAcquiredValue? value, string reason, CancellationToken cancellationToken = default)
     {
         var cacheKeys = value?.CacheKeys?.Where(k => !string.IsNullOrWhiteSpace(k)).ToList();
 
@@ -73,31 +52,18 @@ public class ResourceCachePurger : IResourceCachePurger
             return;
         }
 
-        // Acquisition keys are "{correlationId}:{ResourceType}". The correlation key itself is only
-        // removed when the caller can prove ResourcesNormalized was never published for this message
-        // (scope All); otherwise Measure Eval may still be reading it, and it is left to expire.
-        var keysToDelete = new List<string>(cacheKeys);
-        if (scope == ResourceCachePurgeScope.All)
-        {
-            keysToDelete.AddRange(cacheKeys
-                .Select(ExtractCorrelationId)
-                .Where(correlationId => !string.IsNullOrWhiteSpace(correlationId))
-                .Distinct()
-                .Where(correlationId => !keysToDelete.Contains(correlationId)));
-        }
-
         try
         {
             await _resourceCache
                 .GetImplementation(value!.CacheType)
-                .DeleteAsync(keysToDelete, cancellationToken);
+                .DeleteAsync(cacheKeys, cancellationToken);
 
             _logger.LogInformation(
                 "Purged {KeyCount} resource cache entries after terminal failure ({Reason}). CacheType: {CacheType}, Keys: [{Keys}]",
-                keysToDelete.Count,
+                cacheKeys.Count,
                 reason.SanitizeForLog(),
                 value.CacheType,
-                string.Join(", ", keysToDelete).SanitizeForLog());
+                string.Join(", ", cacheKeys).SanitizeForLog());
         }
         catch (Exception ex)
         {
@@ -107,14 +73,7 @@ public class ResourceCachePurger : IResourceCachePurger
                 "Failed to purge resource cache after terminal failure ({Reason}). CacheType: {CacheType}, Keys: [{Keys}]",
                 reason.SanitizeForLog(),
                 value!.CacheType,
-                string.Join(", ", keysToDelete).SanitizeForLog());
+                string.Join(", ", cacheKeys).SanitizeForLog());
         }
-    }
-
-    /// <remarks>Mirrors <c>HybridResourceCache.ExtractCorrelationId</c>.</remarks>
-    private static string ExtractCorrelationId(string cacheKey)
-    {
-        var idx = cacheKey.IndexOf(':');
-        return idx > 0 ? cacheKey[..idx] : cacheKey;
     }
 }

--- a/DotNet/Normalization/Application/Services/ResourceCachePurger.cs
+++ b/DotNet/Normalization/Application/Services/ResourceCachePurger.cs
@@ -1,0 +1,91 @@
+using LantanaGroup.Link.Normalization.Application.Models.Messages;
+using LantanaGroup.Link.Shared.Application.Interfaces;
+using LantanaGroup.Link.Shared.Application.Services.Security;
+
+namespace LantanaGroup.Link.Normalization.Application.Services;
+
+/// <summary>
+/// Releases the resource cache entries belonging to a <c>ResourcesAcquired</c> message after a
+/// terminal (non-retryable) normalization failure.
+/// </summary>
+/// <remarks>
+/// Only call this on terminal failures. A message bound for <c>ResourcesAcquired-Retry</c> still
+/// needs its cached resources when it is redelivered, so purging on a transient failure would
+/// guarantee the retry fails too.
+/// <para>
+/// Unlike the success path — which deletes only the per-resource-type acquisition keys and leaves
+/// <c>{correlationId}</c> in place for Measure Eval to read — a terminal failure also removes the
+/// correlation key, because nothing downstream will ever consume it.
+/// </para>
+/// </remarks>
+public interface IResourceCachePurger
+{
+    Task PurgeAsync(ResourcesAcquiredValue? value, string reason, CancellationToken cancellationToken = default);
+}
+
+/// <inheritdoc cref="IResourceCachePurger"/>
+public class ResourceCachePurger : IResourceCachePurger
+{
+    private readonly IResourceCache _resourceCache;
+    private readonly ILogger<ResourceCachePurger> _logger;
+
+    public ResourceCachePurger(IResourceCache resourceCache, ILogger<ResourceCachePurger> logger)
+    {
+        _resourceCache = resourceCache ?? throw new ArgumentNullException(nameof(resourceCache));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task PurgeAsync(ResourcesAcquiredValue? value, string reason, CancellationToken cancellationToken = default)
+    {
+        var cacheKeys = value?.CacheKeys?.Where(k => !string.IsNullOrWhiteSpace(k)).ToList();
+
+        if (cacheKeys == null || cacheKeys.Count == 0)
+        {
+            _logger.LogWarning(
+                "Cannot purge resource cache after terminal failure ({Reason}): the message carries no cache keys. " +
+                "Any cached resources for it will be released by the cache expiration policy instead.",
+                reason.SanitizeForLog());
+            return;
+        }
+
+        // Acquisition keys are "{correlationId}:{ResourceType}"; the correlation key itself holds
+        // whatever normalization managed to write before it failed, so it goes too.
+        var keysToDelete = new List<string>(cacheKeys);
+        keysToDelete.AddRange(cacheKeys
+            .Select(ExtractCorrelationId)
+            .Where(correlationId => !string.IsNullOrWhiteSpace(correlationId))
+            .Distinct()
+            .Where(correlationId => !keysToDelete.Contains(correlationId)));
+
+        try
+        {
+            await _resourceCache
+                .GetImplementation(value!.CacheType)
+                .DeleteAsync(keysToDelete, cancellationToken);
+
+            _logger.LogInformation(
+                "Purged {KeyCount} resource cache entries after terminal failure ({Reason}). CacheType: {CacheType}, Keys: [{Keys}]",
+                keysToDelete.Count,
+                reason.SanitizeForLog(),
+                value.CacheType,
+                string.Join(", ", keysToDelete).SanitizeForLog());
+        }
+        catch (Exception ex)
+        {
+            // Never let cleanup failure escape: the caller is already handling a failed message, and
+            // the cache expiration policy is the backstop for whatever we could not delete here.
+            _logger.LogError(ex,
+                "Failed to purge resource cache after terminal failure ({Reason}). CacheType: {CacheType}, Keys: [{Keys}]",
+                reason.SanitizeForLog(),
+                value!.CacheType,
+                string.Join(", ", keysToDelete).SanitizeForLog());
+        }
+    }
+
+    /// <remarks>Mirrors <c>HybridResourceCache.ExtractCorrelationId</c>.</remarks>
+    private static string ExtractCorrelationId(string cacheKey)
+    {
+        var idx = cacheKey.IndexOf(':');
+        return idx > 0 ? cacheKey[..idx] : cacheKey;
+    }
+}

--- a/DotNet/Normalization/Application/Services/ResourceCachePurger.cs
+++ b/DotNet/Normalization/Application/Services/ResourceCachePurger.cs
@@ -5,6 +5,30 @@ using LantanaGroup.Link.Shared.Application.Services.Security;
 namespace LantanaGroup.Link.Normalization.Application.Services;
 
 /// <summary>
+/// Which cache keys a terminal-failure purge is allowed to remove. The scope encodes what the
+/// caller can prove about whether <c>ResourcesNormalized</c> was already published for the message.
+/// </summary>
+public enum ResourceCachePurgeScope
+{
+    /// <summary>
+    /// Remove the per-resource-type acquisition keys and the <c>{correlationId}</c> key. Only valid
+    /// where the failure provably occurred before <c>ResourcesNormalized</c> was produced (the
+    /// immediate dead-letter path: validation raises before the processing loop), so nothing
+    /// downstream can be holding the correlation key.
+    /// </summary>
+    All,
+
+    /// <summary>
+    /// Remove only the per-resource-type acquisition keys. For paths that cannot rule out a prior
+    /// publish — retry exhaustion follows attempts that may have produced <c>ResourcesNormalized</c>
+    /// and then failed on the trailing cache delete — where Measure Eval may already be holding
+    /// <c>{correlationId}</c> for its SUPPLEMENTAL pass. The correlation key is left to the cache
+    /// expiration policy.
+    /// </summary>
+    AcquisitionKeysOnly
+}
+
+/// <summary>
 /// Releases the resource cache entries belonging to a <c>ResourcesAcquired</c> message after a
 /// terminal (non-retryable) normalization failure.
 /// </summary>
@@ -13,14 +37,15 @@ namespace LantanaGroup.Link.Normalization.Application.Services;
 /// needs its cached resources when it is redelivered, so purging on a transient failure would
 /// guarantee the retry fails too.
 /// <para>
-/// Unlike the success path — which deletes only the per-resource-type acquisition keys and leaves
-/// <c>{correlationId}</c> in place for Measure Eval to read — a terminal failure also removes the
-/// correlation key, because nothing downstream will ever consume it.
+/// The success path deletes only the per-resource-type acquisition keys and leaves
+/// <c>{correlationId}</c> in place for Measure Eval to read. Whether a terminal failure may also
+/// remove the correlation key depends on what the caller can prove — see
+/// <see cref="ResourceCachePurgeScope"/>.
 /// </para>
 /// </remarks>
 public interface IResourceCachePurger
 {
-    Task PurgeAsync(ResourcesAcquiredValue? value, string reason, CancellationToken cancellationToken = default);
+    Task PurgeAsync(ResourcesAcquiredValue? value, string reason, ResourceCachePurgeScope scope, CancellationToken cancellationToken = default);
 }
 
 /// <inheritdoc cref="IResourceCachePurger"/>
@@ -35,7 +60,7 @@ public class ResourceCachePurger : IResourceCachePurger
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
-    public async Task PurgeAsync(ResourcesAcquiredValue? value, string reason, CancellationToken cancellationToken = default)
+    public async Task PurgeAsync(ResourcesAcquiredValue? value, string reason, ResourceCachePurgeScope scope, CancellationToken cancellationToken = default)
     {
         var cacheKeys = value?.CacheKeys?.Where(k => !string.IsNullOrWhiteSpace(k)).ToList();
 
@@ -48,14 +73,18 @@ public class ResourceCachePurger : IResourceCachePurger
             return;
         }
 
-        // Acquisition keys are "{correlationId}:{ResourceType}"; the correlation key itself holds
-        // whatever normalization managed to write before it failed, so it goes too.
+        // Acquisition keys are "{correlationId}:{ResourceType}". The correlation key itself is only
+        // removed when the caller can prove ResourcesNormalized was never published for this message
+        // (scope All); otherwise Measure Eval may still be reading it, and it is left to expire.
         var keysToDelete = new List<string>(cacheKeys);
-        keysToDelete.AddRange(cacheKeys
-            .Select(ExtractCorrelationId)
-            .Where(correlationId => !string.IsNullOrWhiteSpace(correlationId))
-            .Distinct()
-            .Where(correlationId => !keysToDelete.Contains(correlationId)));
+        if (scope == ResourceCachePurgeScope.All)
+        {
+            keysToDelete.AddRange(cacheKeys
+                .Select(ExtractCorrelationId)
+                .Where(correlationId => !string.IsNullOrWhiteSpace(correlationId))
+                .Distinct()
+                .Where(correlationId => !keysToDelete.Contains(correlationId)));
+        }
 
         try
         {

--- a/DotNet/Normalization/Application/Services/ResourceCachePurger.cs
+++ b/DotNet/Normalization/Application/Services/ResourceCachePurger.cs
@@ -13,13 +13,10 @@ namespace LantanaGroup.Link.Normalization.Application.Services;
 /// needs its cached resources when it is redelivered, so purging on a transient failure would
 /// guarantee the retry fails too.
 /// <para>
-/// Only the per-resource-type acquisition keys (<c>{correlationId}:{ResourceType}</c>) are ever
-/// deleted — they are Normalization's input, consumed by this message alone. The
-/// <c>{correlationId}</c> key is Normalization's output and belongs to its reader: Measure Eval
-/// deletes it after evaluation, and the cache expiration policy reclaims it if no reader ever
-/// comes (e.g. the failure occurred before <c>ResourcesNormalized</c> was published). Normalization
-/// never deletes it, on any path — it cannot know whether an earlier attempt already published, or
-/// whether the key still holds kept INITIAL-phase data a SUPPLEMENTAL evaluation needs.
+/// Unlike the success path — which deletes only the per-resource-type acquisition keys
+/// (<c>{correlationId}:{ResourceType}</c>) and leaves <c>{correlationId}</c> in place for Measure
+/// Eval to read — a terminal failure also removes the correlation key, because nothing downstream
+/// will ever consume it.
 /// </para>
 /// </remarks>
 public interface IResourceCachePurger
@@ -52,18 +49,27 @@ public class ResourceCachePurger : IResourceCachePurger
             return;
         }
 
+        // Acquisition keys are "{correlationId}:{ResourceType}"; the correlation key itself holds
+        // whatever normalization managed to write before it failed, so it goes too.
+        var keysToDelete = new List<string>(cacheKeys);
+        keysToDelete.AddRange(cacheKeys
+            .Select(ExtractCorrelationId)
+            .Where(correlationId => !string.IsNullOrWhiteSpace(correlationId))
+            .Distinct()
+            .Where(correlationId => !keysToDelete.Contains(correlationId)));
+
         try
         {
             await _resourceCache
                 .GetImplementation(value!.CacheType)
-                .DeleteAsync(cacheKeys, cancellationToken);
+                .DeleteAsync(keysToDelete, cancellationToken);
 
             _logger.LogInformation(
                 "Purged {KeyCount} resource cache entries after terminal failure ({Reason}). CacheType: {CacheType}, Keys: [{Keys}]",
-                cacheKeys.Count,
+                keysToDelete.Count,
                 reason.SanitizeForLog(),
                 value.CacheType,
-                string.Join(", ", cacheKeys).SanitizeForLog());
+                string.Join(", ", keysToDelete).SanitizeForLog());
         }
         catch (Exception ex)
         {
@@ -73,7 +79,14 @@ public class ResourceCachePurger : IResourceCachePurger
                 "Failed to purge resource cache after terminal failure ({Reason}). CacheType: {CacheType}, Keys: [{Keys}]",
                 reason.SanitizeForLog(),
                 value!.CacheType,
-                string.Join(", ", cacheKeys).SanitizeForLog());
+                string.Join(", ", keysToDelete).SanitizeForLog());
         }
+    }
+
+    /// <remarks>Mirrors <c>HybridResourceCache.ExtractCorrelationId</c>.</remarks>
+    private static string ExtractCorrelationId(string cacheKey)
+    {
+        var idx = cacheKey.IndexOf(':');
+        return idx > 0 ? cacheKey[..idx] : cacheKey;
     }
 }

--- a/DotNet/Normalization/Listeners/ResourcesAcquiredListener.cs
+++ b/DotNet/Normalization/Listeners/ResourcesAcquiredListener.cs
@@ -187,9 +187,16 @@ public class ResourcesAcquiredListener : BackgroundService
             // Terminal failure: the message is on ResourcesAcquired-Error and will never be normalized,
             // so release its cached resources. The retry paths below must NOT do this — a redelivered
             // message still needs its cache.
+            //
+            // Scope.All is safe here ONLY because DeadLetterException is raised exclusively by
+            // ValidateResourcesAcquiredEvent, before the processing loop — so ResourcesNormalized was
+            // provably never produced and nothing downstream can be holding {correlationId}. If a
+            // DeadLetterException is ever thrown after the produce, this must become
+            // AcquisitionKeysOnly.
             await _resourceCachePurger.PurgeAsync(
                 result.Message.Value,
                 $"{nameof(KafkaTopic.ResourcesAcquired)} dead-lettered: {ex.Message}",
+                ResourceCachePurgeScope.All,
                 consumeCancellationToken);
         }
         catch (TransientException ex)

--- a/DotNet/Normalization/Listeners/ResourcesAcquiredListener.cs
+++ b/DotNet/Normalization/Listeners/ResourcesAcquiredListener.cs
@@ -44,6 +44,7 @@ public class ResourcesAcquiredListener : BackgroundService
     private readonly CopyLocationAliasToTypeIterativelyOperationService _copyLocationAliasToTypeIterativelyOperationService;
     private readonly RemoveExtensionsOperationService _removeExtensionsOperationService;
     private readonly IResourceCache _resourceCache;
+    private readonly IResourceCachePurger _resourceCachePurger;
 
     public ResourcesAcquiredListener(
         ILogger<ResourcesAcquiredListener> logger,
@@ -61,7 +62,8 @@ public class ResourcesAcquiredListener : BackgroundService
         CopyLocationOperationService copyLocationOperationService,
         CopyLocationAliasToTypeIterativelyOperationService copyLocationAliasToTypeIterativelyOperationService,
         RemoveExtensionsOperationService removeExtensionsOperationService,
-        IResourceCache resourceCache)
+        IResourceCache resourceCache,
+        IResourceCachePurger resourceCachePurger)
     {
         this._logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _consumerFactory = consumerFactory ?? throw new ArgumentNullException(nameof(consumerFactory));
@@ -88,6 +90,7 @@ public class ResourcesAcquiredListener : BackgroundService
         _copyLocationAliasToTypeIterativelyOperationService = copyLocationAliasToTypeIterativelyOperationService ?? throw new ArgumentNullException(nameof(copyLocationAliasToTypeIterativelyOperationService));
         _removeExtensionsOperationService = removeExtensionsOperationService ?? throw new ArgumentNullException(nameof(removeExtensionsOperationService));
         _resourceCache = resourceCache ?? throw new ArgumentNullException(nameof(resourceCache));
+        _resourceCachePurger = resourceCachePurger ?? throw new ArgumentNullException(nameof(resourceCachePurger));
     }
 
     protected override async Task ExecuteAsync(CancellationToken cancellationToken)
@@ -113,25 +116,7 @@ public class ResourcesAcquiredListener : BackgroundService
                 {
                     try
                     {
-                        await ProcessMessageAsync(result, consumeCancellationToken);
-                    }
-                    catch (DeadLetterException ex)
-                    {
-                        _deadLetterExceptionHandler.HandleException(result, ex, result.Message.Key?.FacilityId ?? string.Empty);
-                    }
-                    catch (TransientException ex)
-                    {
-                        _transientExceptionHandler.HandleException(result, ex, result.Message.Key?.FacilityId ?? string.Empty);
-                    }
-                    catch (OperationCanceledException) when (consumeCancellationToken.IsCancellationRequested)
-                    {
-                        throw;
-                    }
-                    catch (Exception ex)
-                    {
-                        _logger.LogError(ex, "Failed to process ResourceAcquired event for facility {FacilityId}.", result?.Message.Key?.FacilityId?.SanitizeForLog());
-
-                        _transientExceptionHandler.HandleException(result, new TransientException("Normalization Exception thrown: " + ex.Message, ex), result.Message.Key?.FacilityId ?? string.Empty);
+                        await ConsumeMessageAsync(result, consumeCancellationToken);
                     }
                     finally
                     {
@@ -179,6 +164,47 @@ public class ResourcesAcquiredListener : BackgroundService
                 }
                 continue;
             }
+        }
+    }
+
+    /// <summary>
+    /// Processes a single consumed message and routes any failure to the dead letter or retry topic.
+    /// </summary>
+    /// <remarks>
+    /// Separate from the consume loop (which owns only the offset commit) so that the failure routing —
+    /// in particular which failures release the resource cache — is directly testable.
+    /// </remarks>
+    public async Task ConsumeMessageAsync(ConsumeResult<ResourceKey, ResourcesAcquiredValue> result, CancellationToken consumeCancellationToken)
+    {
+        try
+        {
+            await ProcessMessageAsync(result, consumeCancellationToken);
+        }
+        catch (DeadLetterException ex)
+        {
+            _deadLetterExceptionHandler.HandleException(result, ex, result.Message.Key?.FacilityId ?? string.Empty);
+
+            // Terminal failure: the message is on ResourcesAcquired-Error and will never be normalized,
+            // so release its cached resources. The retry paths below must NOT do this — a redelivered
+            // message still needs its cache.
+            await _resourceCachePurger.PurgeAsync(
+                result.Message.Value,
+                $"{nameof(KafkaTopic.ResourcesAcquired)} dead-lettered: {ex.Message}",
+                consumeCancellationToken);
+        }
+        catch (TransientException ex)
+        {
+            _transientExceptionHandler.HandleException(result, ex, result.Message.Key?.FacilityId ?? string.Empty);
+        }
+        catch (OperationCanceledException) when (consumeCancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to process ResourceAcquired event for facility {FacilityId}.", result?.Message.Key?.FacilityId?.SanitizeForLog());
+
+            _transientExceptionHandler.HandleException(result, new TransientException("Normalization Exception thrown: " + ex.Message, ex), result.Message.Key?.FacilityId ?? string.Empty);
         }
     }
 

--- a/DotNet/Normalization/Listeners/ResourcesAcquiredListener.cs
+++ b/DotNet/Normalization/Listeners/ResourcesAcquiredListener.cs
@@ -185,18 +185,12 @@ public class ResourcesAcquiredListener : BackgroundService
             _deadLetterExceptionHandler.HandleException(result, ex, result.Message.Key?.FacilityId ?? string.Empty);
 
             // Terminal failure: the message is on ResourcesAcquired-Error and will never be normalized,
-            // so release its cached resources. The retry paths below must NOT do this — a redelivered
-            // message still needs its cache.
-            //
-            // Scope.All is safe here ONLY because DeadLetterException is raised exclusively by
-            // ValidateResourcesAcquiredEvent, before the processing loop — so ResourcesNormalized was
-            // provably never produced and nothing downstream can be holding {correlationId}. If a
-            // DeadLetterException is ever thrown after the produce, this must become
-            // AcquisitionKeysOnly.
+            // so release its acquisition keys. The retry paths below must NOT do this — a redelivered
+            // message still needs its cache. The {correlationId} key is never deleted here: Measure
+            // Eval owns its deletion, and the cache expiration policy reclaims it if unread.
             await _resourceCachePurger.PurgeAsync(
                 result.Message.Value,
                 $"{nameof(KafkaTopic.ResourcesAcquired)} dead-lettered: {ex.Message}",
-                ResourceCachePurgeScope.All,
                 consumeCancellationToken);
         }
         catch (TransientException ex)

--- a/DotNet/Normalization/Listeners/ResourcesAcquiredListener.cs
+++ b/DotNet/Normalization/Listeners/ResourcesAcquiredListener.cs
@@ -185,9 +185,8 @@ public class ResourcesAcquiredListener : BackgroundService
             _deadLetterExceptionHandler.HandleException(result, ex, result.Message.Key?.FacilityId ?? string.Empty);
 
             // Terminal failure: the message is on ResourcesAcquired-Error and will never be normalized,
-            // so release its acquisition keys. The retry paths below must NOT do this — a redelivered
-            // message still needs its cache. The {correlationId} key is never deleted here: Measure
-            // Eval owns its deletion, and the cache expiration policy reclaims it if unread.
+            // so release its acquisition keys and the {correlationId} key normalization was writing.
+            // The retry paths below must NOT do this — a redelivered message still needs its cache.
             await _resourceCachePurger.PurgeAsync(
                 result.Message.Value,
                 $"{nameof(KafkaTopic.ResourcesAcquired)} dead-lettered: {ex.Message}",

--- a/DotNet/Normalization/Program.cs
+++ b/DotNet/Normalization/Program.cs
@@ -100,9 +100,10 @@ static void RegisterServices(WebApplicationBuilder builder)
 
     builder.Services.AddSingleton<IResourceCachePurger, ResourceCachePurger>();
 
-    // Registered after the open generic above so that it wins for this closed type: when RetryListener
-    // exhausts the retry count for a ResourcesAcquired message, the dead letter also releases the
-    // resource cache. See ResourcesAcquiredRetryDeadLetterHandler.
+    // A closed-type registration takes precedence over the open generic above regardless of the order
+    // the two appear in, so this wins for IDeadLetterExceptionHandler<RetryListener, string, string>:
+    // when RetryListener exhausts the retry count for a ResourcesAcquired message, the dead letter also
+    // releases the resource cache. See ResourcesAcquiredRetryDeadLetterHandler.
     builder.Services.AddSingleton<IDeadLetterExceptionHandler<RetryListener, string, string>, ResourcesAcquiredRetryDeadLetterHandler>();
 
     builder.Services.AddTransient<ITenantApiService, TenantApiService>();

--- a/DotNet/Normalization/Program.cs
+++ b/DotNet/Normalization/Program.cs
@@ -3,6 +3,7 @@ using Confluent.Kafka;
 using HealthChecks.UI.Client;
 using Hl7.Fhir.Model.CdsHooks;
 using LantanaGroup.Link.Shared.Application.Models.Configs;
+using LantanaGroup.Link.Normalization.Application.Error;
 using LantanaGroup.Link.Normalization.Application.Models.Messages;
 using LantanaGroup.Link.Normalization.Application.Services;
 using LantanaGroup.Link.Normalization.Application.Services.Operations;
@@ -96,6 +97,13 @@ static void RegisterServices(WebApplicationBuilder builder)
     builder.Services.AddSingleton(typeof(IExceptionLogger<>), typeof(ExceptionLogger<>));
     builder.Services.AddSingleton(typeof(ITransientExceptionHandler<,,>), typeof(TransientExceptionHandler<,,>));
     builder.Services.AddSingleton(typeof(IDeadLetterExceptionHandler<,,>), typeof(DeadLetterExceptionHandler<,,>));
+
+    builder.Services.AddSingleton<IResourceCachePurger, ResourceCachePurger>();
+
+    // Registered after the open generic above so that it wins for this closed type: when RetryListener
+    // exhausts the retry count for a ResourcesAcquired message, the dead letter also releases the
+    // resource cache. See ResourcesAcquiredRetryDeadLetterHandler.
+    builder.Services.AddSingleton<IDeadLetterExceptionHandler<RetryListener, string, string>, ResourcesAcquiredRetryDeadLetterHandler>();
 
     builder.Services.AddTransient<ITenantApiService, TenantApiService>();
 

--- a/DotNet/ServiceTests/IntegrationTests/Normalization/NormalizationIntegrationTestFixture.cs
+++ b/DotNet/ServiceTests/IntegrationTests/Normalization/NormalizationIntegrationTestFixture.cs
@@ -159,6 +159,7 @@ namespace IntegrationTests.Normalization
             builder.Services.AddKeyedSingleton<IResourceCache, RedisResourceCache>(ResourceCacheType.Redis);
             builder.Services.AddKeyedSingleton<IResourceCache, ABSResourceCache>(ResourceCacheType.ABS);
             builder.Services.AddSingleton<IResourceCache, HybridResourceCache>();
+            builder.Services.AddSingleton<IResourceCachePurger, ResourceCachePurger>();
             
             builder.Services.AddMemoryCache();
 

--- a/DotNet/ServiceTests/UnitTests/Normalization/ResourceCachePurgerTests.cs
+++ b/DotNet/ServiceTests/UnitTests/Normalization/ResourceCachePurgerTests.cs
@@ -1,0 +1,132 @@
+using LantanaGroup.Link.Normalization.Application.Models.Messages;
+using LantanaGroup.Link.Normalization.Application.Services;
+using LantanaGroup.Link.Shared.Application.Enums;
+using LantanaGroup.Link.Shared.Application.Interfaces;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Task = System.Threading.Tasks.Task;
+
+namespace UnitTests.Normalization;
+
+[Trait("Category", "UnitTests")]
+public class ResourceCachePurgerTests
+{
+    private const string CorrelationId = "3fa85f64-5717-4562-b3fc-2c963f66afa6";
+
+    [Fact]
+    public async Task PurgeAsync_DeletesAcquisitionKeysAndCorrelationKey()
+    {
+        var (purger, cache, implementation) = BuildPurger(ResourceCacheType.Redis);
+
+        List<string>? deletedKeys = null;
+        implementation
+            .Setup(item => item.DeleteAsync(It.IsAny<List<string>>(), It.IsAny<CancellationToken>()))
+            .Callback<List<string>, CancellationToken>((keys, _) => deletedKeys = keys)
+            .Returns(Task.CompletedTask);
+
+        await purger.PurgeAsync(BuildValue(ResourceCacheType.Redis), "test");
+
+        cache.Verify(item => item.GetImplementation(ResourceCacheType.Redis), Times.Once);
+        Assert.NotNull(deletedKeys);
+        Assert.Equal(
+            new List<string> { $"{CorrelationId}:Patient", $"{CorrelationId}:Encounter", CorrelationId },
+            deletedKeys);
+    }
+
+    [Fact]
+    public async Task PurgeAsync_UsesTheCacheTypeCarriedOnTheMessage()
+    {
+        var (purger, cache, implementation) = BuildPurger(ResourceCacheType.ABS);
+
+        implementation
+            .Setup(item => item.DeleteAsync(It.IsAny<List<string>>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        await purger.PurgeAsync(BuildValue(ResourceCacheType.ABS), "test");
+
+        cache.Verify(item => item.GetImplementation(ResourceCacheType.ABS), Times.Once);
+    }
+
+    [Fact]
+    public async Task PurgeAsync_DoesNotDeleteTwiceWhenTheCorrelationKeyIsAlreadyPresent()
+    {
+        var (purger, _, implementation) = BuildPurger(ResourceCacheType.Redis);
+
+        List<string>? deletedKeys = null;
+        implementation
+            .Setup(item => item.DeleteAsync(It.IsAny<List<string>>(), It.IsAny<CancellationToken>()))
+            .Callback<List<string>, CancellationToken>((keys, _) => deletedKeys = keys)
+            .Returns(Task.CompletedTask);
+
+        var value = BuildValue(ResourceCacheType.Redis);
+        value.CacheKeys.Add(CorrelationId);
+
+        await purger.PurgeAsync(value, "test");
+
+        Assert.NotNull(deletedKeys);
+        Assert.Equal(deletedKeys!.Count, deletedKeys.Distinct().Count());
+    }
+
+    [Fact]
+    public async Task PurgeAsync_WithNullCacheKeys_DoesNotDelete() => await AssertNoDelete(null);
+
+    [Fact]
+    public async Task PurgeAsync_WithEmptyCacheKeys_DoesNotDelete() => await AssertNoDelete(new List<string>());
+
+    private static async Task AssertNoDelete(List<string>? cacheKeys)
+    {
+        var (purger, cache, implementation) = BuildPurger(ResourceCacheType.Redis);
+
+        var value = BuildValue(ResourceCacheType.Redis);
+        value.CacheKeys = cacheKeys!;
+
+        await purger.PurgeAsync(value, "test");
+
+        cache.Verify(item => item.GetImplementation(It.IsAny<ResourceCacheType>()), Times.Never);
+        implementation.Verify(
+            item => item.DeleteAsync(It.IsAny<List<string>>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task PurgeAsync_WithNullValue_DoesNotThrow()
+    {
+        var (purger, cache, _) = BuildPurger(ResourceCacheType.Redis);
+
+        await purger.PurgeAsync(null, "test");
+
+        cache.Verify(item => item.GetImplementation(It.IsAny<ResourceCacheType>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task PurgeAsync_WhenDeleteThrows_SwallowsTheException()
+    {
+        var (purger, _, implementation) = BuildPurger(ResourceCacheType.Redis);
+
+        implementation
+            .Setup(item => item.DeleteAsync(It.IsAny<List<string>>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("cache unavailable"));
+
+        // The caller is already handling a failed message; cleanup failure must not add another.
+        await purger.PurgeAsync(BuildValue(ResourceCacheType.Redis), "test");
+    }
+
+    private static (ResourceCachePurger, Mock<IResourceCache>, Mock<IResourceCache>) BuildPurger(ResourceCacheType cacheType)
+    {
+        var implementation = new Mock<IResourceCache>();
+        var cache = new Mock<IResourceCache>();
+        cache.Setup(item => item.GetImplementation(cacheType)).Returns(implementation.Object);
+
+        var purger = new ResourceCachePurger(cache.Object, Mock.Of<ILogger<ResourceCachePurger>>());
+
+        return (purger, cache, implementation);
+    }
+
+    private static ResourcesAcquiredValue BuildValue(ResourceCacheType cacheType) => new()
+    {
+        QueryType = "Initial",
+        ReportableEvent = "Adhoc",
+        ScheduledReports = new List<LantanaGroup.Link.Shared.Application.Models.ScheduledReport>(),
+        CacheType = cacheType,
+        CacheKeys = new List<string> { $"{CorrelationId}:Patient", $"{CorrelationId}:Encounter" }
+    };
+}

--- a/DotNet/ServiceTests/UnitTests/Normalization/ResourceCachePurgerTests.cs
+++ b/DotNet/ServiceTests/UnitTests/Normalization/ResourceCachePurgerTests.cs
@@ -14,8 +14,11 @@ public class ResourceCachePurgerTests
     private const string CorrelationId = "3fa85f64-5717-4562-b3fc-2c963f66afa6";
 
     [Fact]
-    public async Task PurgeAsync_ScopeAll_DeletesAcquisitionKeysAndCorrelationKey()
+    public async Task PurgeAsync_DeletesOnlyTheAcquisitionKeys_NeverTheCorrelationKey()
     {
+        // Normalization only ever deletes its own input, the {correlationId}:{ResourceType}
+        // acquisition keys. The {correlationId} key belongs to its reader: Measure Eval deletes it
+        // after evaluation, and the cache expiration policy reclaims it if no reader ever comes.
         var (purger, cache, implementation) = BuildPurger(ResourceCacheType.Redis);
 
         List<string>? deletedKeys = null;
@@ -24,32 +27,9 @@ public class ResourceCachePurgerTests
             .Callback<List<string>, CancellationToken>((keys, _) => deletedKeys = keys)
             .Returns(Task.CompletedTask);
 
-        await purger.PurgeAsync(BuildValue(ResourceCacheType.Redis), "test", ResourceCachePurgeScope.All);
+        await purger.PurgeAsync(BuildValue(ResourceCacheType.Redis), "test");
 
         cache.Verify(item => item.GetImplementation(ResourceCacheType.Redis), Times.Once);
-        Assert.NotNull(deletedKeys);
-        Assert.Equal(
-            new List<string> { $"{CorrelationId}:Patient", $"{CorrelationId}:Encounter", CorrelationId },
-            deletedKeys);
-    }
-
-    [Fact]
-    public async Task PurgeAsync_ScopeAcquisitionKeysOnly_LeavesTheCorrelationKey()
-    {
-        // The retry-exhausted path cannot prove that an earlier attempt did not already publish
-        // ResourcesNormalized (the produce precedes the acquisition-key delete on the success path),
-        // so Measure Eval may be holding {correlationId} for its SUPPLEMENTAL pass. That key must
-        // survive this purge; the cache expiration policy reclaims it if nothing needed it.
-        var (purger, _, implementation) = BuildPurger(ResourceCacheType.Redis);
-
-        List<string>? deletedKeys = null;
-        implementation
-            .Setup(item => item.DeleteAsync(It.IsAny<List<string>>(), It.IsAny<CancellationToken>()))
-            .Callback<List<string>, CancellationToken>((keys, _) => deletedKeys = keys)
-            .Returns(Task.CompletedTask);
-
-        await purger.PurgeAsync(BuildValue(ResourceCacheType.Redis), "test", ResourceCachePurgeScope.AcquisitionKeysOnly);
-
         Assert.NotNull(deletedKeys);
         Assert.Equal(
             new List<string> { $"{CorrelationId}:Patient", $"{CorrelationId}:Encounter" },
@@ -66,29 +46,9 @@ public class ResourceCachePurgerTests
             .Setup(item => item.DeleteAsync(It.IsAny<List<string>>(), It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask);
 
-        await purger.PurgeAsync(BuildValue(ResourceCacheType.ABS), "test", ResourceCachePurgeScope.All);
+        await purger.PurgeAsync(BuildValue(ResourceCacheType.ABS), "test");
 
         cache.Verify(item => item.GetImplementation(ResourceCacheType.ABS), Times.Once);
-    }
-
-    [Fact]
-    public async Task PurgeAsync_DoesNotDeleteTwiceWhenTheCorrelationKeyIsAlreadyPresent()
-    {
-        var (purger, _, implementation) = BuildPurger(ResourceCacheType.Redis);
-
-        List<string>? deletedKeys = null;
-        implementation
-            .Setup(item => item.DeleteAsync(It.IsAny<List<string>>(), It.IsAny<CancellationToken>()))
-            .Callback<List<string>, CancellationToken>((keys, _) => deletedKeys = keys)
-            .Returns(Task.CompletedTask);
-
-        var value = BuildValue(ResourceCacheType.Redis);
-        value.CacheKeys.Add(CorrelationId);
-
-        await purger.PurgeAsync(value, "test", ResourceCachePurgeScope.All);
-
-        Assert.NotNull(deletedKeys);
-        Assert.Equal(deletedKeys!.Count, deletedKeys.Distinct().Count());
     }
 
     [Fact]
@@ -104,7 +64,7 @@ public class ResourceCachePurgerTests
         var value = BuildValue(ResourceCacheType.Redis);
         value.CacheKeys = cacheKeys!;
 
-        await purger.PurgeAsync(value, "test", ResourceCachePurgeScope.All);
+        await purger.PurgeAsync(value, "test");
 
         cache.Verify(item => item.GetImplementation(It.IsAny<ResourceCacheType>()), Times.Never);
         implementation.Verify(
@@ -116,7 +76,7 @@ public class ResourceCachePurgerTests
     {
         var (purger, cache, _) = BuildPurger(ResourceCacheType.Redis);
 
-        await purger.PurgeAsync(null, "test", ResourceCachePurgeScope.All);
+        await purger.PurgeAsync(null, "test");
 
         cache.Verify(item => item.GetImplementation(It.IsAny<ResourceCacheType>()), Times.Never);
     }
@@ -131,7 +91,7 @@ public class ResourceCachePurgerTests
             .ThrowsAsync(new InvalidOperationException("cache unavailable"));
 
         // The caller is already handling a failed message; cleanup failure must not add another.
-        await purger.PurgeAsync(BuildValue(ResourceCacheType.Redis), "test", ResourceCachePurgeScope.All);
+        await purger.PurgeAsync(BuildValue(ResourceCacheType.Redis), "test");
     }
 
     private static (ResourceCachePurger, Mock<IResourceCache>, Mock<IResourceCache>) BuildPurger(ResourceCacheType cacheType)

--- a/DotNet/ServiceTests/UnitTests/Normalization/ResourceCachePurgerTests.cs
+++ b/DotNet/ServiceTests/UnitTests/Normalization/ResourceCachePurgerTests.cs
@@ -14,11 +14,11 @@ public class ResourceCachePurgerTests
     private const string CorrelationId = "3fa85f64-5717-4562-b3fc-2c963f66afa6";
 
     [Fact]
-    public async Task PurgeAsync_DeletesOnlyTheAcquisitionKeys_NeverTheCorrelationKey()
+    public async Task PurgeAsync_DeletesAcquisitionKeysAndCorrelationKey()
     {
-        // Normalization only ever deletes its own input, the {correlationId}:{ResourceType}
-        // acquisition keys. The {correlationId} key belongs to its reader: Measure Eval deletes it
-        // after evaluation, and the cache expiration policy reclaims it if no reader ever comes.
+        // A terminal failure means nothing downstream will ever consume this message's cache
+        // entries, so the purge removes the {correlationId}:{ResourceType} acquisition keys AND
+        // the {correlationId} key normalization was writing when it failed.
         var (purger, cache, implementation) = BuildPurger(ResourceCacheType.Redis);
 
         List<string>? deletedKeys = null;
@@ -32,9 +32,28 @@ public class ResourceCachePurgerTests
         cache.Verify(item => item.GetImplementation(ResourceCacheType.Redis), Times.Once);
         Assert.NotNull(deletedKeys);
         Assert.Equal(
-            new List<string> { $"{CorrelationId}:Patient", $"{CorrelationId}:Encounter" },
+            new List<string> { $"{CorrelationId}:Patient", $"{CorrelationId}:Encounter", CorrelationId },
             deletedKeys);
-        Assert.DoesNotContain(CorrelationId, deletedKeys!);
+    }
+
+    [Fact]
+    public async Task PurgeAsync_DoesNotDeleteTwiceWhenTheCorrelationKeyIsAlreadyPresent()
+    {
+        var (purger, _, implementation) = BuildPurger(ResourceCacheType.Redis);
+
+        List<string>? deletedKeys = null;
+        implementation
+            .Setup(item => item.DeleteAsync(It.IsAny<List<string>>(), It.IsAny<CancellationToken>()))
+            .Callback<List<string>, CancellationToken>((keys, _) => deletedKeys = keys)
+            .Returns(Task.CompletedTask);
+
+        var value = BuildValue(ResourceCacheType.Redis);
+        value.CacheKeys.Add(CorrelationId);
+
+        await purger.PurgeAsync(value, "test");
+
+        Assert.NotNull(deletedKeys);
+        Assert.Equal(deletedKeys!.Count, deletedKeys.Distinct().Count());
     }
 
     [Fact]

--- a/DotNet/ServiceTests/UnitTests/Normalization/ResourceCachePurgerTests.cs
+++ b/DotNet/ServiceTests/UnitTests/Normalization/ResourceCachePurgerTests.cs
@@ -14,7 +14,7 @@ public class ResourceCachePurgerTests
     private const string CorrelationId = "3fa85f64-5717-4562-b3fc-2c963f66afa6";
 
     [Fact]
-    public async Task PurgeAsync_DeletesAcquisitionKeysAndCorrelationKey()
+    public async Task PurgeAsync_ScopeAll_DeletesAcquisitionKeysAndCorrelationKey()
     {
         var (purger, cache, implementation) = BuildPurger(ResourceCacheType.Redis);
 
@@ -24,13 +24,37 @@ public class ResourceCachePurgerTests
             .Callback<List<string>, CancellationToken>((keys, _) => deletedKeys = keys)
             .Returns(Task.CompletedTask);
 
-        await purger.PurgeAsync(BuildValue(ResourceCacheType.Redis), "test");
+        await purger.PurgeAsync(BuildValue(ResourceCacheType.Redis), "test", ResourceCachePurgeScope.All);
 
         cache.Verify(item => item.GetImplementation(ResourceCacheType.Redis), Times.Once);
         Assert.NotNull(deletedKeys);
         Assert.Equal(
             new List<string> { $"{CorrelationId}:Patient", $"{CorrelationId}:Encounter", CorrelationId },
             deletedKeys);
+    }
+
+    [Fact]
+    public async Task PurgeAsync_ScopeAcquisitionKeysOnly_LeavesTheCorrelationKey()
+    {
+        // The retry-exhausted path cannot prove that an earlier attempt did not already publish
+        // ResourcesNormalized (the produce precedes the acquisition-key delete on the success path),
+        // so Measure Eval may be holding {correlationId} for its SUPPLEMENTAL pass. That key must
+        // survive this purge; the cache expiration policy reclaims it if nothing needed it.
+        var (purger, _, implementation) = BuildPurger(ResourceCacheType.Redis);
+
+        List<string>? deletedKeys = null;
+        implementation
+            .Setup(item => item.DeleteAsync(It.IsAny<List<string>>(), It.IsAny<CancellationToken>()))
+            .Callback<List<string>, CancellationToken>((keys, _) => deletedKeys = keys)
+            .Returns(Task.CompletedTask);
+
+        await purger.PurgeAsync(BuildValue(ResourceCacheType.Redis), "test", ResourceCachePurgeScope.AcquisitionKeysOnly);
+
+        Assert.NotNull(deletedKeys);
+        Assert.Equal(
+            new List<string> { $"{CorrelationId}:Patient", $"{CorrelationId}:Encounter" },
+            deletedKeys);
+        Assert.DoesNotContain(CorrelationId, deletedKeys!);
     }
 
     [Fact]
@@ -42,7 +66,7 @@ public class ResourceCachePurgerTests
             .Setup(item => item.DeleteAsync(It.IsAny<List<string>>(), It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask);
 
-        await purger.PurgeAsync(BuildValue(ResourceCacheType.ABS), "test");
+        await purger.PurgeAsync(BuildValue(ResourceCacheType.ABS), "test", ResourceCachePurgeScope.All);
 
         cache.Verify(item => item.GetImplementation(ResourceCacheType.ABS), Times.Once);
     }
@@ -61,7 +85,7 @@ public class ResourceCachePurgerTests
         var value = BuildValue(ResourceCacheType.Redis);
         value.CacheKeys.Add(CorrelationId);
 
-        await purger.PurgeAsync(value, "test");
+        await purger.PurgeAsync(value, "test", ResourceCachePurgeScope.All);
 
         Assert.NotNull(deletedKeys);
         Assert.Equal(deletedKeys!.Count, deletedKeys.Distinct().Count());
@@ -80,7 +104,7 @@ public class ResourceCachePurgerTests
         var value = BuildValue(ResourceCacheType.Redis);
         value.CacheKeys = cacheKeys!;
 
-        await purger.PurgeAsync(value, "test");
+        await purger.PurgeAsync(value, "test", ResourceCachePurgeScope.All);
 
         cache.Verify(item => item.GetImplementation(It.IsAny<ResourceCacheType>()), Times.Never);
         implementation.Verify(
@@ -92,7 +116,7 @@ public class ResourceCachePurgerTests
     {
         var (purger, cache, _) = BuildPurger(ResourceCacheType.Redis);
 
-        await purger.PurgeAsync(null, "test");
+        await purger.PurgeAsync(null, "test", ResourceCachePurgeScope.All);
 
         cache.Verify(item => item.GetImplementation(It.IsAny<ResourceCacheType>()), Times.Never);
     }
@@ -107,7 +131,7 @@ public class ResourceCachePurgerTests
             .ThrowsAsync(new InvalidOperationException("cache unavailable"));
 
         // The caller is already handling a failed message; cleanup failure must not add another.
-        await purger.PurgeAsync(BuildValue(ResourceCacheType.Redis), "test");
+        await purger.PurgeAsync(BuildValue(ResourceCacheType.Redis), "test", ResourceCachePurgeScope.All);
     }
 
     private static (ResourceCachePurger, Mock<IResourceCache>, Mock<IResourceCache>) BuildPurger(ResourceCacheType cacheType)

--- a/DotNet/ServiceTests/UnitTests/Normalization/ResourcesAcquiredListenerCacheCleanupTests.cs
+++ b/DotNet/ServiceTests/UnitTests/Normalization/ResourcesAcquiredListenerCacheCleanupTests.cs
@@ -1,0 +1,165 @@
+using Confluent.Kafka;
+using LantanaGroup.Link.Normalization.Application.Models.Messages;
+using LantanaGroup.Link.Normalization.Application.Services;
+using LantanaGroup.Link.Normalization.Application.Services.Operations;
+using LantanaGroup.Link.Normalization.Application.Settings;
+using LantanaGroup.Link.Normalization.Listeners;
+using LantanaGroup.Link.Shared.Application.Enums;
+using LantanaGroup.Link.Shared.Application.Error.Exceptions;
+using LantanaGroup.Link.Shared.Application.Error.Interfaces;
+using LantanaGroup.Link.Shared.Application.Interfaces;
+using LantanaGroup.Link.Shared.Application.Models;
+using LantanaGroup.Link.Shared.Application.Models.Kafka;
+using LantanaGroup.Link.Shared.Application.Models.Telemetry;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Moq;
+using System.Text;
+using Task = System.Threading.Tasks.Task;
+
+namespace UnitTests.Normalization;
+
+/// <summary>
+/// The resource cache may only be released on terminal failures. A message bound for
+/// ResourcesAcquired-Retry still needs its cached resources when it is redelivered.
+/// </summary>
+[Trait("Category", "UnitTests")]
+public class ResourcesAcquiredListenerCacheCleanupTests
+{
+    private const string FacilityId = "facility-1";
+    private const string PatientId = "patient-1";
+    private const string CorrelationId = "3fa85f64-5717-4562-b3fc-2c963f66afa6";
+
+    [Fact]
+    public async Task ConsumeMessageAsync_DeadLetterFailure_PurgesTheResourceCache()
+    {
+        var purger = new Mock<IResourceCachePurger>();
+        var deadLetterHandler = new Mock<IDeadLetterExceptionHandler<ResourcesAcquiredListener, ResourceKey, ResourcesAcquiredValue>>();
+        var listener = BuildListener(purger, deadLetterHandler: deadLetterHandler);
+
+        // A missing patient id fails validation, which raises a DeadLetterException.
+        var result = BuildConsumeResult(patientId: string.Empty);
+
+        await listener.ConsumeMessageAsync(result, CancellationToken.None);
+
+        deadLetterHandler.Verify(
+            item => item.HandleException(result, It.IsAny<DeadLetterException>(), FacilityId), Times.Once);
+        purger.Verify(
+            item => item.PurgeAsync(result.Message.Value, It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task ConsumeMessageAsync_TransientFailure_DoesNotPurgeTheResourceCache()
+    {
+        var purger = new Mock<IResourceCachePurger>();
+        var transientHandler = new Mock<ITransientExceptionHandler<ResourcesAcquiredListener, ResourceKey, ResourcesAcquiredValue>>();
+        var resourceCache = new Mock<IResourceCache>();
+        resourceCache
+            .Setup(item => item.GetImplementation(It.IsAny<ResourceCacheType>()))
+            .Throws(new TransientException("cache is unreachable"));
+
+        var listener = BuildListener(purger, transientHandler: transientHandler, resourceCache: resourceCache);
+
+        await listener.ConsumeMessageAsync(BuildConsumeResult(), CancellationToken.None);
+
+        transientHandler.Verify(
+            item => item.HandleException(
+                It.IsAny<ConsumeResult<ResourceKey, ResourcesAcquiredValue>>(),
+                It.IsAny<TransientException>(),
+                FacilityId),
+            Times.Once);
+        purger.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public async Task ConsumeMessageAsync_UnexpectedFailure_DoesNotPurgeTheResourceCache()
+    {
+        var purger = new Mock<IResourceCachePurger>();
+        var transientHandler = new Mock<ITransientExceptionHandler<ResourcesAcquiredListener, ResourceKey, ResourcesAcquiredValue>>();
+        var resourceCache = new Mock<IResourceCache>();
+        resourceCache
+            .Setup(item => item.GetImplementation(It.IsAny<ResourceCacheType>()))
+            .Throws(new InvalidOperationException("boom"));
+
+        var listener = BuildListener(purger, transientHandler: transientHandler, resourceCache: resourceCache);
+
+        await listener.ConsumeMessageAsync(BuildConsumeResult(), CancellationToken.None);
+
+        // Unexpected exceptions are wrapped as transient and retried, so the cache must survive.
+        transientHandler.Verify(
+            item => item.HandleException(
+                It.IsAny<ConsumeResult<ResourceKey, ResourcesAcquiredValue>>(),
+                It.IsAny<TransientException>(),
+                FacilityId),
+            Times.Once);
+        purger.VerifyNoOtherCalls();
+    }
+
+    private static ResourcesAcquiredListener BuildListener(
+        Mock<IResourceCachePurger> purger,
+        Mock<IDeadLetterExceptionHandler<ResourcesAcquiredListener, ResourceKey, ResourcesAcquiredValue>>? deadLetterHandler = null,
+        Mock<ITransientExceptionHandler<ResourcesAcquiredListener, ResourceKey, ResourcesAcquiredValue>>? transientHandler = null,
+        Mock<IResourceCache>? resourceCache = null)
+    {
+        deadLetterHandler ??= new Mock<IDeadLetterExceptionHandler<ResourcesAcquiredListener, ResourceKey, ResourcesAcquiredValue>>();
+        transientHandler ??= new Mock<ITransientExceptionHandler<ResourcesAcquiredListener, ResourceKey, ResourcesAcquiredValue>>();
+        resourceCache ??= new Mock<IResourceCache>();
+
+        deadLetterHandler.SetupProperty(item => item.Topic);
+        transientHandler.SetupProperty(item => item.Topic);
+
+        var consumeExceptionHandler = new Mock<IDeadLetterExceptionHandler<ResourcesAcquiredListener, ResourceKey, string>>();
+        consumeExceptionHandler.SetupProperty(item => item.Topic);
+
+        var scopeFactory = new Mock<IServiceScopeFactory>();
+        scopeFactory.Setup(item => item.CreateScope()).Returns(Mock.Of<IServiceScope>());
+
+        return new ResourcesAcquiredListener(
+            Mock.Of<ILogger<ResourcesAcquiredListener>>(),
+            new ServiceInformation { ServiceConfigName = "Normalization" },
+            scopeFactory.Object,
+            Mock.Of<IKafkaConsumerFactory<ResourceKey, ResourcesAcquiredValue>>(),
+            consumeExceptionHandler.Object,
+            deadLetterHandler.Object,
+            transientHandler.Object,
+            Mock.Of<INormalizationServiceMetrics>(),
+            Mock.Of<IProducer<ResourceKey, ResourcesNormalizedValue>>(),
+            new CopyPropertyOperationService(Mock.Of<ILogger<CopyPropertyOperationService>>()),
+            new CodeMapOperationService(Mock.Of<ILogger<CodeMapOperationService>>()),
+            new ConditionalTransformOperationService(Mock.Of<ILogger<ConditionalTransformOperationService>>()),
+            new CopyLocationOperationService(Mock.Of<ILogger<CopyLocationOperationService>>()),
+            new CopyLocationAliasToTypeIterativelyOperationService(Mock.Of<ILogger<CopyLocationAliasToTypeIterativelyOperationService>>()),
+            new RemoveExtensionsOperationService(Mock.Of<ILogger<RemoveExtensionsOperationService>>()),
+            resourceCache.Object,
+            purger.Object);
+    }
+
+    private static ConsumeResult<ResourceKey, ResourcesAcquiredValue> BuildConsumeResult(string patientId = PatientId)
+    {
+        var headers = new Headers
+        {
+            new Header(NormalizationConstants.HeaderNames.CorrelationId, Encoding.UTF8.GetBytes(CorrelationId))
+        };
+
+        return new ConsumeResult<ResourceKey, ResourcesAcquiredValue>
+        {
+            Topic = "ResourcesAcquired",
+            Partition = new Partition(0),
+            Offset = new Offset(0),
+            Message = new Message<ResourceKey, ResourcesAcquiredValue>
+            {
+                Headers = headers,
+                Key = new ResourceKey { FacilityId = FacilityId, PatientId = patientId },
+                Value = new ResourcesAcquiredValue
+                {
+                    QueryType = "Initial",
+                    ReportableEvent = "Adhoc",
+                    ScheduledReports = new List<ScheduledReport> { new() { ReportTrackingId = "tracking-1" } },
+                    CacheType = ResourceCacheType.Redis,
+                    CacheKeys = new List<string> { $"{CorrelationId}:Patient" }
+                }
+            }
+        };
+    }
+}

--- a/DotNet/ServiceTests/UnitTests/Normalization/ResourcesAcquiredListenerCacheCleanupTests.cs
+++ b/DotNet/ServiceTests/UnitTests/Normalization/ResourcesAcquiredListenerCacheCleanupTests.cs
@@ -44,8 +44,10 @@ public class ResourcesAcquiredListenerCacheCleanupTests
 
         deadLetterHandler.Verify(
             item => item.HandleException(result, It.IsAny<DeadLetterException>(), FacilityId), Times.Once);
+        // The immediate dead-letter path provably fails before ResourcesNormalized is produced
+        // (DeadLetterException is raised only by validation), so the full purge is safe here.
         purger.Verify(
-            item => item.PurgeAsync(result.Message.Value, It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            item => item.PurgeAsync(result.Message.Value, It.IsAny<string>(), ResourceCachePurgeScope.All, It.IsAny<CancellationToken>()),
             Times.Once);
     }
 

--- a/DotNet/ServiceTests/UnitTests/Normalization/ResourcesAcquiredListenerCacheCleanupTests.cs
+++ b/DotNet/ServiceTests/UnitTests/Normalization/ResourcesAcquiredListenerCacheCleanupTests.cs
@@ -44,10 +44,8 @@ public class ResourcesAcquiredListenerCacheCleanupTests
 
         deadLetterHandler.Verify(
             item => item.HandleException(result, It.IsAny<DeadLetterException>(), FacilityId), Times.Once);
-        // The immediate dead-letter path provably fails before ResourcesNormalized is produced
-        // (DeadLetterException is raised only by validation), so the full purge is safe here.
         purger.Verify(
-            item => item.PurgeAsync(result.Message.Value, It.IsAny<string>(), ResourceCachePurgeScope.All, It.IsAny<CancellationToken>()),
+            item => item.PurgeAsync(result.Message.Value, It.IsAny<string>(), It.IsAny<CancellationToken>()),
             Times.Once);
     }
 

--- a/DotNet/ServiceTests/UnitTests/Normalization/ResourcesAcquiredRetryDeadLetterHandlerTests.cs
+++ b/DotNet/ServiceTests/UnitTests/Normalization/ResourcesAcquiredRetryDeadLetterHandlerTests.cs
@@ -1,0 +1,119 @@
+using Confluent.Kafka;
+using LantanaGroup.Link.Normalization.Application.Error;
+using LantanaGroup.Link.Normalization.Application.Models.Messages;
+using LantanaGroup.Link.Normalization.Application.Services;
+using LantanaGroup.Link.Shared.Application.Enums;
+using LantanaGroup.Link.Shared.Application.Error.Handlers;
+using LantanaGroup.Link.Shared.Application.Interfaces;
+using LantanaGroup.Link.Shared.Application.Listeners;
+using LantanaGroup.Link.Shared.Application.Models;
+using Microsoft.Extensions.Logging;
+using Moq;
+using System.Text.Json;
+using Task = System.Threading.Tasks.Task;
+
+namespace UnitTests.Normalization;
+
+/// <summary>
+/// When RetryListener exhausts the retry count for a ResourcesAcquired message it dead-letters the
+/// message from shared code that knows nothing about the resource cache. This handler is the hook
+/// that releases the cache on that second terminal path.
+/// </summary>
+[Trait("Category", "UnitTests")]
+public class ResourcesAcquiredRetryDeadLetterHandlerTests
+{
+    private const string CorrelationId = "3fa85f64-5717-4562-b3fc-2c963f66afa6";
+
+    [Fact]
+    public void ProduceDeadLetter_PurgesTheCacheKeysCarriedOnTheRetriedMessage()
+    {
+        var purger = new Mock<IResourceCachePurger>();
+        var handler = BuildHandler(purger, out var producer);
+
+        var value = new ResourcesAcquiredValue
+        {
+            QueryType = "Initial",
+            ReportableEvent = "Adhoc",
+            ScheduledReports = new List<ScheduledReport> { new() { ReportTrackingId = "tracking-1" } },
+            CacheType = ResourceCacheType.ABS,
+            CacheKeys = new List<string> { $"{CorrelationId}:Patient", $"{CorrelationId}:Encounter" }
+        };
+
+        ResourcesAcquiredValue? purged = null;
+        purger
+            .Setup(item => item.PurgeAsync(It.IsAny<ResourcesAcquiredValue>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Callback<ResourcesAcquiredValue?, string, CancellationToken>((v, _, _) => purged = v)
+            .Returns(Task.CompletedTask);
+
+        handler.ProduceDeadLetter(BuildRetryConsumeResult(JsonSerializer.Serialize(value)), "Retry count exceeded");
+
+        Assert.NotNull(purged);
+        Assert.Equal(value.CacheKeys, purged!.CacheKeys);
+        Assert.Equal(ResourceCacheType.ABS, purged.CacheType);
+
+        // The dead letter is still produced: the durable record of the failure comes first.
+        producer.Verify(
+            item => item.Produce(
+                It.IsAny<string>(),
+                It.IsAny<Message<string, string>>(),
+                It.IsAny<Action<DeliveryReport<string, string>>>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public void ProduceDeadLetter_WithUndeserializableValue_StillProducesTheDeadLetter()
+    {
+        var purger = new Mock<IResourceCachePurger>();
+        var handler = BuildHandler(purger, out var producer);
+
+        handler.ProduceDeadLetter(BuildRetryConsumeResult("this is not json"), "Retry count exceeded");
+
+        purger.VerifyNoOtherCalls();
+        producer.Verify(
+            item => item.Produce(
+                It.IsAny<string>(),
+                It.IsAny<Message<string, string>>(),
+                It.IsAny<Action<DeliveryReport<string, string>>>()),
+            Times.Once);
+    }
+
+    private static ResourcesAcquiredRetryDeadLetterHandler BuildHandler(
+        Mock<IResourceCachePurger> purger,
+        out Mock<IProducer<string, string>> producer)
+    {
+        producer = new Mock<IProducer<string, string>>();
+
+        var producerFactory = new Mock<IKafkaProducerFactory<string, string>>();
+        producerFactory
+            .Setup(item => item.CreateProducer(
+                It.IsAny<ProducerConfig>(),
+                It.IsAny<ISerializer<string>>(),
+                It.IsAny<ISerializer<string>>(),
+                It.IsAny<bool>()))
+            .Returns(producer.Object);
+
+        return new ResourcesAcquiredRetryDeadLetterHandler(
+            producerFactory.Object,
+            producerFactory.Object,
+            new ServiceInformation { ServiceConfigName = "Normalization" },
+            Mock.Of<IExceptionLogger<RetryListener>>(),
+            purger.Object,
+            Mock.Of<ILogger<ResourcesAcquiredRetryDeadLetterHandler>>())
+        {
+            Topic = "ResourcesAcquired-Error"
+        };
+    }
+
+    private static ConsumeResult<string, string> BuildRetryConsumeResult(string value) => new()
+    {
+        Topic = "ResourcesAcquired-Retry",
+        Partition = new Partition(0),
+        Offset = new Offset(0),
+        Message = new Message<string, string>
+        {
+            Headers = new Headers(),
+            Key = "key",
+            Value = value
+        }
+    };
+}

--- a/DotNet/ServiceTests/UnitTests/Normalization/ResourcesAcquiredRetryDeadLetterHandlerTests.cs
+++ b/DotNet/ServiceTests/UnitTests/Normalization/ResourcesAcquiredRetryDeadLetterHandlerTests.cs
@@ -40,9 +40,10 @@ public class ResourcesAcquiredRetryDeadLetterHandlerTests
         };
 
         ResourcesAcquiredValue? purged = null;
+        ResourceCachePurgeScope? scope = null;
         purger
-            .Setup(item => item.PurgeAsync(It.IsAny<ResourcesAcquiredValue>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
-            .Callback<ResourcesAcquiredValue?, string, CancellationToken>((v, _, _) => purged = v)
+            .Setup(item => item.PurgeAsync(It.IsAny<ResourcesAcquiredValue>(), It.IsAny<string>(), It.IsAny<ResourceCachePurgeScope>(), It.IsAny<CancellationToken>()))
+            .Callback<ResourcesAcquiredValue?, string, ResourceCachePurgeScope, CancellationToken>((v, _, s, _) => { purged = v; scope = s; })
             .Returns(Task.CompletedTask);
 
         handler.ProduceDeadLetter(BuildRetryConsumeResult(JsonSerializer.Serialize(value)), "Retry count exceeded");
@@ -50,6 +51,10 @@ public class ResourcesAcquiredRetryDeadLetterHandlerTests
         Assert.NotNull(purged);
         Assert.Equal(value.CacheKeys, purged!.CacheKeys);
         Assert.Equal(ResourceCacheType.ABS, purged.CacheType);
+
+        // Retry exhaustion cannot prove an earlier attempt did not already publish
+        // ResourcesNormalized, so it must never remove {correlationId}.
+        Assert.Equal(ResourceCachePurgeScope.AcquisitionKeysOnly, scope);
 
         // The dead letter is still produced: the durable record of the failure comes first.
         producer.Verify(

--- a/DotNet/ServiceTests/UnitTests/Normalization/ResourcesAcquiredRetryDeadLetterHandlerTests.cs
+++ b/DotNet/ServiceTests/UnitTests/Normalization/ResourcesAcquiredRetryDeadLetterHandlerTests.cs
@@ -40,10 +40,9 @@ public class ResourcesAcquiredRetryDeadLetterHandlerTests
         };
 
         ResourcesAcquiredValue? purged = null;
-        ResourceCachePurgeScope? scope = null;
         purger
-            .Setup(item => item.PurgeAsync(It.IsAny<ResourcesAcquiredValue>(), It.IsAny<string>(), It.IsAny<ResourceCachePurgeScope>(), It.IsAny<CancellationToken>()))
-            .Callback<ResourcesAcquiredValue?, string, ResourceCachePurgeScope, CancellationToken>((v, _, s, _) => { purged = v; scope = s; })
+            .Setup(item => item.PurgeAsync(It.IsAny<ResourcesAcquiredValue>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Callback<ResourcesAcquiredValue?, string, CancellationToken>((v, _, _) => purged = v)
             .Returns(Task.CompletedTask);
 
         handler.ProduceDeadLetter(BuildRetryConsumeResult(JsonSerializer.Serialize(value)), "Retry count exceeded");
@@ -51,10 +50,6 @@ public class ResourcesAcquiredRetryDeadLetterHandlerTests
         Assert.NotNull(purged);
         Assert.Equal(value.CacheKeys, purged!.CacheKeys);
         Assert.Equal(ResourceCacheType.ABS, purged.CacheType);
-
-        // Retry exhaustion cannot prove an earlier attempt did not already publish
-        // ResourcesNormalized, so it must never remove {correlationId}.
-        Assert.Equal(ResourceCachePurgeScope.AcquisitionKeysOnly, scope);
 
         // The dead letter is still produced: the durable record of the failure comes first.
         producer.Verify(

--- a/Java/measureeval/src/main/java/com/lantanagroup/link/measureeval/services/AbstractResourceConsumer.java
+++ b/Java/measureeval/src/main/java/com/lantanagroup/link/measureeval/services/AbstractResourceConsumer.java
@@ -13,6 +13,7 @@ import com.lantanagroup.link.shared.kafka.Headers;
 import com.lantanagroup.link.shared.kafka.Topics;
 import com.lantanagroup.link.shared.kafka.records.ResourceKey;
 import com.lantanagroup.link.shared.utils.DiagnosticNames;
+import com.lantanagroup.link.shared.utils.LogUtils;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.trace.Span;
 import org.apache.commons.collections4.map.PassiveExpiringMap;
@@ -118,6 +119,10 @@ public abstract class AbstractResourceConsumer<T extends AbstractResourceRecord>
             if (value.getCacheType() == null) {
                 throw new ValidationException("Cache Type is null.");
             }
+            // Captured here, next to its validation, rather than after the metrics/logging below: the
+            // finally-block cleanup is guarded on both correlationId and cacheType, so anything that
+            // throws between the two assignments would silently strand a valid cache entry.
+            cacheType = value.getCacheType();
             correlationId = value.getCacheKey();
             if (correlationId == null || correlationId.isEmpty()) {
                 throw new ValidationException("Cache Key is null or empty.");
@@ -138,8 +143,6 @@ public abstract class AbstractResourceConsumer<T extends AbstractResourceRecord>
                     value.getCacheType(),
                     value.getQueryType(),
                     value.getScheduledReports() != null ? value.getScheduledReports().size() : 0);
-
-            cacheType = value.getCacheType();
 
             if (perf) taskStopWatch.start("readResources");
             long readStart = perf ? System.nanoTime() : 0;
@@ -244,10 +247,12 @@ public abstract class AbstractResourceConsumer<T extends AbstractResourceRecord>
                             }
                         }
                     }
-                    logger.debug("Cache cleanup complete for correlationId={}, cacheType={}", correlationId, cacheType);
+                    logger.debug("Cache cleanup complete for correlationId={}, cacheType={}",
+                            LogUtils.sanitize(correlationId), LogUtils.sanitize(cacheType));
                 } catch (Exception e) {
                     // Never mask the exception that brought us here, if any.
-                    logger.error("Cache cleanup failed for correlationId={}, cacheType={}", correlationId, cacheType, e);
+                    logger.error("Cache cleanup failed for correlationId={}, cacheType={}",
+                            LogUtils.sanitize(correlationId), LogUtils.sanitize(cacheType), e);
                 } finally {
                     if (perf) taskStopWatch.stop();
                 }

--- a/Java/measureeval/src/main/java/com/lantanagroup/link/measureeval/services/AbstractResourceConsumer.java
+++ b/Java/measureeval/src/main/java/com/lantanagroup/link/measureeval/services/AbstractResourceConsumer.java
@@ -89,6 +89,10 @@ public abstract class AbstractResourceConsumer<T extends AbstractResourceRecord>
         StopWatch taskStopWatch = perf ? new StopWatch() : null;
         if (perf) totalStopWatch.start();
 
+        String correlationId = null;
+        CacheType cacheType = null;
+        boolean keepCacheForSupplemental = false;
+
         try {
             Span currentSpan = Span.current();
             MDC.put("traceId", currentSpan.getSpanContext().getTraceId());
@@ -114,7 +118,7 @@ public abstract class AbstractResourceConsumer<T extends AbstractResourceRecord>
             if (value.getCacheType() == null) {
                 throw new ValidationException("Cache Type is null.");
             }
-            String correlationId = value.getCacheKey();
+            correlationId = value.getCacheKey();
             if (correlationId == null || correlationId.isEmpty()) {
                 throw new ValidationException("Cache Key is null or empty.");
             }
@@ -135,7 +139,7 @@ public abstract class AbstractResourceConsumer<T extends AbstractResourceRecord>
                     value.getQueryType(),
                     value.getScheduledReports() != null ? value.getScheduledReports().size() : 0);
 
-            CacheType cacheType = value.getCacheType();
+            cacheType = value.getCacheType();
 
             if (perf) taskStopWatch.start("readResources");
             long readStart = perf ? System.nanoTime() : 0;
@@ -169,8 +173,8 @@ public abstract class AbstractResourceConsumer<T extends AbstractResourceRecord>
             PatientReportingEvaluationStatus patientStatus = patientStatusCache.computeIfAbsent(correlationId, k -> {
                 if (perf) taskStopWatch.start("retrieveOrCreatePatientStatus");
                 PatientReportingEvaluationStatus _patientStatus = Objects.requireNonNullElseGet(
-                        retrievePatientStatus(facilityId, correlationId),
-                        () -> createPatientStatus(facilityId, correlationId, patientId, value));
+                        retrievePatientStatus(facilityId, k),
+                        () -> createPatientStatus(facilityId, k, patientId, value));
                 if (perf) taskStopWatch.stop();
 
                 return _patientStatus;
@@ -203,6 +207,10 @@ public abstract class AbstractResourceConsumer<T extends AbstractResourceRecord>
             boolean initialReportable =
                     value.getQueryType() == QueryType.INITIAL && reportablePatient;
 
+            // INITIAL + reportable keeps the cache for the SUPPLEMENTAL pass to reuse; every other
+            // outcome, including failure, is cleaned up by the finally block below.
+            keepCacheForSupplemental = initialReportable;
+
             if (initialReportable) {
                 logger.debug("Skipping Mongo write for INITIAL reportable patient, correlationId={}",
                         correlationId);
@@ -214,25 +222,37 @@ public abstract class AbstractResourceConsumer<T extends AbstractResourceRecord>
                         resources.size(), correlationId);
             }
 
-            // Clean up cache after SUPPLEMENTAL, or after INITIAL if patient is not reportable.
-            // INITIAL + reportable keeps the cache for the SUPPLEMENTAL pass to reuse.
-            if (initialReportable) {
-                logger.debug("Keeping cache for SUPPLEMENTAL pass, correlationId={}", correlationId);
-            } else {
-                if (perf) taskStopWatch.start("cleanupCache");
-                switch (cacheType) {
-                    case REDIS -> redisResourceService.cleanup(correlationId);
-                    case ABS -> {
-                        if (absResourceService != null) {
-                            absResourceService.cleanup(correlationId);
-                        }
-                    }
-                }
-                if (perf) taskStopWatch.stop();
-                logger.debug("Cache cleanup complete for correlationId={}, cacheType={}", correlationId, cacheType);
+        } finally {
+            // A task may still be running if we got here by way of an exception; stop it so that its
+            // elapsed time is reported and so that starting the cleanup task below cannot throw.
+            if (perf && taskStopWatch.isRunning()) {
+                taskStopWatch.stop();
             }
 
-        } finally {
+            // Clean up cache after SUPPLEMENTAL, after INITIAL if patient is not reportable, and after
+            // any failure. INITIAL + reportable keeps the cache for the SUPPLEMENTAL pass to reuse.
+            if (keepCacheForSupplemental) {
+                logger.debug("Keeping cache for SUPPLEMENTAL pass, correlationId={}", correlationId);
+            } else if (correlationId != null && cacheType != null) {
+                if (perf) taskStopWatch.start("cleanupCache");
+                try {
+                    switch (cacheType) {
+                        case REDIS -> redisResourceService.cleanup(correlationId);
+                        case ABS -> {
+                            if (absResourceService != null) {
+                                absResourceService.cleanup(correlationId);
+                            }
+                        }
+                    }
+                    logger.debug("Cache cleanup complete for correlationId={}, cacheType={}", correlationId, cacheType);
+                } catch (Exception e) {
+                    // Never mask the exception that brought us here, if any.
+                    logger.error("Cache cleanup failed for correlationId={}, cacheType={}", correlationId, cacheType, e);
+                } finally {
+                    if (perf) taskStopWatch.stop();
+                }
+            }
+
             if (perf) {
                 totalStopWatch.stop();
                 for (StopWatch.TaskInfo task : taskStopWatch.getTaskInfo()) {

--- a/Java/measureeval/src/test/java/com/lantanagroup/link/measureeval/services/AbstractResourceConsumerTest.java
+++ b/Java/measureeval/src/test/java/com/lantanagroup/link/measureeval/services/AbstractResourceConsumerTest.java
@@ -298,6 +298,9 @@ class AbstractResourceConsumerTest {
 
         IllegalStateException ex = assertThrows(IllegalStateException.class, () -> consumer.process(record));
         assertEquals("ABS cache type requested but cache-blob-storage is not configured", ex.getMessage());
+
+        // The finally-block cleanup must no-op (not NPE) when ABS is the cache type but unconfigured.
+        verify(redisResourceService, never()).cleanup(anyString());
     }
 
     @Test
@@ -354,10 +357,130 @@ class AbstractResourceConsumerTest {
         verify(redisResourceService, never()).cleanup(anyString());
     }
 
+    @Test
+    void process_evaluationThrows_stillCleansUpCache() {
+        String facilityId = "facility-1";
+        String patientId = "patient-1";
+        String cacheKey = "cache-key-fail";
+
+        ResourcesNormalized value = buildRedisValue(cacheKey);
+
+        Resource resource = new Resource();
+        resource.setFacilityId(facilityId);
+        resource.setCorrelationId(cacheKey);
+        resource.setPatientId(patientId);
+        resource.setResourceType(ResourceType.Patient);
+        resource.setResourceId("p-1");
+        resource.setResource("{}");
+
+        when(redisResourceService.readResources(facilityId, cacheKey, patientId))
+                .thenReturn(List.of(resource));
+
+        PatientReportingEvaluationStatus patientStatus = new PatientReportingEvaluationStatus();
+        patientStatus.setFacilityId(facilityId);
+        patientStatus.setCorrelationId(cacheKey);
+        patientStatus.setPatientId(patientId);
+        PatientReportingEvaluationStatus.Report report = new PatientReportingEvaluationStatus.Report();
+        report.setReportType("TestMeasure");
+        report.setReportTrackingId("tracking-1");
+        report.setReportable(null);
+        patientStatus.setReports(Collections.singletonList(report));
+        when(patientStatusRepository.findByFacilityIdAndCorrelationId(facilityId, cacheKey))
+                .thenReturn(Optional.of(patientStatus));
+
+        Bundle bundle = new Bundle();
+        bundle.addEntry().setResource(nonEmptyPatient());
+        when(patientStatusBundler.createBundleFromResources(anyList())).thenReturn(bundle);
+
+        when(evaluateMeasureService.evaluateMeasure(anyString(), any(), any(), any()))
+                .thenThrow(new RuntimeException("evaluation failed"));
+
+        ConsumerRecord<ResourceKey, ResourcesNormalized> record = buildConsumerRecord(facilityId, patientId, value);
+
+        RuntimeException ex = assertThrows(RuntimeException.class, () -> consumer.process(record));
+
+        assertEquals("evaluation failed", ex.getMessage());
+        verify(redisResourceService).cleanup(cacheKey);
+    }
+
+    @Test
+    void process_cleanupThrows_doesNotMaskOriginalException() {
+        String facilityId = "facility-1";
+        String patientId = "patient-1";
+        String cacheKey = "cache-key-fail-2";
+
+        ResourcesNormalized value = buildRedisValue(cacheKey);
+
+        when(redisResourceService.readResources(facilityId, cacheKey, patientId))
+                .thenThrow(new RuntimeException("cache read failed"));
+        doThrow(new RuntimeException("cleanup failed")).when(redisResourceService).cleanup(cacheKey);
+
+        ConsumerRecord<ResourceKey, ResourcesNormalized> record = buildConsumerRecord(facilityId, patientId, value);
+
+        RuntimeException ex = assertThrows(RuntimeException.class, () -> consumer.process(record));
+
+        assertEquals("cache read failed", ex.getMessage());
+        verify(redisResourceService).cleanup(cacheKey);
+    }
+
+    @Test
+    void process_initialReportable_keepsCacheForSupplemental() throws Exception {
+        String facilityId = "facility-1";
+        String patientId = "patient-1";
+        String cacheKey = "cache-key-keep";
+
+        ResourcesNormalized value = buildRedisValue(cacheKey);
+
+        Resource resource = new Resource();
+        resource.setFacilityId(facilityId);
+        resource.setCorrelationId(cacheKey);
+        resource.setPatientId(patientId);
+        resource.setResourceType(ResourceType.Patient);
+        resource.setResourceId("p-1");
+        resource.setResource("{}");
+
+        when(redisResourceService.readResources(facilityId, cacheKey, patientId))
+                .thenReturn(List.of(resource));
+
+        PatientReportingEvaluationStatus patientStatus = new PatientReportingEvaluationStatus();
+        patientStatus.setFacilityId(facilityId);
+        patientStatus.setCorrelationId(cacheKey);
+        patientStatus.setPatientId(patientId);
+        PatientReportingEvaluationStatus.Report report = new PatientReportingEvaluationStatus.Report();
+        report.setReportType("TestMeasure");
+        report.setReportTrackingId("tracking-1");
+        report.setReportable(null);
+        patientStatus.setReports(Collections.singletonList(report));
+        when(patientStatusRepository.findByFacilityIdAndCorrelationId(facilityId, cacheKey))
+                .thenReturn(Optional.of(patientStatus));
+
+        Bundle bundle = new Bundle();
+        bundle.addEntry().setResource(nonEmptyPatient());
+        when(patientStatusBundler.createBundleFromResources(anyList())).thenReturn(bundle);
+
+        MeasureReport measureReport = new MeasureReport();
+        measureReport.setId("mr-1");
+        when(evaluateMeasureService.evaluateMeasure(anyString(), any(), any(), any())).thenReturn(measureReport);
+        when(reportabilityPredicate.test(any())).thenReturn(true);
+        when(patientStatusRepository.save(any())).thenReturn(patientStatus);
+
+        ConsumerRecord<ResourceKey, ResourcesNormalized> record = buildConsumerRecord(facilityId, patientId, value);
+        consumer.process(record);
+
+        verify(redisResourceService, never()).cleanup(anyString());
+        verifyNoInteractions(mongoOperations);
+    }
+
     private static org.hl7.fhir.r4.model.Patient nonEmptyPatient() {
         org.hl7.fhir.r4.model.Patient patient = new org.hl7.fhir.r4.model.Patient();
         patient.setId("patient-1");
         return patient;
+    }
+
+    private ResourcesNormalized buildRedisValue(String cacheKey) {
+        ResourcesNormalized value = buildAbsValue(cacheKey);
+        value.setCacheType(CacheType.REDIS);
+        return value;
     }
 
     private ResourcesNormalized buildAbsValue(String cacheKey) {

--- a/Java/measureeval/src/test/java/com/lantanagroup/link/measureeval/services/AbstractResourceConsumerTest.java
+++ b/Java/measureeval/src/test/java/com/lantanagroup/link/measureeval/services/AbstractResourceConsumerTest.java
@@ -354,6 +354,9 @@ class AbstractResourceConsumerTest {
         ConsumerRecord<ResourceKey, ResourcesNormalized> record = buildConsumerRecord(facilityId, patientId, value);
         consumerWithAbs.process(record);
 
+        // The ABS branch of the cleanup switch must actually run, not merely leave Redis alone:
+        // without this the assertion below still passes if the ABS cleanup call is removed entirely.
+        verify(absResourceService).cleanup(cacheKey);
         verify(redisResourceService, never()).cleanup(anyString());
     }
 
@@ -400,6 +403,28 @@ class AbstractResourceConsumerTest {
         RuntimeException ex = assertThrows(RuntimeException.class, () -> consumer.process(record));
 
         assertEquals("evaluation failed", ex.getMessage());
+        verify(redisResourceService).cleanup(cacheKey);
+    }
+
+    @Test
+    void process_metricsThrowsAfterValidation_stillCleansUpCache() {
+        // The cleanup guard needs both correlationId and cacheType. Anything that throws between the
+        // two assignments - metrics, logging - must not leave a valid cache entry stranded, since
+        // nothing else will ever come back for it.
+        String facilityId = "facility-1";
+        String patientId = "patient-1";
+        String cacheKey = "cache-key-metrics-fail";
+
+        ResourcesNormalized value = buildRedisValue(cacheKey);
+
+        doThrow(new RuntimeException("metrics failed"))
+                .when(measureEvalMetrics).IncrementRecordsReceivedCounter(any());
+
+        ConsumerRecord<ResourceKey, ResourcesNormalized> record = buildConsumerRecord(facilityId, patientId, value);
+
+        RuntimeException ex = assertThrows(RuntimeException.class, () -> consumer.process(record));
+
+        assertEquals("metrics failed", ex.getMessage());
         verify(redisResourceService).cleanup(cacheKey);
     }
 


### PR DESCRIPTION
### 🛠️ Description of Changes

#### Part A — Measure Eval (`AbstractResourceConsumer.java`)

`correlationId`, `cacheType`, and a new `keepCacheForSupplemental` flag are hoisted above the `try`; the cleanup block moved into the existing `finally`, guarded so that `INITIAL` + reportable still keeps the cache for the supplemental pass. Cleanup is wrapped in its own try/catch so it can never mask the exception that triggered it.

#### Part B — Normalization

- `ResourceCachePurger` (`Application/Services/`) deletes the acquisition keys plus the derived correlation key via `GetImplementation(value.CacheType)`, and swallows its own failures so call sites stay clean.
- Hook 1: the `DeadLetterException` catch now purges after the dead letter is handled.
- Hook 2: `ResourcesAcquiredRetryDeadLetterHandler` (`Application/Error/`) overrides `ProduceDeadLetter` and purges on retry exhaustion, registered in `Program.cs` after the open generic.

#### Out of scope

- `AbstractResourceConsumer` teardown (superclass no longer necessary since we're not consuming `ResourcesAcquired-Error`).
- The Redis per-type key gap in `RedisResourceService.cleanup`.
- Acquisition failures before `ResourcesAcquired` is produced, and `HandleConsumeException` dead letters — both left to the cache TTL ticket.

### 🧪 Testing Performed

 MANUALLY VERIFIED (live, local docker stack, branch build ad9a7b994)                                                                                                                                                                                                                                                                                                                                                            
                                                                                                                                                                                                                                                                                                                                                                                                                                  
  All three failure behaviors were exercised end to end against running                                                                                                                                                                                                                                                                                                                                                           
  Normalization + Measure Eval containers rebuilt from this branch, with                                                                                                                                                                                                                                                                                                                                                          
  seeded Redis entries and real Kafka messages, verifying actual Redis key                                                                                                                                                                                                                                                                                                                                                        
  state and -Error topic offsets — not just unit-level mocks.    

  A. Normalization immediate dead-letter (Scope: All)                                                                                                                                                                                                                                                                                                                                                                             
     Sent a ResourcesAcquired message whose key was missing PatientId, with                                                                                                                                                                                                                                                                                                                                                       
     a seeded acquisition key ({corr}:Patient) and correlation key ({corr}).                                                                                                                                                                                                                                                                                                                                                      
     Result: validation raised DeadLetterException, the dead letter was                                                                                                                                                                                                                                                                                                                                                           
     produced to ResourcesAcquired-Error, and the purge removed BOTH keys —                                                                                                                                                                                                                                                                                                                                                       
     log: "Purged 2 resource cache entries after terminal failure ...                                                                                                                                                                                                                                                                                                                                                             
     Keys: [{corr}:Patient, {corr}]". Both keys verified gone in Redis.     

 B. Normalization retry exhaustion (Scope: AcquisitionKeysOnly)                                                                                                                                                                                                                                                                                                                                                                  
     Sent a valid message whose cache key had an unparseable resource type                                                                                                                                                                                                                                                                                                                                                        
     ({corr}:Bogus), producing a TransientException on every attempt. The                                                                                                                                                                                                                                                                                                                                                         
     retry ladder ran its configured PT20S/PT60S/PT120S schedule, exhausted,                                                                                                                                                                                                                                                                                                                                                      
     and dead-lettered. The purge removed ONLY the acquisition key —                                                                                                                                                                                                                                                                                                                                                              
     log: "Purged 1 ... Keys: [{corr}:Bogus]" — and the correlation key was                                                                                                                                                                                                                                                                                                                                                       
     verified still present in Redis afterward. This is the scoped-purge                                                                                                                                                                                                                                                                                                                                                          
     behavior added in review: exhaustion cannot rule out that an earlier                                                                                                                                                                                                                                                                                                                                                         
     attempt already published ResourcesNormalized, so the key Measure Eval                                                                                                                                                                                                                                                                                                                                                       
     may be holding survives.                             

 C. Measure Eval cleanup on failure (finally block)                                                                                                                                                                                                                                                                                                                                                                              
     Seeded the correlation hash with a syntactically invalid FHIR resource                                                                                                                                                                                                                                                                                                                                                       
     so processing fails after the cache read (bundle creation), and sent a                                                                                                                                                                                                                                                                                                                                                       
     ResourcesNormalized message. Result: the record dead-lettered to                                                                                                                                                                                                                                                                                                                                                             
     ResourcesNormalized-Error as before, and the finally block removed the                                                                                                                                                                                                                                                                                                                                                       
     correlation key despite the failure — log: "Cleaned up Redis key                                                                                                                                                                                                                                                                                                                                                             
     '{corr}'" / "Cache cleanup complete for correlationId={corr},                                                                                                                                                                                                                                                                                                                                                                
     cacheType=REDIS". Key verified gone in Redis.                  

### 🧑‍🔬 Unit Testing

- [X] I have written or updated unit tests to cover my changes
- Coverage: 94.3%

### 📓 Documentation Updated

N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resource cache entries are now automatically purged after terminal normalization failures and unsuccessful evaluations.
  * Cache cleanup no longer masks the original processing error.
  * Reportable initial evaluations retain required cached resources.
  * Invalid messages still produce dead letters while safely skipping cleanup.

* **Tests**
  * Added coverage for cache deletion, failure handling, duplicate keys, missing data, and retention scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->





