### PR TITLE
LEGLINK-871: manifest.ndjson Device and List resources are missing meta.profile

### DIFF
--- a/DotNet/Automation.Link/Validation/ReportAbsManifestValidator.cs
+++ b/DotNet/Automation.Link/Validation/ReportAbsManifestValidator.cs
@@ -13,6 +13,12 @@ public class ReportAbsManifestValidator
     private const int MaxErrors = 200;
     private const string ApplicablePeriodExtensionUrl = "http://www.cdc.gov/nhsn/fhirportal/dqm/ig/StructureDefinition/link-patient-list-applicable-period-extension";
 
+    // NHSN DQM IG profiles the Report service stamps on the manifest resources
+    // (Report.ReportConstants.BundleSettings). Asserted here so a regression that drops
+    // meta.profile fails the automation suite rather than the downstream IG validator.
+    private const string DeviceProfileUrl = "http://hl7.org/fhir/us/nhsn-dqm/StructureDefinition/nhsn-submitting-device";
+    private const string PatientListProfileUrl = "http://hl7.org/fhir/us/nhsn-dqm/StructureDefinition/poi-list";
+
     /// <summary>
     /// Controls expected derived OperationOutcome writes per failed-validation patient.
     /// </summary>
@@ -322,6 +328,12 @@ public class ReportAbsManifestValidator
         if (orgResources.Count != 1) AddError(errors, $"Manifest should contain exactly one Organization resource. Actual={orgResources.Count}");
         if (deviceResources.Count != 1) AddError(errors, $"Manifest should contain exactly one Device resource. Actual={deviceResources.Count}");
         if (listResources.Count != 1) AddError(errors, $"Manifest should contain exactly one List resource. Actual={listResources.Count}");
+
+        foreach (var device in deviceResources)
+            ValidateMetaProfile(device, "Device", DeviceProfileUrl, errors);
+
+        foreach (var list in listResources)
+            ValidateMetaProfile(list, "List", PatientListProfileUrl, errors);
 
         var patientList = listResources.FirstOrDefault();
         if (patientList.ValueKind == JsonValueKind.Undefined)
@@ -789,6 +801,51 @@ public class ReportAbsManifestValidator
         }
 
         return resources;
+    }
+
+    /// <summary>
+    /// Asserts that a manifest resource declares the NHSN DQM IG profile it is meant to conform to.
+    /// Downstream IG validation cannot resolve the resource without it.
+    /// </summary>
+    private static void ValidateMetaProfile(
+        JsonElement resource,
+        string resourceType,
+        string expectedProfileUrl,
+        List<string> errors)
+    {
+        var profiles = GetMetaProfiles(resource);
+
+        if (profiles.Count == 0)
+        {
+            AddError(errors, $"Manifest {resourceType} is missing meta.profile. Expected '{expectedProfileUrl}'.");
+            return;
+        }
+
+        if (!profiles.Contains(expectedProfileUrl, StringComparer.Ordinal))
+            AddError(errors, $"Manifest {resourceType} meta.profile mismatch. Expected '{expectedProfileUrl}', actual [{string.Join(", ", profiles)}].");
+    }
+
+    private static List<string> GetMetaProfiles(JsonElement resource)
+    {
+        var profiles = new List<string>();
+
+        if (!resource.TryGetProperty("meta", out var meta) || meta.ValueKind != JsonValueKind.Object)
+            return profiles;
+
+        if (!meta.TryGetProperty("profile", out var profileArr) || profileArr.ValueKind != JsonValueKind.Array)
+            return profiles;
+
+        foreach (var profile in profileArr.EnumerateArray())
+        {
+            if (profile.ValueKind == JsonValueKind.String)
+            {
+                var value = profile.GetString();
+                if (!string.IsNullOrWhiteSpace(value))
+                    profiles.Add(value);
+            }
+        }
+
+        return profiles;
     }
 
     private static bool IsType(JsonElement resource, string type) =>

