### PR TITLE
LEGLINK-1028: Answer facility client errors with RFC 7807 problem details

### DIFF
--- a/DotNet/ServiceTests/IntegrationTests/Tenant/FacilityControllerTests.cs
+++ b/DotNet/ServiceTests/IntegrationTests/Tenant/FacilityControllerTests.cs
@@ -17,6 +17,7 @@ using LantanaGroup.Link.Tenant.Models;
 using LantanaGroup.Link.Tenant.Services;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -39,6 +40,21 @@ public class FacilityControllerTests : IDisposable
     private readonly IServiceScope _scope;
     private readonly FacilityController _controller;
     private readonly TenantDbContext _dbContext;
+
+    /// <summary>
+    /// Real MVC services, so the controller's problem responses are built by the actual
+    /// <see cref="ProblemDetailsFactory"/>. The fixture registers no MVC services of its own, and
+    /// <c>ControllerBase.Problem</c> resolves the factory rather than constructing one.
+    /// </summary>
+    private static readonly IServiceProvider MvcServices = BuildMvcServices();
+
+    private static IServiceProvider BuildMvcServices()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddControllers();
+        return services.BuildServiceProvider();
+    }
 
     public FacilityControllerTests(TenantIntegrationTestFixture fixture, ITestOutputHelper output)
     {
@@ -77,6 +93,7 @@ public class FacilityControllerTests : IDisposable
         {
             HttpContext = httpContext
         };
+        _controller.ProblemDetailsFactory = MvcServices.GetRequiredService<ProblemDetailsFactory>();
 
         Quartz.Logging.LogProvider.SetCurrentLogProvider(new NoOpQuartzLogProvider());
 
@@ -250,6 +267,23 @@ public class FacilityControllerTests : IDisposable
         Assert.IsType<NoContentResult>(result);
     }
 
+    /// <summary>
+    /// Every client error answers with RFC 7807 problem details rather than a bare string, so the
+    /// assertion has to look at <see cref="ProblemDetails.Detail"/>. A result whose value is still a
+    /// string would satisfy a <c>Contains</c> on <c>Value.ToString()</c> and hide the regression.
+    /// </summary>
+    private static ProblemDetails AssertProblem(IActionResult? result, int expectedStatusCode, string expectedDetail)
+    {
+        var objectResult = Assert.IsType<ObjectResult>(result);
+        Assert.Equal(expectedStatusCode, objectResult.StatusCode);
+
+        var problem = Assert.IsType<ProblemDetails>(objectResult.Value);
+        Assert.Equal(expectedStatusCode, problem.Status);
+        Assert.Contains(expectedDetail, problem.Detail);
+
+        return problem;
+    }
+
     [Fact]
     public async Task SoftDeleteFacility_FacilityNotFound_ReturnsNotFound()
     {
@@ -257,8 +291,7 @@ public class FacilityControllerTests : IDisposable
 
         var result = await _controller.SoftDeleteFacility(nonExistentFacilityId, CancellationToken.None);
 
-        var notFoundResult = Assert.IsType<NotFoundObjectResult>(result);
-        Assert.Contains("Not Found", notFoundResult.Value?.ToString());
+        AssertProblem(result, StatusCodes.Status404NotFound, "Not Found");
     }
 
     [Fact]
@@ -291,8 +324,7 @@ public class FacilityControllerTests : IDisposable
 
         var result = await _controller.RestoreFacility(nonExistentFacilityId, CancellationToken.None);
 
-        var notFoundResult = Assert.IsType<NotFoundObjectResult>(result);
-        Assert.Contains("Not Found", notFoundResult.Value?.ToString());
+        AssertProblem(result, StatusCodes.Status404NotFound, "Not Found");
     }
 
     [Fact]
@@ -312,8 +344,7 @@ public class FacilityControllerTests : IDisposable
         // Try to restore a facility that is not deleted
         var result = await _controller.RestoreFacility(facilityId, CancellationToken.None);
 
-        var badRequestResult = Assert.IsType<BadRequestObjectResult>(result);
-        Assert.Contains("is not deleted", badRequestResult.Value?.ToString());
+        AssertProblem(result, StatusCodes.Status400BadRequest, "is not deleted");
     }
 
     /// <summary>
@@ -447,8 +478,7 @@ public class FacilityControllerTests : IDisposable
 
         var result = await _controller.GenerateAdHocReport(facilityId, request);
         var actionResult = result.Result as IActionResult;
-        var badRequestResult = Assert.IsType<BadRequestObjectResult>(actionResult);
-        Assert.Contains("FacilityId must be provided", badRequestResult.Value?.ToString());
+        AssertProblem(actionResult, StatusCodes.Status400BadRequest, "FacilityId must be provided");
     }
 
     [Fact]
@@ -465,7 +495,7 @@ public class FacilityControllerTests : IDisposable
 
         var result = await _controller.GenerateAdHocReport(Guid.NewGuid().ToString(), request);
         var actionResult = result.Result as IActionResult;
-        Assert.IsType<NotFoundObjectResult>(actionResult);
+        AssertProblem(actionResult, StatusCodes.Status404NotFound, "Facility does not exist");
     }
 
     [Theory]
