### PR TITLE
LEGLINK-960: Add a one-week expiration policy to all Redis resource cache entries

### DIFF
--- a/Config/app-config.dev.json
+++ b/Config/app-config.dev.json
@@ -1633,6 +1633,15 @@
 			}
 		},
 		{
+			"key": "ResourceCache:Redis:CacheEntryTtlDays",
+			"value": "7",
+			"label": null,
+			"content_type": "",
+			"tags": {
+				"link:consumers": "DataAcquisition,DataAcquisitionWorker,Normalization"
+			}
+		},
+		{
 			"key": "ResourceCache:Redis:Password",
 			"value": "{\"uri\":\"https://link-vault.vault.azure.net/secrets/redis-password\"}",
 			"label": null,

--- a/Config/app-config.qa.json
+++ b/Config/app-config.qa.json
@@ -1616,6 +1616,15 @@
 			}
 		},
 		{
+			"key": "ResourceCache:Redis:CacheEntryTtlDays",
+			"value": "7",
+			"label": null,
+			"content_type": "",
+			"tags": {
+				"link:consumers": "DataAcquisition,DataAcquisitionWorker,Normalization"
+			}
+		},
+		{
 			"key": "ResourceCache:Redis:Password",
 			"value": "{\"uri\":\"https://nhsnlink-kv-qa.vault.azure.net/secrets/link-resource-cache-redis-password\"}",
 			"label": null,

--- a/Config/app-config.qa2.json
+++ b/Config/app-config.qa2.json
@@ -1616,6 +1616,15 @@
 			}
 		},
 		{
+			"key": "ResourceCache:Redis:CacheEntryTtlDays",
+			"value": "7",
+			"label": null,
+			"content_type": "",
+			"tags": {
+				"link:consumers": "DataAcquisition,DataAcquisitionWorker,Normalization"
+			}
+		},
+		{
 			"key": "ResourceCache:Redis:Password",
 			"value": "{\"uri\":\"https://nhsnlink-kv-qa2.vault.azure.net/secrets/link-resource-cache-redis-password\"}",
 			"label": null,

--- a/Config/app-config.test.json
+++ b/Config/app-config.test.json
@@ -1665,6 +1665,15 @@
 			}
 		},
 		{
+			"key": "ResourceCache:Redis:CacheEntryTtlDays",
+			"value": "7",
+			"label": null,
+			"content_type": "",
+			"tags": {
+				"link:consumers": "DataAcquisition,DataAcquisitionWorker,Normalization"
+			}
+		},
+		{
 			"key": "ResourceCache:Redis:Password",
 			"value": "{\"uri\":\"https://nhsnlink-kv-test.vault.azure.net/secrets/link-resource-cache-redis-password\"}",
 			"label": null,

--- a/DotNet/ServiceTests/UnitTests/Shared/ResourceCache/RedisResourceCacheTests.cs
+++ b/DotNet/ServiceTests/UnitTests/Shared/ResourceCache/RedisResourceCacheTests.cs
@@ -1,5 +1,7 @@
 using LantanaGroup.Link.Shared.Application.Services.ResourceCache;
+using LantanaGroup.Link.Shared.Application.Models.Configs;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Moq;
 using StackExchange.Redis;
 using StackExchange.Redis.Extensions.Core.Abstractions;
@@ -20,11 +22,58 @@ public class RedisResourceCacheTests
             .ReturnsAsync(true);
         redisDatabase.SetupGet(item => item.Database).Returns(database.Object);
 
-        var cache = new RedisResourceCache(redisDatabase.Object, Mock.Of<ILogger<RedisResourceCache>>());
+        var cache = new RedisResourceCache(
+            redisDatabase.Object,
+            Options.Create(new ResourceCacheSettings()),
+            Mock.Of<ILogger<RedisResourceCache>>());
 
         await cache.DeleteAsync(new List<string> { "first" });
         await cache.DeleteAsync(new List<string> { "second" });
 
         redisDatabase.VerifyGet(item => item.Database, Times.Exactly(2));
+    }
+
+    [Fact]
+    public async Task UpdateCorrelationCacheAsync_SetsConfiguredExpiryAfterWritingEntries()
+    {
+        const int cacheEntryTtlDays = 14;
+        var redisDatabase = new Mock<IRedisDatabase>();
+        var database = new Mock<IDatabase>();
+        database
+            .Setup(item => item.HashSetAsync(
+                It.IsAny<RedisKey>(),
+                It.IsAny<HashEntry[]>(),
+                It.IsAny<CommandFlags>()))
+            .Returns(Task.CompletedTask);
+        database
+            .Setup(item => item.KeyExpireAsync(
+                It.IsAny<RedisKey>(),
+                It.IsAny<TimeSpan?>(),
+                It.IsAny<ExpireWhen>(),
+                It.IsAny<CommandFlags>()))
+            .ReturnsAsync(true);
+        redisDatabase.SetupGet(item => item.Database).Returns(database.Object);
+
+        var cache = new RedisResourceCache(
+            redisDatabase.Object,
+            Options.Create(new ResourceCacheSettings
+            {
+                Redis = new ResourceCacheRedisSettings { CacheEntryTtlDays = cacheEntryTtlDays }
+            }),
+            Mock.Of<ILogger<RedisResourceCache>>());
+
+        await cache.UpdateCorrelationCacheAsync("correlation-id", [], ResourceType.Patient);
+
+        database.Verify(item => item.HashSetAsync(
+            "correlation-id",
+            It.IsAny<HashEntry[]>(),
+            CommandFlags.None),
+            Times.Once);
+        database.Verify(item => item.KeyExpireAsync(
+            "correlation-id",
+            TimeSpan.FromDays(cacheEntryTtlDays),
+            ExpireWhen.Always,
+            CommandFlags.None),
+            Times.Once);
     }
 }

