### PR TITLE
LEGLINK-969: Validation: fetchValueSet requests full ValueSet expansions with _summary=false, transferring hundreds of thousands of concepts per bundle

### DIFF
--- a/Java/validation/src/main/java/com/lantanagroup/link/validation/providers/RemoteTermServiceValidation.java
+++ b/Java/validation/src/main/java/com/lantanagroup/link/validation/providers/RemoteTermServiceValidation.java
@@ -261,9 +261,26 @@ public class RemoteTermServiceValidation extends BaseValidationSupport implement
         return conceptDesignation;
     }
 
+    /**
+     * Summary mode used when HAPI asks us to resolve a bound ValueSet.
+     * <p>
+     * Deliberately {@link SummaryEnum#TRUE}: {@code _summary=false} is the condition that makes the Link
+     * terminology service enumerate every code of the value set into {@code ValueSet.expansion.contains}
+     * (see {@code Terminology/Services/FhirService.cs}), which for large value sets is the client-side
+     * trigger for terminology-service memory exhaustion. The expansion is not read by this class -- when
+     * the resolved ValueSet carries a canonical URL, {@link #validateCodeInValueSet} uses only that URL and
+     * routes validation through {@code $validate-code}. The Link terminology service's summary handling is
+     * bespoke rather than element-filtering: at {@code _summary=true} it still returns the stored ValueSet
+     * with its {@code compose} intact, so downstream chain members (e.g. HAPI's in-memory terminology
+     * support) can still expand it in-process.
+     * <p>
+     * Change this only with before/after comparison of validation results -- see
+     * {@code RemoteTermServiceValidationTest#fetchValueSet_requestsSummaryModeTrue}.
+     */
+    static final SummaryEnum FETCH_VALUE_SET_SUMMARY_MODE = SummaryEnum.TRUE;
+
     public IBaseResource fetchValueSet(String theValueSetUrl) {
-        SummaryEnum summaryParam = SummaryEnum.FALSE;
-        return this.fetchValueSet(theValueSetUrl, summaryParam);
+        return this.fetchValueSet(theValueSetUrl, FETCH_VALUE_SET_SUMMARY_MODE);
     }
 
     @Nullable

--- a/Java/validation/src/test/java/com/lantanagroup/link/validation/providers/RemoteTermServiceValidationTest.java
+++ b/Java/validation/src/test/java/com/lantanagroup/link/validation/providers/RemoteTermServiceValidationTest.java
@@ -3,14 +3,20 @@ package com.lantanagroup.link.validation.providers;
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.context.support.IValidationSupport.CodeValidationResult;
 import ca.uhn.fhir.context.support.IValidationSupport.IssueSeverity;
+import ca.uhn.fhir.rest.api.SummaryEnum;
 import ca.uhn.fhir.rest.client.api.IGenericClient;
+import ca.uhn.fhir.rest.gclient.ICriterion;
 import ca.uhn.fhir.rest.gclient.IOperation;
 import ca.uhn.fhir.rest.gclient.IOperationUnnamed;
 import ca.uhn.fhir.rest.gclient.IOperationUntyped;
 import ca.uhn.fhir.rest.gclient.IOperationUntypedWithInputAndPartialOutput;
+import ca.uhn.fhir.rest.gclient.IQuery;
+import ca.uhn.fhir.rest.gclient.IUntypedQuery;
 import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
 import ca.uhn.fhir.rest.server.exceptions.ResourceNotFoundException;
 import com.lantanagroup.link.shared.utils.LogUtils;
+import org.hl7.fhir.instance.model.api.IBaseBundle;
+import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.hl7.fhir.r4.model.*;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -64,6 +70,34 @@ class RemoteTermServiceValidationTest {
             when(withInput.execute()).thenReturn(executeResult);
         }
         return operation;