@@ -477,8 +507,7 @@ public class FacilityControllerTests : IDisposable
 
         var result = await _controller.RegenerateReport(facilityId, request);
         var actionResult = result.Result as IActionResult;
-        var badRequestResult = Assert.IsType<BadRequestObjectResult>(actionResult);
-        Assert.Contains("FacilityId must be provided", badRequestResult.Value?.ToString());
+        AssertProblem(actionResult, StatusCodes.Status400BadRequest, "FacilityId must be provided");
     }
 
     [Fact]
@@ -488,7 +517,7 @@ public class FacilityControllerTests : IDisposable
 
         var result = await _controller.RegenerateReport(Guid.NewGuid().ToString(), request);
         var actionResult = result.Result as IActionResult;
-        Assert.IsType<NotFoundObjectResult>(actionResult);
+        AssertProblem(actionResult, StatusCodes.Status404NotFound, "Facility does not exist");
     }
 
     private class StubHttpMessageHandler : HttpMessageHandler

--- a/DotNet/ServiceTests/UnitTests/Tenant/FacilityControllerProblemDetailsTests.cs
+++ b/DotNet/ServiceTests/UnitTests/Tenant/FacilityControllerProblemDetailsTests.cs
@@ -1,0 +1,195 @@
+﻿using LantanaGroup.Link.DMRP.Business;
+using LantanaGroup.Link.DMRP.Models.Exceptions;
+using LantanaGroup.Link.Shared.Application.Models.Tenant;
+using static LantanaGroup.Link.Shared.Application.Extensions.Security.BackendAuthenticationServiceExtension;
+using LantanaGroup.Link.Tenant.Business.Queries;
+using LantanaGroup.Link.Tenant.Controllers;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
+using LantanaGroup.Link.Shared.Application.Models.Configs;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Moq;
+using Moq.AutoMock;
+using Task = System.Threading.Tasks.Task;
+
+namespace UnitTests.Tenant;
+
+/// <summary>
+/// Every client error from the facility endpoints answers with RFC 7807 problem details.
+/// </summary>
+/// <remarks>
+/// The refusals themselves are covered by <c>DmrpFacilityOperationsTests</c>; what is asserted here
+/// is the shape the caller receives. <c>BadRequest(ex.Message)</c> passes a bare <c>string</c>,
+/// which the client-error mapping does not convert to problem details - it goes out as
+/// <c>text/plain</c> with no type, title or traceId - so a test that only checks the status code
+/// passes either way.
+/// </remarks>
+[Trait("Category", "UnitTests")]
+public class FacilityControllerProblemDetailsTests
+{
+    private const string FacilityId = "test-facility";
+    private const string BadRequestType = "https://tools.ietf.org/html/rfc9110#section-15.5.1";
+
+    private const string ScheduleRefusal =
+        "Scheduled reports cannot be set on a facility while DMRP is enabled. They are derived from the facility's DMRP reporting plans. Resubmit with empty daily, weekly and monthly arrays in scheduledReports.";
+
+    private static readonly IServiceProvider MvcServices = BuildMvcServices();
+
+    private static IServiceProvider BuildMvcServices()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddControllers();
+        return services.BuildServiceProvider();
+    }
+
+    private static FacilityController CreateController(AutoMocker mocker)
+    {
+        // The constructor null-checks these and reads .Value, which an auto-mocked IOptions returns
+        // null for. None of them is reached on the paths under test.
+        mocker.Use<IOptions<ServiceRegistry>>(Options.Create(new ServiceRegistry()));
+        mocker.Use<IOptions<LinkTokenServiceSettings>>(Options.Create(new LinkTokenServiceSettings()));
+        mocker.Use<IOptions<LinkBearerServiceOptions>>(Options.Create(new LinkBearerServiceOptions()));
+
+        var controller = mocker.CreateInstance<FacilityController>();
+        controller.ControllerContext = new ControllerContext
+        {
+            HttpContext = new DefaultHttpContext { RequestServices = MvcServices }
+        };
+        controller.ProblemDetailsFactory = MvcServices.GetRequiredService<ProblemDetailsFactory>();
+        return controller;
+    }
+
+    private static FacilityModel Facility(string[]? monthly = null) => new()
+    {
+        FacilityId = FacilityId,
+        FacilityName = "Test Facility",
+        TimeZone = "America/Chicago",
+        ScheduledReports = new TenantScheduledReportConfig
+        {
+            Daily = Array.Empty<string>(),
+            Weekly = Array.Empty<string>(),
+            Monthly = monthly ?? Array.Empty<string>()
+        }
+    };
+
+    private static ProblemDetails AssertProblem(IActionResult? result, int expectedStatusCode, string expectedDetail)
+    {
+        var objectResult = Assert.IsType<ObjectResult>(result);
+        Assert.Equal(expectedStatusCode, objectResult.StatusCode);
+
+        var problem = Assert.IsType<ProblemDetails>(objectResult.Value);
+        Assert.Equal(expectedStatusCode, problem.Status);
+        Assert.Equal(expectedDetail, problem.Detail);
+
+        return problem;
+    }
+
+    [Fact]
+    public async Task Create_with_a_caller_supplied_schedule_answers_with_problem_details()
+    {
+        var mocker = new AutoMocker();
+        mocker.GetMock<IFacilityOperations>()
+            .Setup(o => o.CreateAsync(It.IsAny<FacilityModel>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new ScheduledReportsNotAcceptedException(ScheduleRefusal));
+
+        var result = await CreateController(mocker)
+            .StoreFacility(Facility(new[] { "NHSNAcuteCareHospitalMonthlyInitialPopulation" }), CancellationToken.None);
+
+        var problem = AssertProblem(result, StatusCodes.Status400BadRequest, ScheduleRefusal);
+        Assert.Equal("Bad Request", problem.Title);
+        Assert.Equal(BadRequestType, problem.Type);
+    }
+
+    [Fact]
+    public async Task Update_with_a_caller_supplied_schedule_answers_with_problem_details()
+    {
+        var mocker = new AutoMocker();
+        mocker.GetMock<IFacilityQueries>()
+            .Setup(q => q.GetAsync(FacilityId, null, It.IsAny<CancellationToken>(), false))
+            .ReturnsAsync(Facility());
+        mocker.GetMock<IFacilityOperations>()
+            .Setup(o => o.UpdateAsync(It.IsAny<FacilityModel>(), It.IsAny<FacilityModel>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new ScheduledReportsNotAcceptedException(ScheduleRefusal));
+
+        var result = await CreateController(mocker).PutFacility(
+            FacilityId,
+            Facility(new[] { "NHSNAcuteCareHospitalMonthlyInitialPopulation" }),
+            CancellationToken.None);
+
+        var problem = AssertProblem(result.Result, StatusCodes.Status400BadRequest, ScheduleRefusal);
+        Assert.Equal("Bad Request", problem.Title);
+        Assert.Equal(BadRequestType, problem.Type);
+    }
+
+    [Fact]
+    public async Task Create_without_a_facility_id_names_the_field()
+    {
+        var facility = Facility();
+        facility.FacilityId = null;
+
+        var result = await CreateController(new AutoMocker()).StoreFacility(facility, CancellationToken.None);
+
+        AssertProblem(result, StatusCodes.Status400BadRequest, "Facility ID is required.");
+    }
+
+    [Fact]
+    public async Task Create_without_a_facility_name_names_the_field()
+    {
+        var facility = Facility();
+        facility.FacilityName = null;
+
+        var result = await CreateController(new AutoMocker()).StoreFacility(facility, CancellationToken.None);
+
+        AssertProblem(result, StatusCodes.Status400BadRequest, "Facility name is required.");
+    }
+
+    /// <summary>
+    /// The manager assembles its messages with <c>AppendLine</c>, so the message arrives with a
+    /// trailing newline. <c>detail</c> is prose and must not carry it.
+    /// </summary>
+    [Fact]
+    public async Task A_validation_message_reaches_detail_without_its_trailing_newline()
+    {
+        var mocker = new AutoMocker();
+        mocker.GetMock<IFacilityOperations>()
+            .Setup(o => o.CreateAsync(It.IsAny<FacilityModel>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new ApplicationException("Timezone is required." + Environment.NewLine));
+
+        var result = await CreateController(mocker).StoreFacility(Facility(), CancellationToken.None);
+
+        AssertProblem(result, StatusCodes.Status400BadRequest, "Timezone is required.");
+    }
+
+    /// <summary>
+    /// Messages are also read from logs and asserted in other tests, so they are written as
+    /// fragments. The terminating period belongs to the prose, and is added on the way out.
+    /// </summary>
+    [Fact]
+    public async Task A_message_written_as_a_fragment_is_finished_as_a_sentence()
+    {
+        var mocker = new AutoMocker();
+        mocker.GetMock<IFacilityOperations>()
+            .Setup(o => o.CreateAsync(It.IsAny<FacilityModel>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new ApplicationException("Timezone Not Found: Mars/Olympus_Mons"));
+
+        var result = await CreateController(mocker).StoreFacility(Facility(), CancellationToken.None);
+
+        AssertProblem(result, StatusCodes.Status400BadRequest, "Timezone Not Found: Mars/Olympus_Mons.");
+    }
+
+    [Fact]
+    public async Task An_unknown_facility_answers_with_problem_details()
+    {
+        var mocker = new AutoMocker();
+        mocker.GetMock<IFacilityQueries>()
+            .Setup(q => q.GetAsync(FacilityId, null, It.IsAny<CancellationToken>(), false))
+            .ReturnsAsync((FacilityModel?)null);
+
+        var result = await CreateController(mocker).GetFacility(FacilityId, CancellationToken.None);
+
+        AssertProblem(result, StatusCodes.Status404NotFound, $"Facility with Id: {FacilityId} Not Found.");
+    }
+}

--- a/DotNet/Tenant/Business/Managers/FacilityManager.cs
+++ b/DotNet/Tenant/Business/Managers/FacilityManager.cs
@@ -448,6 +448,14 @@ namespace LantanaGroup.Link.Tenant.Business.Managers
                 validationErrors.AppendLine("FacilityName must be entered.");
             }
 
+            // Checked here rather than left to the lookup below. An absent timezone reaches
+            // FindSystemTimeZoneById as "" or null, which answers with "Timezone Not Found: " or an
+            // ArgumentNullException the caller sees as a 500 - neither of which names the field.
+            if (string.IsNullOrWhiteSpace(facility.TimeZone))
+            {
+                validationErrors.AppendLine("Timezone is required.");
+            }
+
             if (!string.IsNullOrEmpty(validationErrors.ToString()))
             {
                 throw new ApplicationException(validationErrors.ToString());

--- a/DotNet/Tenant/Controllers/FacilityController.cs
+++ b/DotNet/Tenant/Controllers/FacilityController.cs
@@ -13,6 +13,7 @@ using LantanaGroup.Link.Shared.Application.Services.Security;
 using LantanaGroup.Link.Tenant.Business.Managers;
 using LantanaGroup.Link.Tenant.Business.Models;
 using LantanaGroup.Link.Tenant.Business.Queries;
+using LantanaGroup.Link.Tenant.Extensions;
 using LantanaGroup.Link.Tenant.Models;
 using Link.Authorization.Policies;
 using Microsoft.AspNetCore.Authorization;
@@ -73,6 +74,41 @@ namespace LantanaGroup.Link.Tenant.Controllers
             _createSystemToken = createSystemToken ?? throw new ArgumentNullException(nameof(createSystemToken));
             _linkBearerServiceOptions = linkBearerServiceOptions ?? throw new ArgumentNullException(nameof(linkBearerServiceOptions));
         }
+
+        /// <summary>
+        /// A problem response carrying an explicit type, so the same status always answers with the
+        /// same one rather than depending on the framework's client-error mapping.
+        /// </summary>
+        /// <remarks>
+        /// Every client error answers through these rather than through <c>BadRequest</c> or
+        /// <c>NotFound</c>. Those take the message as a bare <c>string</c>, which the client-error
+        /// mapping does not convert, so it leaves as <c>text/plain</c> with no type, title or
+        /// traceId - the shape callers were being given before.
+        /// <para>
+        /// Validation messages are assembled as fragments and are also read from logs, so they
+        /// arrive with a trailing newline or without a terminating period. <c>detail</c> is prose,
+        /// so it is tidied here rather than at every throw site.
+        /// </para>
+        /// </remarks>
+        private ObjectResult TenantProblem(HttpStatusCode statusCode, string title, string type, string detail)
+        {
+            var sentence = detail?.Trim() ?? string.Empty;
+
+            if (sentence.Length > 0 && !sentence.EndsWith('.') && !sentence.EndsWith('?') && !sentence.EndsWith('!'))
+            {
+                sentence += ".";
+            }
+
+            return Problem(detail: sentence, statusCode: (int)statusCode, title: title, type: type);
+        }
+
+        /// <summary>Client input failed validation. RFC 9110 section 15.5.1.</summary>
+        private ObjectResult BadRequestProblem(string detail) => TenantProblem(
+            HttpStatusCode.BadRequest, "Bad Request", TenantProblemTypes.BadRequest, detail);
+
+        /// <summary>The requested facility or report does not exist. RFC 9110 section 15.5.5.</summary>
+        private ObjectResult NotFoundProblem(string detail) => TenantProblem(
+            HttpStatusCode.NotFound, "Not Found", TenantProblemTypes.NotFound, detail);
 
         /// <summary>
         /// Get facilities
@@ -183,24 +219,24 @@ namespace LantanaGroup.Link.Tenant.Controllers
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
         [ProducesResponseType(StatusCodes.Status201Created, Type = typeof(FacilityModel))]
-        [ProducesResponseType(StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest, Type = typeof(ProblemDetails))]
         [ProducesResponseType(StatusCodes.Status500InternalServerError)]
         [HttpPost]
         public async Task<IActionResult> StoreFacility(FacilityModel newFacility, CancellationToken cancellationToken)
         {
             if (newFacility == null)
             {
-                return BadRequest();
-            }
-
-            if (newFacility.FacilityName == null)
-            {
-                return BadRequest();
+                return BadRequestProblem("A facility must be supplied.");
             }
 
             if (newFacility.FacilityId == null)
             {
-                return BadRequest();
+                return BadRequestProblem("Facility ID is required.");
+            }
+
+            if (newFacility.FacilityName == null)
+            {
+                return BadRequestProblem("Facility name is required.");
             }
 
             try
@@ -209,11 +245,11 @@ namespace LantanaGroup.Link.Tenant.Controllers
             }
             catch (ScheduledReportsNotAcceptedException ex)
             {
-                return BadRequest(ex.Message);
+                return BadRequestProblem(ex.Message);
             }
             catch (ApplicationException ex)
             {
-                return BadRequest(ex.Message);
+                return BadRequestProblem(ex.Message);
             }
             catch (Exception ex)
             {
@@ -233,8 +269,8 @@ namespace LantanaGroup.Link.Tenant.Controllers
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
         [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(FacilityModel))]
-        [ProducesResponseType(StatusCodes.Status400BadRequest)]
-        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest, Type = typeof(ProblemDetails))]
+        [ProducesResponseType(StatusCodes.Status404NotFound, Type = typeof(ProblemDetails))]
         [ProducesResponseType(StatusCodes.Status500InternalServerError)]
         [HttpGet("{facilityId}")]
         public async Task<IActionResult> GetFacility(string facilityId, CancellationToken cancellationToken)