--- a/DotNet/Shared/Application/Extensions/ResourceCacheExtensions.cs
+++ b/DotNet/Shared/Application/Extensions/ResourceCacheExtensions.cs
@@ -38,7 +38,7 @@ namespace LantanaGroup.Link.Shared.Application.Extensions
         /// <code>
         /// "ResourceCache": {
         ///   "CacheImplementation": "Hybrid",
-        ///   "Redis": { "ConnectionString": "", "Password": "", "PoolSize": 5, "MemoryThresholdPercent": 80.0 },
+        ///   "Redis": { "ConnectionString": "", "Password": "", "PoolSize": 5, "CacheEntryTtlDays": 7, "MemoryThresholdPercent": 80.0 },
         ///   "BlobStorage": { "ConnectionString": "", "BlobContainerName": "", "BlobRoot": "" }
         /// }
         /// </code>

--- a/DotNet/Shared/Application/Models/Configs/ResourceCacheSettings.cs
+++ b/DotNet/Shared/Application/Models/Configs/ResourceCacheSettings.cs
@@ -25,6 +25,13 @@ namespace LantanaGroup.Link.Shared.Application.Models.Configs
         public string? ConnectionString { get; set; }
         public string? Password { get; set; }
         public int PoolSize { get; set; } = 5;
+
+        /// <summary>
+        /// The number of days Redis resource-cache entries remain after their most recent write.
+        /// Defaults to 7.
+        /// </summary>
+        public int CacheEntryTtlDays { get; set; } = 7;
+
         /// <summary>
         /// The percentage of the configured Redis max-memory (<see cref="MaxMemoryBytes"/>) at
         /// which Hybrid caching falls back to ABS. Defaults to 80. When

--- a/DotNet/Shared/Application/Services/ResourceCache/RedisResourceCache.cs
+++ b/DotNet/Shared/Application/Services/ResourceCache/RedisResourceCache.cs
@@ -2,8 +2,10 @@
 using Hl7.Fhir.Serialization;
 using LantanaGroup.Link.Shared.Application.Enums;
 using LantanaGroup.Link.Shared.Application.Interfaces;
+using LantanaGroup.Link.Shared.Application.Models.Configs;
 using LantanaGroup.Link.Shared.Application.SerDes;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using StackExchange.Redis;
 using StackExchange.Redis.Extensions.Core.Abstractions;
 using System.Text.Json;