--- a/DotNet/Report/Application/Settings/ReportConstants.cs
+++ b/DotNet/Report/Application/Settings/ReportConstants.cs
@@ -15,7 +15,7 @@
             public const string BundlingUrlBase = "https://www.cdc.gov/nhsn/nhsn-measures";
             public const string BundlingFullUrlFormat = BundlingUrlBase + "/{0}";
             public const string CdcOrgIdSystem = "https://www.cdc.gov/nhsn/OrgID";
-            public const string CensusProfileUrl = "https://www.cdc.gov/nhsn/nhsn-measures/StructureDefinition/poi-list";
+            public const string CensusProfileUrl = "http://hl7.org/fhir/us/nhsn-dqm/StructureDefinition/poi-list";
             public const string DataAbsentReasonExtensionUrl = "http://hl7.org/fhir/StructureDefinition/data-absent-reason";
             public const string DataAbsentReasonUnknownCode = "unknown";
             public const string IdentifierSystem = "urn:ietf:rfc:3986";
@@ -25,6 +25,7 @@
             public const string OrganizationTypeSystem = "http://terminology.hl7.org/CodeSystem/organization-type";
             public const string ReportBundleProfileUrl = "https://www.cdc.gov/nhsn/nhsn-measures/StructureDefinition/nhsn-measurereport-bundle";
             public const string SubjectListMeasureReportProfile = "http://www.cdc.gov/nhsn/fhirportal/dqm/ig/StructureDefinition/subjectlist-measurereport";
+            public const string SubmittingDeviceProfile = "http://hl7.org/fhir/us/nhsn-dqm/StructureDefinition/nhsn-submitting-device";
             public const string SubmittingOrganizationProfile = "https://www.cdc.gov/nhsn/nhsn-measures/StructureDefinition/nhsn-submitting-organization";
         }
 