@@ -249,7 +285,7 @@ namespace LantanaGroup.Link.Tenant.Controllers
             }
             catch (ApplicationException ex)
             {
-                return BadRequest(ex.Message);
+                return BadRequestProblem(ex.Message);
             }
             catch (Exception ex)
             {
@@ -259,7 +295,7 @@ namespace LantanaGroup.Link.Tenant.Controllers
 
             if (facilityConfigModel == null)
             {
-                return NotFound();
+                return NotFoundProblem($"Facility with Id: {facilityId} Not Found");
             }
 
             return Ok(facilityConfigModel);
@@ -273,8 +309,8 @@ namespace LantanaGroup.Link.Tenant.Controllers
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
         [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(FacilityModel))]
-        [ProducesResponseType(StatusCodes.Status400BadRequest)]
-        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest, Type = typeof(ProblemDetails))]
+        [ProducesResponseType(StatusCodes.Status404NotFound, Type = typeof(ProblemDetails))]
         [ProducesResponseType(StatusCodes.Status500InternalServerError)]
         [HttpPut("{facilityId}")]
         public async Task<ActionResult<FacilityModel>> PutFacility(string facilityId, FacilityModel facilityConfig, CancellationToken cancellationToken)
@@ -289,7 +325,7 @@ namespace LantanaGroup.Link.Tenant.Controllers
             }
             catch (ApplicationException ex)
             {
-                return BadRequest(ex.Message);
+                return BadRequestProblem(ex.Message);
             }
             catch (Exception ex)
             {
@@ -299,7 +335,7 @@ namespace LantanaGroup.Link.Tenant.Controllers
 
             if (existingModel == null)
             {
-                return NotFound();
+                return NotFoundProblem($"Facility with Id: {facilityId} Not Found");
             }
 
             try
@@ -308,11 +344,11 @@ namespace LantanaGroup.Link.Tenant.Controllers
             }
             catch (ScheduledReportsNotAcceptedException ex)
             {
-                return BadRequest(ex.Message);
+                return BadRequestProblem(ex.Message);
             }
             catch (ApplicationException ex)
             {
-                return BadRequest(ex.Message);
+                return BadRequestProblem(ex.Message);
             }
             catch (Exception ex)
             {
@@ -332,8 +368,8 @@ namespace LantanaGroup.Link.Tenant.Controllers
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
         [ProducesResponseType(StatusCodes.Status204NoContent)]
-        [ProducesResponseType(StatusCodes.Status400BadRequest)]
-        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest, Type = typeof(ProblemDetails))]
+        [ProducesResponseType(StatusCodes.Status404NotFound, Type = typeof(ProblemDetails))]
         [ProducesResponseType(StatusCodes.Status500InternalServerError)]
         [HttpDelete("{facilityId}")]
         public async Task<IActionResult> DeleteFacility(string facilityId, CancellationToken cancellationToken)