@@ -15,11 +17,25 @@ namespace LantanaGroup.Link.Shared.Application.Services.ResourceCache
     {
         private readonly IRedisDatabase _redisDatabase;
         private readonly ILogger<RedisResourceCache> _logger;
+        private readonly TimeSpan _cacheEntryTtl;
 
-        public RedisResourceCache(IRedisDatabase redisDatabase, ILogger<RedisResourceCache> logger)
+        public RedisResourceCache(
+            IRedisDatabase redisDatabase,
+            IOptions<ResourceCacheSettings> settings,
+            ILogger<RedisResourceCache> logger)
         {
             _redisDatabase = redisDatabase;
             _logger = logger;
+
+            var cacheEntryTtlDays = settings.Value.Redis.CacheEntryTtlDays;
+            if (cacheEntryTtlDays <= 0)
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(settings),
+                    "ResourceCache:Redis:CacheEntryTtlDays must be greater than zero.");
+            }
+
+            _cacheEntryTtl = TimeSpan.FromDays(cacheEntryTtlDays);
         }
 
         public async Task DeleteAsync(List<string> cacheKeys, CancellationToken cancellationToken = default)
@@ -83,6 +99,7 @@ namespace LantanaGroup.Link.Shared.Application.Services.ResourceCache
             }
 
             await _redisDatabase.Database.HashSetAsync(correlationId, correlationHash.ToArray()).WaitAsync(cancellationToken);
+            await _redisDatabase.Database.KeyExpireAsync(correlationId, _cacheEntryTtl).WaitAsync(cancellationToken);
         }
 
         public ResourceCacheType GetCacheTypeForCorrelationId(string correlationId)

--- a/app-config.yaml
+++ b/app-config.yaml
@@ -522,6 +522,10 @@ services:
     - key: "ResourceCache:CacheImplementation"
       description: "The resource cache implementation to register. Defaults to Hybrid; supported values are Hybrid, Redis, and ABS. Redis and Hybrid use ConnectionStrings:Redis and Redis:Password."
       required: false
+    - key: "ResourceCache:Redis:CacheEntryTtlDays"
+      description: "The number of days Redis resource-cache entries remain after their most recent write. Defaults to 7."
+      required: false
+      defaultValue: "7"
     - key: "ResourceCache:Redis:MemoryThresholdPercent"
       description: "Optional percentage of ResourceCache:Redis:MaxMemoryBytes at which Hybrid caching falls back to blob storage. Defaults to 80.0."
       required: false
@@ -559,6 +563,10 @@ services:
     - key: "ResourceCache:CacheImplementation"
       description: "The resource cache implementation to register. Defaults to Hybrid; supported values are Hybrid, Redis, and ABS. Redis and Hybrid use ConnectionStrings:Redis and Redis:Password."
       required: false
+    - key: "ResourceCache:Redis:CacheEntryTtlDays"
+      description: "The number of days Redis resource-cache entries remain after their most recent write. Defaults to 7."
+      required: false
+      defaultValue: "7"
     - key: "ResourceCache:Redis:MemoryThresholdPercent"
       description: "Optional percentage of ResourceCache:Redis:MaxMemoryBytes at which Hybrid caching falls back to blob storage. Defaults to 80.0."
       required: false
@@ -640,6 +648,10 @@ services:
       description: "Optional Redis password for the resource cache. Defaults to empty."
       required: false
       sensitive: true
+    - key: "ResourceCache:Redis:CacheEntryTtlDays"
+      description: "The number of days Redis resource-cache entries remain after their most recent write. Defaults to 7."
+      required: false
+      defaultValue: "7"
     - key: "ResourceCache:Redis:MemoryThresholdPercent"
       description: "Optional percentage of ResourceCache:Redis:MaxMemoryBytes at which Hybrid caching falls back to blob storage. Defaults to 80.0."
       required: false


### PR DESCRIPTION
### 🛠️ Description of Changes

Adds a configurable time-to-live for Redis resource cache entries. This is a fallback to prevent entries from persisting in Redis forever when there are errors during processing.

### 🧪 Testing Performed

Automated tests for regressions

### 🧑‍🔬 Unit Testing

- [x] I have written or updated unit tests to cover my changes
- Coverage: 75.0%

### 📓 Documentation Updated

App-config.yaml updated to include the new optional setting.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Redis cache entries now automatically expire after a configurable retention period, defaulting to 7 days.
  - Cache retention can be configured across development, testing, QA, and production environments.

- **Documentation**
  - Added configuration guidance describing the cache retention setting and its default value.

- **Tests**
  - Added coverage verifying that cached correlation data receives the configured expiration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
