### PR TITLE
LEGLINK-790: Automation UI: Add /info & /health endpoints to API Health across all services.

### DIFF
--- a/DotNet/Automation.UI/Services/ApiHealth/TestSuites/AdminBffTestSuite.cs
+++ b/DotNet/Automation.UI/Services/ApiHealth/TestSuites/AdminBffTestSuite.cs
@@ -83,14 +83,14 @@ public sealed class AdminBffTestSuite : ServiceTestSuiteBase
         results.Add(await CallRawGetAsync(
             StepNames.InfoGet200,
             baseUrl,
-            "/api/info",
+            "/info",
             ct));
 
         // --- /health ---
         results.Add(await CallRawGetAsync(
             StepNames.RootHealthGet200,
             baseUrl,
-            "/api//health",
+            "/health",
             ct));
 
         var adminBffClient = _serviceProvider.GetRequiredService<IAdminBffIntegrationClient>();

--- a/DotNet/Automation.UI/Services/ApiHealth/TestSuites/AdminBffTestSuite.cs
+++ b/DotNet/Automation.UI/Services/ApiHealth/TestSuites/AdminBffTestSuite.cs
@@ -83,14 +83,14 @@ public sealed class AdminBffTestSuite : ServiceTestSuiteBase
         results.Add(await CallRawGetAsync(
             StepNames.InfoGet200,
             baseUrl,
-            "/info",
+            "/api/info",
             ct));
 
         // --- /health ---
         results.Add(await CallRawGetAsync(
             StepNames.RootHealthGet200,
             baseUrl,
-            "/health",
+            "/api/monitor/health",
             ct));
 
         var adminBffClient = _serviceProvider.GetRequiredService<IAdminBffIntegrationClient>();

--- a/DotNet/Automation.UI/Services/ApiHealth/TestSuites/AdminBffTestSuite.cs
+++ b/DotNet/Automation.UI/Services/ApiHealth/TestSuites/AdminBffTestSuite.cs
@@ -58,7 +58,6 @@ public sealed class AdminBffTestSuite : ServiceTestSuiteBase
             foreach (var endpointName in new[]
             {
                 StepNames.InfoGet200,
-                StepNames.RootHealthGet200,
                 StepNames.HealthGet200
             })
             {
@@ -84,13 +83,6 @@ public sealed class AdminBffTestSuite : ServiceTestSuiteBase
             StepNames.InfoGet200,
             baseUrl,
             "/api/info",
-            ct));
-
-        // --- /health ---
-        results.Add(await CallRawGetAsync(
-            StepNames.RootHealthGet200,
-            baseUrl,
-            "/api/monitor/health",
             ct));
 
         var adminBffClient = _serviceProvider.GetRequiredService<IAdminBffIntegrationClient>();

--- a/DotNet/Automation.UI/Services/ApiHealth/TestSuites/AdminBffTestSuite.cs
+++ b/DotNet/Automation.UI/Services/ApiHealth/TestSuites/AdminBffTestSuite.cs
@@ -83,14 +83,14 @@ public sealed class AdminBffTestSuite : ServiceTestSuiteBase
         results.Add(await CallRawGetAsync(
             StepNames.InfoGet200,
             baseUrl,
-            "/api/AdminBff/info",
+            "/api/info",
             ct));
 
         // --- /health ---
         results.Add(await CallRawGetAsync(
             StepNames.RootHealthGet200,
             baseUrl,
-            "/health",
+            "/api//health",
             ct));
 
         var adminBffClient = _serviceProvider.GetRequiredService<IAdminBffIntegrationClient>();

--- a/DotNet/Automation.UI/Services/ApiHealth/TestSuites/AdminBffTestSuite.cs
+++ b/DotNet/Automation.UI/Services/ApiHealth/TestSuites/AdminBffTestSuite.cs
@@ -49,21 +49,49 @@ public sealed class AdminBffTestSuite : ServiceTestSuiteBase
     public override async Task<IReadOnlyList<ApiTestRunResult>> ExecuteAsync(CancellationToken ct = default)
     {
         var results = new List<ApiTestRunResult>();
-        var baseUrl = _serviceRegistry.Value.AdminBffServiceApiUrl?.TrimEnd('/');
+        var baseUrl = _serviceRegistry.Value.AdminBffServiceUrl?.TrimEnd('/');
 
         if (string.IsNullOrWhiteSpace(baseUrl))
         {
-            results.Add(new ApiTestRunResult
+            const string error = "ServiceRegistry:AdminBffServiceUrl is not configured.";
+
+            foreach (var endpointName in new[]
             {
-                EndpointKey = $"{ServiceName}::{StepNames.HealthGet200}",
-                ServiceName = ServiceName,
-                Passed = false,
-                ErrorMessage = "ServiceRegistry:AdminBffServiceUrl is not configured.",
-                RequestBody = "Request was not sent because ServiceRegistry:AdminBffServiceUrl is missing.",
-                ResponseBody = "Response was not received because ServiceRegistry:AdminBffServiceUrl is missing."
-            });
+                StepNames.InfoGet200,
+                StepNames.RootHealthGet200,
+                StepNames.HealthGet200
+            })
+            {
+                results.Add(new ApiTestRunResult
+                {
+                    EndpointKey = $"{ServiceName}::{endpointName}",
+                    ServiceName = ServiceName,
+                    EndpointName = endpointName,
+                    Passed = false,
+                    ExpectedStatusCode = 200,
+                    ErrorMessage = error,
+                    RequestBody = "Request was not sent because the Admin BFF service URL is missing.",
+                    ResponseBody = "Response was not received because the Admin BFF service URL is missing.",
+                    ExecutedAt = DateTimeOffset.UtcNow
+                });
+            }
+
             return results;
         }
+
+        // --- /api/AdminBff/info ---
+        results.Add(await CallRawGetAsync(
+            StepNames.InfoGet200,
+            baseUrl,
+            "/api/AdminBff/info",
+            ct));
+
+        // --- /health ---
+        results.Add(await CallRawGetAsync(
+            StepNames.RootHealthGet200,
+            baseUrl,
+            "/health",
+            ct));
 
         var adminBffClient = _serviceProvider.GetRequiredService<IAdminBffIntegrationClient>();
 
@@ -336,6 +364,85 @@ public sealed class AdminBffTestSuite : ServiceTestSuiteBase
         {
             return trimmed;
         }
+    }
+
+    private async Task<ApiTestRunResult> CallRawGetAsync(
+        string endpointName,
+        string baseUrl,
+        string relativePath,
+        CancellationToken ct)
+    {
+        var result = new ApiTestRunResult
+        {
+            EndpointKey = $"{ServiceName}::{endpointName}",
+            ServiceName = ServiceName,
+            EndpointName = endpointName,
+            ExpectedStatusCode = 200,
+            ExecutedAt = DateTimeOffset.UtcNow,
+            RequestMethod = "GET",
+            RequestUrl = $"{baseUrl}{relativePath}",
+            RequestBody = "No request body was sent (GET)."
+        };
+
+        var sw = Stopwatch.StartNew();
+
+        try
+        {
+            ct.ThrowIfCancellationRequested();
+
+            var httpClientFactory = _serviceProvider.GetRequiredService<IHttpClientFactory>();
+            var httpClient = httpClientFactory.CreateClient("ApiHealthTest");
+            using var response = await httpClient.GetAsync(
+                $"{baseUrl}{relativePath}",
+                ct);
+
+            var responseBody = await response.Content.ReadAsStringAsync(ct);
+
+            sw.Stop();
+
+            result.ActualStatusCode = (int)response.StatusCode;
+            result.DurationMs = sw.ElapsedMilliseconds;
+            result.Passed = result.ActualStatusCode == 200;
+
+            result.ResponseBody = string.IsNullOrWhiteSpace(responseBody)
+                ? $"No response body was returned (HTTP {result.ActualStatusCode})."
+                : responseBody.Length > 500
+                    ? responseBody[..500]
+                    : responseBody;
+
+            if (!result.Passed)
+            {
+                result.ErrorMessage = BuildStatusMismatchMessage(
+                    200,
+                    result.ActualStatusCode ?? 0,
+                    result.ResponseBody,
+                    null);
+            }
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (TaskCanceledException)
+        {
+            sw.Stop();
+            result.DurationMs = sw.ElapsedMilliseconds;
+            result.Passed = false;
+            result.ErrorMessage = "Request timed out.";
+            result.ResponseBody =
+                "No response body was received because the request timed out.";
+        }
+        catch (HttpRequestException ex)
+        {
+            sw.Stop();
+            result.DurationMs = sw.ElapsedMilliseconds;
+            result.Passed = false;
+            result.ErrorMessage = $"HTTP error: {ex.Message}";
+            result.ResponseBody =
+                "No response body was received because the HTTP request failed.";
+        }
+
+        return result;
     }
 
 }

--- a/DotNet/Automation.UI/Services/ApiHealth/TestSuites/ApiEndPointLibrary.cs
+++ b/DotNet/Automation.UI/Services/ApiHealth/TestSuites/ApiEndPointLibrary.cs
@@ -133,8 +133,8 @@ public static class ApiEndPointLibrary
 
     private static IReadOnlyDictionary<string, EndpointMeta> BuildAdminBffMetadata() => new Dictionary<string, EndpointMeta>(StringComparer.Ordinal)
     {
-        [AdminBffSteps.InfoGet200] = new EndpointMeta("Returns Admin BFF service information.", "GET /api/AdminBff/info"),
-        [AdminBffSteps.RootHealthGet200] = new EndpointMeta("Returns Admin BFF root health status.", "GET /health"),
+        [AdminBffSteps.InfoGet200] = new EndpointMeta("Returns Admin BFF service information.", "GET /api/info"),
+        [AdminBffSteps.RootHealthGet200] = new EndpointMeta("Returns Admin BFF root health status.", "GET /api/health"),
         [AdminBffSteps.HealthGet200] = new EndpointMeta("Returns Admin BFF monitor health status.", "GET /api/monitor/health")
     };
 

--- a/DotNet/Automation.UI/Services/ApiHealth/TestSuites/ApiEndPointLibrary.cs
+++ b/DotNet/Automation.UI/Services/ApiHealth/TestSuites/ApiEndPointLibrary.cs
@@ -134,7 +134,6 @@ public static class ApiEndPointLibrary
     private static IReadOnlyDictionary<string, EndpointMeta> BuildAdminBffMetadata() => new Dictionary<string, EndpointMeta>(StringComparer.Ordinal)
     {
         [AdminBffSteps.InfoGet200] = new EndpointMeta("Returns Admin BFF service information.", "GET /api/info"),
-        [AdminBffSteps.RootHealthGet200] = new EndpointMeta("Returns Admin BFF root health status.", "GET /api/monitor/health"),
         [AdminBffSteps.HealthGet200] = new EndpointMeta("Returns Admin BFF monitor health status.", "GET /api/monitor/health")
     };
 