@@ -344,7 +380,7 @@ namespace LantanaGroup.Link.Tenant.Controllers
 
             if (existingModel == null)
             {
-                return NotFound($"Facility with Id: {facilityId} Not Found");
+                return NotFoundProblem($"Facility with Id: {facilityId} Not Found");
             }
 
             try
@@ -353,7 +389,7 @@ namespace LantanaGroup.Link.Tenant.Controllers
             }
             catch (ApplicationException ex)
             {
-                return BadRequest(ex.Message);
+                return BadRequestProblem(ex.Message);
             }
             catch (Exception ex)
             {
@@ -366,8 +402,8 @@ namespace LantanaGroup.Link.Tenant.Controllers
 
         [HttpDelete("softDelete/{facilityId}")]
         [ProducesResponseType(StatusCodes.Status204NoContent)]
-        [ProducesResponseType(StatusCodes.Status400BadRequest)]
-        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest, Type = typeof(ProblemDetails))]
+        [ProducesResponseType(StatusCodes.Status404NotFound, Type = typeof(ProblemDetails))]
         [ProducesResponseType(StatusCodes.Status500InternalServerError)]
         public async Task<IActionResult> SoftDeleteFacility(string facilityId, CancellationToken cancellationToken)
         {
@@ -375,7 +411,7 @@ namespace LantanaGroup.Link.Tenant.Controllers
 
             var existingModel = await _facilityQueries.GetAsync(facilityId, null, cancellationToken, includeDeleted: true);
             if (existingModel == null)
-                return NotFound($"Facility with Id: {facilityId} Not Found");
+                return NotFoundProblem($"Facility with Id: {facilityId} Not Found");
 
             try
             {
@@ -383,7 +419,7 @@ namespace LantanaGroup.Link.Tenant.Controllers
             }
             catch (ApplicationException ex)
             {
-                return BadRequest(ex.Message);
+                return BadRequestProblem(ex.Message);
             }
             catch (Exception ex)
             {
@@ -402,8 +438,8 @@ namespace LantanaGroup.Link.Tenant.Controllers
         /// <returns></returns>
         [HttpPatch("restore/{facilityId}")]
         [ProducesResponseType(StatusCodes.Status204NoContent)]
-        [ProducesResponseType(StatusCodes.Status400BadRequest)]
-        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest, Type = typeof(ProblemDetails))]
+        [ProducesResponseType(StatusCodes.Status404NotFound, Type = typeof(ProblemDetails))]
         [ProducesResponseType(StatusCodes.Status500InternalServerError)]
         public async Task<IActionResult> RestoreFacility(string facilityId, CancellationToken cancellationToken)
         {
@@ -411,7 +447,7 @@ namespace LantanaGroup.Link.Tenant.Controllers
 
             var existingModel = await _facilityQueries.GetAsync(facilityId, null, cancellationToken, includeDeleted: true);
             if (existingModel == null)
-                return NotFound($"Facility with Id: {facilityId} Not Found");
+                return NotFoundProblem($"Facility with Id: {facilityId} Not Found");
 
             try
             {
@@ -419,7 +455,7 @@ namespace LantanaGroup.Link.Tenant.Controllers
             }
             catch (ApplicationException ex)
             {
-                return BadRequest(ex.Message);
+                return BadRequestProblem(ex.Message);
             }
             catch (Exception ex)
             {
@@ -437,39 +473,39 @@ namespace LantanaGroup.Link.Tenant.Controllers
         /// <param name="request"></param>
         /// <returns></returns>
         [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(GenerateAdhocReportResponse))]
-        [ProducesResponseType(StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest, Type = typeof(ProblemDetails))]
         [ProducesResponseType(StatusCodes.Status500InternalServerError)]
         [HttpPost("{facilityId}/AdHocReport")]
         public async Task<ActionResult<GenerateAdhocReportResponse>> GenerateAdHocReport(string facilityId, AdHocReportRequest request)
         {
             if (string.IsNullOrWhiteSpace(facilityId))
             {
-                return BadRequest("FacilityId must be provided.");
+                return BadRequestProblem("FacilityId must be provided.");
             }
 
             if (await _facilityQueries.GetAsync(facilityId, null, CancellationToken.None) == null)
             {
-                return NotFound("Facility does not exist.");
+                return NotFoundProblem("Facility does not exist.");
             }
 
             if (request.ReportTypes == null || request.ReportTypes.Count == 0)
             {
-                return BadRequest("ReportTypes must be provided.");
+                return BadRequestProblem("ReportTypes must be provided.");
             }
 
             if (request.StartDate == null || request.StartDate == DateTime.MinValue)
             {
-                return BadRequest("StartDate must be provided.");
+                return BadRequestProblem("StartDate must be provided.");
             }
 
             if (request.EndDate == null || request.EndDate == DateTime.MinValue)
             {
-                return BadRequest("EndDate must be provided.");
+                return BadRequestProblem("EndDate must be provided.");
             }
 
             if (request.EndDate <= request.StartDate)
             {
-                return BadRequest("EndDate must be after StartDate.");
+                return BadRequestProblem("EndDate must be after StartDate.");
             }
 
             var reportId = Guid.NewGuid();
@@ -534,25 +570,25 @@ namespace LantanaGroup.Link.Tenant.Controllers
         }
 
         [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(GenerateAdhocReportResponse))]