+    }
+
+    /**
+     * Stubs the fluent {@code client.search().forResource(..).where(..).summaryMode(..).returnBundle(..).execute()}
+     * chain so that {@code execute()} returns the supplied bundle. Returns the query mock so callers can capture
+     * the summary mode requested.
+     */
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    private IQuery stubSearchChain(RemoteTermServiceValidation subject, IBaseBundle executeResult) {
+        IGenericClient client = mock(IGenericClient.class);
+        IUntypedQuery untypedQuery = mock(IUntypedQuery.class);
+        IQuery query = mock(IQuery.class);
+
+        doReturn(client).when(subject).provideClient();
+        when(client.search()).thenReturn(untypedQuery);
+        when(untypedQuery.forResource(anyString())).thenReturn(query);
+        when(query.where(any(ICriterion.class))).thenReturn(query);
+        when(query.summaryMode(any(SummaryEnum.class))).thenReturn(query);
+        when(query.returnBundle(any(Class.class))).thenReturn(query);
+        when(query.execute()).thenReturn(executeResult);
+        return query;
+    }
+
+    private Bundle searchsetContaining(Resource resource) {
+        Bundle bundle = new Bundle();
+        bundle.setType(Bundle.BundleType.SEARCHSET);
+        bundle.addEntry().setResource(resource);
+        return bundle;
     }
 
     private Parameters validateCodeResponse(boolean result, String paramName, String paramValue) {
@@ -296,6 +330,56 @@ class RemoteTermServiceValidationTest {
                 result.getMessage());
         // The inline path targets the ValueSet resource, not CodeSystem.
         verify(operation).onType("ValueSet");
+    }
+
+    // ---------- fetchValueSet summary mode ----------
+    // fetchValueSet(String) is the public IValidationSupport hook HAPI calls to resolve a bound ValueSet.
+    // Requesting _summary=false makes the Link terminology service enumerate every code of the value set
+    // into ValueSet.expansion.contains, which is the client-side trigger for terminology-service memory
+    // exhaustion -- and the expansion is never read (validateCodeInValueSet uses only the canonical URL).
+    // These tests pin the summary mode so it cannot be silently changed back.
+
+    @Test
+    @SuppressWarnings("rawtypes")
+    void fetchValueSet_requestsSummaryModeTrue() {
+        RemoteTermServiceValidation subject = newSpy();
+        ValueSet valueSet = new ValueSet();
+        valueSet.setUrl(VALUE_SET_URL);
+        IQuery query = stubSearchChain(subject, searchsetContaining(valueSet));
+
+        IBaseResource result = subject.fetchValueSet(VALUE_SET_URL);
+
+        ArgumentCaptor<SummaryEnum> summaryMode = ArgumentCaptor.forClass(SummaryEnum.class);
+        verify(query).summaryMode(summaryMode.capture());
+        assertEquals(SummaryEnum.TRUE, summaryMode.getValue(),
+                "fetchValueSet must not request _summary=false: that makes the terminology service "
+                        + "enumerate the full expansion for a resource whose expansion is never read.");
+        assertSame(valueSet, result);
+    }
+
+    @Test
+    @SuppressWarnings("rawtypes")
+    void fetchValueSet_noMatch_returnsNull() {
+        RemoteTermServiceValidation subject = newSpy();
+        Bundle empty = new Bundle();
+        empty.setType(Bundle.BundleType.SEARCHSET);
+        IQuery query = stubSearchChain(subject, empty);
+
+        assertNull(subject.fetchValueSet(VALUE_SET_URL));
+        verify(query).summaryMode(SummaryEnum.TRUE);
+    }
+
+    @Test
+    @SuppressWarnings("rawtypes")
+    void invokeIsValueSetSupported_requestsSummaryModeTrue() {
+        // The existence check has always used _summary=true; fetchValueSet(String) now matches it.
+        RemoteTermServiceValidation subject = newSpy();
+        ValueSet valueSet = new ValueSet();
+        valueSet.setUrl(VALUE_SET_URL);
+        IQuery query = stubSearchChain(subject, searchsetContaining(valueSet));
+
+        assertTrue(subject.invokeIsValueSetSupported(VALUE_SET_URL));
+        verify(query).summaryMode(SummaryEnum.TRUE);
     }
 
     // ---------- isCodeSystemSupported / isValueSetSupported delegation to cache ----------


### PR DESCRIPTION
### 🛠️ Description of Changes

`RemoteTermServiceValidation.fetchValueSet(String)` — the public `IValidationSupport` method HAPI calls
to resolve a bound ValueSet — hardcoded `SummaryEnum.FALSE`. It now requests `_summary=true`, matching
the neighboring `invokeIsCodeSystemSupported` / `invokeIsValueSetSupported` methods in the same class.

The risk flagged in the ticket — that a summary-only ValueSet reaching
`InMemoryTerminologyServerValidationSupport` could change validation outcomes — is materially smaller than
assumed, and worth recording.

The Link terminology service's summary handling is **bespoke, not spec-conformant element filtering**:
`FhirService.GetValueSets` (`DotNet/Terminology/Services/FhirService.cs:61-88`) deep-copies the stored
ValueSet and, when `summary == SummaryType.True`, simply *skips generating* `expansion.contains`. It
returns the resource whole — `compose` intact — and the controller (`DotNet/Terminology/Controllers/FhirController.cs:139`)
passes the bundle straight to `Ok()` with no serializer-level summary filtering.

So `InMemoryTerminologyServerValidationSupport` still receives a ValueSet it can expand in-process from
`compose`; it is not getting a metadata-only stub. This is noted in the javadoc on the new constant.

### 🧪 Testing Performed

TODO

### 🧑‍🔬 Unit Testing

- [X] I have written or updated unit tests to cover my changes
- Coverage: 100.0%

### 📓 Documentation Updated

N/A