@@ -236,7 +235,6 @@ public static class ApiEndPointLibrary
     public static class AdminBffSteps
     {
         public const string InfoGet200 = "Service Info GET → 200";
-        public const string RootHealthGet200 = "Root Health GET → 200";
         public const string HealthGet200 = "Health GET → 200";
         public const string FacilityDelete200 = "Facility DELETE → 200";
         public const string FacilityDelete404 = "Facility DELETE → 404";

--- a/DotNet/Automation.UI/Services/ApiHealth/TestSuites/ApiEndPointLibrary.cs
+++ b/DotNet/Automation.UI/Services/ApiHealth/TestSuites/ApiEndPointLibrary.cs
@@ -149,13 +149,13 @@ public static class ApiEndPointLibrary
 
     private static IReadOnlyDictionary<string, EndpointMeta> BuildDataAcquisitionMetadata() => new Dictionary<string, EndpointMeta>(StringComparer.Ordinal)
     {
-        [DataAcquisitionSteps.InfoGet200] = new EndpointMeta("Returns Data Acquisition service information.", "GET /api/DataAcquisition/info"),
+        [DataAcquisitionSteps.InfoGet200] = new EndpointMeta("Returns Data Acquisition service information.", "GET /api/data/info"),
         [DataAcquisitionSteps.RootHealthGet200] = new EndpointMeta("Returns Data Acquisition service health status.", "GET /health")
     };
 
     private static IReadOnlyDictionary<string, EndpointMeta> BuildMeasureEvalMetadata() => new Dictionary<string, EndpointMeta>(StringComparer.Ordinal)
     {
-        [MeasureEvalSteps.InfoGet200] = new EndpointMeta("Returns MeasureEval service information.", "GET /api/MeasureEval/info"),
+        [MeasureEvalSteps.InfoGet200] = new EndpointMeta("Returns MeasureEval service information.", "GET /api/measureeval/info"),
         [MeasureEvalSteps.RootHealthGet200] = new EndpointMeta("Returns MeasureEval service health status.", "GET /health")
     };
 
@@ -187,13 +187,13 @@ public static class ApiEndPointLibrary
 
     private static IReadOnlyDictionary<string, EndpointMeta> BuildTenantMetadata() => new Dictionary<string, EndpointMeta>(StringComparer.Ordinal)
     {
-        [TenantSteps.InfoGet200] = new EndpointMeta("Returns Tenant service information.", "GET /api/Tenant/info"),
+        [TenantSteps.InfoGet200] = new EndpointMeta("Returns Tenant service information.", "GET /api/facility/info"),
         [TenantSteps.RootHealthGet200] = new EndpointMeta("Returns Tenant service health status.", "GET /health")
     };
 
     private static IReadOnlyDictionary<string, EndpointMeta> BuildValidationMetadata() => new Dictionary<string, EndpointMeta>(StringComparer.Ordinal)
     {
-        [ValidationSteps.InfoGet200] = new EndpointMeta("Returns Validation service information.", "GET /api/Validation/info"),
+        [ValidationSteps.InfoGet200] = new EndpointMeta("Returns Validation service information.", "GET /api/validation/info"),
         [ValidationSteps.RootHealthGet200] = new EndpointMeta("Returns Validation service health status.", "GET /health")
     };
 

--- a/DotNet/Automation.UI/Services/ApiHealth/TestSuites/ApiEndPointLibrary.cs
+++ b/DotNet/Automation.UI/Services/ApiHealth/TestSuites/ApiEndPointLibrary.cs
@@ -134,7 +134,7 @@ public static class ApiEndPointLibrary
     private static IReadOnlyDictionary<string, EndpointMeta> BuildAdminBffMetadata() => new Dictionary<string, EndpointMeta>(StringComparer.Ordinal)
     {
         [AdminBffSteps.InfoGet200] = new EndpointMeta("Returns Admin BFF service information.", "GET /api/info"),
-        [AdminBffSteps.RootHealthGet200] = new EndpointMeta("Returns Admin BFF root health status.", "GET /api/health"),
+        [AdminBffSteps.RootHealthGet200] = new EndpointMeta("Returns Admin BFF root health status.", "GET /api/monitor/health"),
         [AdminBffSteps.HealthGet200] = new EndpointMeta("Returns Admin BFF monitor health status.", "GET /api/monitor/health")
     };
 

--- a/DotNet/Automation.UI/Services/ApiHealth/TestSuites/ApiEndPointLibrary.cs
+++ b/DotNet/Automation.UI/Services/ApiHealth/TestSuites/ApiEndPointLibrary.cs
@@ -68,17 +68,17 @@ public static class ApiEndPointLibrary
     private static IReadOnlyList<ApiEndpointDefinition> BuildServiceEndpoints(string serviceName) =>
         serviceName switch
         {
-            ServiceNames.AdminBff => BuildFromStepConstants(ServiceNames.AdminBff, typeof(AdminBffSteps)),
+            ServiceNames.AdminBff => BuildFromStepConstants(ServiceNames.AdminBff, typeof(AdminBffSteps),BuildAdminBffMetadata()),
             ServiceNames.AdminBffAuth => BuildFromStepConstants(ServiceNames.AdminBffAuth, typeof(AdminBffAuthSteps), BuildAdminBffAuthMetadata()),
             ServiceNames.Census => BuildFromStepConstants(ServiceNames.Census, typeof(CensusSteps), BuildCensusMetadata()),
-            ServiceNames.DataAcquisition => BuildFromStepConstants(ServiceNames.DataAcquisition, typeof(DataAcquisitionSteps)),
-            ServiceNames.MeasureEval => BuildFromStepConstants(ServiceNames.MeasureEval, typeof(MeasureEvalSteps)),
-            ServiceNames.Normalization => BuildFromStepConstants(ServiceNames.Normalization, typeof(NormalizationSteps)),
-            ServiceNames.QueryDispatch => BuildFromStepConstants(ServiceNames.QueryDispatch, typeof(QueryDispatchSteps)),
+            ServiceNames.DataAcquisition => BuildFromStepConstants(ServiceNames.DataAcquisition, typeof(DataAcquisitionSteps), BuildDataAcquisitionMetadata()),
+            ServiceNames.MeasureEval => BuildFromStepConstants(ServiceNames.MeasureEval, typeof(MeasureEvalSteps), BuildMeasureEvalMetadata()),
+            ServiceNames.Normalization => BuildFromStepConstants(ServiceNames.Normalization, typeof(NormalizationSteps), BuildNormalizationMetadata()),
+            ServiceNames.QueryDispatch => BuildFromStepConstants(ServiceNames.QueryDispatch, typeof(QueryDispatchSteps), BuildQueryDispatchMetadata()),
             ServiceNames.Report => BuildFromStepConstants(ServiceNames.Report, typeof(ReportSteps), BuildReportMetadata()),
-            ServiceNames.Submission => BuildFromStepConstants(ServiceNames.Submission, typeof(SubmissionSteps)),
-            ServiceNames.Tenant => BuildFromStepConstants(ServiceNames.Tenant, typeof(TenantSteps)),
-            ServiceNames.Validation => BuildFromStepConstants(ServiceNames.Validation, typeof(ValidationSteps)),
+            ServiceNames.Submission => BuildFromStepConstants(ServiceNames.Submission, typeof(SubmissionSteps), BuildSubmissionMetadata()),
+            ServiceNames.Tenant => BuildFromStepConstants(ServiceNames.Tenant, typeof(TenantSteps), BuildTenantMetadata()),
+            ServiceNames.Validation => BuildFromStepConstants(ServiceNames.Validation, typeof(ValidationSteps), BuildValidationMetadata()),
             _ => []
         };
 
@@ -118,18 +118,6 @@ public static class ApiEndPointLibrary
         return endpoints;
     }
 
-    private static IReadOnlyDictionary<string, EndpointMeta> BuildCensusMetadata() => new Dictionary<string, EndpointMeta>(StringComparer.Ordinal)
-    {
-        [CensusSteps.AdmittedGet200] = new EndpointMeta(CensusSteps.AdmittedGet200, "/api/census/{facilityId}/history/admitted", "Admitted census rows are produced by downstream ingestion workflows and cannot be deterministically created through Census HTTP endpoints in a self-contained health run."),
-        [CensusSteps.PatientEventsGet200] = new EndpointMeta(CensusSteps.PatientEventsGet200, "/api/census/patient-events", "Patient events are created by Kafka listeners, not HTTP APIs, so a deterministic 200 fixture cannot be self-seeded in this suite."),
-        [CensusSteps.PatientEventDelete202] = new EndpointMeta(CensusSteps.PatientEventDelete202, "/api/census/patient-events/{id}", "Patient events are written exclusively by the Kafka PatientListsAcquiredListener. No HTTP endpoint exists to create them, so the 202 path cannot be exercised in a self-contained health test.")
-    };
-
-    private static IReadOnlyDictionary<string, EndpointMeta> BuildReportMetadata() => new Dictionary<string, EndpointMeta>(StringComparer.Ordinal)
-    {
-        [ReportSteps.ResourceGet200HasData] = new EndpointMeta(ReportSteps.ResourceGet200HasData, "GET /api/resources/{id}", "Resource rows are intentionally not persisted for seeded runs in this environment, so no deterministic resource id exists.")
-    };
-
     private static IReadOnlyDictionary<string, EndpointMeta> BuildAdminBffAuthMetadata() => new Dictionary<string, EndpointMeta>(StringComparer.Ordinal)
     {
         [AdminBffAuthSteps.ValidBearerGet200] = new EndpointMeta("Valid Bearer token GET \u2192 200", "GET /aggregate/reports/summaries (auth)"),
@@ -141,6 +129,72 @@ public static class ApiEndPointLibrary
         [AdminBffAuthSteps.MissingAuthHeaderGet401] = new EndpointMeta("Missing Authorization header GET \u2192 401", "GET /aggregate/reports/summaries (auth)"),
         [AdminBffAuthSteps.InvalidAuthSchemeGet401] = new EndpointMeta("Invalid auth scheme (Basic) GET \u2192 401", "GET /aggregate/reports/summaries (auth)"),
         [AdminBffAuthSteps.CrossApiTokenReuseGet401] = new EndpointMeta("Cross-API token reuse GET \u2192 401", "GET /aggregate/reports/summaries (auth)")
+    };
+
+    private static IReadOnlyDictionary<string, EndpointMeta> BuildAdminBffMetadata() => new Dictionary<string, EndpointMeta>(StringComparer.Ordinal)
+    {
+        [AdminBffSteps.InfoGet200] = new EndpointMeta("Returns Admin BFF service information.", "GET /api/AdminBff/info"),
+        [AdminBffSteps.RootHealthGet200] = new EndpointMeta("Returns Admin BFF root health status.", "GET /health"),
+        [AdminBffSteps.HealthGet200] = new EndpointMeta("Returns Admin BFF monitor health status.", "GET /api/monitor/health")
+    };
+
+    private static IReadOnlyDictionary<string, EndpointMeta> BuildCensusMetadata() => new Dictionary<string, EndpointMeta>(StringComparer.Ordinal)
+    {
+        [CensusSteps.InfoGet200] = new EndpointMeta("Returns Census service information.", "GET /api/Census/info"),
+        [CensusSteps.RootHealthGet200] = new EndpointMeta("Returns Census service health status.", "GET /health"),
+        [CensusSteps.AdmittedGet200] = new EndpointMeta(CensusSteps.AdmittedGet200, "/api/census/{facilityId}/history/admitted", "Admitted census rows are produced by downstream ingestion workflows and cannot be deterministically created through Census HTTP endpoints in a self-contained health run."),
+        [CensusSteps.PatientEventsGet200] = new EndpointMeta(CensusSteps.PatientEventsGet200, "/api/census/patient-events", "Patient events are created by Kafka listeners, not HTTP APIs, so a deterministic 200 fixture cannot be self-seeded in this suite."),
+        [CensusSteps.PatientEventDelete202] = new EndpointMeta(CensusSteps.PatientEventDelete202, "/api/census/patient-events/{id}", "Patient events are written exclusively by the Kafka PatientListsAcquiredListener. No HTTP endpoint exists to create them, so the 202 path cannot be exercised in a self-contained health test.")
+    };
+
+    private static IReadOnlyDictionary<string, EndpointMeta> BuildDataAcquisitionMetadata() => new Dictionary<string, EndpointMeta>(StringComparer.Ordinal)
+    {
+        [DataAcquisitionSteps.InfoGet200] = new EndpointMeta("Returns Data Acquisition service information.", "GET /api/DataAcquisition/info"),
+        [DataAcquisitionSteps.RootHealthGet200] = new EndpointMeta("Returns Data Acquisition service health status.", "GET /health")
+    };
+
+    private static IReadOnlyDictionary<string, EndpointMeta> BuildMeasureEvalMetadata() => new Dictionary<string, EndpointMeta>(StringComparer.Ordinal)
+    {
+        [MeasureEvalSteps.InfoGet200] = new EndpointMeta("Returns MeasureEval service information.", "GET /api/MeasureEval/info"),
+        [MeasureEvalSteps.RootHealthGet200] = new EndpointMeta("Returns MeasureEval service health status.", "GET /health")
+    };
+
+    private static IReadOnlyDictionary<string, EndpointMeta> BuildNormalizationMetadata() => new Dictionary<string, EndpointMeta>(StringComparer.Ordinal)
+    {
+        [NormalizationSteps.InfoGet200] = new EndpointMeta("Returns Normalization service information.", "GET /api/Normalization/info"),
+        [NormalizationSteps.RootHealthGet200] = new EndpointMeta("Returns Normalization service health status.", "GET /health")
+    };
+
+    private static IReadOnlyDictionary<string, EndpointMeta> BuildQueryDispatchMetadata() => new Dictionary<string, EndpointMeta>(StringComparer.Ordinal)
+    {
+        [QueryDispatchSteps.InfoGet200] = new EndpointMeta("Returns QueryDispatch service information.", "GET /api/QueryDispatch/info"),
+        [QueryDispatchSteps.RootHealthGet200] = new EndpointMeta("Returns QueryDispatch service health status.", "GET /health")
+    };
+
+    private static IReadOnlyDictionary<string, EndpointMeta> BuildReportMetadata() => new Dictionary<string, EndpointMeta>(StringComparer.Ordinal)
+    {
+        [ReportSteps.InfoGet200] = new EndpointMeta("Returns Report service information.", "GET /api/Report/info"),
+        [ReportSteps.RootHealthGet200] = new EndpointMeta("Returns Report service health status.", "GET /health"),
+        [ReportSteps.ResourceGet200HasData] = new EndpointMeta(ReportSteps.ResourceGet200HasData, "GET /api/resources/{id}", "Resource rows are intentionally not persisted for seeded runs in this environment, so no deterministic resource id exists.")
+    };
+
+    private static IReadOnlyDictionary<string, EndpointMeta> BuildSubmissionMetadata() =>
+    new Dictionary<string, EndpointMeta>(StringComparer.Ordinal)
+    {
+        [SubmissionSteps.InfoGet200] = new EndpointMeta("Returns Submission service information.", "GET /api/Submission/info"),
+        [SubmissionSteps.RootHealthGet200] = new EndpointMeta("Returns Submission service health status.", "GET /health")
+    };
+
+    private static IReadOnlyDictionary<string, EndpointMeta> BuildTenantMetadata() => new Dictionary<string, EndpointMeta>(StringComparer.Ordinal)
+    {
+        [TenantSteps.InfoGet200] = new EndpointMeta("Returns Tenant service information.", "GET /api/Tenant/info"),
+        [TenantSteps.RootHealthGet200] = new EndpointMeta("Returns Tenant service health status.", "GET /health")
+    };
+
+    private static IReadOnlyDictionary<string, EndpointMeta> BuildValidationMetadata() => new Dictionary<string, EndpointMeta>(StringComparer.Ordinal)
+    {
+        [ValidationSteps.InfoGet200] = new EndpointMeta("Returns Validation service information.", "GET /api/Validation/info"),
+        [ValidationSteps.RootHealthGet200] = new EndpointMeta("Returns Validation service health status.", "GET /health")
     };
 
     private sealed record EndpointMeta(string? Description, string? Group, string? SkipReason = null);