-        [ProducesResponseType(StatusCodes.Status400BadRequest)]
-        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest, Type = typeof(ProblemDetails))]
+        [ProducesResponseType(StatusCodes.Status404NotFound, Type = typeof(ProblemDetails))]
         [ProducesResponseType(StatusCodes.Status500InternalServerError)]
         [HttpPost("{facilityId}/RegenerateReport")]
         public async Task<ActionResult<GenerateAdhocReportResponse>> RegenerateReport(string facilityId, RegenerateReportRequest request)
         {
             if (string.IsNullOrWhiteSpace(facilityId))
             {
-                return BadRequest("FacilityId must be provided.");
+                return BadRequestProblem("FacilityId must be provided.");
             }
 
             if (await _facilityQueries.GetAsync(facilityId, null, CancellationToken.None) == null)
             {
-                return NotFound("Facility does not exist.");
+                return NotFoundProblem("Facility does not exist.");
             }
 
             if (string.IsNullOrEmpty(request.ReportId))
             {
-                return BadRequest("ReportId must be provided.");
+                return BadRequestProblem("ReportId must be provided.");
             }
 
             var reportId = Guid.NewGuid();
@@ -580,7 +616,7 @@ namespace LantanaGroup.Link.Tenant.Controllers
 
                 if (response.StatusCode == HttpStatusCode.NotFound)
                 {
-                    return NotFound($"Report schedule {request.ReportId} not found.");
+                    return NotFoundProblem($"Report schedule {request.ReportId} not found.");
                 }
 
                 if (!response.IsSuccessStatusCode)

--- a/DotNet/Tenant/Extensions/TenantProblemDetailsExtensions.cs
+++ b/DotNet/Tenant/Extensions/TenantProblemDetailsExtensions.cs
@@ -1,0 +1,86 @@
+﻿using LantanaGroup.Link.Tenant.Config;
+using System.Diagnostics;
+using System.Net;
+
+namespace LantanaGroup.Link.Tenant.Extensions
+{
+    /// <summary>
+    /// The RFC 9110 sections used as problem-detail <c>type</c> values.
+    /// </summary>
+    /// <remarks>
+    /// Named rather than inlined so the same status always carries the same type, matching
+    /// <c>DmrpProblemTypes</c> in MockDmrpApi.
+    /// </remarks>
+    internal static class TenantProblemTypes
+    {
+        public const string BadRequest = "https://tools.ietf.org/html/rfc9110#section-15.5.1";
+        public const string NotFound = "https://tools.ietf.org/html/rfc9110#section-15.5.5";
+        public const string InternalServerError = "https://tools.ietf.org/html/rfc9110#section-15.6.1";
+    }
+
+    /// <summary>
+    /// Problem-detail shaping, following the pattern Terminology and MockDmrpApi use.
+    /// </summary>
+    /// <remarks>
+    /// What this guarantees that <c>AddProblemDetails()</c> on its own does not:
+    /// <list type="bullet">
+    /// <item>A <c>traceId</c> on every problem response, so a report of "it returned 500" can be
+    /// traced without asking the reporter to reproduce it.</item>
+    /// <item>A <c>detail</c> on responses that would otherwise carry only a status code — a bare
+    /// 400 tells a caller nothing about which field was rejected.</item>
+    /// <item>No exception detail leaking outside development. A 500's detail is replaced wholesale
+    /// rather than filtered, so an exception message cannot reach a caller by accident.</item>
+    /// </list>
+    /// <para>
+    /// This only shapes responses that reach the problem-details pipeline. A controller that
+    /// returns a bare string — <c>BadRequest(ex.Message)</c> — bypasses it entirely and is written
+    /// out as <c>text/plain</c>, so the endpoints answer through the <c>*Problem</c> helpers on
+    /// <see cref="Controllers.FacilityController"/> rather than through <c>BadRequest</c>.
+    /// </para>
+    /// </remarks>
+    internal static class TenantProblemDetailsExtensions
+    {
+        internal static IServiceCollection AddTenantProblemDetails(
+            this IServiceCollection services,
+            IWebHostEnvironment environment,
+            bool includeExceptionDetails = false)
+        {
+            services.AddProblemDetails(options =>
+            {
+                options.CustomizeProblemDetails = ctx =>
+                {
+                    var statusCode = ctx.ProblemDetails.Status ?? ctx.HttpContext.Response.StatusCode;
+
+                    // A 500 may carry a raw exception message the caller should not see. Every
+                    // other status is framework- or controller-authored and already safe to show,
+                    // so only fall back to the generic text when nothing more specific was set.
+                    if (statusCode == (int)HttpStatusCode.InternalServerError
+                        || string.IsNullOrWhiteSpace(ctx.ProblemDetails.Detail))
+                    {
+                        ctx.ProblemDetails.Detail = "An error occured in our API. Please use the trace id when requesting assistence.";
+                    }
+
+                    if (!ctx.ProblemDetails.Extensions.ContainsKey("traceId"))
+                    {
+                        string? traceId = Activity.Current?.Id ?? ctx.HttpContext.TraceIdentifier;
+                        ctx.ProblemDetails.Extensions.Add(new KeyValuePair<string, object?>("traceId", traceId));
+                    }
+
+                    if (environment.IsDevelopment() || includeExceptionDetails)
+                    {
+                        // Indexer rather than Add: Add throws on a key that is already present, and
+                        // throwing while building an error response replaces a useful 400 with an
+                        // opaque 500.
+                        ctx.ProblemDetails.Extensions["service"] = TenantConstants.ServiceName;
+                    }
+                    else
+                    {
+                        ctx.ProblemDetails.Extensions.Remove("exception");
+                    }
+                };
+            });
+
+            return services;
+        }
+    }
+}

--- a/DotNet/Tenant/Program.cs
+++ b/DotNet/Tenant/Program.cs
@@ -1,5 +1,4 @@
-﻿using System.Diagnostics;
-using System.Reflection;
+﻿using System.Reflection;
 using Confluent.Kafka;
 using HealthChecks.UI.Client;
 using LantanaGroup.Link.Shared.Application.Extensions;
@@ -26,6 +25,7 @@ using LantanaGroup.Link.Tenant.Commands;
 using LantanaGroup.Link.Tenant.Config;
 using LantanaGroup.Link.Tenant.Data.Repository;
 using LantanaGroup.Link.Tenant.Entities;
+using LantanaGroup.Link.Tenant.Extensions;
 using LantanaGroup.Link.Tenant.Interfaces;
 using LantanaGroup.Link.Tenant.Jobs;
 using LantanaGroup.Link.Tenant.Models;
@@ -159,38 +159,7 @@ namespace Tenant
             builder.AddDmrpModule<TenantDbContext, TenantFacilityOperations>(mvcBuilder);
 
             //Add problem details
-            builder.Services.AddProblemDetails(options =>
-            {
-                options.CustomizeProblemDetails = ctx =>
-                {
-                    var statusCode = ctx.ProblemDetails.Status ?? ctx.HttpContext.Response.StatusCode;
-
-                    // A 500 may carry a raw exception message the caller should not see. Every
-                    // other status is framework- or controller-authored and already safe to show,
-                    // so only fall back to the generic text when nothing more specific was set
-                    // (matches the pattern Terminology and MockDmrpApi already use).
-                    if (statusCode == StatusCodes.Status500InternalServerError
-                        || string.IsNullOrWhiteSpace(ctx.ProblemDetails.Detail))
-                    {
-                        ctx.ProblemDetails.Detail = "An error occured in our API. Please use the trace id when requesting assistence.";
-                    }
-
-                    if (!ctx.ProblemDetails.Extensions.ContainsKey("traceId"))
-                    {
-                        string? traceId = Activity.Current?.Id ?? ctx.HttpContext.TraceIdentifier;
-                        ctx.ProblemDetails.Extensions.Add(new KeyValuePair<string, object?>("traceId", traceId));
-                    }
-
-                    if (builder.Environment.IsDevelopment())
-                    {
-                        ctx.ProblemDetails.Extensions.Add("service", "Tenant");
-                    }
-                    else
-                    {
-                        ctx.ProblemDetails.Extensions.Remove("exception");
-                    }
-                };
-            });
+            builder.Services.AddTenantProblemDetails(builder.Environment);
 
             //Add health checks
             var kafkaHealthOptions = new KafkaHealthCheckConfiguration(kafkaConnection, TenantConstants.ServiceName).GetHealthCheckOptions();
@@ -265,6 +234,22 @@ namespace Tenant
             app.Logger.LogInformation("DMRP module enabled: {DmrpEnabled}", dmrpSettings.Enabled);
 
             app.AutoMigrateEF<TenantDbContext>();
+
+            app.UseStatusCodePages();
+
+            // Without a handler an unhandled exception never reaches the problem-details
+            // pipeline, so it answers with an empty body instead of a traceable problem
+            // response. The developer page only outside deployment, as Terminology does: it
+            // renders the stack trace, which is what you want on a workstation and never what
+            // a caller should receive.
+            if (app.Environment.IsDevelopment())
+            {
+                app.UseDeveloperExceptionPage();
+            }
+            else
+            {
+                app.UseExceptionHandler();
+            }
 
             app.UseRouting();
             app.UseCors(CorsSettings.DefaultCorsPolicyName);


### PR DESCRIPTION
### 🛠️ Description of Changes

With DMRP enabled, a facility request carrying `scheduledReports` was refused with the right status and the right sentence, but the wrong shape. The endpoints answered client errors with `BadRequest(ex.Message)`, which passes a bare `string` — the client-error mapping does not convert it, so it left through `StringOutputFormatter` as `text/plain` with no `type`, `title` or `traceId`. The service's problem-details customization was never reached, which is why it looked like it was not working.

- Factor the `AddProblemDetails` block out of `Program.cs` into `TenantProblemDetailsExtensions`, alongside a `TenantProblemTypes` constants class, following the pattern `TerminologyProblemDetailsExtensions` and `DmrpProblemDetailsExtensions` already use. Behaviour is unchanged; the Development-only extension key stays `"service"`, and its `Add` becomes an indexer so a key already present cannot turn an error response into a 500.
- Add `TenantProblem`/`BadRequestProblem`/`NotFoundProblem` to `FacilityController` and route all 19 `BadRequest` and 6 `NotFound` returns through them. `detail` is trimmed and finished as a sentence, since validation messages are assembled with `AppendLine` and are also read from logs.
- Name the field on the three checks that answered bodyless, and on the two bodyless `NotFound()` returns in `GetFacility` and `PutFacility`.
- Validate that a timezone was supplied. An absent one reached `FindSystemTimeZoneById` as `""` or `null`, answering with `"Timezone Not Found: "` or, on an explicit `null`, a 500 from `ArgumentNullException`.
- Annotate the 400 and 404 responses with `ProblemDetails` so Swagger documents the shape callers now receive.
- Add `UseStatusCodePages` and the developer-page/exception-handler pair Tenant was alone in missing, so an unhandled exception reaches the problem-details pipeline instead of answering with an empty body.

Covers TestRail cases 11934, 11935, 11936 and 11938 (project 6 / suite 134 / section 3095). The three cases linked from the ticket — 11920, 11922, 11923 — were deleted and recreated on 2026-08-22; these are the live equivalents.

**Two notes for reviewers:**

1. `StoreFacility` now checks `FacilityId` before `FacilityName`, matching `ValidateFacility`'s order. This only changes which message you get when *both* are missing.
2. `UseStatusCodePages()` is the broadest change here — responses that previously went out bodyless (401s, unmatched-route 404s) will now carry a `ProblemDetails` body across the whole service. This matches Terminology and MockDmrpApi. Happy to drop it if you would rather keep this PR to the facility endpoints.

Separately: case 11938's step says `PUT /api/Facility` with no `{facilityId}` segment, which 405s regardless of this change. QA will need that corrected to `PUT /api/Facility/{facilityId}` before the fix is observable in that case.

### 🧪 Testing Performed

- `dotnet build link-cloud.sln` — clean, 0 errors.
- `dotnet test DotNet/ServiceTests/ServiceTests.csproj` — **2429 passed, 0 failed, 1 pre-existing skip.**
- The Tenant integration suite (`IntegrationTests.Tenant.FacilityControllerTests`, 19 tests) and the full `Category=IntegrationTests` run (622 passed) were both run against Docker.

Not verified against a deployed environment — the TestRail cases require `DMRP:Enabled=true` and `MockDmrpApi:Enabled=true` in TEST App Config.

### 🧑‍🔬 Unit Testing

- [x] I have written or updated unit tests to cover my changes
- Coverage: 30.4%

### 📓 Documentation Updated

No documentation changes. No new configuration keys, so `app-config.yaml` is unaffected. The endpoints' Swagger annotations are updated in place.