--- a/DotNet/Report/KafkaProducers/ReportManifestProducer.cs
+++ b/DotNet/Report/KafkaProducers/ReportManifestProducer.cs
@@ -158,7 +158,10 @@ namespace LantanaGroup.Link.Report.KafkaProducers
 
         private Device CreateDevice()
         {
-            var device = new Device();
+            var device = new Device
+            {
+                Meta = new Meta { Profile = [ReportConstants.BundleSettings.SubmittingDeviceProfile] }
+            };
             device.DeviceName.Add(new Device.DeviceNameComponent()
             {
                 Name = "NHSNLink"
@@ -180,6 +183,7 @@ namespace LantanaGroup.Link.Report.KafkaProducers
         private List CreatePatientList(List<string> patientIds, DateTime startDate, DateTime endDate)
         {
             var admittedPatients = new List();
+            admittedPatients.Meta = new Meta { Profile = [ReportConstants.BundleSettings.CensusProfileUrl] };
             admittedPatients.Status = List.ListStatus.Current;
             admittedPatients.Mode = ListMode.Snapshot;
             admittedPatients.Extension.Add(new Extension()

--- a/DotNet/ServiceTests/UnitTests/Automation/ReportAbsManifestValidatorTests.cs
+++ b/DotNet/ServiceTests/UnitTests/Automation/ReportAbsManifestValidatorTests.cs
@@ -16,6 +16,8 @@ public class ReportAbsManifestValidatorTests
 {
     private const string ExpectedStart = "2025-01-01T00:00:00Z";
     private const string ExpectedEnd = "2025-01-31T23:59:59Z";
+    private const string DeviceProfile = "http://hl7.org/fhir/us/nhsn-dqm/StructureDefinition/nhsn-submitting-device";
+    private const string PatientListProfile = "http://hl7.org/fhir/us/nhsn-dqm/StructureDefinition/poi-list";
 
     [Fact]
     public async Task ValidateAllAsync_WithMockExternalAbsFromGeneratedData_Passes()
@@ -269,12 +271,67 @@ public class ReportAbsManifestValidatorTests
         Assert.Contains("VALIDATION failed", ex.Message, StringComparison.OrdinalIgnoreCase);
     }
 
+    [Fact]
+    public async Task ValidateAllAsync_WhenDeviceIsMissingProfile_Fails()
+    {
+        var output = new BufferingAutomationOutput();
+        var (patientIds, bundles) = FhirBundleGenerator.Generate(output, patientCount: 1, totalResourcesPerPatient: 120);
+        var patientId = patientIds.Single();
+
+        var mockExternalAbsResources = BuildMockExternalAbsResources(
+            patientId, bundles, "MEASURE-UT-4", ExpectedStart, ExpectedEnd, deviceProfile: null);
+
+        var validator = new ReportAbsManifestValidator(output, CreatePipelineDataReader());
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            validator.ValidateAllAsync(
+                mockExternalAbsResources,
+                new[] { patientId },
+                "MEASURE-UT-4",
+                ExpectedStart,
+                ExpectedEnd));
+
+        Assert.Contains(output.Lines, line =>
+            line.Contains("Manifest Device is missing meta.profile", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public async Task ValidateAllAsync_WhenPatientListProfileIsWrong_Fails()
+    {
+        var output = new BufferingAutomationOutput();
+        var (patientIds, bundles) = FhirBundleGenerator.Generate(output, patientCount: 1, totalResourcesPerPatient: 120);
+        var patientId = patientIds.Single();
+
+        var mockExternalAbsResources = BuildMockExternalAbsResources(
+            patientId,
+            bundles,
+            "MEASURE-UT-5",
+            ExpectedStart,
+            ExpectedEnd,
+            patientListProfile: "https://www.cdc.gov/nhsn/nhsn-measures/StructureDefinition/poi-list");
+
+        var validator = new ReportAbsManifestValidator(output, CreatePipelineDataReader());
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            validator.ValidateAllAsync(
+                mockExternalAbsResources,
+                new[] { patientId },
+                "MEASURE-UT-5",
+                ExpectedStart,
+                ExpectedEnd));
+
+        Assert.Contains(output.Lines, line =>
+            line.Contains("Manifest List meta.profile mismatch", StringComparison.OrdinalIgnoreCase));
+    }
+
     private static Dictionary<string, object> BuildMockExternalAbsResources(
         string patientId,
         IReadOnlyList<(string Name, string Json)> bundles,
         string measureId,
         string start,
-        string end)
+        string end,
+        string? deviceProfile = DeviceProfile,
+        string? patientListProfile = PatientListProfile)
     {
         var generatedPatientJson = ExtractGeneratedPatientJson(patientId, bundles);
 
@@ -290,18 +347,18 @@ public class ReportAbsManifestValidatorTests
                 resourceType = "Organization",
                 id = orgId
             }),
-            JsonSerializer.Serialize(new
+            SerializeWithOptionalProfile(deviceProfile, new Dictionary<string, object>
             {
-                resourceType = "Device",
-                id = deviceId
+                ["resourceType"] = "Device",
+                ["id"] = deviceId
             }),
-            JsonSerializer.Serialize(new
+            SerializeWithOptionalProfile(patientListProfile, new Dictionary<string, object>
             {
-                resourceType = "List",
-                id = "PatientList-UT",
-                status = "current",
-                mode = "snapshot",
-                extension = new object[]
+                ["resourceType"] = "List",
+                ["id"] = "PatientList-UT",
+                ["status"] = "current",
+                ["mode"] = "snapshot",
+                ["extension"] = new object[]
                 {
                     new
                     {
@@ -313,7 +370,7 @@ public class ReportAbsManifestValidatorTests
                         }
                     }
                 },
-                entry = new object[]
+                ["entry"] = new object[]
                 {
                     new { item = new { reference = $"Patient/{patientId}" } }
                 }
@@ -373,11 +430,12 @@ public class ReportAbsManifestValidatorTests
         var manifestNdjson = string.Join("\n", new[]
         {
             JsonSerializer.Serialize(new { resourceType = "Organization", id = "Org-UT" }),
-            JsonSerializer.Serialize(new { resourceType = "Device", id = "Device-UT" }),
+            JsonSerializer.Serialize(new { resourceType = "Device", id = "Device-UT", meta = new { profile = new[] { DeviceProfile } } }),
             JsonSerializer.Serialize(new
             {
                 resourceType = "List",
                 id = "PatientList-UT",
+                meta = new { profile = new[] { PatientListProfile } },
                 status = "current",
                 mode = "snapshot",
                 extension = new object[]
@@ -437,6 +495,18 @@ public class ReportAbsManifestValidatorTests
         };
     }
 
+    /// <summary>
+    /// Serializes a manifest resource, adding meta.profile only when a profile is supplied so
+    /// tests can model a resource that is missing it entirely.
+    /// </summary>
+    private static string SerializeWithOptionalProfile(string? profile, Dictionary<string, object> resource)
+    {
+        if (profile != null)
+            resource["meta"] = new { profile = new[] { profile } };
+
+        return JsonSerializer.Serialize(resource);
+    }
+
     private static string ExtractGeneratedPatientJson(string patientId, IReadOnlyList<(string Name, string Json)> bundles)
     {
         foreach (var (_, bundleJson) in bundles)
@@ -474,11 +544,12 @@ public class ReportAbsManifestValidatorTests
         var manifestNdjson = string.Join("\n", new[]
         {
             JsonSerializer.Serialize(new { resourceType = "Organization", id = "Org-UT" }),
-            JsonSerializer.Serialize(new { resourceType = "Device", id = "Device-UT" }),
+            JsonSerializer.Serialize(new { resourceType = "Device", id = "Device-UT", meta = new { profile = new[] { DeviceProfile } } }),
             JsonSerializer.Serialize(new
             {
                 resourceType = "List",
                 id = "PatientList-UT",
+                meta = new { profile = new[] { PatientListProfile } },
                 status = "current",
                 mode = "snapshot",
                 extension = new object[]

--- a/DotNet/ServiceTests/UnitTests/Report/ReportManifestProducerTests.cs
+++ b/DotNet/ServiceTests/UnitTests/Report/ReportManifestProducerTests.cs
@@ -1,0 +1,209 @@
+using Confluent.Kafka;
+using Hl7.Fhir.Model;
+using LantanaGroup.Link.Report.Application.Core;
+using LantanaGroup.Link.Report.Application.Options;
+using LantanaGroup.Link.Report.Data;
+using LantanaGroup.Link.Report.Data.Entities;
+using LantanaGroup.Link.Report.Domain.Enums;
+using LantanaGroup.Link.Report.Domain.Managers;
+using LantanaGroup.Link.Report.KafkaProducers;
+using LantanaGroup.Link.Report.Models;
+using LantanaGroup.Link.Report.Services;
+using LantanaGroup.Link.Report.Settings;
+using LantanaGroup.Link.Shared.Application.Models;
+using LantanaGroup.Link.Shared.Application.Models.Kafka;
+using LantanaGroup.Link.Shared.Application.Models.Tenant;
+using LantanaGroup.Link.Shared.Application.Services;
+using LantanaGroup.Link.Shared.Domain.Repositories.Interfaces;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+using System.Linq.Expressions;
+using List = Hl7.Fhir.Model.List;
+using Task = System.Threading.Tasks.Task;
+
+namespace UnitTests.Report;
+
+/// <summary>
+/// Covers the meta.profile stamped on the resources that make up manifest.ndjson (LEGLINK-871).
+/// Downstream NHSN DQM IG validation cannot resolve a resource to its profile without it.
+/// </summary>
+[Trait("Category", "UnitTests")]
+public class ReportManifestProducerTests
+{
+    private const string FacilityId = "facility-a";
+    private const string FacilityName = "Facility A";
+    private const string PatientId = "patient-1";
+    private const string Measure = "NHSNdQMAcuteCareHospitalInitialPopulation";
+
+    [Fact]
+    public async Task Generate_StampsSubmittingDeviceProfileOnDevice()
+    {
+        var harness = new Harness();
+
+        var resources = await harness.Producer.Generate(harness.Schedule);
+
+        var device = Assert.Single(resources.OfType<Device>());
+        Assert.Equal(
+            new[] { "http://hl7.org/fhir/us/nhsn-dqm/StructureDefinition/nhsn-submitting-device" },
+            device.Meta?.Profile);
+    }
+
+    [Fact]
+    public async Task Generate_StampsPoiListProfileOnPatientCensusList()
+    {
+        var harness = new Harness();
+
+        var resources = await harness.Producer.Generate(harness.Schedule);
+
+        var patientList = Assert.Single(resources.OfType<List>());
+        Assert.Equal(
+            new[] { "http://hl7.org/fhir/us/nhsn-dqm/StructureDefinition/poi-list" },
+            patientList.Meta?.Profile);
+    }
+
+    /// <summary>
+    /// The profiles that already existed must survive, and the manifest shape must not change.
+    /// </summary>
+    [Fact]
+    public async Task Generate_LeavesOrganizationAndAggregateMeasureReportProfilesUnchanged()
+    {
+        var harness = new Harness();
+
+        var resources = await harness.Producer.Generate(harness.Schedule);
+
+        var organization = Assert.Single(resources.OfType<Organization>());
+        Assert.Equal(
+            new[] { "https://www.cdc.gov/nhsn/nhsn-measures/StructureDefinition/nhsn-submitting-organization" },
+            organization.Meta?.Profile);
+
+        var measureReport = Assert.Single(resources.OfType<MeasureReport>());
+        Assert.Equal(
+            new[] { "http://www.cdc.gov/nhsn/fhirportal/dqm/ig/StructureDefinition/subjectlist-measurereport" },
+            measureReport.Meta?.Profile);
+
+        Assert.Single(resources.OfType<Device>());
+        Assert.Single(resources.OfType<List>());
+        Assert.Equal(4, resources.Count);
+    }
+
+    [Fact]
+    public async Task Generate_ProfileUrlsComeFromBundleSettingsConstants()
+    {
+        var harness = new Harness();
+
+        var resources = await harness.Producer.Generate(harness.Schedule);
+
+        Assert.Equal(
+            new[] { ReportConstants.BundleSettings.SubmittingDeviceProfile },
+            resources.OfType<Device>().Single().Meta?.Profile);
+        Assert.Equal(
+            new[] { ReportConstants.BundleSettings.CensusProfileUrl },
+            resources.OfType<List>().Single().Meta?.Profile);
+    }
+
+    private sealed class Harness
+    {
+        public ReportScheduleModel Schedule { get; }
+        public ReportManifestProducer Producer { get; }
+
+        public Harness()
+        {
+            Schedule = new ReportScheduleModel
+            {
+                Id = Guid.NewGuid(),
+                FacilityId = FacilityId,
+                ReportStartDate = new DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero),
+                ReportEndDate = new DateTimeOffset(2025, 1, 31, 23, 59, 59, TimeSpan.Zero),
+                ReportTypes = [Measure]
+            };
+
+            var reportEntryRepository = new Mock<IEntityRepository<ReportEntry>>();
+            reportEntryRepository
+                .Setup(r => r.FindAsync(It.IsAny<Expression<Func<ReportEntry, bool>>>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(
+                [
+                    new ReportEntry
+                    {
+                        Id = Guid.NewGuid(),
+                        FacilityId = FacilityId,
+                        ReportScheduleId = Schedule.Id,
+                        PatientId = PatientId,
+                        ReportingStatus = ReportingStatus.PassedValidation,
+                        SubmissionStatus = SubmissionStatus.Submitted
+                    }
+                ]);
+
+            var database = new Mock<IDatabase>();
+            database.SetupGet(d => d.ReportEntryRepository).Returns(reportEntryRepository.Object);
+
+            var services = new ServiceCollection();
+            services.AddScoped(_ => database.Object);
+            var scopeFactory = services.BuildServiceProvider().GetRequiredService<IServiceScopeFactory>();
+
+            var tenantApiService = new Mock<ITenantApiService>();
+            tenantApiService
+                .Setup(t => t.GetFacilityConfig(FacilityId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new FacilityModel { FacilityId = FacilityId, FacilityName = FacilityName });
+
+            var reportPopulationManager = new Mock<IReportPopulationManager>();
+            reportPopulationManager
+                .Setup(m => m.FindAsync(It.IsAny<Expression<Func<ReportPopulation, bool>>>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(
+                [
+                    new ReportPopulationModel
+                    {
+                        Id = Guid.NewGuid(),
+                        FacilityId = FacilityId,
+                        ReportScheduleId = Schedule.Id,
+                        Measure = Measure,
+                        ReportType = Measure,
+                        GroupPopulations =
+                        [
+                            new GroupPopulationModel
+                            {
+                                PopulationId = "initial-population",
+                                PopulationCodeJson = """{"coding":[{"code":"initial-population"}]}""",
+                                TotalPopulationCount = 1,
+                                MeasureReportPopulations =
+                                [
+                                    new MeasureReportPopulationModel { MeasureReportId = "mr-1", PopulationCount = 1 }
+                                ]
+                            }
+                        ]
+                    }
+                ]);
+
+            var aggregator = new MeasureReportAggregator(
+                Mock.Of<ILogger<MeasureReportAggregator>>(),
+                reportPopulationManager.Object);
+
+            var blobSettings = Options.Create(new BlobStorageSettings
+            {
+                ConnectionString = "UseDevelopmentStorage=true",
+                BlobContainerName = "internal"
+            });
+
+            var submitPayloadProducer = new SubmitPayloadProducer(
+                scopeFactory,
+                Mock.Of<IProducer<SubmitPayloadKey, SubmitPayloadValue>>(),
+                Mock.Of<ILogger<SubmitPayloadProducer>>());
+
+            var auditableEventOccurredProducer = new AuditableEventOccurredProducer(
+                Mock.Of<ILogger<AuditableEventOccurredProducer>>(),
+                Mock.Of<IProducer<string, AuditEventMessage>>(),
+                new ServiceInformation { ServiceConfigName = "Report" });
+
+            Producer = new ReportManifestProducer(
+                Mock.Of<ILogger<ReportManifestProducer>>(),
+                scopeFactory,
+                aggregator,
+                tenantApiService.Object,
+                new BlobStorageService(blobSettings),
+                submitPayloadProducer,
+                auditableEventOccurredProducer,
+                Mock.Of<IReportEntryManager>());
+        }
+    }
+}


### PR DESCRIPTION
### 🛠️ Description of Changes

The Report service's `manifest.ndjson` carried `meta.profile` on the Organization and aggregate
MeasureReport, but not on the Device or the List (patient census). Downstream consumers validating
the submission against the NHSN DQM IG could not resolve those two resources to their intended
profiles.

#### `DotNet/Report/Application/Settings/ReportConstants.cs`

- `CensusProfileUrl` corrected to `http://hl7.org/fhir/us/nhsn-dqm/StructureDefinition/poi-list`
  (was the stale `https://www.cdc.gov/nhsn/nhsn-measures/StructureDefinition/poi-list` value) and is
  now actually referenced — it had been dead since it was defined.
- Added `SubmittingDeviceProfile = "http://hl7.org/fhir/us/nhsn-dqm/StructureDefinition/nhsn-submitting-device"`,
  alphabetically alongside the other profile constants.

No unused profile constant is left behind.

#### `DotNet/Report/KafkaProducers/ReportManifestProducer.cs`

- `CreateDevice()` and `CreatePatientList()` now set `Meta.Profile` from those constants.
- Organization (`FhirHelperMethods.CreateOrganization`) and the aggregate MeasureReport
  (`MeasureReportAggregator`) are untouched.
- OperationOutcome remains without a profile — out of scope per the ticket.

#### `DotNet/Automation.Link/Validation/ReportAbsManifestValidator.cs`

- New `ValidateMetaProfile` / `GetMetaProfiles` helpers.
- `ValidateManifest()` now asserts the expected profile on the Device and List resources, so a
  dropped profile fails the automation run with a specific error instead of surfacing downstream.

#### Expected values

| Resource | `meta.profile` |
| --- | --- |
| Device | `http://hl7.org/fhir/us/nhsn-dqm/StructureDefinition/nhsn-submitting-device` |
| List (patient census) | `http://hl7.org/fhir/us/nhsn-dqm/StructureDefinition/poi-list` |

### 🧪 Testing Performed

TODO

### 🧑‍🔬 Unit Testing

- [X] I have written or updated unit tests to cover my changes
- Coverage: 96.3%

### 📓 Documentation Updated

N/A