@@ -181,6 +235,8 @@ public static class ApiEndPointLibrary
 
     public static class AdminBffSteps
     {
+        public const string InfoGet200 = "Service Info GET → 200";
+        public const string RootHealthGet200 = "Root Health GET → 200";
         public const string HealthGet200 = "Health GET → 200";
         public const string FacilityDelete200 = "Facility DELETE → 200";
         public const string FacilityDelete404 = "Facility DELETE → 404";
@@ -210,6 +266,8 @@ public static class ApiEndPointLibrary
 
     public static class CensusSteps
     {
+        public const string InfoGet200 = "Service Info GET → 200";
+        public const string RootHealthGet200 = "Root Health GET → 200";
         public const string ConfigPost201 = "Config POST → 201";
         public const string ConfigPost400EmptyScheduledTrigger = "Config POST → 400 (empty ScheduledTrigger)";
         public const string ConfigPost400EmptyFacilityId = "Config POST → 400 (empty FacilityId)";
@@ -247,6 +305,8 @@ public static class ApiEndPointLibrary
 
     public static class DataAcquisitionSteps
     {
+        public const string InfoGet200 = "Service Info GET → 200";
+        public const string RootHealthGet200 = "Root Health GET → 200";
         public const string FhirConfigPost201 = "FhirConfig POST → 201";
         public const string FhirConfigPost409 = "FhirConfig POST → 409";
         public const string FhirConfigGet200 = "FhirConfig GET → 200";
@@ -309,6 +369,8 @@ public static class ApiEndPointLibrary
 
     public static class NormalizationSteps
     {
+        public const string InfoGet200 = "Service Info GET → 200";
+        public const string RootHealthGet200 = "Root Health GET → 200";
         public const string Post201 = "POST → 201";
         public const string Post400InvalidOperationType = "POST → 400 (invalid operation type)";
         public const string Post400EmptyResourceTypes = "POST → 400 (empty resourceTypes)";
@@ -329,6 +391,8 @@ public static class ApiEndPointLibrary
 
     public static class QueryDispatchSteps
     {
+        public const string InfoGet200 = "Service Info GET → 200";
+        public const string RootHealthGet200 = "Root Health GET → 200";
         public const string Post400NullModel = "POST → 400 (empty model)";
         public const string Post400EmptyFacilityId = "POST → 400 (empty facilityId)";
         public const string Post400InvalidDuration = "POST → 400 (invalid duration)";
@@ -347,6 +411,8 @@ public static class ApiEndPointLibrary
 
     public static class ReportSteps
     {
+        public const string InfoGet200 = "Service Info GET → 200";
+        public const string RootHealthGet200 = "Root Health GET → 200";
         public const string GetSchedule200HasData = "Get Schedule → 200 (has data)";
         public const string GetSchedule404 = "Get Schedule → 404";
         public const string GetSchedule400BadGuid = "Get Schedule → 400 (bad guid)";
@@ -404,6 +470,8 @@ public static class ApiEndPointLibrary
 
     public static class TenantSteps
     {
+        public const string InfoGet200 = "Service Info GET → 200";
+        public const string RootHealthGet200 = "Root Health GET → 200";
         public const string Create201 = "Create → 201";
         public const string Create400Duplicate = "Create → 400 (duplicate)";
         public const string Create400NoName = "Create → 400 (no name)";
@@ -444,6 +512,8 @@ public static class ApiEndPointLibrary
 
     public static class MeasureEvalSteps
     {
+        public const string InfoGet200 = "Service Info GET → 200";
+        public const string RootHealthGet200 = "Root Health GET → 200";
         public const string GetAll200 = "GET ALL → 200";
         public const string Get200 = "GET → 200";
         public const string Get404 = "GET → 404";
@@ -453,6 +523,8 @@ public static class ApiEndPointLibrary
 
     public static class SubmissionSteps
     {
+        public const string InfoGet200 = "Service Info GET → 200";
+        public const string RootHealthGet200 = "Root Health GET → 200";
         public const string Get200 = "GET → 200";
         public const string Get400BadReportId = "GET → 400 (bad reportId)";
         public const string Get404NotFound = "GET → 404 (not found)";
@@ -462,6 +534,8 @@ public static class ApiEndPointLibrary
 
     public static class ValidationSteps
     {
+        public const string InfoGet200 = "Service Info GET → 200";
+        public const string RootHealthGet200 = "Root Health GET → 200";
         public const string ArtifactsGet200 = "Artifacts GET → 200";
         public const string CategoriesGet200 = "Categories GET → 200";
         public const string ArtifactPut200Or201 = "Artifact PUT → 200/201";

--- a/DotNet/Automation.UI/Services/ApiHealth/TestSuites/CensusServiceTestSuite.cs
+++ b/DotNet/Automation.UI/Services/ApiHealth/TestSuites/CensusServiceTestSuite.cs
@@ -1,8 +1,11 @@
 ﻿using Automation.UI.Models.ApiHealth;
 using LantanaGroup.Link.Sdk.Clients;
 using LantanaGroup.Link.Shared.Application.Enums;
+using LantanaGroup.Link.Shared.Application.Models.Configs;
 using LantanaGroup.Link.Shared.Application.Models.Integration.Census;
 using LantanaGroup.Link.Shared.Application.Models.Tenant;
+using Microsoft.Extensions.Options;
+using System.Diagnostics;
 using StepNames = Automation.UI.Services.ApiHealth.TestSuites.ApiEndPointLibrary.CensusSteps;
 
 namespace Automation.UI.Services.ApiHealth.TestSuites;
@@ -42,16 +45,22 @@ public sealed class CensusServiceTestSuite : ServiceTestSuiteBase
     private readonly ICensusServiceClient _client;
     private readonly IFacilityServiceClient _facilityClient;
     private readonly ILogger<CensusServiceTestSuite> _logger;
+    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly IOptions<ServiceRegistry> _serviceRegistry;
 
     public override string ServiceName => "Census";
     public CensusServiceTestSuite(
         ICensusServiceClient client,
         IFacilityServiceClient facilityClient,
-        ILogger<CensusServiceTestSuite> logger)
+        ILogger<CensusServiceTestSuite> logger,
+        IHttpClientFactory httpClientFactory,
+        IOptions<ServiceRegistry> serviceRegistry)
     {
         _client = client;
         _facilityClient = facilityClient;
         _logger = logger;
+        _httpClientFactory = httpClientFactory;
+        _serviceRegistry = serviceRegistry;
     }
 
     public override IReadOnlyList<ApiEndpointDefinition> GetEndpointDefinitions() =>
@@ -60,6 +69,50 @@ public sealed class CensusServiceTestSuite : ServiceTestSuiteBase
     public override async Task<IReadOnlyList<ApiTestRunResult>> ExecuteAsync(CancellationToken ct = default)
     {
         var results = new List<ApiTestRunResult>();
+        var baseUrl = _serviceRegistry.Value.CensusServiceUrl?.TrimEnd('/');
+
+        if (string.IsNullOrWhiteSpace(baseUrl))
+        {
+            const string error =
+                "ServiceRegistry:CensusServiceUrl is not configured.";
+
+            foreach (var endpointName in new[]
+            {
+                StepNames.InfoGet200,
+                StepNames.RootHealthGet200
+            })
+            {
+                results.Add(new ApiTestRunResult
+                {
+                    EndpointKey = $"{ServiceName}::{endpointName}",
+                    ServiceName = ServiceName,
+                    EndpointName = endpointName,
+                    Passed = false,
+                    ExpectedStatusCode = 200,
+                    ErrorMessage = error,
+                    RequestBody =
+                        "Request was not sent because the Census service URL is missing.",
+                    ResponseBody =
+                        "Response was not received because the Census service URL is missing.",
+                    ExecutedAt = DateTimeOffset.UtcNow
+                });
+            }
+        }
+        else
+        {
+            results.Add(await CallRawGetAsync(
+                StepNames.InfoGet200,
+                baseUrl,
+                "/api/Census/info",
+                ct));
+
+            results.Add(await CallRawGetAsync(
+                StepNames.RootHealthGet200,
+                baseUrl,
+                "/health",
+                ct));
+        }
+
         var facilityId = $"ApiHealth-Census-{Guid.NewGuid():N}";
         var facilityCreated = false;
         var censusCreated = false;
@@ -311,5 +364,81 @@ public sealed class CensusServiceTestSuite : ServiceTestSuiteBase
             ScheduledReports = new TenantScheduledReportConfig { Daily = [], Weekly = [], Monthly = [] }
         };
         await _facilityClient.CreateAsync(model, ct);
+    }
+
+    private async Task<ApiTestRunResult> CallRawGetAsync(
+        string endpointName,
+        string baseUrl,
+        string relativePath,
+        CancellationToken ct)
+    {
+        var result = new ApiTestRunResult
+        {
+            EndpointKey = $"{ServiceName}::{endpointName}",
+            ServiceName = ServiceName,
+            EndpointName = endpointName,
+            ExpectedStatusCode = 200,
+            ExecutedAt = DateTimeOffset.UtcNow,
+            RequestMethod = "GET",
+            RequestUrl = $"{baseUrl}{relativePath}",
+            RequestBody = "No request body was sent (GET)."
+        };
+
+        var sw = Stopwatch.StartNew();
+
+        try
+        {
+            ct.ThrowIfCancellationRequested();
+
+            var httpClient = _httpClientFactory.CreateClient("ApiHealthTest");
+
+            using var response = await httpClient.GetAsync(
+                $"{baseUrl}{relativePath}",
+                ct);
+
+            var responseBody = await response.Content.ReadAsStringAsync(ct);
+
+            sw.Stop();
+
+            result.ActualStatusCode = (int)response.StatusCode;
+            result.DurationMs = sw.ElapsedMilliseconds;
+            result.Passed = result.ActualStatusCode == 200;
+
+            result.ResponseBody = string.IsNullOrWhiteSpace(responseBody)
+                ? $"No response body was returned (HTTP {result.ActualStatusCode})."
+                : responseBody.Length > 500
+                    ? responseBody[..500]
+                    : responseBody;
+
+            if (!result.Passed)
+            {
+                result.ErrorMessage =
+                    $"Expected HTTP 200 but got {result.ActualStatusCode}.";
+            }
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (TaskCanceledException)
+        {
+            sw.Stop();
+            result.DurationMs = sw.ElapsedMilliseconds;
+            result.Passed = false;
+            result.ErrorMessage = "Request timed out.";
+            result.ResponseBody =
+                "No response body was received because the request timed out.";
+        }
+        catch (HttpRequestException ex)
+        {
+            sw.Stop();
+            result.DurationMs = sw.ElapsedMilliseconds;
+            result.Passed = false;
+            result.ErrorMessage = $"HTTP error: {ex.Message}";
+            result.ResponseBody =
+                "No response body was received because the HTTP request failed.";
+        }
+
+        return result;
     }
 }

--- a/DotNet/Automation.UI/Services/ApiHealth/TestSuites/DataAcquisitionTestSuite.cs
+++ b/DotNet/Automation.UI/Services/ApiHealth/TestSuites/DataAcquisitionTestSuite.cs
@@ -9,6 +9,8 @@ using LantanaGroup.Link.Shared.Application.Models.Integration.DataAcquisition;
 using LantanaGroup.Link.Shared.Application.Models.Tenant;
 using Microsoft.Extensions.Options;
 using StepNames = Automation.UI.Services.ApiHealth.TestSuites.ApiEndPointLibrary.DataAcquisitionSteps;
+using LantanaGroup.Link.Shared.Application.Models.Configs;
+using System.Diagnostics;
 
 namespace Automation.UI.Services.ApiHealth.TestSuites;
 
@@ -24,6 +26,8 @@ public sealed class DataAcquisitionTestSuite : ServiceTestSuiteBase
     private readonly IApiHealthSeedContextAccessor _seedContext;
     private readonly IOptions<AutomationConfig> _automationConfig;
     private readonly IOrganizationResourceMapTemplateStore _organizationResourceMapTemplateStore;
+    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly IOptions<ServiceRegistry> _serviceRegistry;
 
     public override string ServiceName => "DataAcquisition";
     public DataAcquisitionTestSuite(
@@ -31,13 +35,17 @@ public sealed class DataAcquisitionTestSuite : ServiceTestSuiteBase
         IFacilityServiceClient facilityClient,
         IApiHealthSeedContextAccessor seedContext,
         IOptions<AutomationConfig> automationConfig,
-        IOrganizationResourceMapTemplateStore organizationResourceMapTemplateStore)
+        IOrganizationResourceMapTemplateStore organizationResourceMapTemplateStore,
+        IHttpClientFactory httpClientFactory,
+        IOptions<ServiceRegistry> serviceRegistry)
     {
         _client = client;
         _facilityClient = facilityClient;
         _seedContext = seedContext;
         _automationConfig = automationConfig;
         _organizationResourceMapTemplateStore = organizationResourceMapTemplateStore;
+        _httpClientFactory = httpClientFactory;
+        _serviceRegistry = serviceRegistry;
     }
 
     public override IReadOnlyList<ApiHealthSeedRequirement> GetSeedRequirements() =>
@@ -51,6 +59,50 @@ public sealed class DataAcquisitionTestSuite : ServiceTestSuiteBase
     public override async Task<IReadOnlyList<ApiTestRunResult>> ExecuteAsync(CancellationToken ct = default)
     {
         var results = new List<ApiTestRunResult>();
+
+        var baseUrl = _serviceRegistry.Value.DataAcquisitionServiceUrl?.TrimEnd('/');
+
+        if (string.IsNullOrWhiteSpace(baseUrl))
+        {
+            const string error =
+                "ServiceRegistry:DataAcquisitionServiceUrl is not configured.";
+
+            foreach (var endpointName in new[]
+            {
+                StepNames.InfoGet200,
+                StepNames.RootHealthGet200
+            })
+            {
+                results.Add(new ApiTestRunResult
+                {
+                    EndpointKey = $"{ServiceName}::{endpointName}",
+                    ServiceName = ServiceName,
+                    EndpointName = endpointName,
+                    Passed = false,
+                    ExpectedStatusCode = 200,
+                    ErrorMessage = error,
+                    RequestBody =
+                        "Request was not sent because the Data Acquisition service URL is missing.",
+                    ResponseBody =
+                        "Response was not received because the Data Acquisition service URL is missing.",
+                    ExecutedAt = DateTimeOffset.UtcNow
+                });
+            }
+        }
+        else
+        {
+            results.Add(await CallRawGetAsync(
+                StepNames.InfoGet200,
+                baseUrl,
+                "/api/DataAcquisition/info",
+                ct));
+
+            results.Add(await CallRawGetAsync(
+                StepNames.RootHealthGet200,
+                baseUrl,
+                "/health",
+                ct));
+        }
 
         async Task AddSeededOrSkipAsync(
             bool canRun,
@@ -483,5 +535,83 @@ public sealed class DataAcquisitionTestSuite : ServiceTestSuiteBase
                 c.FhirId
             }).ToList()
         };
+    }
+
+    private async Task<ApiTestRunResult> CallRawGetAsync(
+        string endpointName,
+        string baseUrl,
+        string relativePath,
+        CancellationToken ct)
+    {
+        var result = new ApiTestRunResult
+        {
+            EndpointKey = $"{ServiceName}::{endpointName}",
+            ServiceName = ServiceName,
+            EndpointName = endpointName,
+            ExpectedStatusCode = 200,
+            ExecutedAt = DateTimeOffset.UtcNow,
+            RequestMethod = "GET",
+            RequestUrl = $"{baseUrl}{relativePath}",
+            RequestBody = "No request body was sent (GET)."
+        };
+
+        var sw = Stopwatch.StartNew();
+
+        try
+        {
+            ct.ThrowIfCancellationRequested();
+
+            var httpClient =
+                _httpClientFactory.CreateClient("ApiHealthTest");
+
+            using var response = await httpClient.GetAsync(
+                $"{baseUrl}{relativePath}",
+                ct);
+
+            var responseBody =
+                await response.Content.ReadAsStringAsync(ct);
+
+            sw.Stop();
+
+            result.ActualStatusCode = (int)response.StatusCode;
+            result.DurationMs = sw.ElapsedMilliseconds;
+            result.Passed = result.ActualStatusCode == 200;
+
+            result.ResponseBody = string.IsNullOrWhiteSpace(responseBody)
+                ? $"No response body was returned (HTTP {result.ActualStatusCode})."
+                : responseBody.Length > 500
+                    ? responseBody[..500]
+                    : responseBody;
+
+            if (!result.Passed)
+            {
+                result.ErrorMessage =
+                    $"Expected HTTP 200 but got {result.ActualStatusCode}.";
+            }
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (TaskCanceledException)
+        {
+            sw.Stop();
+            result.DurationMs = sw.ElapsedMilliseconds;
+            result.Passed = false;
+            result.ErrorMessage = "Request timed out.";
+            result.ResponseBody =
+                "No response body was received because the request timed out.";
+        }
+        catch (HttpRequestException ex)
+        {
+            sw.Stop();
+            result.DurationMs = sw.ElapsedMilliseconds;
+            result.Passed = false;
+            result.ErrorMessage = $"HTTP error: {ex.Message}";
+            result.ResponseBody =
+                "No response body was received because the HTTP request failed.";
+        }
+
+        return result;
     }
 }

--- a/DotNet/Automation.UI/Services/ApiHealth/TestSuites/DataAcquisitionTestSuite.cs
+++ b/DotNet/Automation.UI/Services/ApiHealth/TestSuites/DataAcquisitionTestSuite.cs
@@ -94,7 +94,7 @@ public sealed class DataAcquisitionTestSuite : ServiceTestSuiteBase
             results.Add(await CallRawGetAsync(
                 StepNames.InfoGet200,
                 baseUrl,
-                "/api/DataAcquisition/info",
+                "/api/data/info",
                 ct));
 
             results.Add(await CallRawGetAsync(

--- a/DotNet/Automation.UI/Services/ApiHealth/TestSuites/MeasureEvalTestSuite.cs
+++ b/DotNet/Automation.UI/Services/ApiHealth/TestSuites/MeasureEvalTestSuite.cs
@@ -2,6 +2,9 @@
 using LantanaGroup.Link.Sdk.Clients;
 using System.Text.Json;
 using StepNames = Automation.UI.Services.ApiHealth.TestSuites.ApiEndPointLibrary.MeasureEvalSteps;
+using LantanaGroup.Link.Shared.Application.Models.Configs;
+using Microsoft.Extensions.Options;
+using System.Diagnostics;
 
 namespace Automation.UI.Services.ApiHealth.TestSuites;
 
@@ -22,6 +25,8 @@ namespace Automation.UI.Services.ApiHealth.TestSuites;
 public sealed class MeasureEvalTestSuite : ServiceTestSuiteBase
 {
     private readonly IMeasureEvalServiceClient _client;
+    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly IOptions<ServiceRegistry> _serviceRegistry;
 
     private static readonly string NoMeasureBundleJson = """
         {
@@ -33,9 +38,14 @@ public sealed class MeasureEvalTestSuite : ServiceTestSuiteBase
         """;
 
     public override string ServiceName => "MeasureEval";
-    public MeasureEvalTestSuite(IMeasureEvalServiceClient client)
+    public MeasureEvalTestSuite(
+        IMeasureEvalServiceClient client,
+        IHttpClientFactory httpClientFactory,
+        IOptions<ServiceRegistry> serviceRegistry)
     {
         _client = client;
+        _httpClientFactory = httpClientFactory;
+        _serviceRegistry = serviceRegistry;
     }
 
     public override IReadOnlyList<ApiEndpointDefinition> GetEndpointDefinitions() =>
@@ -43,22 +53,88 @@ public sealed class MeasureEvalTestSuite : ServiceTestSuiteBase
 
     public override async Task<IReadOnlyList<ApiTestRunResult>> ExecuteAsync(CancellationToken ct = default)
     {
-        return
-        [
-            await RunStepAsync(StepNames.GetAll200, 200, async () =>
-                await _client.GetAllMeasureDefinitionsAsync(ct), ct: ct),
+        var results = new List<ApiTestRunResult>();
 
-            await RunGetByIdSuccessStepAsync(StepNames.Get200, ct),
+        var baseUrl = _serviceRegistry.Value.MeasureServiceUrl?.TrimEnd('/');
 
-            await RunStepAsync(StepNames.Get404, 404, async () =>
-                await _client.GetMeasureDefinitionAsync($"ApiHealth-Measure-{Guid.NewGuid():N}", ct), ct: ct),
+        if (string.IsNullOrWhiteSpace(baseUrl))
+        {
+            const string error =
+                "ServiceRegistry:MeasureServiceUrl is not configured.";
 
-            await RunStepAsync(StepNames.Put400MalformedBody, 400, async () =>
-                await _client.PutMeasureDefinitionAsync("{}", ct), ct: ct),
+            foreach (var endpointName in new[]
+            {
+            StepNames.InfoGet200,
+            StepNames.RootHealthGet200
+        })
+            {
+                results.Add(new ApiTestRunResult
+                {
+                    EndpointKey = $"{ServiceName}::{endpointName}",
+                    ServiceName = ServiceName,
+                    EndpointName = endpointName,
+                    Passed = false,
+                    ExpectedStatusCode = 200,
+                    ErrorMessage = error,
+                    RequestBody =
+                        "Request was not sent because the MeasureEval service URL is missing.",
+                    ResponseBody =
+                        "Response was not received because the MeasureEval service URL is missing.",
+                    ExecutedAt = DateTimeOffset.UtcNow
+                });
+            }
+        }
+        else
+        {
+            results.Add(await CallRawGetAsync(
+                StepNames.InfoGet200,
+                baseUrl,
+                "/api/MeasureEval/info",
+                ct));
 
-            await RunStepAsync(StepNames.Put400NoMeasureInBundle, 400, async () =>
-                await _client.PutMeasureDefinitionAsync(NoMeasureBundleJson, ct), ct: ct)
-        ];
+            results.Add(await CallRawGetAsync(
+                StepNames.RootHealthGet200,
+                baseUrl,
+                "/health",
+                ct));
+        }
+
+        results.Add(await RunStepAsync(
+            StepNames.GetAll200,
+            200,
+            async () => await _client.GetAllMeasureDefinitionsAsync(ct),
+            ct: ct));
+
+        results.Add(await RunGetByIdSuccessStepAsync(
+            StepNames.Get200,
+            ct));
+
+        results.Add(await RunStepAsync(
+            StepNames.Get404,
+            404,
+            async () =>
+                await _client.GetMeasureDefinitionAsync(
+                    $"ApiHealth-Measure-{Guid.NewGuid():N}",
+                    ct),
+            ct: ct));
+
+        results.Add(await RunStepAsync(
+            StepNames.Put400MalformedBody,
+            400,
+            async () =>
+                await _client.PutMeasureDefinitionAsync("{}", ct),
+            ct: ct));
+
+        results.Add(await RunStepAsync(
+            StepNames.Put400NoMeasureInBundle,
+            400,
+            async () =>
+                await _client.PutMeasureDefinitionAsync(
+                    NoMeasureBundleJson,
+                    ct),
+            ct: ct));
+
+        return results;
     }
 
     private async Task<ApiTestRunResult> RunGetByIdSuccessStepAsync(string stepName, CancellationToken ct)
@@ -103,5 +179,83 @@ public sealed class MeasureEvalTestSuite : ServiceTestSuiteBase
         }
 
         return null;
+    }
+
+    private async Task<ApiTestRunResult> CallRawGetAsync(
+        string endpointName,
+        string baseUrl,
+        string relativePath,
+        CancellationToken ct)
+    {
+        var result = new ApiTestRunResult
+        {
+            EndpointKey = $"{ServiceName}::{endpointName}",
+            ServiceName = ServiceName,
+            EndpointName = endpointName,
+            ExpectedStatusCode = 200,
+            ExecutedAt = DateTimeOffset.UtcNow,
+            RequestMethod = "GET",
+            RequestUrl = $"{baseUrl}{relativePath}",
+            RequestBody = "No request body was sent (GET)."
+        };
+
+        var sw = Stopwatch.StartNew();
+
+        try
+        {
+            ct.ThrowIfCancellationRequested();
+
+            var httpClient =
+                _httpClientFactory.CreateClient("ApiHealthTest");
+
+            using var response = await httpClient.GetAsync(
+                $"{baseUrl}{relativePath}",
+                ct);
+
+            var responseBody =
+                await response.Content.ReadAsStringAsync(ct);
+
+            sw.Stop();
+
+            result.ActualStatusCode = (int)response.StatusCode;
+            result.DurationMs = sw.ElapsedMilliseconds;
+            result.Passed = result.ActualStatusCode == 200;
+
+            result.ResponseBody = string.IsNullOrWhiteSpace(responseBody)
+                ? $"No response body was returned (HTTP {result.ActualStatusCode})."
+                : responseBody.Length > 500
+                    ? responseBody[..500]
+                    : responseBody;
+
+            if (!result.Passed)
+            {
+                result.ErrorMessage =
+                    $"Expected HTTP 200 but got {result.ActualStatusCode}.";
+            }
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (TaskCanceledException)
+        {
+            sw.Stop();
+            result.DurationMs = sw.ElapsedMilliseconds;
+            result.Passed = false;
+            result.ErrorMessage = "Request timed out.";
+            result.ResponseBody =
+                "No response body was received because the request timed out.";
+        }
+        catch (HttpRequestException ex)
+        {
+            sw.Stop();
+            result.DurationMs = sw.ElapsedMilliseconds;
+            result.Passed = false;
+            result.ErrorMessage = $"HTTP error: {ex.Message}";
+            result.ResponseBody =
+                "No response body was received because the HTTP request failed.";
+        }
+
+        return result;
     }
 }

--- a/DotNet/Automation.UI/Services/ApiHealth/TestSuites/MeasureEvalTestSuite.cs
+++ b/DotNet/Automation.UI/Services/ApiHealth/TestSuites/MeasureEvalTestSuite.cs
@@ -89,7 +89,7 @@ public sealed class MeasureEvalTestSuite : ServiceTestSuiteBase
             results.Add(await CallRawGetAsync(
                 StepNames.InfoGet200,
                 baseUrl,
-                "/api/MeasureEval/info",
+                "/api/measureeval/info",
                 ct));
 
             results.Add(await CallRawGetAsync(

--- a/DotNet/Automation.UI/Services/ApiHealth/TestSuites/NormalizationTestSuite.cs
+++ b/DotNet/Automation.UI/Services/ApiHealth/TestSuites/NormalizationTestSuite.cs
@@ -4,6 +4,9 @@ using LantanaGroup.Link.Shared.Application.Enums;
 using LantanaGroup.Link.Shared.Application.Models.Integration.Normalization;
 using LantanaGroup.Link.Shared.Application.Models.Tenant;
 using StepNames = Automation.UI.Services.ApiHealth.TestSuites.ApiEndPointLibrary.NormalizationSteps;
+using LantanaGroup.Link.Shared.Application.Models.Configs;
+using Microsoft.Extensions.Options;
+using System.Diagnostics;
 
 namespace Automation.UI.Services.ApiHealth.TestSuites;
 
@@ -17,16 +20,22 @@ public sealed class NormalizationTestSuite : ServiceTestSuiteBase
     private readonly INormalizationServiceClient _client;
     private readonly IFacilityServiceClient _facilityClient;
     private readonly ILogger<NormalizationTestSuite> _logger;
+    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly IOptions<ServiceRegistry> _serviceRegistry;
 
     public override string ServiceName => "Normalization";
     public NormalizationTestSuite(
         INormalizationServiceClient client,
         IFacilityServiceClient facilityClient,
-        ILogger<NormalizationTestSuite> logger)
+        ILogger<NormalizationTestSuite> logger,
+        IHttpClientFactory httpClientFactory,
+        IOptions<ServiceRegistry> serviceRegistry)
     {
         _client = client;
         _facilityClient = facilityClient;
         _logger = logger;
+        _httpClientFactory = httpClientFactory;
+        _serviceRegistry = serviceRegistry;
     }
 
     public override IReadOnlyList<ApiEndpointDefinition> GetEndpointDefinitions() =>
@@ -35,6 +44,51 @@ public sealed class NormalizationTestSuite : ServiceTestSuiteBase
     public override async Task<IReadOnlyList<ApiTestRunResult>> ExecuteAsync(CancellationToken ct = default)
     {
         var results = new List<ApiTestRunResult>();
+
+        var baseUrl = _serviceRegistry.Value.NormalizationServiceUrl?.TrimEnd('/');
+
+        if (string.IsNullOrWhiteSpace(baseUrl))
+        {
+            const string error =
+                "ServiceRegistry:NormalizationServiceUrl is not configured.";
+
+            foreach (var endpointName in new[]
+            {
+                StepNames.InfoGet200,
+                StepNames.RootHealthGet200
+            })
+            {
+                results.Add(new ApiTestRunResult
+                {
+                    EndpointKey = $"{ServiceName}::{endpointName}",
+                    ServiceName = ServiceName,
+                    EndpointName = endpointName,
+                    Passed = false,
+                    ExpectedStatusCode = 200,
+                    ErrorMessage = error,
+                    RequestBody =
+                        "Request was not sent because the Normalization service URL is missing.",
+                    ResponseBody =
+                        "Response was not received because the Normalization service URL is missing.",
+                    ExecutedAt = DateTimeOffset.UtcNow
+                });
+            }
+        }
+        else
+        {
+            results.Add(await CallRawGetAsync(
+                StepNames.InfoGet200,
+                baseUrl,
+                "/api/Normalization/info",
+                ct));
+
+            results.Add(await CallRawGetAsync(
+                StepNames.RootHealthGet200,
+                baseUrl,
+                "/health",
+                ct));
+        }
+
         var facilityId = $"ApiHealth-Norm-{Guid.NewGuid():N}";
         var facilityCreated = false;
         var operationCreated = false;
@@ -233,4 +287,81 @@ public sealed class NormalizationTestSuite : ServiceTestSuiteBase
         await _facilityClient.CreateAsync(model, ct);
     }
 
+    private async Task<ApiTestRunResult> CallRawGetAsync(
+        string endpointName,
+        string baseUrl,
+        string relativePath,
+        CancellationToken ct)
+    {
+        var result = new ApiTestRunResult
+        {
+            EndpointKey = $"{ServiceName}::{endpointName}",
+            ServiceName = ServiceName,
+            EndpointName = endpointName,
+            ExpectedStatusCode = 200,
+            ExecutedAt = DateTimeOffset.UtcNow,
+            RequestMethod = "GET",
+            RequestUrl = $"{baseUrl}{relativePath}",
+            RequestBody = "No request body was sent (GET)."
+        };
+
+        var sw = Stopwatch.StartNew();
+
+        try
+        {
+            ct.ThrowIfCancellationRequested();
+
+            var httpClient =
+                _httpClientFactory.CreateClient("ApiHealthTest");
+
+            using var response = await httpClient.GetAsync(
+                $"{baseUrl}{relativePath}",
+                ct);
+
+            var responseBody =
+                await response.Content.ReadAsStringAsync(ct);
+
+            sw.Stop();
+
+            result.ActualStatusCode = (int)response.StatusCode;
+            result.DurationMs = sw.ElapsedMilliseconds;
+            result.Passed = result.ActualStatusCode == 200;
+
+            result.ResponseBody = string.IsNullOrWhiteSpace(responseBody)
+                ? $"No response body was returned (HTTP {result.ActualStatusCode})."
+                : responseBody.Length > 500
+                    ? responseBody[..500]
+                    : responseBody;
+
+            if (!result.Passed)
+            {
+                result.ErrorMessage =
+                    $"Expected HTTP 200 but got {result.ActualStatusCode}.";
+            }
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (TaskCanceledException)
+        {
+            sw.Stop();
+            result.DurationMs = sw.ElapsedMilliseconds;
+            result.Passed = false;
+            result.ErrorMessage = "Request timed out.";
+            result.ResponseBody =
+                "No response body was received because the request timed out.";
+        }
+        catch (HttpRequestException ex)
+        {
+            sw.Stop();
+            result.DurationMs = sw.ElapsedMilliseconds;
+            result.Passed = false;
+            result.ErrorMessage = $"HTTP error: {ex.Message}";
+            result.ResponseBody =
+                "No response body was received because the HTTP request failed.";
+        }
+
+        return result;
+    }
 }

--- a/DotNet/Automation.UI/Services/ApiHealth/TestSuites/QueryDispatchTestSuite.cs
+++ b/DotNet/Automation.UI/Services/ApiHealth/TestSuites/QueryDispatchTestSuite.cs
@@ -4,6 +4,9 @@ using LantanaGroup.Link.Shared.Application.Enums;
 using LantanaGroup.Link.Shared.Application.Models.Integration.QueryDispatch;
 using LantanaGroup.Link.Shared.Application.Models.Tenant;
 using StepNames = Automation.UI.Services.ApiHealth.TestSuites.ApiEndPointLibrary.QueryDispatchSteps;
+using LantanaGroup.Link.Shared.Application.Models.Configs;
+using Microsoft.Extensions.Options;
+using System.Diagnostics;
 
 namespace Automation.UI.Services.ApiHealth.TestSuites;
 
@@ -25,16 +28,22 @@ public sealed class QueryDispatchTestSuite : ServiceTestSuiteBase
     private readonly IQueryDispatchServiceClient _client;
     private readonly IFacilityServiceClient _facilityClient;
     private readonly ILogger<QueryDispatchTestSuite> _logger;
+    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly IOptions<ServiceRegistry> _serviceRegistry;
 
     public override string ServiceName => "QueryDispatch";
     public QueryDispatchTestSuite(
         IQueryDispatchServiceClient client,
         IFacilityServiceClient facilityClient,
-        ILogger<QueryDispatchTestSuite> logger)
+        ILogger<QueryDispatchTestSuite> logger,
+        IHttpClientFactory httpClientFactory,
+        IOptions<ServiceRegistry> serviceRegistry)
     {
         _client = client;
         _facilityClient = facilityClient;
         _logger = logger;
+        _httpClientFactory = httpClientFactory;
+        _serviceRegistry = serviceRegistry;
     }
 
     public override IReadOnlyList<ApiEndpointDefinition> GetEndpointDefinitions() =>
@@ -43,6 +52,51 @@ public sealed class QueryDispatchTestSuite : ServiceTestSuiteBase
     public override async Task<IReadOnlyList<ApiTestRunResult>> ExecuteAsync(CancellationToken ct = default)
     {
         var results = new List<ApiTestRunResult>();
+
+        var baseUrl = _serviceRegistry.Value.QueryDispatchServiceUrl?.TrimEnd('/');
+
+        if (string.IsNullOrWhiteSpace(baseUrl))
+        {
+            const string error =
+                "ServiceRegistry:QueryDispatchServiceUrl is not configured.";
+
+            foreach (var endpointName in new[]
+            {
+                StepNames.InfoGet200,
+                StepNames.RootHealthGet200
+            })
+            {
+                results.Add(new ApiTestRunResult
+                {
+                    EndpointKey = $"{ServiceName}::{endpointName}",
+                    ServiceName = ServiceName,
+                    EndpointName = endpointName,
+                    Passed = false,
+                    ExpectedStatusCode = 200,
+                    ErrorMessage = error,
+                    RequestBody =
+                        "Request was not sent because the QueryDispatch service URL is missing.",
+                    ResponseBody =
+                        "Response was not received because the QueryDispatch service URL is missing.",
+                    ExecutedAt = DateTimeOffset.UtcNow
+                });
+            }
+        }
+        else
+        {
+            results.Add(await CallRawGetAsync(
+                StepNames.InfoGet200,
+                baseUrl,
+                "/api/QueryDispatch/info",
+                ct));
+
+            results.Add(await CallRawGetAsync(
+                StepNames.RootHealthGet200,
+                baseUrl,
+                "/health",
+                ct));
+        }
+
         var facilityId = $"ApiHealth-QD-{Guid.NewGuid():N}";
         var facilityCreated = false;
         var configCreated = false;
@@ -236,4 +290,81 @@ public sealed class QueryDispatchTestSuite : ServiceTestSuiteBase
         await _facilityClient.CreateAsync(model, ct);
     }
 
+    private async Task<ApiTestRunResult> CallRawGetAsync(
+        string endpointName,
+        string baseUrl,
+        string relativePath,
+        CancellationToken ct)
+    {
+        var result = new ApiTestRunResult
+        {
+            EndpointKey = $"{ServiceName}::{endpointName}",
+            ServiceName = ServiceName,
+            EndpointName = endpointName,
+            ExpectedStatusCode = 200,
+            ExecutedAt = DateTimeOffset.UtcNow,
+            RequestMethod = "GET",
+            RequestUrl = $"{baseUrl}{relativePath}",
+            RequestBody = "No request body was sent (GET)."
+        };
+
+        var sw = Stopwatch.StartNew();
+
+        try
+        {
+            ct.ThrowIfCancellationRequested();
+
+            var httpClient =
+                _httpClientFactory.CreateClient("ApiHealthTest");
+
+            using var response = await httpClient.GetAsync(
+                $"{baseUrl}{relativePath}",
+                ct);
+
+            var responseBody =
+                await response.Content.ReadAsStringAsync(ct);
+
+            sw.Stop();
+
+            result.ActualStatusCode = (int)response.StatusCode;
+            result.DurationMs = sw.ElapsedMilliseconds;
+            result.Passed = result.ActualStatusCode == 200;
+
+            result.ResponseBody = string.IsNullOrWhiteSpace(responseBody)
+                ? $"No response body was returned (HTTP {result.ActualStatusCode})."
+                : responseBody.Length > 500
+                    ? responseBody[..500]
+                    : responseBody;
+
+            if (!result.Passed)
+            {
+                result.ErrorMessage =
+                    $"Expected HTTP 200 but got {result.ActualStatusCode}.";
+            }
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (TaskCanceledException)
+        {
+            sw.Stop();
+            result.DurationMs = sw.ElapsedMilliseconds;
+            result.Passed = false;
+            result.ErrorMessage = "Request timed out.";
+            result.ResponseBody =
+                "No response body was received because the request timed out.";
+        }
+        catch (HttpRequestException ex)
+        {
+            sw.Stop();
+            result.DurationMs = sw.ElapsedMilliseconds;
+            result.Passed = false;
+            result.ErrorMessage = $"HTTP error: {ex.Message}";
+            result.ResponseBody =
+                "No response body was received because the HTTP request failed.";
+        }
+
+        return result;
+    }
 }

--- a/DotNet/Automation.UI/Services/ApiHealth/TestSuites/ReportServiceTestSuite.cs
+++ b/DotNet/Automation.UI/Services/ApiHealth/TestSuites/ReportServiceTestSuite.cs
@@ -3,6 +3,9 @@ using LantanaGroup.Link.Sdk.Clients;
 using LantanaGroup.Link.Sdk.ApiClient;
 using Automation.UI.Services.ApiHealth.Seeding;
 using StepNames = Automation.UI.Services.ApiHealth.TestSuites.ApiEndPointLibrary.ReportSteps;
+using LantanaGroup.Link.Shared.Application.Models.Configs;
+using Microsoft.Extensions.Options;
+using System.Diagnostics;
 
 namespace Automation.UI.Services.ApiHealth.TestSuites;
 
@@ -14,14 +17,20 @@ public sealed class ReportServiceTestSuite : ServiceTestSuiteBase
 {
     private readonly IReportServiceClient _client;
     private readonly IApiHealthSeedContextAccessor _seedContext;
+    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly IOptions<ServiceRegistry> _serviceRegistry;
 
     public override string ServiceName => "Report";
     public ReportServiceTestSuite(
         IReportServiceClient client,
-        IApiHealthSeedContextAccessor seedContext)
+        IApiHealthSeedContextAccessor seedContext,
+        IHttpClientFactory httpClientFactory,
+        IOptions<ServiceRegistry> serviceRegistry)
     {
         _client = client;
         _seedContext = seedContext;
+        _httpClientFactory = httpClientFactory;
+        _serviceRegistry = serviceRegistry;
     }
 
     public override IReadOnlyList<ApiEndpointDefinition> GetEndpointDefinitions() =>
@@ -35,6 +44,50 @@ public sealed class ReportServiceTestSuite : ServiceTestSuiteBase
     public override async Task<IReadOnlyList<ApiTestRunResult>> ExecuteAsync(CancellationToken ct = default)
     {
         var results = new List<ApiTestRunResult>();
+
+        var baseUrl = _serviceRegistry.Value.ReportServiceUrl?.TrimEnd('/');
+
+        if (string.IsNullOrWhiteSpace(baseUrl))
+        {
+            const string error =
+                "ServiceRegistry:ReportServiceUrl is not configured.";
+
+            foreach (var endpointName in new[]
+            {
+                StepNames.InfoGet200,
+                StepNames.RootHealthGet200
+            })
+            {
+                results.Add(new ApiTestRunResult
+                {
+                    EndpointKey = $"{ServiceName}::{endpointName}",
+                    ServiceName = ServiceName,
+                    EndpointName = endpointName,
+                    Passed = false,
+                    ExpectedStatusCode = 200,
+                    ErrorMessage = error,
+                    RequestBody =
+                        "Request was not sent because the Report service URL is missing.",
+                    ResponseBody =
+                        "Response was not received because the Report service URL is missing.",
+                    ExecutedAt = DateTimeOffset.UtcNow
+                });
+            }
+        }
+        else
+        {
+            results.Add(await CallRawGetAsync(
+                StepNames.InfoGet200,
+                baseUrl,
+                "/api/Report/info",
+                ct));
+
+            results.Add(await CallRawGetAsync(
+                StepNames.RootHealthGet200,
+                baseUrl,
+                "/health",
+                ct));
+        }
 
         async Task AddSeededOrSkipAsync<T>(
             bool canRun,
@@ -332,4 +385,81 @@ public sealed class ReportServiceTestSuite : ServiceTestSuiteBase
         return results;
     }
 
+    private async Task<ApiTestRunResult> CallRawGetAsync(
+        string endpointName,
+        string baseUrl,
+        string relativePath,
+        CancellationToken ct)
+    {
+        var result = new ApiTestRunResult
+        {
+            EndpointKey = $"{ServiceName}::{endpointName}",
+            ServiceName = ServiceName,
+            EndpointName = endpointName,
+            ExpectedStatusCode = 200,
+            ExecutedAt = DateTimeOffset.UtcNow,
+            RequestMethod = "GET",
+            RequestUrl = $"{baseUrl}{relativePath}",
+            RequestBody = "No request body was sent (GET)."
+        };
+
+        var sw = Stopwatch.StartNew();
+
+        try
+        {
+            ct.ThrowIfCancellationRequested();
+
+            var httpClient =
+                _httpClientFactory.CreateClient("ApiHealthTest");
+
+            using var response = await httpClient.GetAsync(
+                $"{baseUrl}{relativePath}",
+                ct);
+
+            var responseBody =
+                await response.Content.ReadAsStringAsync(ct);
+
+            sw.Stop();
+
+            result.ActualStatusCode = (int)response.StatusCode;
+            result.DurationMs = sw.ElapsedMilliseconds;
+            result.Passed = result.ActualStatusCode == 200;
+
+            result.ResponseBody = string.IsNullOrWhiteSpace(responseBody)
+                ? $"No response body was returned (HTTP {result.ActualStatusCode})."
+                : responseBody.Length > 500
+                    ? responseBody[..500]
+                    : responseBody;
+
+            if (!result.Passed)
+            {
+                result.ErrorMessage =
+                    $"Expected HTTP 200 but got {result.ActualStatusCode}.";
+            }
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (TaskCanceledException)
+        {
+            sw.Stop();
+            result.DurationMs = sw.ElapsedMilliseconds;
+            result.Passed = false;
+            result.ErrorMessage = "Request timed out.";
+            result.ResponseBody =
+                "No response body was received because the request timed out.";
+        }
+        catch (HttpRequestException ex)
+        {
+            sw.Stop();
+            result.DurationMs = sw.ElapsedMilliseconds;
+            result.Passed = false;
+            result.ErrorMessage = $"HTTP error: {ex.Message}";
+            result.ResponseBody =
+                "No response body was received because the HTTP request failed.";
+        }
+
+        return result;
+    }
 }

--- a/DotNet/Automation.UI/Services/ApiHealth/TestSuites/ServiceTestSuiteBase.cs
+++ b/DotNet/Automation.UI/Services/ApiHealth/TestSuites/ServiceTestSuiteBase.cs
@@ -260,6 +260,36 @@ public abstract class ServiceTestSuiteBase : IServiceTestSuite
     };
 
     /// <summary>
+    /// Creates the standard service metadata endpoints required by API Health.
+    /// </summary>
+    protected IReadOnlyList<ApiEndpointDefinition> StandardHealthEndpointDefinitions(
+        string apiServiceName) =>
+    [
+        new ApiEndpointDefinition
+    {
+        ServiceName = ServiceName,
+        EndpointName = "Service Info → 200",
+        Description = "Returns service information.",
+        GroupName = $"GET /api/{apiServiceName}/info",
+        RelativePath = $"/api/{apiServiceName}/info",
+        HttpMethod = "GET",
+        ExpectedStatusCode = 200,
+        IsTestSuiteStep = true
+    },
+    new ApiEndpointDefinition
+    {
+        ServiceName = ServiceName,
+        EndpointName = "Health → 200",
+        Description = "Returns service health status.",
+        GroupName = "GET /health",
+        RelativePath = "/health",
+        HttpMethod = "GET",
+        ExpectedStatusCode = 200,
+        IsTestSuiteStep = true
+    }
+    ];
+
+    /// <summary>
     /// Executes an action ignoring any errors (used for cleanup).
     /// </summary>
     protected static async Task TryCleanupAsync(Func<Task> action)

--- a/DotNet/Automation.UI/Services/ApiHealth/TestSuites/SubmissionServiceTestSuite.cs
+++ b/DotNet/Automation.UI/Services/ApiHealth/TestSuites/SubmissionServiceTestSuite.cs
@@ -2,6 +2,9 @@
 using Automation.UI.Services.ApiHealth.Seeding;
 using LantanaGroup.Link.Sdk.Clients;
 using StepNames = Automation.UI.Services.ApiHealth.TestSuites.ApiEndPointLibrary.SubmissionSteps;
+using LantanaGroup.Link.Shared.Application.Models.Configs;
+using Microsoft.Extensions.Options;
+using System.Diagnostics;
 
 namespace Automation.UI.Services.ApiHealth.TestSuites;
 
@@ -20,15 +23,21 @@ public sealed class SubmissionServiceTestSuite : ServiceTestSuiteBase
 {
     private readonly ISubmissionServiceClient _client;
     private readonly IApiHealthSeedContextAccessor _seedContext;
+    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly IOptions<ServiceRegistry> _serviceRegistry;
 
     public override string ServiceName => "Submission";
 
     public SubmissionServiceTestSuite(
         ISubmissionServiceClient client,
-        IApiHealthSeedContextAccessor seedContext)
+        IApiHealthSeedContextAccessor seedContext,
+        IHttpClientFactory httpClientFactory,
+        IOptions<ServiceRegistry> serviceRegistry)
     {
         _client = client;
         _seedContext = seedContext;
+        _httpClientFactory = httpClientFactory;
+        _serviceRegistry = serviceRegistry;
     }
 
     public override IReadOnlyList<ApiEndpointDefinition> GetEndpointDefinitions() =>
@@ -41,25 +50,100 @@ public sealed class SubmissionServiceTestSuite : ServiceTestSuiteBase
 
     public override async Task<IReadOnlyList<ApiTestRunResult>> ExecuteAsync(CancellationToken ct = default)
     {
+        var results = new List<ApiTestRunResult>();
+
+        var baseUrl = _serviceRegistry.Value.SubmissionServiceUrl?.TrimEnd('/');
+
+        if (string.IsNullOrWhiteSpace(baseUrl))
+        {
+            const string error =
+                "ServiceRegistry:SubmissionServiceUrl is not configured.";
+
+            foreach (var endpointName in new[]
+            {
+                StepNames.InfoGet200,
+                StepNames.RootHealthGet200
+            })
+            {
+                results.Add(new ApiTestRunResult
+                {
+                    EndpointKey = $"{ServiceName}::{endpointName}",
+                    ServiceName = ServiceName,
+                    EndpointName = endpointName,
+                    Passed = false,
+                    ExpectedStatusCode = 200,
+                    ErrorMessage = error,
+                    RequestBody =
+                        "Request was not sent because the Submission service URL is missing.",
+                    ResponseBody =
+                        "Response was not received because the Submission service URL is missing.",
+                    ExecutedAt = DateTimeOffset.UtcNow
+                });
+            }
+        }
+        else
+        {
+            results.Add(await CallRawGetAsync(
+                StepNames.InfoGet200,
+                baseUrl,
+                "/api/Submission/info",
+                ct));
+
+            results.Add(await CallRawGetAsync(
+                StepNames.RootHealthGet200,
+                baseUrl,
+                "/health",
+                ct));
+        }
+
         var fakeFacilityId = $"ApiHealth-Sub-{Guid.NewGuid():N}";
         var fakeReportId = Guid.NewGuid().ToString();
 
-        return
-        [
-            await RunSeededSuccessStepAsync(StepNames.Get200, ct),
+        results.Add(await RunSeededSuccessStepAsync(
+            StepNames.Get200,
+            ct));
 
-            await RunStepAsync(StepNames.Get400BadReportId, 400, async () =>
-                await _client.DownloadSubmissionAsync(fakeFacilityId, "not-a-valid-guid", cancellationToken: ct), ct: ct),
+        results.Add(await RunStepAsync(
+            StepNames.Get400BadReportId,
+            400,
+            async () =>
+                await _client.DownloadSubmissionAsync(
+                    fakeFacilityId,
+                    "not-a-valid-guid",
+                    cancellationToken: ct),
+            ct: ct));
 
-            await RunStepAsync(StepNames.Get404NotFound, 404, async () =>
-                await _client.DownloadSubmissionAsync(fakeFacilityId, fakeReportId, cancellationToken: ct), ct: ct),
+        results.Add(await RunStepAsync(
+            StepNames.Get404NotFound,
+            404,
+            async () =>
+                await _client.DownloadSubmissionAsync(
+                    fakeFacilityId,
+                    fakeReportId,
+                    cancellationToken: ct),
+            ct: ct));
 
-            await RunStepAsync(StepNames.Get400EmptyFacilityId, 400, async () =>
-                await _client.DownloadSubmissionAsync(" ", fakeReportId, cancellationToken: ct), ct: ct),
+        results.Add(await RunStepAsync(
+            StepNames.Get400EmptyFacilityId,
+            400,
+            async () =>
+                await _client.DownloadSubmissionAsync(
+                    " ",
+                    fakeReportId,
+                    cancellationToken: ct),
+            ct: ct));
 
-            await RunStepAsync(StepNames.Get400EmptyReportId, 400, async () =>
-                await _client.DownloadSubmissionAsync(fakeFacilityId, " ", cancellationToken: ct), ct: ct)
-        ];
+        results.Add(await RunStepAsync(
+            StepNames.Get400EmptyReportId,
+            400,
+            async () =>
+                await _client.DownloadSubmissionAsync(
+                    fakeFacilityId,
+                    " ",
+                    cancellationToken: ct),
+            ct: ct));
+
+        return results;
     }
 
     private async Task<ApiTestRunResult> RunSeededSuccessStepAsync(string stepName, CancellationToken ct)
@@ -74,5 +158,83 @@ public sealed class SubmissionServiceTestSuite : ServiceTestSuiteBase
 
         return await RunStepAsync(stepName, 200, async () =>
             await _client.DownloadSubmissionAsync(facilityId, reportId, cancellationToken: ct), ct: ct);
+    }
+
+    private async Task<ApiTestRunResult> CallRawGetAsync(
+        string endpointName,
+        string baseUrl,
+        string relativePath,
+        CancellationToken ct)
+    {
+        var result = new ApiTestRunResult
+        {
+            EndpointKey = $"{ServiceName}::{endpointName}",
+            ServiceName = ServiceName,
+            EndpointName = endpointName,
+            ExpectedStatusCode = 200,
+            ExecutedAt = DateTimeOffset.UtcNow,
+            RequestMethod = "GET",
+            RequestUrl = $"{baseUrl}{relativePath}",
+            RequestBody = "No request body was sent (GET)."
+        };
+
+        var sw = Stopwatch.StartNew();
+
+        try
+        {
+            ct.ThrowIfCancellationRequested();
+
+            var httpClient =
+                _httpClientFactory.CreateClient("ApiHealthTest");
+
+            using var response = await httpClient.GetAsync(
+                $"{baseUrl}{relativePath}",
+                ct);
+
+            var responseBody =
+                await response.Content.ReadAsStringAsync(ct);
+
+            sw.Stop();
+
+            result.ActualStatusCode = (int)response.StatusCode;
+            result.DurationMs = sw.ElapsedMilliseconds;
+            result.Passed = result.ActualStatusCode == 200;
+
+            result.ResponseBody = string.IsNullOrWhiteSpace(responseBody)
+                ? $"No response body was returned (HTTP {result.ActualStatusCode})."
+                : responseBody.Length > 500
+                    ? responseBody[..500]
+                    : responseBody;
+
+            if (!result.Passed)
+            {
+                result.ErrorMessage =
+                    $"Expected HTTP 200 but got {result.ActualStatusCode}.";
+            }
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (TaskCanceledException)
+        {
+            sw.Stop();
+            result.DurationMs = sw.ElapsedMilliseconds;
+            result.Passed = false;
+            result.ErrorMessage = "Request timed out.";
+            result.ResponseBody =
+                "No response body was received because the request timed out.";
+        }
+        catch (HttpRequestException ex)
+        {
+            sw.Stop();
+            result.DurationMs = sw.ElapsedMilliseconds;
+            result.Passed = false;
+            result.ErrorMessage = $"HTTP error: {ex.Message}";
+            result.ResponseBody =
+                "No response body was received because the HTTP request failed.";
+        }
+
+        return result;
     }
 }

--- a/DotNet/Automation.UI/Services/ApiHealth/TestSuites/TenantServiceTestSuite.cs
+++ b/DotNet/Automation.UI/Services/ApiHealth/TestSuites/TenantServiceTestSuite.cs
@@ -89,7 +89,7 @@ public sealed class TenantServiceTestSuite : ServiceTestSuiteBase
             results.Add(await CallRawGetAsync(
                 StepNames.InfoGet200,
                 baseUrl,
-                "/api/Tenant/info",
+                "/api/facility/info",
                 ct));
 
             results.Add(await CallRawGetAsync(

--- a/DotNet/Automation.UI/Services/ApiHealth/TestSuites/TenantServiceTestSuite.cs
+++ b/DotNet/Automation.UI/Services/ApiHealth/TestSuites/TenantServiceTestSuite.cs
@@ -4,6 +4,9 @@ using LantanaGroup.Link.Sdk.Clients;
 using LantanaGroup.Link.Shared.Application.Enums;
 using LantanaGroup.Link.Shared.Application.Models.Tenant;
 using StepNames = Automation.UI.Services.ApiHealth.TestSuites.ApiEndPointLibrary.TenantSteps;
+using LantanaGroup.Link.Shared.Application.Models.Configs;
+using Microsoft.Extensions.Options;
+using System.Diagnostics;
 
 namespace Automation.UI.Services.ApiHealth.TestSuites;
 
@@ -16,17 +19,23 @@ public sealed class TenantServiceTestSuite : ServiceTestSuiteBase
     private readonly IFacilityServiceClient _client;
     private readonly IReportServiceClient _reportClient;
     private readonly IApiHealthSeedContextAccessor _seedContext;
+    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly IOptions<ServiceRegistry> _serviceRegistry;
 
     public override string ServiceName => "Tenant";
 
     public TenantServiceTestSuite(
         IFacilityServiceClient client,
         IReportServiceClient reportClient,
-        IApiHealthSeedContextAccessor seedContext)
+        IApiHealthSeedContextAccessor seedContext,
+        IHttpClientFactory httpClientFactory,
+        IOptions<ServiceRegistry> serviceRegistry)
     {
         _client = client;
         _reportClient = reportClient;
         _seedContext = seedContext;
+        _httpClientFactory = httpClientFactory;
+        _serviceRegistry = serviceRegistry;
     }
 
     public override IReadOnlyList<ApiHealthSeedRequirement> GetSeedRequirements() =>
@@ -40,6 +49,56 @@ public sealed class TenantServiceTestSuite : ServiceTestSuiteBase
     public override async Task<IReadOnlyList<ApiTestRunResult>> ExecuteAsync(CancellationToken ct = default)
     {
         var results = new List<ApiTestRunResult>();
+
+        var serviceApiUrl = _serviceRegistry.Value.TenantServiceApiUrl?.TrimEnd('/');
+
+        var baseUrl = !string.IsNullOrWhiteSpace(serviceApiUrl) &&
+                      serviceApiUrl.EndsWith("/api", StringComparison.OrdinalIgnoreCase)
+                        ? serviceApiUrl[..^4]
+                        : serviceApiUrl;
+
+        if (string.IsNullOrWhiteSpace(baseUrl))
+        {
+            const string error =
+                "ServiceRegistry:TenantServiceApiUrl is not configured.";
+
+            foreach (var endpointName in new[]
+            {
+                StepNames.InfoGet200,
+                StepNames.RootHealthGet200
+            })
+            {
+                results.Add(new ApiTestRunResult
+                {
+                    EndpointKey = $"{ServiceName}::{endpointName}",
+                    ServiceName = ServiceName,
+                    EndpointName = endpointName,
+                    Passed = false,
+                    ExpectedStatusCode = 200,
+                    ErrorMessage = error,
+                    RequestBody =
+                        "Request was not sent because the Tenant service URL is missing.",
+                    ResponseBody =
+                        "Response was not received because the Tenant service URL is missing.",
+                    ExecutedAt = DateTimeOffset.UtcNow
+                });
+            }
+        }
+        else
+        {
+            results.Add(await CallRawGetAsync(
+                StepNames.InfoGet200,
+                baseUrl,
+                "/api/Tenant/info",
+                ct));
+
+            results.Add(await CallRawGetAsync(
+                StepNames.RootHealthGet200,
+                baseUrl,
+                "/health",
+                ct));
+        }
+
         var testVendor = new VendorModel { Name = $"ApiHealth-Vendor-{Guid.NewGuid():N}" };
         FacilityModel BuildFacility(
             string id,
@@ -326,5 +385,83 @@ public sealed class TenantServiceTestSuite : ServiceTestSuiteBase
         }
 
         return results;
+    }
+
+    private async Task<ApiTestRunResult> CallRawGetAsync(
+        string endpointName,
+        string baseUrl,
+        string relativePath,
+        CancellationToken ct)
+    {
+        var result = new ApiTestRunResult
+        {
+            EndpointKey = $"{ServiceName}::{endpointName}",
+            ServiceName = ServiceName,
+            EndpointName = endpointName,
+            ExpectedStatusCode = 200,
+            ExecutedAt = DateTimeOffset.UtcNow,
+            RequestMethod = "GET",
+            RequestUrl = $"{baseUrl}{relativePath}",
+            RequestBody = "No request body was sent (GET)."
+        };
+
+        var sw = Stopwatch.StartNew();
+
+        try
+        {
+            ct.ThrowIfCancellationRequested();
+
+            var httpClient =
+                _httpClientFactory.CreateClient("ApiHealthTest");
+
+            using var response = await httpClient.GetAsync(
+                $"{baseUrl}{relativePath}",
+                ct);
+
+            var responseBody =
+                await response.Content.ReadAsStringAsync(ct);
+
+            sw.Stop();
+
+            result.ActualStatusCode = (int)response.StatusCode;
+            result.DurationMs = sw.ElapsedMilliseconds;
+            result.Passed = result.ActualStatusCode == 200;
+
+            result.ResponseBody = string.IsNullOrWhiteSpace(responseBody)
+                ? $"No response body was returned (HTTP {result.ActualStatusCode})."
+                : responseBody.Length > 500
+                    ? responseBody[..500]
+                    : responseBody;
+
+            if (!result.Passed)
+            {
+                result.ErrorMessage =
+                    $"Expected HTTP 200 but got {result.ActualStatusCode}.";
+            }
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (TaskCanceledException)
+        {
+            sw.Stop();
+            result.DurationMs = sw.ElapsedMilliseconds;
+            result.Passed = false;
+            result.ErrorMessage = "Request timed out.";
+            result.ResponseBody =
+                "No response body was received because the request timed out.";
+        }
+        catch (HttpRequestException ex)
+        {
+            sw.Stop();
+            result.DurationMs = sw.ElapsedMilliseconds;
+            result.Passed = false;
+            result.ErrorMessage = $"HTTP error: {ex.Message}";
+            result.ResponseBody =
+                "No response body was received because the HTTP request failed.";
+        }
+
+        return result;
     }
 }

--- a/DotNet/Automation.UI/Services/ApiHealth/TestSuites/ValidationServiceTestSuite.cs
+++ b/DotNet/Automation.UI/Services/ApiHealth/TestSuites/ValidationServiceTestSuite.cs
@@ -1,7 +1,10 @@
-using Automation.UI.Models.ApiHealth;
+﻿using Automation.UI.Models.ApiHealth;
 using Automation.UI.Services.ApiHealth.Seeding;
 using LantanaGroup.Link.Sdk.Clients;
 using StepNames = Automation.UI.Services.ApiHealth.TestSuites.ApiEndPointLibrary.ValidationSteps;
+using LantanaGroup.Link.Shared.Application.Models.Configs;
+using Microsoft.Extensions.Options;
+using System.Diagnostics;
 
 namespace Automation.UI.Services.ApiHealth.TestSuites;
 
@@ -10,7 +13,7 @@ namespace Automation.UI.Services.ApiHealth.TestSuites;
 ///   1. Has Artifacts (check if initialized)
 ///   2. Has Categories (check if initialized)
 ///   3. Upsert Resource Artifact
-///   4. Get Validation Results (non-existent � proves reachability)
+///   4. Get Validation Results (non-existent — proves reachability)
 ///
 /// NOTE: Validation is a Java service. InitializeArtifacts/InitializeCategories
 /// are only called if not already initialized, to avoid disrupting existing state.
@@ -19,14 +22,20 @@ public sealed class ValidationServiceTestSuite : ServiceTestSuiteBase
 {
     private readonly IValidationServiceClient _client;
     private readonly IApiHealthSeedContextAccessor _seedContext;
+    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly IOptions<ServiceRegistry> _serviceRegistry;
 
     public override string ServiceName => "Validation";
     public ValidationServiceTestSuite(
         IValidationServiceClient client,
-        IApiHealthSeedContextAccessor seedContext)
+        IApiHealthSeedContextAccessor seedContext,
+        IHttpClientFactory httpClientFactory,
+        IOptions<ServiceRegistry> serviceRegistry)
     {
         _client = client;
         _seedContext = seedContext;
+        _httpClientFactory = httpClientFactory;
+        _serviceRegistry = serviceRegistry;
     }
 
     public override IReadOnlyList<ApiHealthSeedRequirement> GetSeedRequirements() =>
@@ -39,38 +48,106 @@ public sealed class ValidationServiceTestSuite : ServiceTestSuiteBase
 
     public override async Task<IReadOnlyList<ApiTestRunResult>> ExecuteAsync(CancellationToken ct = default)
     {
+        var results = new List<ApiTestRunResult>();
+
+        var baseUrl = _serviceRegistry.Value.ValidationServiceUrl?.TrimEnd('/');
+
+        if (string.IsNullOrWhiteSpace(baseUrl))
+        {
+            const string error =
+                "ServiceRegistry:ValidationServiceUrl is not configured.";
+
+            foreach (var endpointName in new[]
+            {
+                StepNames.InfoGet200,
+                StepNames.RootHealthGet200
+            })
+            {
+                results.Add(new ApiTestRunResult
+                {
+                    EndpointKey = $"{ServiceName}::{endpointName}",
+                    ServiceName = ServiceName,
+                    EndpointName = endpointName,
+                    Passed = false,
+                    ExpectedStatusCode = 200,
+                    ErrorMessage = error,
+                    RequestBody =
+                        "Request was not sent because the Validation service URL is missing.",
+                    ResponseBody =
+                        "Response was not received because the Validation service URL is missing.",
+                    ExecutedAt = DateTimeOffset.UtcNow
+                });
+            }
+        }
+        else
+        {
+            results.Add(await CallRawGetAsync(
+                StepNames.InfoGet200,
+                baseUrl,
+                "/api/Validation/info",
+                ct));
+
+            results.Add(await CallRawGetAsync(
+                StepNames.RootHealthGet200,
+                baseUrl,
+                "/health",
+                ct));
+        }
+
         var fakeFacilityId = $"ApiHealth-Val-{Guid.NewGuid():N}";
 
-        return
-        [
-            await RunStepAsync(StepNames.ArtifactsGet200, 200, async () =>
-                await _client.GetArtifactsAsync(ct), ct: ct),
+        results.Add(await RunStepAsync(
+            StepNames.ArtifactsGet200,
+            200,
+            async () => await _client.GetArtifactsAsync(ct),
+            ct: ct));
 
-            await RunStepAsync(StepNames.CategoriesGet200, 200, async () =>
-                await _client.GetCategoriesAsync(ct), ct: ct),
+        results.Add(await RunStepAsync(
+            StepNames.CategoriesGet200,
+            200,
+            async () => await _client.GetCategoriesAsync(ct),
+            ct: ct));
 
-            await RunStepAsync(StepNames.ArtifactPut200Or201, [200, 201], async () =>
+        results.Add(await RunStepAsync(
+            StepNames.ArtifactPut200Or201,
+            [200, 201],
+            async () =>
             {
                 var artifactId = $"OperationOutcome-{Guid.NewGuid():N}";
                 var payload = $$"""
-                {
-                    "resourceType": "OperationOutcome",
-                    "id": "{{Guid.NewGuid():N}}",
-                    "issue": [{
-                        "severity": "information",
-                        "code": "informational",
-                        "diagnostics": "ApiHealth stability test artifact"
-                    }]
-                }
-                """;
-                return await _client.UpsertResourceArtifactAsync(artifactId, payload, ct);
-            }, ct: ct),
+            {
+                "resourceType": "OperationOutcome",
+                "id": "{{Guid.NewGuid():N}}",
+                "issue": [{
+                    "severity": "information",
+                    "code": "informational",
+                    "diagnostics": "ApiHealth stability test artifact"
+                }]
+            }
+            """;
 
-            await RunSeededResultsStepAsync(StepNames.ResultsGet200Seeded, ct),
+                return await _client.UpsertResourceArtifactAsync(
+                    artifactId,
+                    payload,
+                    ct);
+            },
+            ct: ct));
 
-            await RunStepAsync(StepNames.ResultsGet200Empty, 200, async () =>
-                await _client.GetValidationResultsAsync(fakeFacilityId, Guid.NewGuid().ToString(), cancellationToken: ct), ct: ct)
-        ];
+        results.Add(await RunSeededResultsStepAsync(
+            StepNames.ResultsGet200Seeded,
+            ct));
+
+        results.Add(await RunStepAsync(
+            StepNames.ResultsGet200Empty,
+            200,
+            async () =>
+                await _client.GetValidationResultsAsync(
+                    fakeFacilityId,
+                    Guid.NewGuid().ToString(),
+                    cancellationToken: ct),
+            ct: ct));
+
+        return results;
     }
 
     private async Task<ApiTestRunResult> RunSeededResultsStepAsync(string stepName, CancellationToken ct)
@@ -81,5 +158,83 @@ public sealed class ValidationServiceTestSuite : ServiceTestSuiteBase
 
         return await RunStepAsync(stepName, 200, async () =>
             await _client.GetValidationResultsAsync(facilityId, reportId, cancellationToken: ct), ct: ct);
+    }
+
+    private async Task<ApiTestRunResult> CallRawGetAsync(
+        string endpointName,
+        string baseUrl,
+        string relativePath,
+        CancellationToken ct)
+    {
+        var result = new ApiTestRunResult
+        {
+            EndpointKey = $"{ServiceName}::{endpointName}",
+            ServiceName = ServiceName,
+            EndpointName = endpointName,
+            ExpectedStatusCode = 200,
+            ExecutedAt = DateTimeOffset.UtcNow,
+            RequestMethod = "GET",
+            RequestUrl = $"{baseUrl}{relativePath}",
+            RequestBody = "No request body was sent (GET)."
+        };
+
+        var sw = Stopwatch.StartNew();
+
+        try
+        {
+            ct.ThrowIfCancellationRequested();
+
+            var httpClient =
+                _httpClientFactory.CreateClient("ApiHealthTest");
+
+            using var response = await httpClient.GetAsync(
+                $"{baseUrl}{relativePath}",
+                ct);
+
+            var responseBody =
+                await response.Content.ReadAsStringAsync(ct);
+
+            sw.Stop();
+
+            result.ActualStatusCode = (int)response.StatusCode;
+            result.DurationMs = sw.ElapsedMilliseconds;
+            result.Passed = result.ActualStatusCode == 200;
+
+            result.ResponseBody = string.IsNullOrWhiteSpace(responseBody)
+                ? $"No response body was returned (HTTP {result.ActualStatusCode})."
+                : responseBody.Length > 500
+                    ? responseBody[..500]
+                    : responseBody;
+
+            if (!result.Passed)
+            {
+                result.ErrorMessage =
+                    $"Expected HTTP 200 but got {result.ActualStatusCode}.";
+            }
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (TaskCanceledException)
+        {
+            sw.Stop();
+            result.DurationMs = sw.ElapsedMilliseconds;
+            result.Passed = false;
+            result.ErrorMessage = "Request timed out.";
+            result.ResponseBody =
+                "No response body was received because the request timed out.";
+        }
+        catch (HttpRequestException ex)
+        {
+            sw.Stop();
+            result.DurationMs = sw.ElapsedMilliseconds;
+            result.Passed = false;
+            result.ErrorMessage = $"HTTP error: {ex.Message}";
+            result.ResponseBody =
+                "No response body was received because the HTTP request failed.";
+        }
+
+        return result;
     }
 }

--- a/DotNet/Automation.UI/Services/ApiHealth/TestSuites/ValidationServiceTestSuite.cs
+++ b/DotNet/Automation.UI/Services/ApiHealth/TestSuites/ValidationServiceTestSuite.cs
@@ -84,7 +84,7 @@ public sealed class ValidationServiceTestSuite : ServiceTestSuiteBase
             results.Add(await CallRawGetAsync(
                 StepNames.InfoGet200,
                 baseUrl,
-                "/api/Validation/info",
+                "/api/validation/info",
                 ct));
 
             results.Add(await CallRawGetAsync(

--- a/DotNet/ServiceTests/UnitTests/AutomationUI/AdminBffTestSuiteTests.cs
+++ b/DotNet/ServiceTests/UnitTests/AutomationUI/AdminBffTestSuiteTests.cs
@@ -29,12 +29,19 @@ public class AdminBffTestSuiteTests
 
         var results = await suite.ExecuteAsync();
 
-        results.Should().ContainSingle();
-        var result = results.Single();
-        result.Passed.Should().BeFalse();
-        result.ErrorMessage.Should().Be("ServiceRegistry:AdminBffServiceUrl is not configured.");
-        result.RequestBody.Should().Contain("ServiceRegistry:AdminBffServiceUrl is missing");
-        result.ResponseBody.Should().Contain("ServiceRegistry:AdminBffServiceUrl is missing");
+        results.Should().HaveCount(2);
+
+        results.Should().OnlyContain(result =>
+            !result.Passed &&
+            result.ErrorMessage == "ServiceRegistry:AdminBffServiceUrl is not configured." &&
+            result.RequestBody.Contains("Admin BFF service URL is missing") &&
+            result.ResponseBody.Contains("Admin BFF service URL is missing"));
+
+        results.Select(r => r.EndpointName).Should().BeEquivalentTo(
+        [
+            ApiEndPointLibrary.AdminBffSteps.InfoGet200,
+            ApiEndPointLibrary.AdminBffSteps.HealthGet200
+        ]);
 
         serviceProvider.Verify(sp => sp.GetService(typeof(LantanaGroup.Link.Sdk.Clients.IAdminBffIntegrationClient)), Times.Never);
     }


### PR DESCRIPTION
### 🛠️ Description of Changes

Add API Health coverage for /api/{serviceName}/info and /health endpoints across all applicable Automation UI service test suites. Update endpoint metadata and service URL handling while preserving existing API Health test execution and failure reporting.

### 🧪 Testing Performed

I was able to see the /Api/{Service Name}/Info and /Health endpoints for each service under the API health tab and verified the endpoints exist and work through postman.

### 🧑‍🔬 Unit Testing

- Coverage: 9.2%

N/A

### 📓 Documentation Updated

N/A


