### PR TITLE
LEGLINK-1068: Align ACH measure bundles and predict ABS from measure CQL

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -178,6 +178,7 @@ jobs:
           # name|category|trx-file
           TESTS=(
             "Adhoc Report|AdhocReportTest|adhoc-report-test-results.trx"
+            "Adhoc Report Daily ACH|AdhocReportDailyAchTest|adhoc-report-daily-ach-test-results.trx"
             "API Stability|ApiStabilityTest|api-stability-test-results.trx"
             "Automation UI API Smoke|AutomationUiSmokeTest|automation-ui-api-smoke-test-results.trx"
             "Report Scheduled|ReportScheduledTest|report-scheduled-test-results.trx"

--- a/DotNet/Automation.Link/README.md
+++ b/DotNet/Automation.Link/README.md
@@ -150,12 +150,9 @@ There is no tolerant `actual >= expected` mode. Pipeline-derived types (`Patient
 strict mode holds.
 
 Prediction is intentionally narrower than "generated and acquired". The manifest also applies
-CQL type reachability and resource-level SDE filtering from `Automation.CqlFilterSimulator`.
-This includes patient-context retrieval checks for referenced resources. For example, an
-acquired `Specimen` is only expected in ABS when the selected measure's SDE logic would return
-it for the evaluated patient: ACH Monthly requires patient-owned specimen collection overlap
-with IP, ACH Daily requires a qualifying respiratory-pathogen lab observation reference, and
-Hypoglycemic requires patient-owned collection fully during IP.
+CQL type reachability and resource-level SDE filtering from `Automation.CqlFilterSimulator`,
+which derives instance filters from the selected measure's embedded bundle CQL (not from a
+frozen measure-family profile).
 
 ### 5.2 Validators
 

--- a/DotNet/Automation.UI/README.md
+++ b/DotNet/Automation.UI/README.md
@@ -611,7 +611,7 @@ Why SSE here:
      - Data Acquisition org-location configuration for the run facility, and
      - generation/prediction modeling so expected ABS counts are org-scope aware.
    - `QueryPlanAcquisitionSimulator` runs per-patient with the resolved clinical period.
-   - `CqlFilterSimulator` runs per-patient over the patient's qualifying measures only.
+   - `CqlFilterSimulator` runs per-patient over the qualifying measures' embedded bundle CQL.
 3. **Initialize validation dependencies** -- validation artifacts and categories.
 4. **Load measure bundles** -- `MeasureLoader.LoadAllAsync()` (supports multi-measure).
 5. **Ensure tenant/pipeline setup** -- facility, normalization config, query plans/config,
@@ -651,8 +651,8 @@ with:
 - Organization Resource Map post-filtering over simulated acquired keys
   (`OrgResourceMapPredictionFilter`).
 - CQL-referenced resource types (`CqlResourceTypeExtractor`).
-- Per-resource CQL exclusions (`CqlFilterSimulator`, measure-family profiles, intersection
-  semantics across the patient's qualifying measures).
+- Per-resource CQL exclusions (`CqlFilterSimulator`, derived from embedded measure-bundle
+  CQL, intersection semantics across the patient's qualifying measures).
 
 That manifest is passed to `ReportAbsManifestValidator` and `ReportDatabaseValidator` for
 strict prediction-vs-actual comparison. Generation does not predict `OperationOutcome`.

--- a/DotNet/Automation.UI/README.md
+++ b/DotNet/Automation.UI/README.md
@@ -425,6 +425,7 @@ UI scenario and the backend test produces equivalent FHIR input:
 | System scenario | Seed | Patients | Resources |
 |---|---:|---:|---:|
 | Adhoc Report Test | 20260326 | 1 | 1000 |
+| Adhoc Report Daily ACH Test | 20260825 | 1 | 1000 |
 | Multi Patient Test | 20260328 | 150 | 25-50 |
 | Mega Patient Test | 20260327 | 1 | 5000 |
 | Mega Multi Patient Test | 20260330 | 150 | 5000 / 25-50 |

--- a/DotNet/Automation.UI/Services/ScenarioSeedService.cs
+++ b/DotNet/Automation.UI/Services/ScenarioSeedService.cs
@@ -23,9 +23,13 @@ public sealed class ScenarioSeedService : IHostedService
     private static readonly Guid MultiMeasureId = new("00000000-0000-0000-0000-000000000006");
     private static readonly Guid MegaMultiPatientId = new("00000000-0000-0000-0000-000000000007");
     private static readonly Guid ApiHealthScenarioId = new("00000000-0000-0000-0000-000000000008");
+    private static readonly Guid AdhocReportDailyAchTestId = new("00000000-0000-0000-0000-000000000009");
 
     private static readonly List<ProfiledMeasureType> DefaultMeasures =
         [ProfiledMeasureType.NhsnAcuteCareHospitalMonthlyInitialPopulation];
+
+    private static readonly List<ProfiledMeasureType> DailyAchMeasures =
+        [ProfiledMeasureType.NhsnAcuteCareHospitalDailyInitialPopulation];
 
     private const string AdhocReportTestNhsnOrganizationId = "10756";
     private const string ApiHealthScenarioNhsnOrganizationId = "10757";
@@ -35,6 +39,7 @@ public sealed class ScenarioSeedService : IHostedService
     private const string ScheduledReportTestNhsnOrganizationId = "10761";
     private const string RegenerateReportTestNhsnOrganizationId = "10762";
     private const string MultiMeasureTestNhsnOrganizationId = "10763";
+    private const string AdhocReportDailyAchTestNhsnOrganizationId = "10764";
 
     private static readonly List<string> DefaultEligibleScenarioIds =
         [.. ClinicalScenarioEligibility.GetEligibleScenarioIds(DefaultMeasures, MeasureEligibility.Qualifying)];
@@ -47,6 +52,12 @@ public sealed class ScenarioSeedService : IHostedService
 
     private static readonly Dictionary<ProfiledMeasureType, MeasureEligibility> DefaultNonQualifyingEligibilities =
         DefaultMeasures.ToDictionary(m => m, _ => MeasureEligibility.NonQualifying);
+
+    private static readonly List<string> DailyAchEligibleScenarioIds =
+        [.. ClinicalScenarioEligibility.GetEligibleScenarioIds(DailyAchMeasures, MeasureEligibility.Qualifying)];
+
+    private static readonly Dictionary<ProfiledMeasureType, MeasureEligibility> DailyAchQualifyingEligibilities =
+        DailyAchMeasures.ToDictionary(m => m, _ => MeasureEligibility.Qualifying);
 
     public ScenarioSeedService(IScenarioStore store, ILogger<ScenarioSeedService> logger)
     {
@@ -101,6 +112,38 @@ public sealed class ScenarioSeedService : IHostedService
                     PatientCount = 1,
                     MeasureEligibilities = new(DefaultQualifyingEligibilities),
                     EligibleClinicalScenarioIds = [..DefaultEligibleScenarioIds],
+                    ResourcesPerPatientMin = 1000,
+                    ResourcesPerPatientMax = 1000,
+                    ScheduledInpatientPattern = ScheduledInpatientPattern.AdmittedBeforePeriodRemainsInpatientAfterPeriod
+                }
+            ],
+            CleanupServiceData = false,
+            CleanupFhirData = true,
+        },
+
+        // --- Adhoc Report Daily ACH Test (ad-hoc, ACH Daily, 1 patient, 1000 resources) ---
+        new TestScenarioDefinition
+        {
+            Id = AdhocReportDailyAchTestId,
+            Name = "Adhoc Report Daily ACH Test",
+            Description = "Single patient ad-hoc report against ACH Daily. Mirrors the AdhocReportDailyAchTest backend E2E test.",
+            IsSystemScenario = true,
+            ReportMethod = ReportMethod.Adhoc,
+            SelectedMeasures = [..DailyAchMeasures],
+            NhsnOrganizationId = AdhocReportDailyAchTestNhsnOrganizationId,
+            Seed = 20260825,
+            PatientCount = 1,
+            ResourcesPerPatientMin = 1000,
+            ResourcesPerPatientMax = 1000,
+            ReportPeriodStart = new DateTimeOffset(2023, 1, 15, 0, 0, 0, TimeSpan.Zero),
+            ReportPeriodEnd = new DateTimeOffset(2023, 1, 15, 23, 59, 59, TimeSpan.Zero),
+            PatientCohorts =
+            [
+                new PatientCohortDefinition
+                {
+                    PatientCount = 1,
+                    MeasureEligibilities = new(DailyAchQualifyingEligibilities),
+                    EligibleClinicalScenarioIds = [..DailyAchEligibleScenarioIds],
                     ResourcesPerPatientMin = 1000,
                     ResourcesPerPatientMax = 1000,
                     ScheduledInpatientPattern = ScheduledInpatientPattern.AdmittedBeforePeriodRemainsInpatientAfterPeriod

--- a/DotNet/Automation/Generation/CqlFilterInputExtractor.cs
+++ b/DotNet/Automation/Generation/CqlFilterInputExtractor.cs
@@ -137,13 +137,34 @@ public static class CqlFilterInputExtractor
 
         var recordedDate = ParseFhirDateTime(cond.RecordedDate) ?? DateTime.MinValue;
         var encounterReference = cond.Encounter?.Reference ?? string.Empty;
+        DateTime onsetStart;
+        DateTime onsetEnd;
+        switch (cond.Onset)
+        {
+            case Period p:
+                onsetStart = ParseFhirDateTime(p.Start) ?? recordedDate;
+                onsetEnd = ParseFhirDateTime(p.End) ?? onsetStart;
+                break;
+            case FhirDateTime dt:
+                onsetStart = ParseFhirDateTime(dt.Value) ?? recordedDate;
+                onsetEnd = onsetStart;
+                break;
+            default:
+                onsetStart = recordedDate;
+                onsetEnd = recordedDate;
+                break;
+        }
 
         return new CqlFilterSimulator.ConditionContext(
             cond.Id,
             isActive,
             recordedDate.Date,
             encounterReference,
-            categories);
+            categories)
+        {
+            OnsetStart = onsetStart,
+            OnsetEnd = onsetEnd
+        };
     }
 
     private static DateTime? ParseFhirDateTime(string? s)
@@ -219,10 +240,21 @@ public static class CqlFilterInputExtractor
                 break;
         }
 
+        var categories = (report.Category ?? [])
+            .SelectMany(cat => cat.Coding ?? [])
+            .Select(c => c.Code)
+            .Where(code => !string.IsNullOrWhiteSpace(code))
+            .Select(code => code!)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
         return new CqlFilterSimulator.DiagnosticReportContext(
             report.Id,
             effectiveStart,
-            effectiveEnd);
+            effectiveEnd)
+        {
+            CategoryCodes = categories
+        };
     }
 
     // ---------- Procedure / MedicationRequest / MedicationAdministration / Coverage / ServiceRequest ----------
@@ -251,7 +283,10 @@ public static class CqlFilterInputExtractor
             proc.Id,
             performedStart,
             performedEnd,
-            proc.Encounter?.Reference ?? string.Empty);
+            proc.Encounter?.Reference ?? string.Empty)
+        {
+            Codes = ExtractCodeableConceptCodes(proc.Code)
+        };
     }
 
     private static CqlFilterSimulator.MedicationRequestContext BuildMedicationRequestContext(MedicationRequest mr)
@@ -260,7 +295,11 @@ public static class CqlFilterInputExtractor
         return new CqlFilterSimulator.MedicationRequestContext(
             mr.Id,
             authoredOn,
-            mr.Encounter?.Reference ?? string.Empty);
+            mr.Encounter?.Reference ?? string.Empty)
+        {
+            MedicationCodes = ExtractCodeableConceptCodes(mr.Medication as CodeableConcept),
+            Intent = mr.Intent?.ToString() ?? string.Empty
+        };
     }
 
     private static CqlFilterSimulator.MedicationAdministrationContext BuildMedicationAdministrationContext(MedicationAdministration ma)
@@ -287,7 +326,11 @@ public static class CqlFilterInputExtractor
             ma.Id,
             effectiveStart,
             effectiveEnd,
-            ma.Context?.Reference ?? string.Empty);
+            ma.Context?.Reference ?? string.Empty)
+        {
+            MedicationCodes = ExtractCodeableConceptCodes(ma.Medication as CodeableConcept),
+            Status = ma.Status?.ToString() ?? string.Empty
+        };
     }
 
     private static CqlFilterSimulator.CoverageContext BuildCoverageContext(Coverage cov)
@@ -306,7 +349,11 @@ public static class CqlFilterInputExtractor
         return new CqlFilterSimulator.ServiceRequestContext(
             sr.Id,
             authoredOn,
-            sr.Encounter?.Reference ?? string.Empty);
+            sr.Encounter?.Reference ?? string.Empty)
+        {
+            Codes = ExtractCodeableConceptCodes(sr.Code),
+            Intent = sr.Intent?.ToString() ?? string.Empty
+        };
     }
 
     private static CqlFilterSimulator.SpecimenContext BuildSpecimenContext(Specimen specimen)
@@ -336,5 +383,17 @@ public static class CqlFilterInputExtractor
         {
             SubjectReference = specimen.Subject?.Reference ?? string.Empty
         };
+    }
+
+    private static List<string> ExtractCodeableConceptCodes(CodeableConcept? concept)
+    {
+        if (concept?.Coding == null)
+            return [];
+        return concept.Coding
+            .Select(c => c.Code)
+            .Where(code => !string.IsNullOrWhiteSpace(code))
+            .Select(code => code!)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
     }
 }

--- a/DotNet/Automation/Generation/CqlFilterInputExtractor.cs
+++ b/DotNet/Automation/Generation/CqlFilterInputExtractor.cs
@@ -22,7 +22,8 @@ public static class CqlFilterInputExtractor
     /// </summary>
     public static CqlFilterSimulator.PatientCqlInput? ExtractFromEntries(
         string patientId,
-        IEnumerable<Bundle.EntryComponent> entries)
+        IEnumerable<Bundle.EntryComponent> entries,
+        IReadOnlyList<(string ResourceType, string ResourceId, string Key, JsonElement Resource)>? sharedResourceEntries = null)
     {
         var encounters = new List<Encounter>();
         var conditions = new List<Condition>();
@@ -34,6 +35,7 @@ public static class CqlFilterInputExtractor
         var coverages = new List<Coverage>();
         var serviceRequests = new List<ServiceRequest>();
         var specimens = new List<Specimen>();
+        var locations = new List<CqlFilterSimulator.LocationContext>();
 
         foreach (var entry in entries)
         {
@@ -69,7 +71,21 @@ public static class CqlFilterInputExtractor
                 case Specimen specimen:
                     specimens.Add(specimen);
                     break;
+                case Location location:
+                    locations.Add(new CqlFilterSimulator.LocationContext(location.Id ?? string.Empty));
+                    break;
             }
+        }
+
+        foreach (var loc in ExtractLocations(sharedResourceEntries))
+        {
+            if (locations.Any(existing =>
+                    string.Equals(existing.ResourceId, loc.ResourceId, StringComparison.OrdinalIgnoreCase)))
+            {
+                continue;
+            }
+
+            locations.Add(loc);
         }
 
         if (encounters.Count == 0)
@@ -109,8 +125,30 @@ public static class CqlFilterInputExtractor
             MedicationAdministrations = medicationAdministrationContexts,
             Coverages = coverageContexts,
             ServiceRequests = serviceRequestContexts,
-            Specimens = specimenContexts
+            Specimens = specimenContexts,
+            Locations = locations
         };
+    }
+
+    internal static List<CqlFilterSimulator.LocationContext> ExtractLocations(
+        IReadOnlyList<(string ResourceType, string ResourceId, string Key, JsonElement Resource)>? entries)
+    {
+        var locations = new List<CqlFilterSimulator.LocationContext>();
+        if (entries == null)
+            return locations;
+
+        foreach (var (resourceType, resourceId, _, _) in entries)
+        {
+            if (!string.Equals(resourceType, "Location", StringComparison.OrdinalIgnoreCase)
+                || string.IsNullOrWhiteSpace(resourceId))
+            {
+                continue;
+            }
+
+            locations.Add(new CqlFilterSimulator.LocationContext(resourceId));
+        }
+
+        return locations;
     }
 
     private static CqlFilterSimulator.EncounterContext BuildEncounterContext(Encounter enc)
@@ -119,7 +157,16 @@ public static class CqlFilterInputExtractor
         var end = ParseFhirDateTime(enc.Period?.End) ?? DateTime.MaxValue;
         var classCode = enc.Class?.Code ?? string.Empty;
         var status = enc.Status?.ToString() ?? string.Empty;
-        return new CqlFilterSimulator.EncounterContext(enc.Id ?? string.Empty, start, end, classCode, status);
+        var locationRefs = (enc.Location ?? [])
+            .Select(loc => loc.Location?.Reference)
+            .Where(reference => !string.IsNullOrWhiteSpace(reference))
+            .Select(reference => reference!)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+        return new CqlFilterSimulator.EncounterContext(enc.Id ?? string.Empty, start, end, classCode, status)
+        {
+            LocationReferences = locationRefs
+        };
     }
 
     private static CqlFilterSimulator.ConditionContext BuildConditionContext(Condition cond)

--- a/DotNet/Automation/Generation/CqlFilterSimulator.cs
+++ b/DotNet/Automation/Generation/CqlFilterSimulator.cs
@@ -458,6 +458,14 @@ public static class CqlFilterSimulator
         {
             case CqlInstanceFilterAnalyzer.DateRelation.None:
                 return true;
+            default:
+                if (start == DateTime.MinValue && end == DateTime.MaxValue)
+                    return false;
+                break;
+        }
+
+        switch (date)
+        {
             case CqlInstanceFilterAnalyzer.DateRelation.OverlapsIpPeriod:
                 return input.IpWindows.AnyOverlaps(start, end);
             case CqlInstanceFilterAnalyzer.DateRelation.DuringIpPeriod:

--- a/DotNet/Automation/Generation/CqlFilterSimulator.cs
+++ b/DotNet/Automation/Generation/CqlFilterSimulator.cs
@@ -251,6 +251,13 @@ public static class CqlFilterSimulator
                             included.Add($"Specimen/{s.ResourceId}");
                     }
                     break;
+                case "Location":
+                    foreach (var loc in input.Locations)
+                    {
+                        if (MatchesLocation(loc, rule, input))
+                            included.Add($"Location/{loc.ResourceId}");
+                    }
+                    break;
             }
         }
 
@@ -301,6 +308,7 @@ public static class CqlFilterSimulator
         "ServiceRequest" => input.ServiceRequests.Select(s => $"ServiceRequest/{s.ResourceId}").ToHashSet(StringComparer.OrdinalIgnoreCase),
         "Encounter" => EffectiveEncounters(input).Select(e => $"Encounter/{e.EncounterId}").ToHashSet(StringComparer.OrdinalIgnoreCase),
         "Specimen" => input.Specimens.Select(s => $"Specimen/{s.ResourceId}").ToHashSet(StringComparer.OrdinalIgnoreCase),
+        "Location" => input.Locations.Select(l => $"Location/{l.ResourceId}").ToHashSet(StringComparer.OrdinalIgnoreCase),
         _ => new HashSet<string>(StringComparer.OrdinalIgnoreCase)
     };
 
@@ -376,6 +384,29 @@ public static class CqlFilterSimulator
         return PassesCommon(rule, input, s.CollectionStart, s.CollectionEnd, null, categories: [], status: null, codes: []);
     }
 
+    private static bool MatchesLocation(LocationContext loc, CqlInstanceFilterAnalyzer.CqlInclusionRule rule, PatientCqlInput input)
+    {
+        if (rule.RequireIpExists && input.IpWindows.Count == 0)
+            return false;
+        if (!rule.LocationFromIpEncounterLocations)
+            return true;
+
+        var ipLocationIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var enc in EffectiveEncounters(input))
+        {
+            if (!input.IpWindows.AnyEncounterMatches(enc.EncounterId))
+                continue;
+            foreach (var reference in enc.LocationReferences)
+            {
+                var id = ReferenceId(reference);
+                if (!string.IsNullOrWhiteSpace(id))
+                    ipLocationIds.Add(id);
+            }
+        }
+
+        return ipLocationIds.Contains(loc.ResourceId);
+    }
+
     private static bool PassesCommon(
         CqlInstanceFilterAnalyzer.CqlInclusionRule rule,
         PatientCqlInput input,
@@ -390,6 +421,8 @@ public static class CqlFilterSimulator
         if (rule.RequireIpExists && input.IpWindows.Count == 0)
             return false;
         if (rule.CategoryAnyOf is { Count: > 0 } && !categories.Any(c => rule.CategoryAnyOf.Contains(c)))
+            return false;
+        if (rule.CategoryNoneOf is { Count: > 0 } && categories.Any(c => rule.CategoryNoneOf.Contains(c)))
             return false;
         if (rule.StatusAnyOf is { Count: > 0 }
             && (string.IsNullOrWhiteSpace(status)
@@ -468,6 +501,7 @@ public static class CqlFilterSimulator
         public IReadOnlyList<CoverageContext> Coverages { get; init; } = Array.Empty<CoverageContext>();
         public IReadOnlyList<ServiceRequestContext> ServiceRequests { get; init; } = Array.Empty<ServiceRequestContext>();
         public IReadOnlyList<SpecimenContext> Specimens { get; init; } = Array.Empty<SpecimenContext>();
+        public IReadOnlyList<LocationContext> Locations { get; init; } = Array.Empty<LocationContext>();
         public IReadOnlyList<EncounterContext> Encounters { get; init; } = Array.Empty<EncounterContext>();
         public DateTime MeasurementPeriodStart { get; init; } = DateTime.MinValue;
         public DateTime MeasurementPeriodEnd { get; init; } = DateTime.MaxValue;
@@ -480,7 +514,12 @@ public static class CqlFilterSimulator
         DateTime PeriodStart,
         DateTime PeriodEnd,
         string ClassCode,
-        string Status);
+        string Status)
+    {
+        public IReadOnlyList<string> LocationReferences { get; init; } = Array.Empty<string>();
+    }
+
+    public sealed record LocationContext(string ResourceId);
 
     public sealed record ConditionContext(
         string ResourceId,

--- a/DotNet/Automation/Generation/CqlFilterSimulator.cs
+++ b/DotNet/Automation/Generation/CqlFilterSimulator.cs
@@ -1,47 +1,21 @@
-﻿namespace LantanaGroup.Automation.Generation;
+namespace LantanaGroup.Automation.Generation;
 
 /// <summary>
-/// Simulates measure-specific CQL SDE <c>where</c>-clause filtering at the individual-resource level.
+/// Simulates measure CQL instance filtering at generation time by evaluating
+/// inclusion rules derived from the measure bundle CQL that MeasureEval will run.
 ///
-/// Type-level reachability (<c>[ResourceType]</c>) is handled elsewhere. This simulator focuses on
-/// per-resource exclusions where CQL retrieves a type but includes only rows matching additional
-/// predicates (status/date/category/reference constraints).
+/// Type-level reachability (<c>[ResourceType]</c>) is handled elsewhere. This
+/// simulator focuses on per-resource exclusions from SDE <c>where</c> predicates.
 ///
-/// Operates on <b>actual extracted resource attributes</b> (via <see cref="CqlFilterInputExtractor"/>)
-/// rather than seed replay, so it stays accurate even if generator internals drift.
+/// Operates on extracted resource attributes (<see cref="CqlFilterInputExtractor"/>).
 /// </summary>
 public static class CqlFilterSimulator
 {
-    private static readonly IReadOnlyList<ICqlFilterProfile> Profiles =
-    [
-        new AchConditionFilterProfile(),
-        new HypoglycemicConditionFilterProfile(),
-        new AchObservationFilterProfile(),
-        new HypoglycemicObservationFilterProfile(),
-        new AchDiagnosticReportFilterProfile(),
-        new AchProcedureFilterProfile(),
-        new AchHypoMedicationRequestFilterProfile(),
-        new HypoMedicationAdministrationFilterProfile(),
-        new AchHypoCoverageFilterProfile(),
-        new AchHypoServiceRequestFilterProfile(),
-        new AchEncounterFilterProfile(),
-        new AchMonthlySpecimenFilterProfile(),
-        new AchDailySpecimenFilterProfile(),
-        new HypoglycemicSpecimenFilterProfile()
-    ];
-
     /// <summary>
-    /// Computes resource keys CQL SDE <c>where</c> clauses will exclude for the patient.
-    ///
-    /// The intersection rule is applied <b>per resource type</b>: a key is excluded only when
-    /// every applicable profile that targets that resource type excludes it. Profiles for
-    /// other resource types do not participate in that intersection — an Observation profile
-    /// has no opinion about whether a Condition belongs in ABS, and vice-versa.
-    ///
-    /// MeasureEval evaluates each measure independently and writes one <c>.mr</c> file per
-    /// measure; PatientAggregator unions the contained resources across those files when
-    /// producing the patient NDJSON. So if any one applicable measure includes the resource,
-    /// it appears in ABS regardless of the others.
+    /// Computes resource keys the selected measures' CQL will exclude, using each
+    /// measure family's embedded bundle. Prefer
+    /// <see cref="ComputeFilteredKeys(IReadOnlyList{string}, PatientCqlInput)"/>
+    /// when the run has uploaded/edited measure JSON.
     /// </summary>
     public static HashSet<string> ComputeFilteredKeys(
         IReadOnlyList<ProfiledMeasureType> measures,
@@ -50,47 +24,82 @@ public static class CqlFilterSimulator
         if (measures == null || measures.Count == 0 || input == null)
             return new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
-        // Resolve the union of IP windows across all selected (qualifying) measures. Each
-        // profile then queries this set via IpWindowExtensions to model the CQL pattern
-        // "where exists IP InitialPopulation where Resource.X overlaps IP.period".
-        var ipWindows = MeasureInitialPopulationResolver.Resolve(measures, input);
+        var bundles = measures
+            .Select(measure => ProfiledMeasureCatalog.ReadBundleJson(measure))
+            .ToList();
+        return ComputeFilteredKeys(bundles, input);
+    }
 
-        // Back-compat: if the input was built via the legacy single-encounter positional
-        // ctor (no Encounters list), fall back to a single window from the EncounterId/
-        // Start/End triple. Pre-Landing-3 tests and the synthetic single-encounter
-        // generator path both rely on this.
-        if (ipWindows.Count == 0
-            && (input.Encounters == null || input.Encounters.Count == 0)
-            && !string.IsNullOrEmpty(input.EncounterId))
-        {
-            ipWindows = [new MeasureInitialPopulationResolver.IpWindow(input.EncounterId, input.EncounterStart, input.EncounterEnd)];
-        }
-
-        var enriched = input with { IpWindows = ipWindows };
+    /// <summary>
+    /// Computes resource keys CQL SDE <c>where</c> clauses will exclude, using the
+    /// actual measure bundle JSON evaluated for this run.
+    ///
+    /// Each bundle is analyzed independently (its own Initial Population and SDE
+    /// defines). A key is excluded only when every bundle that produces inclusion
+    /// rules for that resource type excludes it — matching MeasureEval writing one
+    /// <c>.mr</c> file per measure and PatientAggregator unioning contained resources.
+    /// </summary>
+    public static HashSet<string> ComputeFilteredKeys(
+        IReadOnlyList<string> measureBundleJsons,
+        PatientCqlInput input)
+    {
+        if (measureBundleJsons == null || measureBundleJsons.Count == 0 || input == null)
+            return new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
         var perTypeExclusions = new Dictionary<string, List<HashSet<string>>>(StringComparer.OrdinalIgnoreCase);
-        foreach (var profile in Profiles)
+
+        foreach (var json in measureBundleJsons)
         {
-            if (!profile.AppliesToAny(measures))
+            if (string.IsNullOrWhiteSpace(json))
                 continue;
 
-            if (!perTypeExclusions.TryGetValue(profile.TargetResourceType, out var bucket))
+            CqlInstanceFilterAnalyzer.MeasureFilterModel model;
+            try
             {
-                bucket = new List<HashSet<string>>();
-                perTypeExclusions[profile.TargetResourceType] = bucket;
+                model = CqlInstanceFilterAnalyzer.Analyze(json);
             }
-            bucket.Add(profile.ComputeExcludedKeys(enriched));
+            catch
+            {
+                continue;
+            }
+
+            if (model.Rules.Count == 0)
+                continue;
+
+            var ipWindows = ResolveIpWindows(model, input);
+            var enriched = input with { IpWindows = ipWindows };
+            var included = EvaluateIncludedKeys(model, enriched);
+
+            foreach (var group in model.Rules.GroupBy(r => r.ResourceType, StringComparer.OrdinalIgnoreCase))
+            {
+                var resourceType = group.Key;
+                var candidates = CandidateKeys(enriched, resourceType);
+                if (candidates.Count == 0)
+                    continue;
+
+                if (!perTypeExclusions.TryGetValue(resourceType, out var bucket))
+                {
+                    bucket = [];
+                    perTypeExclusions[resourceType] = bucket;
+                }
+
+                var excluded = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                foreach (var key in candidates)
+                {
+                    if (!included.Contains(key))
+                        excluded.Add(key);
+                }
+
+                bucket.Add(excluded);
+            }
         }
 
         var result = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         foreach (var bucket in perTypeExclusions.Values)
         {
-            // Intersect within a resource type: keep keys every applicable profile of that
-            // type excludes. Then union across types into the final excluded-key set.
             var intersection = new HashSet<string>(bucket[0], StringComparer.OrdinalIgnoreCase);
             for (var i = 1; i < bucket.Count; i++)
                 intersection.IntersectWith(bucket[i]);
-
             foreach (var key in intersection)
                 result.Add(key);
         }
@@ -98,21 +107,352 @@ public static class CqlFilterSimulator
         return result;
     }
 
-    /// <summary>
-    /// Extracted per-patient inputs used by the simulator.
-    /// Build via <see cref="CqlFilterInputExtractor"/>.
-    ///
-    /// New resource-type collections (Procedures / MedicationRequests / etc.) and
-    /// multi-encounter / measurement-period fields are exposed as <c>init</c> properties
-    /// with sensible defaults so older callers / tests using only the positional ctor for
-    /// Conditions + Observations continue to compile and behave the same.
-    ///
-    /// <list type="bullet">
-    ///   <item><see cref="Encounters"/> — ALL encounters extracted from the patient's data. The simulator's IP resolver consumes this list.</item>
-    ///   <item><see cref="MeasurementPeriodStart"/> / <see cref="MeasurementPeriodEnd"/> — when set, IP encounters must overlap this window. Default is open (MinValue/MaxValue) for back-compat.</item>
-    ///   <item><see cref="IpWindows"/> — populated by <see cref="ComputeFilteredKeys"/> before profiles run; never set by the extractor.</item>
-    /// </list>
-    /// </summary>
+    private static IReadOnlyList<MeasureInitialPopulationResolver.IpWindow> ResolveIpWindows(
+        CqlInstanceFilterAnalyzer.MeasureFilterModel model,
+        PatientCqlInput input)
+    {
+        if (input.Encounters == null || input.Encounters.Count == 0)
+        {
+            if (!string.IsNullOrEmpty(input.EncounterId))
+                return [new MeasureInitialPopulationResolver.IpWindow(input.EncounterId, input.EncounterStart, input.EncounterEnd)];
+            return [];
+        }
+
+        var windows = new List<MeasureInitialPopulationResolver.IpWindow>();
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var enc in input.Encounters)
+        {
+            if (enc == null || string.IsNullOrEmpty(enc.EncounterId))
+                continue;
+            if (!IsIpEncounter(enc, model, input))
+                continue;
+            if (!seen.Add(enc.EncounterId))
+                continue;
+            windows.Add(new MeasureInitialPopulationResolver.IpWindow(enc.EncounterId, enc.PeriodStart, enc.PeriodEnd));
+        }
+
+        return windows;
+    }
+
+    private static bool IsIpEncounter(
+        EncounterContext enc,
+        CqlInstanceFilterAnalyzer.MeasureFilterModel model,
+        PatientCqlInput input)
+    {
+        if (model.IpStatusCodes.Count > 0
+            && !model.IpStatusCodes.Contains(enc.Status)
+            && !StatusMatchesFhirEnum(enc.Status, model.IpStatusCodes))
+        {
+            return false;
+        }
+
+        var mpStart = input.MeasurementPeriodStart;
+        var mpEnd = input.MeasurementPeriodEnd;
+        if (!(mpStart == DateTime.MinValue && mpEnd == DateTime.MaxValue)
+            && !(enc.PeriodStart <= mpEnd && enc.PeriodEnd >= mpStart))
+        {
+            return false;
+        }
+
+        if (model.IpAllowsAnyClass || model.IpClassCodes.Count == 0)
+            return true;
+
+        return model.IpClassCodes.Contains(enc.ClassCode);
+    }
+
+    private static bool StatusMatchesFhirEnum(string status, IReadOnlySet<string> allowed)
+    {
+        foreach (var code in allowed)
+        {
+            if (string.Equals(status, code.Replace("-", string.Empty), StringComparison.OrdinalIgnoreCase))
+                return true;
+        }
+
+        return false;
+    }
+
+    private static HashSet<string> EvaluateIncludedKeys(
+        CqlInstanceFilterAnalyzer.MeasureFilterModel model,
+        PatientCqlInput input)
+    {
+        var included = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var rule in model.Rules.Where(r => !r.SpecimenFromMatchingObservations))
+        {
+            switch (rule.ResourceType)
+            {
+                case "Condition":
+                    foreach (var c in input.Conditions)
+                    {
+                        if (MatchesCondition(c, rule, input))
+                            included.Add($"Condition/{c.ResourceId}");
+                    }
+                    break;
+                case "Observation":
+                    foreach (var o in input.Observations)
+                    {
+                        if (MatchesObservation(o, rule, input))
+                            included.Add($"Observation/{o.ResourceId}");
+                    }
+                    break;
+                case "DiagnosticReport":
+                    foreach (var d in input.DiagnosticReports)
+                    {
+                        if (MatchesDiagnosticReport(d, rule, input))
+                            included.Add($"DiagnosticReport/{d.ResourceId}");
+                    }
+                    break;
+                case "Procedure":
+                    foreach (var p in input.Procedures)
+                    {
+                        if (MatchesProcedure(p, rule, input))
+                            included.Add($"Procedure/{p.ResourceId}");
+                    }
+                    break;
+                case "MedicationRequest":
+                    foreach (var m in input.MedicationRequests)
+                    {
+                        if (MatchesMedicationRequest(m, rule, input))
+                            included.Add($"MedicationRequest/{m.ResourceId}");
+                    }
+                    break;
+                case "MedicationAdministration":
+                    foreach (var m in input.MedicationAdministrations)
+                    {
+                        if (MatchesMedicationAdministration(m, rule, input))
+                            included.Add($"MedicationAdministration/{m.ResourceId}");
+                    }
+                    break;
+                case "Coverage":
+                    foreach (var c in input.Coverages)
+                    {
+                        if (MatchesCoverage(c, rule, input))
+                            included.Add($"Coverage/{c.ResourceId}");
+                    }
+                    break;
+                case "ServiceRequest":
+                    foreach (var s in input.ServiceRequests)
+                    {
+                        if (MatchesServiceRequest(s, rule, input))
+                            included.Add($"ServiceRequest/{s.ResourceId}");
+                    }
+                    break;
+                case "Encounter":
+                    foreach (var enc in EffectiveEncounters(input))
+                    {
+                        if (MatchesEncounter(enc, rule, input))
+                            included.Add($"Encounter/{enc.EncounterId}");
+                    }
+                    break;
+                case "Specimen":
+                    foreach (var s in input.Specimens)
+                    {
+                        if (MatchesSpecimen(s, rule, input))
+                            included.Add($"Specimen/{s.ResourceId}");
+                    }
+                    break;
+            }
+        }
+
+        foreach (var rule in model.Rules.Where(r => r.SpecimenFromMatchingObservations))
+        {
+            var sourceObs = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            foreach (var obsRule in rule.ObservationSourceRules)
+            {
+                foreach (var o in input.Observations)
+                {
+                    if (MatchesObservation(o, obsRule, input))
+                        sourceObs.Add(o.ResourceId);
+                }
+            }
+
+            if (sourceObs.Count == 0)
+                continue;
+
+            foreach (var o in input.Observations)
+            {
+                if (!sourceObs.Contains(o.ResourceId))
+                    continue;
+                var specimenId = ReferenceId(o.SpecimenReference);
+                if (string.IsNullOrWhiteSpace(specimenId))
+                    continue;
+                var specimen = input.Specimens.FirstOrDefault(s =>
+                    string.Equals(s.ResourceId, specimenId, StringComparison.OrdinalIgnoreCase));
+                if (specimen == null)
+                    continue;
+                if (rule.SubjectMustBePatient && !ReferencesPatient(specimen.SubjectReference, input.PatientId))
+                    continue;
+                included.Add($"Specimen/{specimen.ResourceId}");
+            }
+        }
+
+        return included;
+    }
+
+    private static HashSet<string> CandidateKeys(PatientCqlInput input, string resourceType) => resourceType switch
+    {
+        "Condition" => input.Conditions.Select(c => $"Condition/{c.ResourceId}").ToHashSet(StringComparer.OrdinalIgnoreCase),
+        "Observation" => input.Observations.Select(o => $"Observation/{o.ResourceId}").ToHashSet(StringComparer.OrdinalIgnoreCase),
+        "DiagnosticReport" => input.DiagnosticReports.Select(d => $"DiagnosticReport/{d.ResourceId}").ToHashSet(StringComparer.OrdinalIgnoreCase),
+        "Procedure" => input.Procedures.Select(p => $"Procedure/{p.ResourceId}").ToHashSet(StringComparer.OrdinalIgnoreCase),
+        "MedicationRequest" => input.MedicationRequests.Select(m => $"MedicationRequest/{m.ResourceId}").ToHashSet(StringComparer.OrdinalIgnoreCase),
+        "MedicationAdministration" => input.MedicationAdministrations.Select(m => $"MedicationAdministration/{m.ResourceId}").ToHashSet(StringComparer.OrdinalIgnoreCase),
+        "Coverage" => input.Coverages.Select(c => $"Coverage/{c.ResourceId}").ToHashSet(StringComparer.OrdinalIgnoreCase),
+        "ServiceRequest" => input.ServiceRequests.Select(s => $"ServiceRequest/{s.ResourceId}").ToHashSet(StringComparer.OrdinalIgnoreCase),
+        "Encounter" => EffectiveEncounters(input).Select(e => $"Encounter/{e.EncounterId}").ToHashSet(StringComparer.OrdinalIgnoreCase),
+        "Specimen" => input.Specimens.Select(s => $"Specimen/{s.ResourceId}").ToHashSet(StringComparer.OrdinalIgnoreCase),
+        _ => new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+    };
+
+    private static IEnumerable<EncounterContext> EffectiveEncounters(PatientCqlInput input)
+    {
+        if (input.Encounters != null && input.Encounters.Count > 0)
+            return input.Encounters;
+        if (!string.IsNullOrEmpty(input.EncounterId))
+            return [new EncounterContext(input.EncounterId, input.EncounterStart, input.EncounterEnd, string.Empty, "finished")];
+        return [];
+    }
+
+    private static bool MatchesCondition(ConditionContext c, CqlInstanceFilterAnalyzer.CqlInclusionRule rule, PatientCqlInput input)
+    {
+        var start = c.OnsetStart == default ? c.RecordedDate : c.OnsetStart;
+        var end = c.OnsetEnd == default ? start : c.OnsetEnd;
+        if (!PassesCommon(rule, input, start, end, c.EncounterReference, c.CategoryCodes, status: c.IsActive ? "active" : string.Empty, codes: []))
+            return false;
+        if (rule.RequireEncounterLinkedToIp && !input.IpWindows.AnyEncounterMatches(c.EncounterReference))
+            return false;
+        return true;
+    }
+
+    private static bool MatchesObservation(ObservationContext o, CqlInstanceFilterAnalyzer.CqlInclusionRule rule, PatientCqlInput input)
+        => PassesCommon(
+            rule,
+            input,
+            o.EffectiveStart,
+            o.EffectiveEnd,
+            encounterReference: null,
+            o.CategoryCodes,
+            o.Status,
+            codes: string.IsNullOrWhiteSpace(o.LoincCode) ? [] : [o.LoincCode]);
+
+    private static bool MatchesDiagnosticReport(DiagnosticReportContext d, CqlInstanceFilterAnalyzer.CqlInclusionRule rule, PatientCqlInput input)
+        => PassesCommon(rule, input, d.EffectiveStart, d.EffectiveEnd, null, d.CategoryCodes, status: null, codes: []);
+
+    private static bool MatchesProcedure(ProcedureContext p, CqlInstanceFilterAnalyzer.CqlInclusionRule rule, PatientCqlInput input)
+        => PassesCommon(rule, input, p.PerformedStart, p.PerformedEnd, p.EncounterReference, categories: [], status: null, p.Codes);
+
+    private static bool MatchesMedicationRequest(MedicationRequestContext m, CqlInstanceFilterAnalyzer.CqlInclusionRule rule, PatientCqlInput input)
+        => PassesCommon(rule, input, m.AuthoredOn, m.AuthoredOn, m.EncounterReference, categories: [], status: null, m.MedicationCodes, m.Intent);
+
+    private static bool MatchesMedicationAdministration(MedicationAdministrationContext m, CqlInstanceFilterAnalyzer.CqlInclusionRule rule, PatientCqlInput input)
+        => PassesCommon(rule, input, m.EffectiveStart, m.EffectiveEnd, m.EncounterReference, categories: [], m.Status, m.MedicationCodes);
+
+    private static bool MatchesCoverage(CoverageContext c, CqlInstanceFilterAnalyzer.CqlInclusionRule rule, PatientCqlInput input)
+        => PassesCommon(rule, input, c.PeriodStart, c.PeriodEnd, null, categories: [], status: null, codes: []);
+
+    private static bool MatchesServiceRequest(ServiceRequestContext s, CqlInstanceFilterAnalyzer.CqlInclusionRule rule, PatientCqlInput input)
+        => PassesCommon(rule, input, s.AuthoredOn, s.AuthoredOn, s.EncounterReference, categories: [], status: null, s.Codes, s.Intent);
+
+    private static bool MatchesEncounter(EncounterContext enc, CqlInstanceFilterAnalyzer.CqlInclusionRule rule, PatientCqlInput input)
+    {
+        if (rule.RequireIpExists && input.IpWindows.Count == 0)
+            return false;
+        if (rule.MustBeIpEncounter)
+            return input.IpWindows.AnyEncounterMatches(enc.EncounterId);
+        if (rule.Date is CqlInstanceFilterAnalyzer.DateRelation.OverlapsIpPeriod
+            or CqlInstanceFilterAnalyzer.DateRelation.DuringIpPeriod
+            or CqlInstanceFilterAnalyzer.DateRelation.None)
+        {
+            return input.IpWindows.AnyOverlaps(enc.PeriodStart, enc.PeriodEnd);
+        }
+
+        return PassesDate(rule.Date, enc.PeriodStart, enc.PeriodEnd, input);
+    }
+
+    private static bool MatchesSpecimen(SpecimenContext s, CqlInstanceFilterAnalyzer.CqlInclusionRule rule, PatientCqlInput input)
+    {
+        if (rule.SubjectMustBePatient && !ReferencesPatient(s.SubjectReference, input.PatientId))
+            return false;
+        return PassesCommon(rule, input, s.CollectionStart, s.CollectionEnd, null, categories: [], status: null, codes: []);
+    }
+
+    private static bool PassesCommon(
+        CqlInstanceFilterAnalyzer.CqlInclusionRule rule,
+        PatientCqlInput input,
+        DateTime start,
+        DateTime end,
+        string? encounterReference,
+        IReadOnlyList<string> categories,
+        string? status,
+        IReadOnlyList<string> codes,
+        string? intent = null)
+    {
+        if (rule.RequireIpExists && input.IpWindows.Count == 0)
+            return false;
+        if (rule.CategoryAnyOf is { Count: > 0 } && !categories.Any(c => rule.CategoryAnyOf.Contains(c)))
+            return false;
+        if (rule.StatusAnyOf is { Count: > 0 }
+            && (string.IsNullOrWhiteSpace(status)
+                || (!rule.StatusAnyOf.Contains(status) && !StatusMatchesFhirEnum(status, rule.StatusAnyOf))))
+        {
+            return false;
+        }
+
+        if (rule.IntentAnyOf is { Count: > 0 }
+            && (string.IsNullOrWhiteSpace(intent) || !rule.IntentAnyOf.Contains(intent)))
+        {
+            return false;
+        }
+
+        if (rule.CodeAnyOf is { Count: > 0 } && !codes.Any(c => rule.CodeAnyOf.Contains(c)))
+            return false;
+        if (rule.RequireEncounterLinkedToIp
+            && !input.IpWindows.AnyEncounterMatches(encounterReference))
+        {
+            return false;
+        }
+
+        return PassesDate(rule.Date, start, end, input);
+    }
+
+    private static bool PassesDate(
+        CqlInstanceFilterAnalyzer.DateRelation date,
+        DateTime start,
+        DateTime end,
+        PatientCqlInput input)
+    {
+        switch (date)
+        {
+            case CqlInstanceFilterAnalyzer.DateRelation.None:
+                return true;
+            case CqlInstanceFilterAnalyzer.DateRelation.OverlapsIpPeriod:
+                return input.IpWindows.AnyOverlaps(start, end);
+            case CqlInstanceFilterAnalyzer.DateRelation.DuringIpPeriod:
+                return input.IpWindows.AnyContains(start, end);
+            case CqlInstanceFilterAnalyzer.DateRelation.StartDuringIpPeriod:
+                return input.IpWindows.AnyContains(start);
+            case CqlInstanceFilterAnalyzer.DateRelation.DuringMeasurementPeriod:
+                return start >= input.MeasurementPeriodStart && end <= input.MeasurementPeriodEnd;
+            case CqlInstanceFilterAnalyzer.DateRelation.OverlapsMeasurementPeriod:
+                return start <= input.MeasurementPeriodEnd && end >= input.MeasurementPeriodStart;
+            case CqlInstanceFilterAnalyzer.DateRelation.CoverageActiveAtIpEnd:
+                return input.IpWindows.Any(w => start <= w.End && end >= w.End);
+            default:
+                return true;
+        }
+    }
+
+    private static string ReferenceId(string? reference)
+    {
+        if (string.IsNullOrWhiteSpace(reference)) return string.Empty;
+        var slash = reference.IndexOf('/');
+        return slash >= 0 ? reference[(slash + 1)..] : reference;
+    }
+
+    private static bool ReferencesPatient(string? reference, string patientId) =>
+        !string.IsNullOrWhiteSpace(patientId)
+        && string.Equals(ReferenceId(reference), patientId, StringComparison.OrdinalIgnoreCase);
+
     public sealed record PatientCqlInput(
         string PatientId,
         string EncounterId,
@@ -135,11 +475,6 @@ public static class CqlFilterSimulator
             = Array.Empty<MeasureInitialPopulationResolver.IpWindow>();
     }
 
-    /// <summary>
-    /// CQL-relevant attributes of a patient's encounter. <see cref="ClassCode"/> is the
-    /// FHIR <c>class.code</c> ('IMP', 'EMER', 'AMB', etc.) used by the IP resolver to
-    /// decide which encounters constitute the Initial Population for each measure.
-    /// </summary>
     public sealed record EncounterContext(
         string EncounterId,
         DateTime PeriodStart,
@@ -147,90 +482,6 @@ public static class CqlFilterSimulator
         string ClassCode,
         string Status);
 
-    public interface ICqlFilterProfile
-    {
-        /// <summary>
-        /// FHIR resource type this profile produces exclusions for (e.g. <c>Condition</c>,
-        /// <c>Observation</c>). Used by <see cref="ComputeFilteredKeys"/> to scope the
-        /// intersection rule to profiles that operate on the same resource type.
-        /// </summary>
-        string TargetResourceType { get; }
-
-        bool AppliesToAny(IReadOnlyList<ProfiledMeasureType> measures);
-        HashSet<string> ComputeExcludedKeys(PatientCqlInput input);
-    }
-
-    private abstract class ConditionFilterProfileBase : ICqlFilterProfile
-    {
-        public string TargetResourceType => "Condition";
-
-        public abstract bool AppliesToAny(IReadOnlyList<ProfiledMeasureType> measures);
-
-        protected abstract bool IncludeCondition(
-            ConditionContext c,
-            IReadOnlyList<MeasureInitialPopulationResolver.IpWindow> ipWindows);
-
-        public HashSet<string> ComputeExcludedKeys(PatientCqlInput input)
-        {
-            var excluded = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-            foreach (var c in input.Conditions)
-            {
-                if (!IncludeCondition(c, input.IpWindows))
-                    excluded.Add($"Condition/{c.ResourceId}");
-            }
-            return excluded;
-        }
-    }
-
-    /// <summary>
-    /// ACH Monthly + ACH Daily SDE Condition semantics:
-    /// - problem-list-item requires active + recordedDate strictly before the end of any IP encounter
-    /// - OR encounter-diagnosis/health-concern tied to ANY IP encounter
-    /// </summary>
-    private sealed class AchConditionFilterProfile : ConditionFilterProfileBase
-    {
-        public override bool AppliesToAny(IReadOnlyList<ProfiledMeasureType> measures) =>
-            measures.Contains(ProfiledMeasureType.NhsnAcuteCareHospitalMonthlyInitialPopulation)
-            || measures.Contains(ProfiledMeasureType.NhsnAcuteCareHospitalDailyInitialPopulation);
-
-        protected override bool IncludeCondition(ConditionContext c, IReadOnlyList<MeasureInitialPopulationResolver.IpWindow> ipWindows)
-        {
-            if (c.HasCategory("problem-list-item") && c.IsActive
-                && ipWindows.AnyEndStrictlyAfter(c.RecordedDate))
-            {
-                return true;
-            }
-
-            if ((c.HasCategory("encounter-diagnosis") || c.HasCategory("health-concern"))
-                && ipWindows.AnyEncounterMatches(c.EncounterReference))
-            {
-                return true;
-            }
-
-            return false;
-        }
-    }
-
-    /// <summary>
-    /// Hypoglycemic SDE Condition semantics:
-    /// - conditions whose recordedDate is on or before the end of ANY IP encounter are included
-    /// - no active-status constraint in this measure's SDE Condition define.
-    /// </summary>
-    private sealed class HypoglycemicConditionFilterProfile : ConditionFilterProfileBase
-    {
-        public override bool AppliesToAny(IReadOnlyList<ProfiledMeasureType> measures) =>
-            measures.Contains(ProfiledMeasureType.NhsnGlycemicControlHypoglycemicInitialPopulation);
-
-        protected override bool IncludeCondition(ConditionContext c, IReadOnlyList<MeasureInitialPopulationResolver.IpWindow> ipWindows)
-        {
-            return ipWindows.AnyEndOnOrAfter(c.RecordedDate);
-        }
-    }
-
-    /// <summary>
-    /// CQL-relevant attributes of a generated Condition resource.
-    /// Extracted from the actual generated FHIR content (no seed replay).
-    /// </summary>
     public sealed record ConditionContext(
         string ResourceId,
         bool IsActive,
@@ -238,20 +489,13 @@ public static class CqlFilterSimulator
         string EncounterReference,
         IReadOnlyList<string> CategoryCodes)
     {
+        public DateTime OnsetStart { get; init; }
+        public DateTime OnsetEnd { get; init; }
+
         public bool HasCategory(string code) =>
             CategoryCodes.Any(c => string.Equals(c, code, StringComparison.OrdinalIgnoreCase));
     }
 
-    // -------------------------------------------------------------------
-    //  Observation profiles
-    // -------------------------------------------------------------------
-
-    /// <summary>
-    /// CQL-relevant attributes of a generated Observation resource.
-    /// Extracted from the actual generated FHIR content (no seed replay).
-    /// <see cref="EffectiveStart"/> / <see cref="EffectiveEnd"/> normalize both
-    /// <c>effectiveDateTime</c> (start == end) and <c>effectivePeriod</c> shapes.
-    /// </summary>
     public sealed record ObservationContext(
         string ResourceId,
         string LoincCode,
@@ -265,196 +509,55 @@ public static class CqlFilterSimulator
         public bool HasCategory(string code) =>
             CategoryCodes.Any(c => string.Equals(c, code, StringComparison.OrdinalIgnoreCase));
 
-        /// <summary>
-        /// True when the observation's effective range overlaps the closed interval
-        /// [periodStart, periodEnd] using FHIR "overlaps" semantics.
-        /// </summary>
         public bool OverlapsPeriod(DateTime periodStart, DateTime periodEnd) =>
             EffectiveStart <= periodEnd && EffectiveEnd >= periodStart;
     }
 
-    private abstract class ObservationFilterProfileBase : ICqlFilterProfile
-    {
-        public string TargetResourceType => "Observation";
-
-        public abstract bool AppliesToAny(IReadOnlyList<ProfiledMeasureType> measures);
-
-        protected abstract bool IncludeObservation(
-            ObservationContext o,
-            IReadOnlyList<MeasureInitialPopulationResolver.IpWindow> ipWindows);
-
-        public HashSet<string> ComputeExcludedKeys(PatientCqlInput input)
-        {
-            var excluded = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-            foreach (var o in input.Observations)
-            {
-                if (!IncludeObservation(o, input.IpWindows))
-                    excluded.Add($"Observation/{o.ResourceId}");
-            }
-            return excluded;
-        }
-    }
-
-    /// <summary>
-    /// ACH Monthly + ACH Daily SDE Observation semantics:
-    /// <list type="bullet">
-    ///   <item>SDE Observation Lab Category: <c>category ~ "laboratory"</c> AND effective overlaps IP.</item>
-    ///   <item>SDE Observation Vital Signs Category: <c>category ~ "vital-signs"</c> AND effective overlaps IP.</item>
-    ///   <item>SDE Observation Category (catch-all): <c>category</c> in
-    ///         <c>{social-history, survey, imaging, procedure}</c> AND effective overlaps IP.</item>
-    /// </list>
-    /// IP for the simulator is approximated by the patient's encounter period, which is
-    /// how the generator places observations and how the measures' Initial Population
-    /// resolves for the synthetic patients (one qualifying encounter per patient).
-    /// </summary>
-    private sealed class AchObservationFilterProfile : ObservationFilterProfileBase
-    {
-        private static readonly HashSet<string> AchCategoryCodes = new(StringComparer.OrdinalIgnoreCase)
-        {
-            "laboratory",
-            "vital-signs",
-            "social-history",
-            "survey",
-            "imaging",
-            "procedure"
-        };
-
-        public override bool AppliesToAny(IReadOnlyList<ProfiledMeasureType> measures) =>
-            measures.Contains(ProfiledMeasureType.NhsnAcuteCareHospitalMonthlyInitialPopulation)
-            || measures.Contains(ProfiledMeasureType.NhsnAcuteCareHospitalDailyInitialPopulation);
-
-        protected override bool IncludeObservation(ObservationContext o, IReadOnlyList<MeasureInitialPopulationResolver.IpWindow> ipWindows)
-        {
-            if (!o.CategoryCodes.Any(c => AchCategoryCodes.Contains(c)))
-                return false;
-
-            return ipWindows.AnyOverlaps(o.EffectiveStart, o.EffectiveEnd);
-        }
-    }
-
-    /// <summary>
-    /// Hypoglycemic SDE Observation semantics:
-    /// <c>[Observation: "Blood Glucose Laboratory and Point of Care Tests"]</c> retrieve,
-    /// then <c>start of effective during InitialPopulation period</c>.
-    ///
-    /// Only blood-glucose lab/POC LOINCs are reachable; every other observation is dropped
-    /// by the value-set bound retrieve regardless of category or effective date.
-    /// The whitelist below is the subset of the measure's value set that the synthetic
-    /// generator currently emits; expanding the generator pool is the only thing that
-    /// would require expanding this whitelist.
-    /// </summary>
-    private sealed class HypoglycemicObservationFilterProfile : ObservationFilterProfileBase
-    {
-        private static readonly HashSet<string> BloodGlucoseLoincCodes = new(StringComparer.OrdinalIgnoreCase)
-        {
-            "2339-0",   // Glucose [Mass/volume] in Blood
-            "2345-7",   // Glucose [Mass/volume] in Serum or Plasma
-            "41653-7"   // Glucose [Mass/volume] in Capillary blood by Glucometer
-        };
-
-        public override bool AppliesToAny(IReadOnlyList<ProfiledMeasureType> measures) =>
-            measures.Contains(ProfiledMeasureType.NhsnGlycemicControlHypoglycemicInitialPopulation);
-
-        protected override bool IncludeObservation(ObservationContext o, IReadOnlyList<MeasureInitialPopulationResolver.IpWindow> ipWindows)
-        {
-            if (!BloodGlucoseLoincCodes.Contains(o.LoincCode))
-                return false;
-
-            // Hypoglycemic uses "start of effective during IP" — point-in-IP semantics.
-            return ipWindows.AnyContains(o.EffectiveStart);
-        }
-    }
-
-    // -------------------------------------------------------------------
-    //  DiagnosticReport profiles
-    // -------------------------------------------------------------------
-
-    /// <summary>
-    /// CQL-relevant attributes of a generated DiagnosticReport resource.
-    /// Effective start/end normalize both effectiveDateTime and effectivePeriod.
-    /// </summary>
     public sealed record DiagnosticReportContext(
         string ResourceId,
         DateTime EffectiveStart,
         DateTime EffectiveEnd)
     {
+        public IReadOnlyList<string> CategoryCodes { get; init; } = Array.Empty<string>();
+
         public bool OverlapsPeriod(DateTime periodStart, DateTime periodEnd) =>
             EffectiveStart <= periodEnd && EffectiveEnd >= periodStart;
     }
 
-    private abstract class DiagnosticReportFilterProfileBase : ICqlFilterProfile
-    {
-        public string TargetResourceType => "DiagnosticReport";
-        public abstract bool AppliesToAny(IReadOnlyList<ProfiledMeasureType> measures);
-        protected abstract bool IncludeDiagnosticReport(DiagnosticReportContext d, IReadOnlyList<MeasureInitialPopulationResolver.IpWindow> ipWindows);
-
-        public HashSet<string> ComputeExcludedKeys(PatientCqlInput input)
-        {
-            var excluded = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-            foreach (var d in input.DiagnosticReports)
-            {
-                if (!IncludeDiagnosticReport(d, input.IpWindows))
-                    excluded.Add($"DiagnosticReport/{d.ResourceId}");
-            }
-            return excluded;
-        }
-    }
-
-    /// <summary>
-    /// ACH Monthly + Daily SDE DiagnosticReport semantics:
-    /// include reports whose effective period overlaps any Initial Population encounter window.
-    /// </summary>
-    private sealed class AchDiagnosticReportFilterProfile : DiagnosticReportFilterProfileBase
-    {
-        public override bool AppliesToAny(IReadOnlyList<ProfiledMeasureType> measures) =>
-            measures.Contains(ProfiledMeasureType.NhsnAcuteCareHospitalMonthlyInitialPopulation)
-            || measures.Contains(ProfiledMeasureType.NhsnAcuteCareHospitalDailyInitialPopulation);
-
-        protected override bool IncludeDiagnosticReport(DiagnosticReportContext d, IReadOnlyList<MeasureInitialPopulationResolver.IpWindow> ipWindows) =>
-            ipWindows.AnyOverlaps(d.EffectiveStart, d.EffectiveEnd);
-    }
-
-    // -------------------------------------------------------------------
-    //  Procedure / MedicationRequest / MedicationAdministration / Coverage / ServiceRequest
-    //
-    //  These resource types are retrieved by SDE definitions in both ACH and Hypoglycemic
-    //  measures and are filtered against the Initial Population (IP) encounter's period.
-    //  Each profile iterates the resolved IpWindows, modeling the CQL pattern
-    //  "where exists IP InitialPopulation where Resource.X overlaps IP.period".
-    // -------------------------------------------------------------------
-
-    /// <summary>
-    /// CQL-relevant attributes of a Procedure resource. Performed start/end normalize both
-    /// <c>performedDateTime</c> (start == end) and <c>performedPeriod</c> shapes.
-    /// </summary>
     public sealed record ProcedureContext(
         string ResourceId,
         DateTime PerformedStart,
         DateTime PerformedEnd,
         string EncounterReference)
     {
+        public IReadOnlyList<string> Codes { get; init; } = Array.Empty<string>();
+
         public bool OverlapsPeriod(DateTime periodStart, DateTime periodEnd) =>
             PerformedStart <= periodEnd && PerformedEnd >= periodStart;
     }
 
-    /// <summary>CQL-relevant attributes of a MedicationRequest. <c>authoredOn</c> is the only date.</summary>
     public sealed record MedicationRequestContext(
         string ResourceId,
         DateTime AuthoredOn,
-        string EncounterReference);
+        string EncounterReference)
+    {
+        public IReadOnlyList<string> MedicationCodes { get; init; } = Array.Empty<string>();
+        public string Intent { get; init; } = string.Empty;
+    }
 
-    /// <summary>CQL-relevant attributes of a MedicationAdministration. <c>effective</c> normalizes both DateTime and Period shapes.</summary>
     public sealed record MedicationAdministrationContext(
         string ResourceId,
         DateTime EffectiveStart,
         DateTime EffectiveEnd,
         string EncounterReference)
     {
+        public IReadOnlyList<string> MedicationCodes { get; init; } = Array.Empty<string>();
+        public string Status { get; init; } = string.Empty;
+
         public bool OverlapsPeriod(DateTime periodStart, DateTime periodEnd) =>
             EffectiveStart <= periodEnd && EffectiveEnd >= periodStart;
     }
 
-    /// <summary>CQL-relevant attributes of a Coverage. <c>period</c> normalizes start/end with open-end support.</summary>
     public sealed record CoverageContext(
         string ResourceId,
         DateTime PeriodStart,
@@ -464,16 +567,15 @@ public static class CqlFilterSimulator
             PeriodStart <= periodEnd && PeriodEnd >= periodStart;
     }
 
-    /// <summary>CQL-relevant attributes of a ServiceRequest. <c>authoredOn</c> is the only date.</summary>
     public sealed record ServiceRequestContext(
         string ResourceId,
         DateTime AuthoredOn,
-        string EncounterReference);
+        string EncounterReference)
+    {
+        public IReadOnlyList<string> Codes { get; init; } = Array.Empty<string>();
+        public string Intent { get; init; } = string.Empty;
+    }
 
-    /// <summary>
-    /// CQL-relevant attributes of a Specimen. <c>collection.collected</c> normalizes both
-    /// DateTime and Period shapes.
-    /// </summary>
     public sealed record SpecimenContext(
         string ResourceId,
         DateTime CollectionStart,
@@ -483,315 +585,5 @@ public static class CqlFilterSimulator
 
         public bool OverlapsPeriod(DateTime periodStart, DateTime periodEnd) =>
             CollectionStart <= periodEnd && CollectionEnd >= periodStart;
-    }
-
-    // ----- Procedure profiles -----
-
-    private abstract class ProcedureFilterProfileBase : ICqlFilterProfile
-    {
-        public string TargetResourceType => "Procedure";
-        public abstract bool AppliesToAny(IReadOnlyList<ProfiledMeasureType> measures);
-        protected abstract bool IncludeProcedure(ProcedureContext p, IReadOnlyList<MeasureInitialPopulationResolver.IpWindow> ipWindows);
-
-        public HashSet<string> ComputeExcludedKeys(PatientCqlInput input)
-        {
-            var excluded = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-            foreach (var p in input.Procedures)
-            {
-                if (!IncludeProcedure(p, input.IpWindows))
-                    excluded.Add($"Procedure/{p.ResourceId}");
-            }
-            return excluded;
-        }
-    }
-
-    /// <summary>
-    /// ACH Monthly + Daily SDE Procedure: <c>Procedures.performed overlaps IP.period</c>
-    /// (overlap against ANY IP encounter window).
-    /// </summary>
-    private sealed class AchProcedureFilterProfile : ProcedureFilterProfileBase
-    {
-        public override bool AppliesToAny(IReadOnlyList<ProfiledMeasureType> measures) =>
-            measures.Contains(ProfiledMeasureType.NhsnAcuteCareHospitalMonthlyInitialPopulation)
-            || measures.Contains(ProfiledMeasureType.NhsnAcuteCareHospitalDailyInitialPopulation);
-
-        protected override bool IncludeProcedure(ProcedureContext p, IReadOnlyList<MeasureInitialPopulationResolver.IpWindow> ipWindows) =>
-            ipWindows.AnyOverlaps(p.PerformedStart, p.PerformedEnd);
-    }
-
-    // ----- MedicationRequest profiles -----
-
-    private abstract class MedicationRequestFilterProfileBase : ICqlFilterProfile
-    {
-        public string TargetResourceType => "MedicationRequest";
-        public abstract bool AppliesToAny(IReadOnlyList<ProfiledMeasureType> measures);
-        protected abstract bool IncludeMedicationRequest(MedicationRequestContext m, IReadOnlyList<MeasureInitialPopulationResolver.IpWindow> ipWindows);
-
-        public HashSet<string> ComputeExcludedKeys(PatientCqlInput input)
-        {
-            var excluded = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-            foreach (var m in input.MedicationRequests)
-            {
-                if (!IncludeMedicationRequest(m, input.IpWindows))
-                    excluded.Add($"MedicationRequest/{m.ResourceId}");
-            }
-            return excluded;
-        }
-    }
-
-    /// <summary>
-    /// ACH Monthly + Daily + Hypoglycemic SDE Medication Request:
-    /// <c>MedicationRequests.authoredOn during IP.period</c> (during ANY IP encounter window).
-    /// (Hypoglycemic actually uses <c>HospitalizationWithObservationOrEmergency(IP)</c> which
-    /// extends the window to include adjacent observation/ED encounters; approximated here
-    /// by relying on the union of IP windows the resolver returns.)
-    /// </summary>
-    private sealed class AchHypoMedicationRequestFilterProfile : MedicationRequestFilterProfileBase
-    {
-        public override bool AppliesToAny(IReadOnlyList<ProfiledMeasureType> measures) =>
-            measures.Contains(ProfiledMeasureType.NhsnAcuteCareHospitalMonthlyInitialPopulation)
-            || measures.Contains(ProfiledMeasureType.NhsnAcuteCareHospitalDailyInitialPopulation)
-            || measures.Contains(ProfiledMeasureType.NhsnGlycemicControlHypoglycemicInitialPopulation);
-
-        protected override bool IncludeMedicationRequest(MedicationRequestContext m, IReadOnlyList<MeasureInitialPopulationResolver.IpWindow> ipWindows) =>
-            ipWindows.AnyContains(m.AuthoredOn);
-    }
-
-    // ----- MedicationAdministration profiles -----
-
-    private abstract class MedicationAdministrationFilterProfileBase : ICqlFilterProfile
-    {
-        public string TargetResourceType => "MedicationAdministration";
-        public abstract bool AppliesToAny(IReadOnlyList<ProfiledMeasureType> measures);
-        protected abstract bool IncludeMedicationAdministration(MedicationAdministrationContext m, IReadOnlyList<MeasureInitialPopulationResolver.IpWindow> ipWindows);
-
-        public HashSet<string> ComputeExcludedKeys(PatientCqlInput input)
-        {
-            var excluded = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-            foreach (var m in input.MedicationAdministrations)
-            {
-                if (!IncludeMedicationAdministration(m, input.IpWindows))
-                    excluded.Add($"MedicationAdministration/{m.ResourceId}");
-            }
-            return excluded;
-        }
-    }
-
-    /// <summary>
-    /// Hypoglycemic SDE Medication Administration:
-    /// <c>MedicationAdministrations.effective overlaps HospitalizationWithObservationOrEmergency(IP)</c>.
-    /// Approximated as overlap with ANY IP encounter window. ACH measures do not retrieve
-    /// MedicationAdministration directly.
-    /// </summary>
-    private sealed class HypoMedicationAdministrationFilterProfile : MedicationAdministrationFilterProfileBase
-    {
-        public override bool AppliesToAny(IReadOnlyList<ProfiledMeasureType> measures) =>
-            measures.Contains(ProfiledMeasureType.NhsnGlycemicControlHypoglycemicInitialPopulation);
-
-        protected override bool IncludeMedicationAdministration(MedicationAdministrationContext m, IReadOnlyList<MeasureInitialPopulationResolver.IpWindow> ipWindows) =>
-            ipWindows.AnyOverlaps(m.EffectiveStart, m.EffectiveEnd);
-    }
-
-    // ----- Coverage profiles -----
-
-    private abstract class CoverageFilterProfileBase : ICqlFilterProfile
-    {
-        public string TargetResourceType => "Coverage";
-        public abstract bool AppliesToAny(IReadOnlyList<ProfiledMeasureType> measures);
-        protected abstract bool IncludeCoverage(CoverageContext c, IReadOnlyList<MeasureInitialPopulationResolver.IpWindow> ipWindows);
-
-        public HashSet<string> ComputeExcludedKeys(PatientCqlInput input)
-        {
-            var excluded = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-            foreach (var c in input.Coverages)
-            {
-                if (!IncludeCoverage(c, input.IpWindows))
-                    excluded.Add($"Coverage/{c.ResourceId}");
-            }
-            return excluded;
-        }
-    }
-
-    /// <summary>
-    /// ACH Monthly + Daily + Hypoglycemic SDE Coverage:
-    /// <c>Coverages.period overlaps IP.period</c> (overlap against ANY IP encounter window).
-    /// </summary>
-    private sealed class AchHypoCoverageFilterProfile : CoverageFilterProfileBase
-    {
-        public override bool AppliesToAny(IReadOnlyList<ProfiledMeasureType> measures) =>
-            measures.Contains(ProfiledMeasureType.NhsnAcuteCareHospitalMonthlyInitialPopulation)
-            || measures.Contains(ProfiledMeasureType.NhsnAcuteCareHospitalDailyInitialPopulation)
-            || measures.Contains(ProfiledMeasureType.NhsnGlycemicControlHypoglycemicInitialPopulation);
-
-        protected override bool IncludeCoverage(CoverageContext c, IReadOnlyList<MeasureInitialPopulationResolver.IpWindow> ipWindows) =>
-            ipWindows.AnyOverlaps(c.PeriodStart, c.PeriodEnd);
-    }
-
-    // ----- ServiceRequest profiles -----
-
-    private abstract class ServiceRequestFilterProfileBase : ICqlFilterProfile
-    {
-        public string TargetResourceType => "ServiceRequest";
-        public abstract bool AppliesToAny(IReadOnlyList<ProfiledMeasureType> measures);
-        protected abstract bool IncludeServiceRequest(ServiceRequestContext s, IReadOnlyList<MeasureInitialPopulationResolver.IpWindow> ipWindows);
-
-        public HashSet<string> ComputeExcludedKeys(PatientCqlInput input)
-        {
-            var excluded = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-            foreach (var s in input.ServiceRequests)
-            {
-                if (!IncludeServiceRequest(s, input.IpWindows))
-                    excluded.Add($"ServiceRequest/{s.ResourceId}");
-            }
-            return excluded;
-        }
-    }
-
-    /// <summary>
-    /// ACH Monthly + Daily + Hypoglycemic SDE Service Request:
-    /// <c>ServiceRequests.authoredOn during IP.period</c> (during ANY IP encounter window).
-    /// </summary>
-    private sealed class AchHypoServiceRequestFilterProfile : ServiceRequestFilterProfileBase
-    {
-        public override bool AppliesToAny(IReadOnlyList<ProfiledMeasureType> measures) =>
-            measures.Contains(ProfiledMeasureType.NhsnAcuteCareHospitalMonthlyInitialPopulation)
-            || measures.Contains(ProfiledMeasureType.NhsnAcuteCareHospitalDailyInitialPopulation)
-            || measures.Contains(ProfiledMeasureType.NhsnGlycemicControlHypoglycemicInitialPopulation);
-
-        protected override bool IncludeServiceRequest(ServiceRequestContext s, IReadOnlyList<MeasureInitialPopulationResolver.IpWindow> ipWindows) =>
-            ipWindows.AnyContains(s.AuthoredOn);
-    }
-
-    // ----- Encounter profile -----
-
-    private abstract class EncounterFilterProfileBase : ICqlFilterProfile
-    {
-        public string TargetResourceType => "Encounter";
-        public abstract bool AppliesToAny(IReadOnlyList<ProfiledMeasureType> measures);
-        protected abstract bool IncludeEncounter(EncounterContext enc, IReadOnlyList<MeasureInitialPopulationResolver.IpWindow> ipWindows);
-
-        public HashSet<string> ComputeExcludedKeys(PatientCqlInput input)
-        {
-            var excluded = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-            foreach (var enc in input.Encounters)
-            {
-                if (!IncludeEncounter(enc, input.IpWindows))
-                    excluded.Add($"Encounter/{enc.EncounterId}");
-            }
-            return excluded;
-        }
-    }
-
-    /// <summary>
-    /// ACH Monthly + Daily Encounter retrieval:
-    /// IP encounters (qualifying class within measurement period) plus SDE Encounter
-    /// (encounters NOT in IP whose period overlaps an IP encounter's period). Both
-    /// reduce to: <c>encounter.period overlaps ANY IP.period</c> — an IP encounter
-    /// trivially overlaps its own period, and SDE Encounter pulls in non-IP overlappers.
-    ///
-    /// Hypoglycemic only retrieves IP encounters (no SDE Encounter equivalent), so the
-    /// same predicate applies — non-IP-overlapping encounters are excluded for both.
-    /// </summary>
-    private sealed class AchEncounterFilterProfile : EncounterFilterProfileBase
-    {
-        public override bool AppliesToAny(IReadOnlyList<ProfiledMeasureType> measures) =>
-            measures.Contains(ProfiledMeasureType.NhsnAcuteCareHospitalMonthlyInitialPopulation)
-            || measures.Contains(ProfiledMeasureType.NhsnAcuteCareHospitalDailyInitialPopulation)
-            || measures.Contains(ProfiledMeasureType.NhsnGlycemicControlHypoglycemicInitialPopulation);
-
-        protected override bool IncludeEncounter(EncounterContext enc, IReadOnlyList<MeasureInitialPopulationResolver.IpWindow> ipWindows) =>
-            ipWindows.AnyOverlaps(enc.PeriodStart, enc.PeriodEnd);
-    }
-
-    // ----- Specimen profiles -----
-
-    private abstract class SpecimenFilterProfileBase : ICqlFilterProfile
-    {
-        public string TargetResourceType => "Specimen";
-        public abstract bool AppliesToAny(IReadOnlyList<ProfiledMeasureType> measures);
-        protected abstract bool IncludeSpecimen(SpecimenContext s, PatientCqlInput input);
-
-        public HashSet<string> ComputeExcludedKeys(PatientCqlInput input)
-        {
-            var excluded = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-            foreach (var s in input.Specimens)
-            {
-                if (!IncludeSpecimen(s, input))
-                    excluded.Add($"Specimen/{s.ResourceId}");
-            }
-            return excluded;
-        }
-
-        protected static string ReferenceId(string? reference)
-        {
-            if (string.IsNullOrWhiteSpace(reference)) return string.Empty;
-            var slash = reference.IndexOf('/');
-            return slash >= 0 ? reference[(slash + 1)..] : reference;
-        }
-
-        protected static bool ReferencesPatient(string? reference, string patientId) =>
-            !string.IsNullOrWhiteSpace(patientId)
-            && string.Equals(ReferenceId(reference), patientId, StringComparison.OrdinalIgnoreCase);
-    }
-
-    /// <summary>
-    /// ACH Monthly SDE Specimen: <c>Specimens.collection.collected overlaps IP.period</c>.
-    /// </summary>
-    private sealed class AchMonthlySpecimenFilterProfile : SpecimenFilterProfileBase
-    {
-        public override bool AppliesToAny(IReadOnlyList<ProfiledMeasureType> measures) =>
-            measures.Contains(ProfiledMeasureType.NhsnAcuteCareHospitalMonthlyInitialPopulation);
-
-        protected override bool IncludeSpecimen(SpecimenContext s, PatientCqlInput input) =>
-            ReferencesPatient(s.SubjectReference, input.PatientId)
-            && input.IpWindows.AnyOverlaps(s.CollectionStart, s.CollectionEnd);
-    }
-
-    /// <summary>
-    /// ACH Daily returns only specimens reached through respiratory pathogen lab observations
-    /// (COVID-19, influenza, or RSV value sets), not every generated or acquired Specimen.
-    /// </summary>
-    private sealed class AchDailySpecimenFilterProfile : SpecimenFilterProfileBase
-    {
-        private static readonly HashSet<string> RespiratoryPathogenObservationLoincCodes = new(StringComparer.OrdinalIgnoreCase)
-        {
-            "100343-3", "100344-1", "22825-4", "22827-0", "23769-3", "23781-8", "23782-6", "24015-0", "30075-6", "30076-4", "31858-4", "31859-2", "31860-0", "31863-4", "31864-2", "31949-1", "31950-9", "32040-8", "33045-6", "33535-6", "34487-9", "38270-5", "38271-3", "38272-1", "38381-0", "39025-2", "39102-9", "39103-7", "40982-1", "40987-0", "40988-8", "43874-7", "43895-2", "44263-2", "44264-0", "44265-7", "44266-5", "44558-5", "44559-3", "44560-1", "44561-9", "44562-7", "44563-5", "44564-3", "44566-8", "44567-6", "44571-8", "44572-6", "44573-4", "44574-2", "44575-9", "44576-7", "44577-5", "44795-3", "46082-4", "46083-2", "48509-4", "49521-8", "49524-2", "49528-3", "50329-2", "50700-4", "53250-7", "53251-5", "54240-7", "54243-1", "55463-4", "55464-2", "55465-9", "56024-3", "57985-4", "5860-2", "5861-0", "5862-8", "5863-6", "5864-4", "5865-1", "5866-9", "5867-7", "5874-3", "5875-0", "5876-8", "5877-6", "59423-4", "60538-6", "61101-2", "61102-0", "62462-7", "6435-2", "6436-0", "6437-8", "6438-6", "68966-1", "68986-9", "68987-7", "72356-9", "72365-0", "72366-8", "72367-6", "72885-7", "74038-1", "74039-9", "74040-7", "74784-0", "74785-7", "74786-5", "76077-7", "76078-5", "76079-3", "76080-1", "76088-4", "76089-2", "77022-2", "77023-0", "77026-3", "77027-1", "77028-9", "77383-8", "77384-6", "77389-5", "77390-3", "77605-4", "80382-5", "80383-3", "80588-7", "80589-5", "80590-3", "80591-1", "80597-8", "80598-6", "81305-5", "81307-1", "81308-9", "81309-7", "81320-4", "81321-2", "81325-3", "81327-9", "81428-5", "82166-0", "82167-8", "82168-6", "82169-4", "82170-2", "82176-9", "82461-5", "85477-8", "85478-6", "85479-4", "86317-5", "86565-9", "86568-3", "86569-1", "86571-7", "86572-5", "88187-0", "88193-8", "88194-6", "88195-3", "88202-7", "88204-3", "88528-5", "88592-1", "88595-4", "88596-2", "88597-0", "88599-6", "88600-2", "88835-4", "88904-8", "88905-5", "88909-7", "90886-3", "91072-9", "91133-9", "91771-6", "91794-8", "91795-5", "92131-2", "92141-1", "92142-9", "92808-5", "92809-3", "92957-0", "92976-0", "92977-8", "94307-6", "94308-4", "94309-2", "94310-0", "94311-8", "94312-6", "94313-4", "94314-2", "94315-9", "94316-7", "94394-4", "94395-1", "94396-9", "94500-6", "94502-2", "94509-7", "94510-5", "94511-3", "94532-9", "94533-7", "94534-5", "94558-4", "94559-2", "94565-9", "94639-2", "94640-0", "94641-8", "94642-6", "94643-4", "94644-2", "94645-9", "94646-7", "94647-5", "94660-8", "94745-7", "94746-5", "94756-4", "94757-2", "94758-0", "94759-8", "94760-6", "94765-5", "94766-3", "94767-1", "94819-0", "94822-4", "94845-5", "95209-3", "95406-5", "95409-9", "95424-8", "95425-5", "95521-1", "95522-9", "95608-6", "95609-4", "95658-1", "95823-1", "95824-9", "95970-0", "96091-4", "96119-3", "96120-1", "96121-9", "96122-7", "96123-5", "96448-6", "96756-2", "96757-0", "96763-8", "96764-6", "96765-3", "96797-6", "96898-2", "96899-0", "96900-6", "96957-6", "96958-4", "96986-5", "97097-0", "97098-8", "97104-4", "99623-1"
-        };
-
-        private static readonly HashSet<string> AllowedObservationStatuses = new(StringComparer.OrdinalIgnoreCase)
-        {
-            "final", "registered", "preliminary", "partial"
-        };
-
-        public override bool AppliesToAny(IReadOnlyList<ProfiledMeasureType> measures) =>
-            measures.Contains(ProfiledMeasureType.NhsnAcuteCareHospitalDailyInitialPopulation);
-
-        protected override bool IncludeSpecimen(SpecimenContext s, PatientCqlInput input)
-        {
-            if (input.IpWindows.Count == 0)
-                return false;
-
-            if (!ReferencesPatient(s.SubjectReference, input.PatientId))
-                return false;
-
-            return input.Observations.Any(o =>
-                string.Equals(ReferenceId(o.SpecimenReference), s.ResourceId, StringComparison.OrdinalIgnoreCase)
-                && o.HasCategory("laboratory")
-                && AllowedObservationStatuses.Contains(o.Status)
-                && RespiratoryPathogenObservationLoincCodes.Contains(o.LoincCode));
-        }
-    }
-
-    /// <summary>
-    /// Hypoglycemic SDE Specimen: <c>Specimens.collection.collected during IP.period</c>.
-    /// </summary>
-    private sealed class HypoglycemicSpecimenFilterProfile : SpecimenFilterProfileBase
-    {
-        public override bool AppliesToAny(IReadOnlyList<ProfiledMeasureType> measures) =>
-            measures.Contains(ProfiledMeasureType.NhsnGlycemicControlHypoglycemicInitialPopulation);
-
-        protected override bool IncludeSpecimen(SpecimenContext s, PatientCqlInput input) =>
-            ReferencesPatient(s.SubjectReference, input.PatientId)
-            && input.IpWindows.AnyContains(s.CollectionStart, s.CollectionEnd);
     }
 }

--- a/DotNet/Automation/Generation/CqlInstanceFilterAnalyzer.cs
+++ b/DotNet/Automation/Generation/CqlInstanceFilterAnalyzer.cs
@@ -44,6 +44,7 @@ internal static class CqlInstanceFilterAnalyzer
         ["SpecimenResource"] = "Specimen",
         ["DiagnosticReportLabResource"] = "DiagnosticReport",
         ["DiagnosticReportResource"] = "DiagnosticReport",
+        ["GetLocation"] = "Location",
         ["LocationResource"] = "Location",
         ["DeviceResource"] = "Device",
         ["PatientResource"] = "Patient",
@@ -62,6 +63,7 @@ internal static class CqlInstanceFilterAnalyzer
     {
         public string ResourceType { get; init; } = string.Empty;
         public HashSet<string>? CategoryAnyOf { get; init; }
+        public HashSet<string>? CategoryNoneOf { get; init; }
         public HashSet<string>? StatusAnyOf { get; init; }
         public HashSet<string>? IntentAnyOf { get; init; }
         public HashSet<string>? CodeAnyOf { get; init; }
@@ -69,6 +71,7 @@ internal static class CqlInstanceFilterAnalyzer
         public bool RequireIpExists { get; init; }
         public bool RequireEncounterLinkedToIp { get; init; }
         public bool MustBeIpEncounter { get; init; }
+        public bool LocationFromIpEncounterLocations { get; init; }
         public bool SubjectMustBePatient { get; init; }
         public bool SpecimenFromMatchingObservations { get; init; }
         public List<CqlInclusionRule> ObservationSourceRules { get; init; } = [];
@@ -145,6 +148,8 @@ internal static class CqlInstanceFilterAnalyzer
         var whereClause = CqlText.ExtractTopLevelWhere(body);
         var returnClause = CqlText.ExtractTopLevelReturn(body);
         var predicates = ParseWhere(model, whereClause);
+        if (LooksLikeLocationFromIpEncounter(body))
+            predicates.LocationFromIpEncounter = true;
         var returnType = InferReturnType(returnClause);
 
         if (LooksLikeSpecimenFromObservation(body, returnClause)
@@ -241,6 +246,7 @@ internal static class CqlInstanceFilterAnalyzer
         {
             ResourceType = returnType ?? source.ResourceType,
             CategoryAnyOf = IntersectOrReplace(source.CategoryAnyOf, predicates.CategoryAnyOf),
+            CategoryNoneOf = UnionOrReplace(source.CategoryNoneOf, predicates.CategoryNoneOf),
             StatusAnyOf = IntersectOrReplace(source.StatusAnyOf, predicates.StatusAnyOf),
             IntentAnyOf = IntersectOrReplace(source.IntentAnyOf, predicates.IntentAnyOf),
             CodeAnyOf = IntersectOrReplace(source.CodeAnyOf, predicates.CodeAnyOf),
@@ -248,6 +254,7 @@ internal static class CqlInstanceFilterAnalyzer
             RequireIpExists = source.RequireIpExists || predicates.RequireIpExists,
             RequireEncounterLinkedToIp = source.RequireEncounterLinkedToIp || predicates.RequireEncounterLinkedToIp,
             MustBeIpEncounter = source.MustBeIpEncounter,
+            LocationFromIpEncounterLocations = source.LocationFromIpEncounterLocations || predicates.LocationFromIpEncounter,
             SubjectMustBePatient = source.SubjectMustBePatient,
             SpecimenFromMatchingObservations = source.SpecimenFromMatchingObservations,
             ObservationSourceRules = source.ObservationSourceRules
@@ -265,6 +272,17 @@ internal static class CqlInstanceFilterAnalyzer
         return merged.Count == 0 ? extra : merged;
     }
 
+    private static HashSet<string>? UnionOrReplace(HashSet<string>? inherited, HashSet<string>? extra)
+    {
+        if (extra == null || extra.Count == 0)
+            return inherited;
+        if (inherited == null || inherited.Count == 0)
+            return extra;
+        var merged = new HashSet<string>(inherited, StringComparer.OrdinalIgnoreCase);
+        merged.UnionWith(extra);
+        return merged;
+    }
+
     private static HashSet<string>? UnionCodes(HashSet<string>? existing, IEnumerable<string> extra)
     {
         var set = existing ?? new HashSet<string>(StringComparer.OrdinalIgnoreCase);
@@ -280,12 +298,14 @@ internal static class CqlInstanceFilterAnalyzer
     private sealed class WherePredicates
     {
         public HashSet<string>? CategoryAnyOf { get; set; }
+        public HashSet<string>? CategoryNoneOf { get; set; }
         public HashSet<string>? StatusAnyOf { get; set; }
         public HashSet<string>? IntentAnyOf { get; set; }
         public HashSet<string>? CodeAnyOf { get; set; }
         public DateRelation Date { get; set; }
         public bool RequireIpExists { get; set; }
         public bool RequireEncounterLinkedToIp { get; set; }
+        public bool LocationFromIpEncounter { get; set; }
     }
 
     private static WherePredicates ParseWhere(CqlMeasureBundleModel model, string? whereClause)
@@ -308,17 +328,25 @@ internal static class CqlInstanceFilterAnalyzer
             result.RequireEncounterLinkedToIp = true;
         }
 
-        var categories = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var categoryAnyOf = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var categoryNoneOf = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var notSpans = FindNotSpans(text);
         foreach (Match match in Regex.Matches(
                      text,
                      @"\.category\b[\s\S]{0,160}~\s*""([^""]+)""",
                      RegexOptions.IgnoreCase))
         {
-            categories.Add(model.ResolveCode(match.Groups[1].Value));
+            var code = model.ResolveCode(match.Groups[1].Value);
+            if (notSpans.Any(span => match.Index >= span.Start && match.Index <= span.End))
+                categoryNoneOf.Add(code);
+            else
+                categoryAnyOf.Add(code);
         }
 
-        if (categories.Count > 0)
-            result.CategoryAnyOf = categories;
+        if (categoryAnyOf.Count > 0)
+            result.CategoryAnyOf = categoryAnyOf;
+        if (categoryNoneOf.Count > 0)
+            result.CategoryNoneOf = categoryNoneOf;
 
         var statusIn = StatusInPattern.Match(text);
         if (statusIn.Success)
@@ -403,6 +431,65 @@ internal static class CqlInstanceFilterAnalyzer
         }
 
         return null;
+    }
+
+    private static bool LooksLikeLocationFromIpEncounter(string body)
+    {
+        if (body.Contains("GetLocation", StringComparison.OrdinalIgnoreCase)
+            && (body.Contains("IP.location", StringComparison.Ordinal)
+                || body.Contains("locationElements", StringComparison.OrdinalIgnoreCase)
+                || body.Contains("InitialPopulation.location", StringComparison.OrdinalIgnoreCase)
+                || (body.Contains("\"Initial Population\"", StringComparison.Ordinal)
+                    && body.Contains(".location", StringComparison.OrdinalIgnoreCase))))
+        {
+            return true;
+        }
+
+        return Regex.IsMatch(
+            body,
+            @"Get Locations from (IP|Initial Population)",
+            RegexOptions.IgnoreCase);
+    }
+
+    private static List<(int Start, int End)> FindNotSpans(string text)
+    {
+        var spans = new List<(int Start, int End)>();
+        for (var i = 0; i < text.Length; i++)
+        {
+            if (!CqlText.IsKeywordAt(text, i, "not"))
+                continue;
+
+            var j = i + 3;
+            while (j < text.Length && char.IsWhiteSpace(text[j]))
+                j++;
+            if (j >= text.Length || text[j] != '(')
+                continue;
+
+            var end = MatchingCloseParen(text, j);
+            if (end > j)
+                spans.Add((j, end));
+            i = j;
+        }
+
+        return spans;
+    }
+
+    private static int MatchingCloseParen(string text, int openIndex)
+    {
+        var depth = 0;
+        for (var i = openIndex; i < text.Length; i++)
+        {
+            if (text[i] == '(')
+                depth++;
+            else if (text[i] == ')')
+            {
+                depth--;
+                if (depth == 0)
+                    return i;
+            }
+        }
+
+        return -1;
     }
 
     private static bool LooksLikeSpecimenFromObservation(string body, string? returnClause)

--- a/DotNet/Automation/Generation/CqlInstanceFilterAnalyzer.cs
+++ b/DotNet/Automation/Generation/CqlInstanceFilterAnalyzer.cs
@@ -1,0 +1,494 @@
+using System.Text.RegularExpressions;
+
+namespace LantanaGroup.Automation.Generation;
+
+/// <summary>
+/// Derives per-resource inclusion rules from a measure bundle's CQL SDE/population
+/// defines. Used at generation time so ABS prediction follows the CQL that will
+/// actually run in MeasureEval, not a frozen measure-family profile.
+/// </summary>
+internal static class CqlInstanceFilterAnalyzer
+{
+    private static readonly Regex RetrievePattern = new(
+        """\[\s*([A-Z][A-Za-z]+)\s*(?:\]|:\s*(?:class\s+in\s+"([^"]+)"|class\s+~\s*"([^"]+)"|class\s+in\s*\{([^}]+)\}|"([^"]+)"))""",
+        RegexOptions.Compiled);
+
+    private static readonly Regex NamedDefineRefPattern = new(
+        """^\s*"([^"]+)"(?:\s+[A-Za-z_][A-Za-z0-9_]*)?""",
+        RegexOptions.Compiled);
+
+    private static readonly Regex QuotedPattern = new("\"([^\"]+)\"", RegexOptions.Compiled);
+    private static readonly Regex SingleQuotedPattern = new("'([^']+)'", RegexOptions.Compiled);
+    private static readonly Regex StatusInPattern = new(
+        """status\s+in\s*\{([^}]+)\}""",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase);
+    private static readonly Regex StatusTildePattern = new(
+        """status\s*~\s*'([^']+)'""",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase);
+    private static readonly Regex IntentTildePattern = new(
+        """intent\s*~\s*'([^']+)'""",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
+    private static readonly Dictionary<string, string> ReturnFunctionToType = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ["ConditionResource"] = "Condition",
+        ["ObservationLabResource"] = "Observation",
+        ["ObservationVitalSignsResource"] = "Observation",
+        ["ObservationResource"] = "Observation",
+        ["EncounterResource"] = "Encounter",
+        ["CoverageResource"] = "Coverage",
+        ["ProcedureResource"] = "Procedure",
+        ["MedicationRequestResource"] = "MedicationRequest",
+        ["MedicationAdministrationResource"] = "MedicationAdministration",
+        ["ServiceRequestResource"] = "ServiceRequest",
+        ["SpecimenResource"] = "Specimen",
+        ["DiagnosticReportLabResource"] = "DiagnosticReport",
+        ["DiagnosticReportResource"] = "DiagnosticReport",
+        ["LocationResource"] = "Location",
+        ["DeviceResource"] = "Device",
+        ["PatientResource"] = "Patient",
+        ["MedicationResource"] = "Medication"
+    };
+
+    public sealed class MeasureFilterModel
+    {
+        public IReadOnlyList<CqlInclusionRule> Rules { get; init; } = [];
+        public IReadOnlySet<string> IpClassCodes { get; init; } = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        public IReadOnlySet<string> IpStatusCodes { get; init; } = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        public bool IpAllowsAnyClass { get; init; }
+    }
+
+    public sealed class CqlInclusionRule
+    {
+        public string ResourceType { get; init; } = string.Empty;
+        public HashSet<string>? CategoryAnyOf { get; init; }
+        public HashSet<string>? StatusAnyOf { get; init; }
+        public HashSet<string>? IntentAnyOf { get; init; }
+        public HashSet<string>? CodeAnyOf { get; init; }
+        public DateRelation Date { get; init; }
+        public bool RequireIpExists { get; init; }
+        public bool RequireEncounterLinkedToIp { get; init; }
+        public bool MustBeIpEncounter { get; init; }
+        public bool SubjectMustBePatient { get; init; }
+        public bool SpecimenFromMatchingObservations { get; init; }
+        public List<CqlInclusionRule> ObservationSourceRules { get; init; } = [];
+    }
+
+    public enum DateRelation
+    {
+        None,
+        OverlapsIpPeriod,
+        DuringIpPeriod,
+        StartDuringIpPeriod,
+        DuringMeasurementPeriod,
+        OverlapsMeasurementPeriod,
+        CoverageActiveAtIpEnd
+    }
+
+    public static MeasureFilterModel Analyze(string bundleJson)
+    {
+        var model = CqlMeasureBundleModel.Parse(bundleJson);
+        var reachable = model.ResolveReachableDefines();
+        var rules = new List<CqlInclusionRule>();
+        foreach (var name in reachable)
+        {
+            if (!model.RootExpressionNames.Contains(name))
+                continue;
+            // Population criteria (Initial Population) retrieve Encounters for membership.
+            // ABS instance prediction follows SDE defines that return resources into contained.
+            if (!name.StartsWith("SDE", StringComparison.OrdinalIgnoreCase))
+                continue;
+            rules.AddRange(AnalyzeDefine(model, name, new HashSet<string>(StringComparer.Ordinal)));
+        }
+
+        var (ipClasses, ipStatuses, ipAnyClass) = ExtractIpConstraints(model);
+        return new MeasureFilterModel
+        {
+            Rules = rules,
+            IpClassCodes = ipClasses,
+            IpStatusCodes = ipStatuses,
+            IpAllowsAnyClass = ipAnyClass
+        };
+    }
+
+    private static List<CqlInclusionRule> AnalyzeDefine(
+        CqlMeasureBundleModel model,
+        string name,
+        HashSet<string> visiting)
+    {
+        if (!visiting.Add(name))
+            return [];
+        if (!model.Defines.TryGetValue(name, out var body))
+            return [];
+
+        var parts = CqlText.SplitTopLevelUnion(CqlText.UnwrapOuterParens(body)).ToList();
+        if (parts.Count > 1)
+        {
+            var unionRules = new List<CqlInclusionRule>();
+            foreach (var part in parts)
+                unionRules.AddRange(AnalyzeFragment(model, part, visiting));
+            visiting.Remove(name);
+            return unionRules;
+        }
+
+        var result = AnalyzeFragment(model, body, visiting);
+        visiting.Remove(name);
+        return result;
+    }
+
+    private static List<CqlInclusionRule> AnalyzeFragment(
+        CqlMeasureBundleModel model,
+        string fragment,
+        HashSet<string> visiting)
+    {
+        var body = CqlText.UnwrapOuterParens(fragment);
+        var whereClause = CqlText.ExtractTopLevelWhere(body);
+        var returnClause = CqlText.ExtractTopLevelReturn(body);
+        var predicates = ParseWhere(model, whereClause);
+        var returnType = InferReturnType(returnClause);
+
+        if (LooksLikeSpecimenFromObservation(body, returnClause)
+            || string.Equals(returnType, "Specimen", StringComparison.OrdinalIgnoreCase)
+               && body.Contains("GetSpecimen", StringComparison.OrdinalIgnoreCase))
+        {
+            var sourceName = FirstNamedDefineReference(body);
+            var observationRules = sourceName != null
+                ? AnalyzeDefine(model, sourceName, visiting)
+                : [];
+            return
+            [
+                new CqlInclusionRule
+                {
+                    ResourceType = "Specimen",
+                    SubjectMustBePatient = true,
+                    SpecimenFromMatchingObservations = true,
+                    ObservationSourceRules = observationRules.Where(r =>
+                        string.Equals(r.ResourceType, "Observation", StringComparison.OrdinalIgnoreCase)).ToList(),
+                    RequireIpExists = predicates.RequireIpExists
+                }
+            ];
+        }
+
+        var named = FirstNamedDefineReference(body);
+        if (named != null && model.Defines.ContainsKey(named))
+        {
+            if (string.Equals(named, "Initial Population", StringComparison.Ordinal)
+                && string.Equals(returnType ?? "Encounter", "Encounter", StringComparison.OrdinalIgnoreCase))
+            {
+                return
+                [
+                    Merge(new CqlInclusionRule
+                    {
+                        ResourceType = "Encounter",
+                        MustBeIpEncounter = true,
+                        RequireIpExists = true
+                    }, predicates, returnType)
+                ];
+            }
+
+            var inherited = AnalyzeDefine(model, named, visiting);
+            if (inherited.Count > 0)
+                return inherited.Select(rule => Merge(rule, predicates, returnType)).ToList();
+        }
+
+        var rules = new List<CqlInclusionRule>();
+        foreach (Match retrieve in RetrievePattern.Matches(body))
+        {
+            var resourceType = retrieve.Groups[1].Value;
+            HashSet<string>? codes = null;
+            var vsName = FirstNonEmpty(retrieve.Groups[2].Value, retrieve.Groups[5].Value);
+            if (!string.IsNullOrWhiteSpace(vsName))
+            {
+                codes = model.CodesForValueSet(vsName)
+                        ?? new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "__unresolved-valueset__" };
+            }
+
+            var classTilde = retrieve.Groups[3].Value;
+            if (!string.IsNullOrWhiteSpace(classTilde))
+                codes = UnionCodes(codes, [model.ResolveCode(classTilde)]);
+
+            var classSet = retrieve.Groups[4].Value;
+            if (!string.IsNullOrWhiteSpace(classSet))
+            {
+                var setCodes = QuotedPattern.Matches(classSet)
+                    .Select(m => model.ResolveCode(m.Groups[1].Value));
+                codes = UnionCodes(codes, setCodes);
+            }
+
+            rules.Add(Merge(new CqlInclusionRule
+            {
+                ResourceType = resourceType,
+                CodeAnyOf = codes,
+                SubjectMustBePatient = string.Equals(resourceType, "Specimen", StringComparison.OrdinalIgnoreCase)
+            }, predicates, returnType ?? resourceType));
+        }
+
+        if (rules.Count == 0 && !string.IsNullOrWhiteSpace(returnType))
+        {
+            rules.Add(Merge(new CqlInclusionRule
+            {
+                ResourceType = returnType,
+                SubjectMustBePatient = string.Equals(returnType, "Specimen", StringComparison.OrdinalIgnoreCase)
+            }, predicates, returnType));
+        }
+
+        return rules;
+    }
+
+    private static CqlInclusionRule Merge(CqlInclusionRule source, WherePredicates predicates, string? returnType)
+    {
+        return new CqlInclusionRule
+        {
+            ResourceType = returnType ?? source.ResourceType,
+            CategoryAnyOf = IntersectOrReplace(source.CategoryAnyOf, predicates.CategoryAnyOf),
+            StatusAnyOf = IntersectOrReplace(source.StatusAnyOf, predicates.StatusAnyOf),
+            IntentAnyOf = IntersectOrReplace(source.IntentAnyOf, predicates.IntentAnyOf),
+            CodeAnyOf = IntersectOrReplace(source.CodeAnyOf, predicates.CodeAnyOf),
+            Date = predicates.Date != DateRelation.None ? predicates.Date : source.Date,
+            RequireIpExists = source.RequireIpExists || predicates.RequireIpExists,
+            RequireEncounterLinkedToIp = source.RequireEncounterLinkedToIp || predicates.RequireEncounterLinkedToIp,
+            MustBeIpEncounter = source.MustBeIpEncounter,
+            SubjectMustBePatient = source.SubjectMustBePatient,
+            SpecimenFromMatchingObservations = source.SpecimenFromMatchingObservations,
+            ObservationSourceRules = source.ObservationSourceRules
+        };
+    }
+
+    private static HashSet<string>? IntersectOrReplace(HashSet<string>? inherited, HashSet<string>? extra)
+    {
+        if (extra == null || extra.Count == 0)
+            return inherited;
+        if (inherited == null || inherited.Count == 0)
+            return extra;
+        var merged = new HashSet<string>(inherited, StringComparer.OrdinalIgnoreCase);
+        merged.IntersectWith(extra);
+        return merged.Count == 0 ? extra : merged;
+    }
+
+    private static HashSet<string>? UnionCodes(HashSet<string>? existing, IEnumerable<string> extra)
+    {
+        var set = existing ?? new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var code in extra)
+        {
+            if (!string.IsNullOrWhiteSpace(code))
+                set.Add(code);
+        }
+
+        return set.Count == 0 ? existing : set;
+    }
+
+    private sealed class WherePredicates
+    {
+        public HashSet<string>? CategoryAnyOf { get; set; }
+        public HashSet<string>? StatusAnyOf { get; set; }
+        public HashSet<string>? IntentAnyOf { get; set; }
+        public HashSet<string>? CodeAnyOf { get; set; }
+        public DateRelation Date { get; set; }
+        public bool RequireIpExists { get; set; }
+        public bool RequireEncounterLinkedToIp { get; set; }
+    }
+
+    private static WherePredicates ParseWhere(CqlMeasureBundleModel model, string? whereClause)
+    {
+        var result = new WherePredicates();
+        if (string.IsNullOrWhiteSpace(whereClause))
+            return result;
+
+        var text = whereClause;
+        if (Regex.IsMatch(text, """exists\s*\(\s*"Initial Population" """, RegexOptions.IgnoreCase)
+            || Regex.IsMatch(text, """exists\s*\(\s*"Initial Population"\s*\)""", RegexOptions.IgnoreCase)
+            || text.Contains("\"Initial Population\"", StringComparison.Ordinal))
+        {
+            result.RequireIpExists = true;
+        }
+
+        if (text.Contains("encounter.reference", StringComparison.OrdinalIgnoreCase)
+            || text.Contains(".diagnosis", StringComparison.OrdinalIgnoreCase))
+        {
+            result.RequireEncounterLinkedToIp = true;
+        }
+
+        var categories = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (Match match in Regex.Matches(
+                     text,
+                     @"\.category\b[\s\S]{0,160}~\s*""([^""]+)""",
+                     RegexOptions.IgnoreCase))
+        {
+            categories.Add(model.ResolveCode(match.Groups[1].Value));
+        }
+
+        if (categories.Count > 0)
+            result.CategoryAnyOf = categories;
+
+        var statusIn = StatusInPattern.Match(text);
+        if (statusIn.Success)
+        {
+            result.StatusAnyOf = SingleQuotedPattern.Matches(statusIn.Groups[1].Value)
+                .Select(m => m.Groups[1].Value)
+                .ToHashSet(StringComparer.OrdinalIgnoreCase);
+        }
+        else
+        {
+            var statusTilde = StatusTildePattern.Match(text);
+            if (statusTilde.Success)
+                result.StatusAnyOf = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { statusTilde.Groups[1].Value };
+        }
+
+        var intent = IntentTildePattern.Match(text);
+        if (intent.Success)
+            result.IntentAnyOf = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { intent.Groups[1].Value };
+
+        result.Date = InferDateRelation(text);
+
+        foreach (Match match in Regex.Matches(text, @"\bin\s+""([^""]+)""", RegexOptions.IgnoreCase))
+        {
+            var vsName = match.Groups[1].Value;
+            if (string.Equals(vsName, "Initial Population", StringComparison.Ordinal)
+                || string.Equals(vsName, "Measurement Period", StringComparison.Ordinal)
+                || vsName.Contains("Hospitalization", StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            var codes = model.CodesForValueSet(vsName);
+            if (codes is not { Count: > 0 })
+                continue;
+            result.CodeAnyOf ??= new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            foreach (var code in codes)
+                result.CodeAnyOf.Add(code);
+        }
+
+        return result;
+    }
+
+    private static DateRelation InferDateRelation(string text)
+    {
+        var ipPeriod = text.Contains("IP.period", StringComparison.OrdinalIgnoreCase)
+                       || text.Contains("InitialPopulation.period", StringComparison.OrdinalIgnoreCase)
+                       || text.Contains("InpatientEncounters.period", StringComparison.OrdinalIgnoreCase);
+
+        if (Regex.IsMatch(text, """start of .+period before""", RegexOptions.IgnoreCase)
+            && text.Contains("Coverages.period", StringComparison.OrdinalIgnoreCase))
+        {
+            return DateRelation.CoverageActiveAtIpEnd;
+        }
+
+        if (text.Contains("\"Measurement Period\"", StringComparison.Ordinal))
+        {
+            return text.Contains("overlaps", StringComparison.OrdinalIgnoreCase)
+                ? DateRelation.OverlapsMeasurementPeriod
+                : DateRelation.DuringMeasurementPeriod;
+        }
+
+        if (!ipPeriod && !text.Contains("HospitalizationWithObservationOrEmergency", StringComparison.Ordinal))
+            return DateRelation.None;
+
+        if (Regex.IsMatch(text, """start of .+ during""", RegexOptions.IgnoreCase))
+            return DateRelation.StartDuringIpPeriod;
+        if (text.Contains("overlaps", StringComparison.OrdinalIgnoreCase))
+            return DateRelation.OverlapsIpPeriod;
+        if (text.Contains("during", StringComparison.OrdinalIgnoreCase))
+            return DateRelation.DuringIpPeriod;
+        return DateRelation.None;
+    }
+
+    private static string? InferReturnType(string? returnClause)
+    {
+        if (string.IsNullOrWhiteSpace(returnClause))
+            return null;
+        foreach (var (fn, type) in ReturnFunctionToType)
+        {
+            if (returnClause.Contains(fn, StringComparison.OrdinalIgnoreCase))
+                return type;
+        }
+
+        return null;
+    }
+
+    private static bool LooksLikeSpecimenFromObservation(string body, string? returnClause)
+        => (body.Contains("SpecimenResource", StringComparison.OrdinalIgnoreCase)
+            || (returnClause ?? string.Empty).Contains("SpecimenResource", StringComparison.OrdinalIgnoreCase))
+           && (body.Contains("GetSpecimen", StringComparison.OrdinalIgnoreCase)
+               || body.Contains(".specimen", StringComparison.OrdinalIgnoreCase));
+
+    private static string? FirstNamedDefineReference(string body)
+    {
+        var trimmed = CqlText.UnwrapOuterParens(body).TrimStart();
+        var match = NamedDefineRefPattern.Match(trimmed);
+        return match.Success ? match.Groups[1].Value : null;
+    }
+
+    private static string? FirstNonEmpty(params string[] values)
+        => values.FirstOrDefault(v => !string.IsNullOrWhiteSpace(v));
+
+    private static (HashSet<string> Classes, HashSet<string> Statuses, bool AnyClass) ExtractIpConstraints(
+        CqlMeasureBundleModel model)
+    {
+        var classes = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var statuses = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var anyClass = false;
+        if (!model.Defines.TryGetValue("Initial Population", out var ipBody))
+            return (classes, statuses, true);
+
+        var stack = new Stack<string>();
+        var seen = new HashSet<string>(StringComparer.Ordinal) { "Initial Population" };
+        stack.Push(ipBody);
+        foreach (Match quoted in QuotedPattern.Matches(ipBody))
+        {
+            if (seen.Add(quoted.Groups[1].Value) && model.Defines.TryGetValue(quoted.Groups[1].Value, out var nested))
+                stack.Push(nested);
+        }
+
+        while (stack.Count > 0)
+        {
+            var body = stack.Pop();
+            foreach (Match quoted in QuotedPattern.Matches(body))
+            {
+                if (seen.Add(quoted.Groups[1].Value) && model.Defines.TryGetValue(quoted.Groups[1].Value, out var nested))
+                    stack.Push(nested);
+            }
+
+            foreach (Match retrieve in RetrievePattern.Matches(body))
+            {
+                if (!string.Equals(retrieve.Groups[1].Value, "Encounter", StringComparison.OrdinalIgnoreCase))
+                    continue;
+
+                var vs = FirstNonEmpty(retrieve.Groups[2].Value, retrieve.Groups[5].Value);
+                var classTilde = retrieve.Groups[3].Value;
+                var classSet = retrieve.Groups[4].Value;
+                if (!string.IsNullOrWhiteSpace(vs) && vs.Contains("Class", StringComparison.OrdinalIgnoreCase))
+                {
+                    var codes = model.CodesForValueSet(vs);
+                    if (codes != null)
+                    {
+                        foreach (var code in codes) classes.Add(code);
+                    }
+                }
+
+                if (!string.IsNullOrWhiteSpace(classTilde))
+                    classes.Add(model.ResolveCode(classTilde));
+
+                if (!string.IsNullOrWhiteSpace(classSet))
+                {
+                    foreach (Match quoted in QuotedPattern.Matches(classSet))
+                        classes.Add(model.ResolveCode(quoted.Groups[1].Value));
+                }
+
+                // Bare [Encounter] and encounter-type valuesets (Encounter Inpatient, ED Visit)
+                // are not class-code filters. EncounterContext does not carry type/location, so
+                // those IP paths stay a documented gap rather than treating every class as IP.
+            }
+
+            var statusIn = StatusInPattern.Match(body);
+            if (statusIn.Success)
+            {
+                foreach (Match quoted in SingleQuotedPattern.Matches(statusIn.Groups[1].Value))
+                    statuses.Add(quoted.Groups[1].Value);
+            }
+        }
+
+        if (classes.Count == 0)
+            anyClass = true;
+        return (classes, statuses, anyClass);
+    }
+}

--- a/DotNet/Automation/Generation/CqlMeasureBundleModel.cs
+++ b/DotNet/Automation/Generation/CqlMeasureBundleModel.cs
@@ -1,0 +1,283 @@
+using System.Text;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+
+namespace LantanaGroup.Automation.Generation;
+
+/// <summary>
+/// Parsed view of one Measure FHIR bundle: CQL define bodies, code/valueset
+/// declarations, ValueSet expansions, and the Measure's population/SDE roots.
+/// </summary>
+internal sealed class CqlMeasureBundleModel
+{
+    private static readonly Regex QuotedNamePattern = new("\"([^\"\\r\\n]+)\"", RegexOptions.Compiled);
+
+    public IReadOnlyDictionary<string, string> Defines { get; }
+    public IReadOnlyDictionary<string, string> CodeDeclarations { get; }
+    public IReadOnlyDictionary<string, HashSet<string>> ValueSetCodes { get; }
+    public IReadOnlySet<string> RootExpressionNames { get; }
+
+    private CqlMeasureBundleModel(
+        Dictionary<string, string> defines,
+        Dictionary<string, string> codeDeclarations,
+        Dictionary<string, HashSet<string>> valueSetCodes,
+        HashSet<string> rootExpressionNames)
+    {
+        Defines = defines;
+        CodeDeclarations = codeDeclarations;
+        ValueSetCodes = valueSetCodes;
+        RootExpressionNames = rootExpressionNames;
+    }
+
+    public static CqlMeasureBundleModel Parse(string bundleJson)
+    {
+        var defines = new Dictionary<string, string>(StringComparer.Ordinal);
+        var codeDeclarations = new Dictionary<string, string>(StringComparer.Ordinal);
+        var valuesetUrls = new Dictionary<string, string>(StringComparer.Ordinal);
+        var roots = new HashSet<string>(StringComparer.Ordinal);
+        var fhirValueSets = new List<FhirValueSet>();
+
+        using var doc = JsonDocument.Parse(bundleJson);
+        if (!doc.RootElement.TryGetProperty("entry", out var entries) || entries.ValueKind != JsonValueKind.Array)
+            return new CqlMeasureBundleModel(defines, codeDeclarations, new(StringComparer.Ordinal), roots);
+
+        foreach (var entry in entries.EnumerateArray())
+        {
+            if (!entry.TryGetProperty("resource", out var resource) || resource.ValueKind != JsonValueKind.Object)
+                continue;
+
+            var resourceType = resource.TryGetProperty("resourceType", out var rt) ? rt.GetString() : null;
+            if (string.Equals(resourceType, "Library", StringComparison.Ordinal))
+            {
+                foreach (var cql in ExtractCqlTexts(resource))
+                {
+                    var stripped = CqlText.StripComments(cql);
+                    foreach (var (name, body) in CqlText.ParseDefineBodies(stripped))
+                    {
+                        if (!defines.ContainsKey(name))
+                            defines[name] = body;
+                    }
+
+                    foreach (var (name, code) in CqlText.ParseCodeDeclarations(stripped))
+                        codeDeclarations[name] = code;
+
+                    foreach (var (name, url) in CqlText.ParseValuesetDeclarations(stripped))
+                        valuesetUrls[name] = url;
+                }
+            }
+            else if (string.Equals(resourceType, "Measure", StringComparison.Ordinal))
+            {
+                AddCriteriaExpressions(resource, "group", "population", roots);
+                AddCriteriaExpressions(resource, "supplementalData", null, roots);
+            }
+            else if (string.Equals(resourceType, "ValueSet", StringComparison.Ordinal))
+            {
+                fhirValueSets.Add(FhirValueSet.From(resource));
+            }
+        }
+
+        var valueSetCodes = new Dictionary<string, HashSet<string>>(StringComparer.OrdinalIgnoreCase);
+        foreach (var vs in fhirValueSets)
+        {
+            IndexValueSet(valueSetCodes, vs.Id, vs.Codes);
+            IndexValueSet(valueSetCodes, vs.Name, vs.Codes);
+            IndexValueSet(valueSetCodes, vs.Title, vs.Codes);
+            IndexValueSet(valueSetCodes, vs.Url, vs.Codes);
+        }
+
+        foreach (var (cqlName, url) in valuesetUrls)
+        {
+            if (valueSetCodes.TryGetValue(NormalizeKey(url), out var byUrl)
+                || valueSetCodes.TryGetValue(url, out byUrl))
+            {
+                IndexValueSet(valueSetCodes, cqlName, byUrl);
+            }
+        }
+
+        return new CqlMeasureBundleModel(defines, codeDeclarations, valueSetCodes, roots);
+    }
+
+    public HashSet<string> ResolveReachableDefines()
+    {
+        var reachable = new HashSet<string>(StringComparer.Ordinal);
+        var start = RootExpressionNames.Where(Defines.ContainsKey).ToHashSet(StringComparer.Ordinal);
+        if (start.Count == 0)
+            start = Defines.Keys.ToHashSet(StringComparer.Ordinal);
+
+        var queue = new Queue<string>(start);
+        while (queue.Count > 0)
+        {
+            var current = queue.Dequeue();
+            if (!reachable.Add(current))
+                continue;
+            if (!Defines.TryGetValue(current, out var body))
+                continue;
+
+            foreach (Match match in QuotedNamePattern.Matches(body))
+            {
+                var candidate = match.Groups[1].Value;
+                if (Defines.ContainsKey(candidate) && !reachable.Contains(candidate))
+                    queue.Enqueue(candidate);
+            }
+        }
+
+        return reachable;
+    }
+
+    public HashSet<string>? CodesForValueSet(string name)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+            return null;
+        if (ValueSetCodes.TryGetValue(name, out var codes) && codes.Count > 0)
+            return codes;
+        var normalized = NormalizeKey(name);
+        if (ValueSetCodes.TryGetValue(normalized, out codes) && codes.Count > 0)
+            return codes;
+        return null;
+    }
+
+    public string ResolveCode(string nameOrCode)
+    {
+        if (CodeDeclarations.TryGetValue(nameOrCode, out var declared))
+            return declared;
+        return nameOrCode;
+    }
+
+    private static void IndexValueSet(Dictionary<string, HashSet<string>> map, string? key, HashSet<string> codes)
+    {
+        if (string.IsNullOrWhiteSpace(key) || codes.Count == 0)
+            return;
+        foreach (var alias in new[] { key, NormalizeKey(key) }.Distinct(StringComparer.OrdinalIgnoreCase))
+        {
+            if (!map.TryGetValue(alias, out var existing))
+            {
+                map[alias] = new HashSet<string>(codes, StringComparer.OrdinalIgnoreCase);
+                continue;
+            }
+
+            foreach (var code in codes)
+                existing.Add(code);
+        }
+    }
+
+    internal static string NormalizeKey(string value)
+    {
+        var normalized = value.Replace('\u00a0', ' ').Trim();
+        return string.Join(' ', normalized.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries));
+    }
+
+    private static IEnumerable<string> ExtractCqlTexts(JsonElement library)
+    {
+        if (!library.TryGetProperty("content", out var content) || content.ValueKind != JsonValueKind.Array)
+            yield break;
+
+        foreach (var item in content.EnumerateArray())
+        {
+            var contentType = item.TryGetProperty("contentType", out var ct) ? ct.GetString() : null;
+            if (!string.Equals(contentType, "text/cql", StringComparison.OrdinalIgnoreCase))
+                continue;
+            var data = item.TryGetProperty("data", out var d) ? d.GetString() : null;
+            if (string.IsNullOrEmpty(data))
+                continue;
+            string decoded;
+            try
+            {
+                decoded = Encoding.UTF8.GetString(Convert.FromBase64String(data));
+            }
+            catch
+            {
+                continue;
+            }
+
+            yield return decoded;
+        }
+    }
+
+    private static void AddCriteriaExpressions(
+        JsonElement measure,
+        string parentName,
+        string? nestedName,
+        HashSet<string> roots)
+    {
+        if (!measure.TryGetProperty(parentName, out var parent) || parent.ValueKind != JsonValueKind.Array)
+            return;
+
+        foreach (var item in parent.EnumerateArray())
+        {
+            if (nestedName != null)
+            {
+                if (!item.TryGetProperty(nestedName, out var nested) || nested.ValueKind != JsonValueKind.Array)
+                    continue;
+                foreach (var nestedItem in nested.EnumerateArray())
+                    AddExpression(nestedItem, roots);
+            }
+            else
+            {
+                AddExpression(item, roots);
+            }
+        }
+    }
+
+    private static void AddExpression(JsonElement element, HashSet<string> roots)
+    {
+        if (!element.TryGetProperty("criteria", out var criteria) || criteria.ValueKind != JsonValueKind.Object)
+            return;
+        var expr = criteria.TryGetProperty("expression", out var exprProp) && exprProp.ValueKind == JsonValueKind.String
+            ? exprProp.GetString()
+            : null;
+        if (!string.IsNullOrWhiteSpace(expr))
+            roots.Add(expr);
+    }
+
+    private sealed record FhirValueSet(string? Id, string? Name, string? Title, string? Url, HashSet<string> Codes)
+    {
+        public static FhirValueSet From(JsonElement resource)
+        {
+            var codes = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            CollectCodes(resource, codes);
+            return new FhirValueSet(
+                GetString(resource, "id"),
+                GetString(resource, "name"),
+                GetString(resource, "title"),
+                GetString(resource, "url"),
+                codes);
+        }
+
+        private static void CollectCodes(JsonElement resource, HashSet<string> codes)
+        {
+            if (resource.TryGetProperty("expansion", out var expansion)
+                && expansion.TryGetProperty("contains", out var contains)
+                && contains.ValueKind == JsonValueKind.Array)
+            {
+                foreach (var item in contains.EnumerateArray())
+                    AddCode(item, codes);
+            }
+
+            if (resource.TryGetProperty("compose", out var compose)
+                && compose.TryGetProperty("include", out var include)
+                && include.ValueKind == JsonValueKind.Array)
+            {
+                foreach (var inc in include.EnumerateArray())
+                {
+                    if (inc.TryGetProperty("concept", out var concepts) && concepts.ValueKind == JsonValueKind.Array)
+                    {
+                        foreach (var concept in concepts.EnumerateArray())
+                            AddCode(concept, codes);
+                    }
+                }
+            }
+        }
+
+        private static void AddCode(JsonElement item, HashSet<string> codes)
+        {
+            var code = GetString(item, "code");
+            if (!string.IsNullOrWhiteSpace(code))
+                codes.Add(code);
+        }
+
+        private static string? GetString(JsonElement element, string name)
+            => element.TryGetProperty(name, out var prop) && prop.ValueKind == JsonValueKind.String
+                ? prop.GetString()
+                : null;
+    }
+}

--- a/DotNet/Automation/Generation/CqlText.cs
+++ b/DotNet/Automation/Generation/CqlText.cs
@@ -1,0 +1,231 @@
+using System.Text.RegularExpressions;
+
+namespace LantanaGroup.Automation.Generation;
+
+/// <summary>
+/// Shared CQL text utilities: comment stripping, define parsing, and lightweight
+/// token extraction. This is not a CQL compiler — it exists so runtime prediction
+/// can read the measure bundle that MeasureEval will actually evaluate.
+/// </summary>
+internal static class CqlText
+{
+    private static readonly Regex DefinePattern = new(
+        """(?im)^\s*define\s+(?:"([^"\r\n]+)"|([A-Za-z_][A-Za-z0-9_]*))\s*:""",
+        RegexOptions.Compiled);
+
+    private static readonly Regex CodeDeclarationPattern = new(
+        """(?im)^\s*code\s+"([^"]+)"\s*:\s*'([^']+)'""",
+        RegexOptions.Compiled);
+
+    private static readonly Regex ValuesetDeclarationPattern = new(
+        """(?im)^\s*valueset\s+"([^"]+)"\s*:\s*'([^']+)'""",
+        RegexOptions.Compiled);
+
+    public static string StripComments(string cql)
+    {
+        if (string.IsNullOrEmpty(cql))
+            return string.Empty;
+
+        var withoutBlock = Regex.Replace(cql, @"/\*.*?\*/", " ", RegexOptions.Singleline);
+        return Regex.Replace(withoutBlock, @"//.*?$", " ", RegexOptions.Multiline);
+    }
+
+    public static Dictionary<string, string> ParseDefineBodies(string cql)
+    {
+        var defines = new Dictionary<string, string>(StringComparer.Ordinal);
+        var matches = DefinePattern.Matches(cql);
+        for (var i = 0; i < matches.Count; i++)
+        {
+            var current = matches[i];
+            var name = current.Groups[1].Success ? current.Groups[1].Value : current.Groups[2].Value;
+            if (string.IsNullOrWhiteSpace(name))
+                continue;
+
+            var bodyStart = current.Index + current.Length;
+            var bodyEnd = i + 1 < matches.Count ? matches[i + 1].Index : cql.Length;
+            if (bodyEnd <= bodyStart)
+                continue;
+
+            defines[name] = cql[bodyStart..bodyEnd];
+        }
+
+        return defines;
+    }
+
+    public static Dictionary<string, string> ParseCodeDeclarations(string cql)
+    {
+        var result = new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach (Match match in CodeDeclarationPattern.Matches(cql))
+        {
+            var name = match.Groups[1].Value;
+            var code = match.Groups[2].Value;
+            if (!string.IsNullOrWhiteSpace(name) && !string.IsNullOrWhiteSpace(code))
+                result[name] = code;
+        }
+
+        return result;
+    }
+
+    public static Dictionary<string, string> ParseValuesetDeclarations(string cql)
+    {
+        var result = new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach (Match match in ValuesetDeclarationPattern.Matches(cql))
+        {
+            var name = match.Groups[1].Value;
+            var url = match.Groups[2].Value;
+            if (!string.IsNullOrWhiteSpace(name) && !string.IsNullOrWhiteSpace(url))
+                result[name] = url;
+        }
+
+        return result;
+    }
+
+    public static IEnumerable<string> SplitTopLevelUnion(string text)
+    {
+        if (string.IsNullOrWhiteSpace(text))
+            yield break;
+
+        var depth = 0;
+        var start = 0;
+        for (var i = 0; i < text.Length; i++)
+        {
+            var c = text[i];
+            if (c is '(' or '{' or '[')
+            {
+                depth++;
+                continue;
+            }
+
+            if (c is ')' or '}' or ']')
+            {
+                if (depth > 0) depth--;
+                continue;
+            }
+
+            if (depth != 0 || i + 5 > text.Length)
+                continue;
+
+            if (!text.AsSpan(i).StartsWith("union", StringComparison.OrdinalIgnoreCase))
+                continue;
+
+            var beforeOk = i == 0 || char.IsWhiteSpace(text[i - 1]) || text[i - 1] is ')' or ']';
+            var afterOk = i + 5 == text.Length || char.IsWhiteSpace(text[i + 5]) || text[i + 5] is '(' or '[';
+            if (!beforeOk || !afterOk)
+                continue;
+
+            var part = text[start..i].Trim();
+            if (part.Length > 0)
+                yield return part;
+            i += 4;
+            start = i + 1;
+        }
+
+        var tail = text[start..].Trim();
+        if (tail.Length > 0)
+            yield return tail;
+    }
+
+    public static string? ExtractTopLevelWhere(string body)
+    {
+        var depth = 0;
+        for (var i = 0; i < body.Length; i++)
+        {
+            var c = body[i];
+            if (c is '(' or '{' or '[')
+            {
+                depth++;
+                continue;
+            }
+
+            if (c is ')' or '}' or ']')
+            {
+                if (depth > 0) depth--;
+                continue;
+            }
+
+            if (depth != 0)
+                continue;
+
+            if (IsKeywordAt(body, i, "where"))
+            {
+                var whereStart = i + 5;
+                var whereEnd = FindTopLevelKeyword(body, whereStart, "return");
+                return whereEnd >= 0
+                    ? body[whereStart..whereEnd].Trim()
+                    : body[whereStart..].Trim();
+            }
+
+            if (IsKeywordAt(body, i, "return"))
+                return null;
+        }
+
+        return null;
+    }
+
+    public static string? ExtractTopLevelReturn(string body)
+    {
+        var idx = FindTopLevelKeyword(body, 0, "return");
+        return idx < 0 ? null : body[(idx + 6)..].Trim();
+    }
+
+    public static bool IsKeywordAt(string text, int index, string keyword)
+    {
+        if (index < 0 || index + keyword.Length > text.Length)
+            return false;
+        if (!text.AsSpan(index).StartsWith(keyword, StringComparison.OrdinalIgnoreCase))
+            return false;
+        if (index > 0 && char.IsLetterOrDigit(text[index - 1]))
+            return false;
+        var after = index + keyword.Length;
+        return after == text.Length || !char.IsLetterOrDigit(text[after]);
+    }
+
+    public static int FindTopLevelKeyword(string text, int start, string keyword)
+    {
+        var depth = 0;
+        for (var i = start; i < text.Length; i++)
+        {
+            var c = text[i];
+            if (c is '(' or '{' or '[')
+            {
+                depth++;
+                continue;
+            }
+
+            if (c is ')' or '}' or ']')
+            {
+                if (depth > 0) depth--;
+                continue;
+            }
+
+            if (depth == 0 && IsKeywordAt(text, i, keyword))
+                return i;
+        }
+
+        return -1;
+    }
+
+    public static string UnwrapOuterParens(string text)
+    {
+        var t = text.Trim();
+        while (t.Length >= 2 && t[0] == '(' && t[^1] == ')' && ParensBalanced(t[1..^1]))
+            t = t[1..^1].Trim();
+        return t;
+    }
+
+    private static bool ParensBalanced(string text)
+    {
+        var depth = 0;
+        foreach (var c in text)
+        {
+            if (c == '(') depth++;
+            else if (c == ')')
+            {
+                depth--;
+                if (depth < 0) return false;
+            }
+        }
+
+        return depth == 0;
+    }
+}

--- a/DotNet/Automation/Generation/FhirGenerationPipeline.cs
+++ b/DotNet/Automation/Generation/FhirGenerationPipeline.cs
@@ -590,6 +590,15 @@ public static class FhirGenerationPipeline
 
         if (cqlInput != null)
         {
+            if (generationClinicalPeriodStart.HasValue || generationClinicalPeriodEnd.HasValue)
+            {
+                cqlInput = cqlInput with
+                {
+                    MeasurementPeriodStart = generationClinicalPeriodStart ?? DateTime.MinValue,
+                    MeasurementPeriodEnd = generationClinicalPeriodEnd ?? DateTime.MaxValue
+                };
+            }
+
             effectiveProfile = ApplyMeasurementPeriodEligibilityPrediction(
                 patientId,
                 profile,
@@ -751,6 +760,15 @@ public static class FhirGenerationPipeline
         var effectiveProfile = profile;
         if (cqlInput != null)
         {
+            if (generationClinicalPeriodStart.HasValue || generationClinicalPeriodEnd.HasValue)
+            {
+                cqlInput = cqlInput with
+                {
+                    MeasurementPeriodStart = generationClinicalPeriodStart ?? DateTime.MinValue,
+                    MeasurementPeriodEnd = generationClinicalPeriodEnd ?? DateTime.MaxValue
+                };
+            }
+
             effectiveProfile = ApplyMeasurementPeriodEligibilityPrediction(
                 patientId,
                 profile,

--- a/DotNet/Automation/Generation/FhirGenerationPipeline.cs
+++ b/DotNet/Automation/Generation/FhirGenerationPipeline.cs
@@ -585,7 +585,7 @@ public static class FhirGenerationPipeline
         // semantics do not contribute to the intersection of exclusions that determines
         // whether a resource reaches ABS.
         HashSet<string>? cqlFilteredKeys = null;
-        var cqlInput = CqlFilterInputExtractor.ExtractFromEntries(patientId, entries);
+        var cqlInput = CqlFilterInputExtractor.ExtractFromEntries(patientId, entries, sharedSimEntries);
         var effectiveProfile = profile;
 
         if (cqlInput != null)
@@ -756,7 +756,7 @@ public static class FhirGenerationPipeline
 
         // 3. CQL filter simulation + period-aware eligibility prediction
         HashSet<string>? cqlFilteredKeys = null;
-        var cqlInput = CqlFilterInputExtractor.ExtractFromEntries(patientId, entries);
+        var cqlInput = CqlFilterInputExtractor.ExtractFromEntries(patientId, entries, sharedSimEntries);
         var effectiveProfile = profile;
         if (cqlInput != null)
         {

--- a/DotNet/Automation/Generation/OrgResourceMapPredictionFilter.cs
+++ b/DotNet/Automation/Generation/OrgResourceMapPredictionFilter.cs
@@ -105,6 +105,11 @@ public static class OrgResourceMapPredictionFilter
                 orgEncounterIds.Add(encounter.ResourceId);
         }
 
+        var orgEncounterAncestorLocationIds = CollectLocationAncestors(
+            locations,
+            orgEncounterLocationIds,
+            effectiveOrgLocationIds);
+
         var filtered = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         foreach (var key in acquiredKeys)
         {
@@ -114,7 +119,7 @@ public static class OrgResourceMapPredictionFilter
                 continue;
             }
 
-            if (MatchesOrganizationScope(entry, orgEncounterIds, orgEncounterLocationIds))
+            if (MatchesOrganizationScope(entry, orgEncounterIds, orgEncounterLocationIds, orgEncounterAncestorLocationIds))
                 filtered.Add(key);
         }
 
@@ -182,16 +187,66 @@ public static class OrgResourceMapPredictionFilter
         return keptKeys;
     }
 
+    private static HashSet<string> CollectLocationAncestors(
+        List<ResourceEntry> locations,
+        HashSet<string> startIds,
+        HashSet<string> allowedIds)
+    {
+        var ancestors = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        if (startIds.Count == 0 || locations.Count == 0)
+            return ancestors;
+
+        var byId = new Dictionary<string, ResourceEntry>(StringComparer.OrdinalIgnoreCase);
+        foreach (var location in locations)
+        {
+            if (!string.IsNullOrWhiteSpace(location.ResourceId))
+                byId[location.ResourceId] = location;
+        }
+
+        foreach (var startId in startIds)
+        {
+            var current = startId;
+            for (var guard = 0; guard < 16; guard++)
+            {
+                if (!byId.TryGetValue(current, out var location))
+                    break;
+                if (!TryGetReferencedResourceIds(location.Resource, "Location", out var parentIds))
+                    break;
+
+                var advanced = false;
+                foreach (var parentId in parentIds)
+                {
+                    if (!allowedIds.Contains(parentId))
+                        continue;
+                    if (!ancestors.Add(parentId))
+                        continue;
+                    current = parentId;
+                    advanced = true;
+                    break;
+                }
+
+                if (!advanced)
+                    break;
+            }
+        }
+
+        return ancestors;
+    }
+
     private static bool MatchesOrganizationScope(
         ResourceEntry resource,
         HashSet<string> orgEncounterIds,
-        HashSet<string> orgEncounterLocationIds)
+        HashSet<string> orgEncounterLocationIds,
+        HashSet<string> orgEncounterAncestorLocationIds)
     {
         if (string.Equals(resource.ResourceType, "Encounter", StringComparison.OrdinalIgnoreCase))
             return orgEncounterIds.Contains(resource.ResourceId);
 
         if (string.Equals(resource.ResourceType, "Location", StringComparison.OrdinalIgnoreCase))
-            return orgEncounterLocationIds.Contains(resource.ResourceId);
+        {
+            return orgEncounterLocationIds.Contains(resource.ResourceId)
+                   || orgEncounterAncestorLocationIds.Contains(resource.ResourceId);
+        }
 
         if (!TryGetReferencedResourceIds(resource.Resource, "Encounter", out var encounterIds))
             return true;

--- a/DotNet/Automation/Generation/ProfiledMeasureCatalog.cs
+++ b/DotNet/Automation/Generation/ProfiledMeasureCatalog.cs
@@ -1,8 +1,10 @@
-﻿namespace LantanaGroup.Automation.Generation;
+﻿using System.Reflection;
+
+namespace LantanaGroup.Automation.Generation;
 
 /// <summary>
 /// Central catalog for measure metadata used by automation (bundle location,
-/// display name, and future profile strategy routing).
+/// display name, and embedded CQL used by instance-level ABS prediction).
 /// </summary>
 public static class ProfiledMeasureCatalog
 {
@@ -24,4 +26,29 @@ public static class ProfiledMeasureCatalog
             => "resource://LantanaGroup.Automation.measures.NHSNGlycemicControlHypoglycemicInitialPopulation.json",
         _ => throw new ArgumentOutOfRangeException(nameof(measure), measure, null)
     };
+
+    /// <summary>
+    /// Reads the embedded FHIR measure-bundle JSON used by MeasureEval and by
+    /// <see cref="CqlFilterSimulator"/> instance prediction.
+    /// </summary>
+    public static string ReadBundleJson(ProfiledMeasureType measure, Assembly? assembly = null)
+    {
+        var resourceName = measure switch
+        {
+            ProfiledMeasureType.NhsnAcuteCareHospitalMonthlyInitialPopulation
+                => "LantanaGroup.Automation.measures.NHSNAcuteCareHospitalMonthlyInitialPopulation.json",
+            ProfiledMeasureType.NhsnAcuteCareHospitalDailyInitialPopulation
+                => "LantanaGroup.Automation.measures.NHSNAcuteCareHospitalDailyInitialPopulation.json",
+            ProfiledMeasureType.NhsnGlycemicControlHypoglycemicInitialPopulation
+                => "LantanaGroup.Automation.measures.NHSNGlycemicControlHypoglycemicInitialPopulation.json",
+            _ => throw new ArgumentOutOfRangeException(nameof(measure), measure, null)
+        };
+
+        assembly ??= typeof(ProfiledMeasureCatalog).Assembly;
+        using var stream = assembly.GetManifestResourceStream(resourceName)
+            ?? throw new FileNotFoundException(
+                $"Embedded measure '{resourceName}' was not found in '{assembly.GetName().Name}'.");
+        using var reader = new StreamReader(stream);
+        return reader.ReadToEnd();
+    }
 }

--- a/DotNet/Automation/Generation/QueryPlanAcquisitionSimulator.cs
+++ b/DotNet/Automation/Generation/QueryPlanAcquisitionSimulator.cs
@@ -209,7 +209,7 @@ public static class QueryPlanAcquisitionSimulator
                     if (TryGetEffective(resource.Resource, out var effStart, out var effEnd))
                     {
                         recognizedAny = true;
-                        matchedAny |= isGe ? effEnd >= bound.Value : effStart <= bound.Value;
+                        matchedAny |= PassesTemporalBound(isGe, bound.Value, effStart, effEnd);
                     }
 
                     if (!recognizedAny)
@@ -268,19 +268,7 @@ public static class QueryPlanAcquisitionSimulator
                     return false;
                 }
 
-                if (isGe && resourceEnd < bound.Value)
-                {
-                    if (allowEncounterAnchoredDateOverrideForOutOfRange
-                        && string.Equals(p.Name, "date", StringComparison.OrdinalIgnoreCase)
-                        && HasEncounterAnchoredDateOverride(resource, acquiredByType))
-                    {
-                        continue;
-                    }
-
-                    return false;
-                }
-
-                if (isLe && resourceStart > bound.Value)
+                if (!PassesTemporalBound(isGe, bound.Value, resourceStart, resourceEnd))
                 {
                     if (allowEncounterAnchoredDateOverrideForOutOfRange
                         && string.Equals(p.Name, "date", StringComparison.OrdinalIgnoreCase)
@@ -295,6 +283,35 @@ public static class QueryPlanAcquisitionSimulator
         }
 
         return true;
+    }
+
+    /// <summary>
+    /// FHIR date search values carry an interval implied by their precision.
+    /// Data Acquisition formats PeriodEnd as <c>yyyy-MM-ddTHH:mm:ssZ</c> (second
+    /// precision, no fraction), so <c>le2023-01-15T23:59:59Z</c> matches any instant
+    /// in <c>[23:59:59.000, 24:00:00.000)</c> — HAPI inclusive-whole-second semantics.
+    /// Treating the bound as an exact tick (<c>resourceStart &lt;= 23:59:59.000</c>)
+    /// drops the last Observation of a Daily ACH 1-day window (spread across a
+    /// ±6h padded encounter at 0.3 of 1000 resources lands at ~23:59:59.167).
+    /// </summary>
+    private static bool PassesTemporalBound(
+        bool isGe,
+        DateTimeOffset bound,
+        DateTimeOffset resourceStart,
+        DateTimeOffset resourceEnd)
+    {
+        if (isGe)
+            return resourceEnd >= bound;
+
+        return resourceStart < ExclusiveLeBound(bound);
+    }
+
+    private static DateTimeOffset ExclusiveLeBound(DateTimeOffset bound)
+    {
+        if (bound.Millisecond == 0 && bound.Ticks % TimeSpan.TicksPerSecond == 0)
+            return bound.AddSeconds(1);
+
+        return bound.AddTicks(1);
     }
 
     /// <summary>

--- a/DotNet/Automation/Generation/QueryPlanAcquisitionSimulator.cs
+++ b/DotNet/Automation/Generation/QueryPlanAcquisitionSimulator.cs
@@ -195,13 +195,13 @@ public static class QueryPlanAcquisitionSimulator
                 if (bound == null)
                     continue;
 
-                // Observation `date` can be represented by different effective shapes; keep
-                // a multi-shape check there. For DiagnosticReport, use effective[x] only.
-                // Including issued here can over-predict boundary resources (issued slightly
-                // after period start while effective is before it), which does not match the
-                // DataAcquisition behavior observed in scheduled runs.
+                // Observation/DiagnosticReport `date` is FHIR effective[x] only.
+                // Including issued here over-predicts boundary resources (issued slightly
+                // after period start while effective is before it) — the DxRpt-042 class of
+                // scheduled ABS misses.
                 if (string.Equals(p.Name, "date", StringComparison.OrdinalIgnoreCase)
-                    && string.Equals(resource.ResourceType, "Observation", StringComparison.OrdinalIgnoreCase))
+                    && (string.Equals(resource.ResourceType, "Observation", StringComparison.OrdinalIgnoreCase)
+                        || string.Equals(resource.ResourceType, "DiagnosticReport", StringComparison.OrdinalIgnoreCase)))
                 {
                     var matchedAny = false;
                     var recognizedAny = false;
@@ -310,8 +310,10 @@ public static class QueryPlanAcquisitionSimulator
         GeneratedResource resource,
         Dictionary<string, HashSet<string>> acquiredByType)
     {
+        // DiagnosticReport date search is effective[x] only. Encounter-anchoring DRs
+        // (including unrecognized-date fallback) over-predicts scheduled ABS
+        // (DxRpt-042 / DxRpt-043 class).
         if (!(string.Equals(resource.ResourceType, "Observation", StringComparison.OrdinalIgnoreCase)
-              || string.Equals(resource.ResourceType, "DiagnosticReport", StringComparison.OrdinalIgnoreCase)
               || string.Equals(resource.ResourceType, "Procedure", StringComparison.OrdinalIgnoreCase)))
         {
             return false;

--- a/DotNet/Automation/Generation/QueryPlanAcquisitionSimulator.cs
+++ b/DotNet/Automation/Generation/QueryPlanAcquisitionSimulator.cs
@@ -357,7 +357,50 @@ public static class QueryPlanAcquisitionSimulator
             }
         }
 
+        if (string.Equals(targetType, "Location", StringComparison.OrdinalIgnoreCase))
+            ExpandReferencedLocationParents(result, typeMap);
+
         return result;
+    }
+
+    /// <summary>
+    /// Data Acquisition follows <c>Location.partOf</c> when resolving referenced locations
+    /// (ward → hospital). Expand the referenced-id set so the Hospital parent is acquired
+    /// along with encounter stay locations.
+    /// </summary>
+    private static void ExpandReferencedLocationParents(
+        HashSet<string> referencedIds,
+        Dictionary<string, List<GeneratedResource>> typeMap)
+    {
+        if (!typeMap.TryGetValue("Location", out var locations) || locations.Count == 0)
+            return;
+
+        var byId = new Dictionary<string, GeneratedResource>(StringComparer.OrdinalIgnoreCase);
+        foreach (var location in locations)
+        {
+            if (!string.IsNullOrWhiteSpace(location.ResourceId))
+                byId[location.ResourceId] = location;
+        }
+
+        var pending = new Queue<string>(referencedIds);
+        while (pending.Count > 0)
+        {
+            var id = pending.Dequeue();
+            if (!byId.TryGetValue(id, out var location))
+                continue;
+
+            foreach (var reference in EnumerateReferences(location.Resource))
+            {
+                if (!reference.StartsWith("Location/", StringComparison.OrdinalIgnoreCase))
+                    continue;
+
+                var parentId = reference["Location/".Length..];
+                if (string.IsNullOrWhiteSpace(parentId))
+                    continue;
+                if (referencedIds.Add(parentId))
+                    pending.Enqueue(parentId);
+            }
+        }
     }
 
     private static IEnumerable<string> EnumerateReferences(JsonElement element)

--- a/DotNet/Automation/Generation/QueryPlanDefaults.cs
+++ b/DotNet/Automation/Generation/QueryPlanDefaults.cs
@@ -83,7 +83,7 @@ public static class QueryPlanDefaults
             VariableParam("patient", 0),
             VariableParam("date", 1, "ge{0}"),
             VariableParam("date", 3, "le{0}"),
-            LiteralParam("category", "imaging,laboratory,social-history,vital-signs")),
+            LiteralParam("category", "imaging,laboratory,social-history,survey,vital-signs")),
         ParameterQuery("Procedure",
             VariableParam("patient", 0),
             VariableParam("date", 1, "ge{0}"),

--- a/DotNet/Automation/Generation/ResourceFactories/ObservationFactory.cs
+++ b/DotNet/Automation/Generation/ResourceFactories/ObservationFactory.cs
@@ -45,7 +45,6 @@ public static class ObservationFactory
         string? organizationId = null)
     {
         var isLab = category == "laboratory";
-        var periodEnd = effective.AddHours(1 + seed % 4);
 
         var categoryDisplay = category switch
         {
@@ -77,20 +76,15 @@ public static class ObservationFactory
             Performer = [Ref($"Organization/{organizationId ?? FhirBundleGenerator.HospitalOrgId}", "General Test Hospital")]
         };
 
-        if (isLab)
-        {
-            obs.Effective = new Period
-            {
-                StartElement = new FhirDateTime(effective),
-                EndElement = new FhirDateTime(periodEnd)
-            };
-            if (specimenIds?.Count > 0)
-                obs.Specimen = Ref($"Specimen/{specimenIds[seed % specimenIds.Count]}");
-        }
-        else
-        {
-            obs.Effective = new FhirDateTime(effective);
-        }
+        // Use a point-in-time effectiveDateTime for every Observation, including labs.
+        // A lab effectivePeriod that starts just before the Daily measurement-period
+        // boundary and extends 1-4 hours into the window is included by HAPI date
+        // search but can disagree with acquisition-simulator overlap, producing a
+        // systematic Observation expected=N actual=N+1 on Daily ACH. Thetis generation
+        // already uses FhirDateTime; keep this factory on the same shape.
+        obs.Effective = new FhirDateTime(effective);
+        if (isLab && specimenIds?.Count > 0)
+            obs.Specimen = Ref($"Specimen/{specimenIds[seed % specimenIds.Count]}");
 
         // ---------------------------------------------------------------
         // Culture / bacteriology — valueString

--- a/DotNet/Automation/README.md
+++ b/DotNet/Automation/README.md
@@ -117,8 +117,9 @@ logic in a streaming pipeline that:
    from in-memory FHIR objects before serialization.
 4. **Runs `QueryPlanAcquisitionSimulator` per-patient** (when configured) before discarding
    FHIR data.
-5. **Runs `CqlFilterSimulator` per-patient** over the patient's *qualifying* measures only, so
-   non-qualifying measure SDE rules do not falsely constrain prediction.
+5. **Runs `CqlFilterSimulator` per-patient** over the qualifying measures' embedded bundle CQL
+   so instance-level ABS prediction follows the measure being evaluated, not a frozen family
+   profile. Non-qualifying measures do not constrain prediction.
 6. **Retains no serialized JSON after upload** -- memory stays proportional to
    `MaxConcurrentPatients -- resources-per-patient`, not the full run size.
 7. **Processes imported patients alongside generated ones** -- after the generated cohort
@@ -499,80 +500,34 @@ appends it directly to the ABS blob, bypassing `PatientAggregator`'s aggregation
 
 ### 8.5 CQL filter simulator semantics
 
-`CqlFilterSimulator.ComputeFilteredKeys(measures, input)` returns resources that will be
-excluded by SDE `where` semantics. The result is the **intersection** of exclusions across
-applicable measure profiles **per resource type**, because MeasureEval evaluates each
-measure independently and writes one `.mr` file per measure; `PatientAggregator` unions
-contained resources across those files into the patient NDJSON. A resource is only truly
-absent from ABS when every applicable measure for its resource type excludes it.
-Profiles for other resource types do not participate in that intersection -- an
-Observation profile has no opinion about whether a Condition belongs in ABS.
+Instance-level ABS prediction is derived from the **measure bundle CQL that this run
+will evaluate**, not from a handwritten measure-family profile.
 
-The simulator also models patient-context CQL retrieval. A DataAcquisition reference query
-can acquire a resource because some other acquired resource references it, but the measure
-CQL still evaluates `[ResourceType]` in the current patient context. Profiles therefore may
-check patient ownership/reference fields before predicting inclusion. The most important
-case today is `Specimen`: `Specimen.subject` must resolve to the evaluated patient before
-monthly ACH or Hypoglycemic specimen rules can include it, and ACH Daily additionally
-requires an included respiratory-pathogen observation to reference the specimen.
+`CqlFilterSimulator.ComputeFilteredKeys(measures, input)` loads each qualifying
+measure's embedded FHIR bundle (`ProfiledMeasureCatalog.ReadBundleJson`), strips CQL
+comments, and turns reachable SDE `define` bodies into inclusion rules (category,
+status, valueset codes, IP/date relations, encounter linkage, specimen-from-observation).
+Resources of a type that the bundle's SDE produces, but that match none of those rules,
+are excluded.
 
-For multi-measure runs with per-patient eligibility, `FhirGenerationPipeline` passes only
-each patient's **qualifying** measures into `ComputeFilteredKeys`, because a measure the
-patient does not qualify for does not contribute contained resources to ABS and therefore
-must not influence the intersection.
+The result is the **intersection** of exclusions across measures **per resource type**,
+because MeasureEval writes one `.mr` file per measure and `PatientAggregator` unions
+contained resources. A resource is absent from ABS only when every applicable measure
+for that type excludes it.
 
-#### Initial-Population windows (`MeasureInitialPopulationResolver`)
+`FhirGenerationPipeline` passes only the patient's qualifying measures. Non-qualifying
+measures do not contribute contained resources and must not influence the intersection.
 
-Most SDE `where` clauses have the shape
-`where exists "Initial Population" IP where Resource.X overlaps IP.period`. The simulator
-resolves the patient's IP windows once per call by walking every encounter in the input
-and keeping those whose `class.code` qualifies them for any selected measure:
+This is why updating the ACH Monthly/Daily CQL bundles does not require recoding a
+family profile: comment-stripping and SDE analysis read the CQL that MeasureEval
+runs. Known remaining gaps (not a full CQL engine): encounter-type and
+encounter-location IP qualification, Hypoglycemic antidiabetic-drug IP membership,
+and `HospitalizationWithObservationOrEmergency` interval expansion (approximated as
+the IP encounter period).
 
-- ACH Monthly + ACH Daily -- `class` in the NHSN inpatient set
-  {`IMP`, `ACUTE`, `NONAC`, `SS`} plus direct emergency / observation codes
-  {`EMER`, `OBSENC`}.
-- Hypoglycemic -- `class` in the NHSN inpatient set {`IMP`, `ACUTE`, `NONAC`, `SS`}.
-
-Known resolver gaps are documented in `EncounterIpClassification`: encounter type-based
-qualification, encounter-location-based qualification, and the full Hypoglycemic
-antidiabetic-medication requirement are approximated rather than fully CQL-evaluated.
-
-The resulting `IpWindow` set is then passed to every applicable filter profile via
-`PatientCqlInput.IpWindows`. The `IpWindowExtensions` helpers (`AnyOverlaps`,
-`AnyContains`, `AnyEncounterMatches`, `AnyEndStrictlyAfter`, `AnyEndOnOrAfter`) let each
-profile express its rule in terms of the resolved set rather than a single legacy
-`EncounterStart`/`EncounterEnd` pair.
-
-When a `PatientCqlInput` is built via the legacy positional constructor (no `Encounters`
-list), the simulator falls back to a single window derived from
-`EncounterId` + `EncounterStart` + `EncounterEnd` so pre-multi-encounter tests and
-single-encounter generators continue to work unchanged.
-
-#### Built-in profiles
-
-`CqlFilterSimulator` ships with profiles spanning every resource type currently retrieved
-by an SDE `define` in the supported measures:
-
-| Profile | Resource type | Measures | Rule (summary) |
-|---|---|---|---|
-| `AchConditionFilterProfile` | `Condition` | ACH Monthly + Daily | `problem-list-item` requires `active` + `recordedDate` strictly before any IP `end`; OR `encounter-diagnosis` / `health-concern` referencing any IP encounter. |
-| `HypoglycemicConditionFilterProfile` | `Condition` | Hypoglycemic | `recordedDate <= IP.end` (no active constraint). |
-| `AchObservationFilterProfile` | `Observation` | ACH Monthly + Daily | `category` in {`laboratory`, `vital-signs`, `social-history`, `survey`, `imaging`, `procedure`} AND effective overlaps any IP. |
-| `HypoglycemicObservationFilterProfile` | `Observation` | Hypoglycemic | LOINC in the blood-glucose lab/POC whitelist (2339-0, 2345-7, 41653-7) AND `start of effective during IP` (point-in-IP). |
-| `AchProcedureFilterProfile` | `Procedure` | ACH Monthly + Daily | `performed` overlaps any IP. |
-| `AchHypoMedicationRequestFilterProfile` | `MedicationRequest` | ACH + Hypoglycemic | `authoredOn` falls inside any IP. |
-| `HypoMedicationAdministrationFilterProfile` | `MedicationAdministration` | Hypoglycemic | `effective` overlaps any IP. |
-| `AchHypoCoverageFilterProfile` | `Coverage` | ACH + Hypoglycemic | `period` overlaps any IP (open ends supported). |
-| `AchHypoServiceRequestFilterProfile` | `ServiceRequest` | ACH + Hypoglycemic | `authoredOn` falls inside any IP. |
-| `AchEncounterFilterProfile` | `Encounter` | ACH Monthly + Daily + Hypoglycemic | Encounter must itself overlap an IP window (IP encounters trivially overlap themselves; ACH SDE also pulls in non-IP encounters that overlap IP). |
-| `AchMonthlySpecimenFilterProfile` | `Specimen` | ACH Monthly | `Specimen.subject` resolves to the evaluated patient AND `collection.collected` overlaps any IP. This mirrors patient-context `[Specimen]` plus the monthly SDE `overlaps IP.period` predicate. |
-| `AchDailySpecimenFilterProfile` | `Specimen` | ACH Daily | `Specimen.subject` resolves to the evaluated patient AND the specimen is referenced by a final/registered/preliminary/partial laboratory observation whose LOINC is in the respiratory pathogen (COVID-19, influenza, RSV) value sets used by the daily measure. Daily does **not** include every collected-in-period specimen. |
-| `HypoglycemicSpecimenFilterProfile` | `Specimen` | Hypoglycemic | `Specimen.subject` resolves to the evaluated patient AND `collection.collected` is fully during any IP. |
-
-All profiles are extracted from real generated FHIR content via
-`CqlFilterInputExtractor` -- the simulator never replays seeds. Adding a new family is a
-matter of implementing `ICqlFilterProfile` (which exposes `TargetResourceType`,
-`AppliesToAny`, and `ComputeExcludedKeys`) and registering it in the `Profiles` list.
+When a `PatientCqlInput` is built via the legacy positional constructor (no
+`Encounters` list), IP falls back to `EncounterId` + `EncounterStart` +
+`EncounterEnd`.
 
 ### 8.6 Related helpers
 

--- a/DotNet/Automation/measures/NHSNAcuteCareHospitalDailyInitialPopulation.json
+++ b/DotNet/Automation/measures/NHSNAcuteCareHospitalDailyInitialPopulation.json
@@ -344,81 +344,14 @@
       "resource": {
         "resourceType": "Library",
         "id": "NHSNAcuteCareHospitalDailyInitialPopulation",
-        "contained": [
-          {
-            "resourceType": "Parameters",
-            "id": "options",
-            "parameter": [
-              {
-                "name": "translatorVersion",
-                "valueString": "3.11.0"
-              },
-              {
-                "name": "option",
-                "valueString": "EnableDateRangeOptimization"
-              },
-              {
-                "name": "option",
-                "valueString": "EnableAnnotations"
-              },
-              {
-                "name": "option",
-                "valueString": "EnableLocators"
-              },
-              {
-                "name": "option",
-                "valueString": "DisableListDemotion"
-              },
-              {
-                "name": "option",
-                "valueString": "DisableListPromotion"
-              },
-              {
-                "name": "analyzeDataRequirements",
-                "valueBoolean": false
-              },
-              {
-                "name": "collapseDataRequirements",
-                "valueBoolean": true
-              },
-              {
-                "name": "compatibilityLevel",
-                "valueString": "1.5"
-              },
-              {
-                "name": "enableCqlOnly",
-                "valueBoolean": false
-              },
-              {
-                "name": "errorLevel",
-                "valueString": "Info"
-              },
-              {
-                "name": "signatureLevel",
-                "valueString": "Overloads"
-              },
-              {
-                "name": "validateUnits",
-                "valueBoolean": true
-              },
-              {
-                "name": "verifyOnly",
-                "valueBoolean": false
-              }
-            ]
-          }
-        ],
-        "extension": [
-          {
-            "url": "http://hl7.org/fhir/StructureDefinition/cqf-cqlOptions",
-            "valueReference": {
-              "reference": "#options"
-            }
-          }
-        ],
+        "text": {
+          "status": "extensions",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n<div>\n    <table class=\"grid dict\">\n        \n        \n\n        \n        \n        <tr>\n            <th scope=\"row\"><b>Id: </b></th>\n            <td style=\"padding-left: 4px;\">NHSNAcuteCareHospitalDailyInitialPopulation</td>\n        </tr>\n        \n\n        \n        \n        <tr>\n            <th scope=\"row\"><b>Version: </b></th>\n            <td style=\"padding-left: 4px;\">2.0.0-cibuild</td>\n        </tr>\n        \n\n        \n        <tr>\n            <th scope=\"row\"><b>Url: </b></th>\n            <td style=\"padding-left: 4px;\"><a href=\"Library-NHSNAcuteCareHospitalDailyInitialPopulation.html\">NHSNAcuteCareHospitalDailyInitialPopulation</a></td>\n        </tr>\n        \n\n        \n\n        \n\n        \n        <tr>\n            <th scope=\"row\"><b>Status: </b></th>\n            <td style=\"padding-left: 4px;\">draft</td>\n        </tr>\n        \n\n        \n\n        \n        <tr>\n            <th scope=\"row\"><b>Type: </b></th>\n            <td style=\"padding-left: 4px;\">\n                \n                    \n                        \n                        <p style=\"margin-bottom: 5px;\">\n                            <b>system: </b> <span><a href=\"http://terminology.hl7.org/7.0.1/CodeSystem-library-type.html\">http://terminology.hl7.org/CodeSystem/library-type</a></span>\n                        </p>\n                        \n                        \n                        <p style=\"margin-bottom: 5px;\">\n                            <b>code: </b> <span>logic-library</span>\n                        </p>\n                        \n                        \n                    \n                \n                \n            </td>\n        </tr>\n        \n\n        \n\n        \n        <tr>\n            <th scope=\"row\"><b>Date: </b></th>\n            <td style=\"padding-left: 4px;\">2026-01-08 14:28:51+0000</td>\n        </tr>\n        \n\n        \n        <tr>\n            <th scope=\"row\"><b>Publisher: </b></th>\n            <td style=\"padding-left: 4px;\">CDC National Healthcare Safety Network (NHSN)</td>\n        </tr>\n        \n\n        \n\n        \n\n        \n\n        \n\n        \n        <tr>\n            <th scope=\"row\"><b>Jurisdiction: </b></th>\n            <td style=\"padding-left: 4px;\">US</td>\n        </tr>\n        \n\n        \n\n        \n\n        \n\n        \n\n        \n\n        \n\n        \n        <tr>\n            <th scope=\"row\"><b>Related Artifacts: </b></th>\n            <td style=\"padding-left: 4px;\">\n                \n                \n                \n                <p><b>Dependencies</b></p>\n                <ul>\n                  \n                    <li><a href=\"http://fhir.org/guides/cqf/common/4.0.1/4.0.1/Library-FHIR-ModelInfo.html\">http://fhir.org/guides/cqf/common/Library/FHIR-ModelInfo|4.0.1</a></li>\n                  \n                    <li><code>http://www.cdc.gov/nhsn/fhirportal/dqm/ig/Library/FHIRHelpers|4.0.2</code></li>\n                  \n                    <li><code>http://www.cdc.gov/nhsn/fhirportal/dqm/ig/Library/NHSNHelpers|0.0.002</code></li>\n                  \n                    <li><code>http://www.cdc.gov/nhsn/fhirportal/dqm/ig/Library/SharedResourceCreation|0.1.010</code></li>\n                  \n                    <li><a href=\"http://terminology.hl7.org/7.0.1/CodeSystem-v3-ActCode.html\">ActCodeversion: null9.0.0)</a></li>\n                  \n                    <li><a href=\"http://terminology.hl7.org/6.5.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></li>\n                  \n                    <li><a href=\"http://terminology.hl7.org/7.0.1/CodeSystem-observation-category.html\">Observation Category Codesversion: null2.0.0)</a></li>\n                  \n                    <li><a href=\"http://terminology.hl7.org/6.5.0/CodeSystem-v3-rxNorm.html\">RxNorm</a></li>\n                  \n                    <li><a href=\"https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.3.666.5.307/expansion\">Encounter Inpatient</a></li>\n                  \n                    <li><a href=\"https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1046.265/expansion\">Inpatient, Emergency, and Observation Locations</a></li>\n                  \n                    <li><a href=\"https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1111.143/expansion\">Observation Services</a></li>\n                  \n                    <li><a href=\"http://terminology.hl7.org/7.0.1/ValueSet-encounter-discharge-disposition.html\">Discharge dispositionversion: null1.0.1)</a></li>\n                  \n                    <li><a href=\"https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1146.1142/expansion\">COVID_19 (Tests for SARS_CoV_2 Nucleic Acid)version: null20250218)</a></li>\n                  \n                    <li><a href=\"https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1146.1158/expansion\">COVID_19 (Tests for SARS_CoV_2 Antigen)version: null20240123)</a></li>\n                  \n                    <li><a href=\"https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1146.1143/expansion\">COVID_19 (Organism or Substance in Lab Results)version: null20250218)</a></li>\n                  \n                    <li><a href=\"https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1146.336/expansion\">Influenza (Tests for influenza A or B virus Nucleic Acid)version: null20250218)</a></li>\n                  \n                    <li><a href=\"https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1146.337/expansion\">Influenza (Tests for influenza A or B virus Antigen)</a></li>\n                  \n                    <li><a href=\"https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1146.340/expansion\">Influenza (influenza A or B virus in Lab Results)</a></li>\n                  \n                    <li><a href=\"https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1146.1311/expansion\">RSV (Tests for RSV Antigen)</a></li>\n                  \n                    <li><a href=\"https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1146.1312/expansion\">RSV (Tests for RSV Nucleic Acid)version: null20250218)</a></li>\n                  \n                    <li><a href=\"https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1146.1308/expansion\">RSV (Organism or Substance in Lab Results)</a></li>\n                  \n                    <li><a href=\"https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1114.10/expansion\">LIVD SARS CoV2 Test Result Codes</a></li>\n                  \n                    <li><a href=\"https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.3.3616.200.110.102.2046/expansion\">Baricitinib</a></li>\n                  \n                    <li><a href=\"https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.3.3616.200.110.102.2054/expansion\">Anakinra</a></li>\n                  \n                    <li><a href=\"https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.3.3616.200.110.102.2084/expansion\">Sarilumab</a></li>\n                  \n                    <li><a href=\"https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.3.3616.200.110.102.2087/expansion\">COVID19 RxNorm Value Set for Tocilizumab</a></li>\n                  \n                    <li><a href=\"https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.3.3616.200.110.102.2097/expansion\">Casirivimab</a></li>\n                  \n                    <li><a href=\"https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.3.3616.200.110.102.2098/expansion\">Imdevimab</a></li>\n                  \n                    <li><a href=\"https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.3.3616.200.110.102.2099/expansion\">Bamlanivimab</a></li>\n                  \n                    <li><a href=\"https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.3.3616.200.110.102.2100/expansion\">Etesevimab</a></li>\n                  \n                    <li><a href=\"https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.3.3616.200.110.102.2101/expansion\">Sotrovimab</a></li>\n                  \n                    <li><a href=\"https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.3.3616.200.110.102.2102/expansion\">Tofacitinib</a></li>\n                  \n                    <li><a href=\"https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.3.3616.200.110.102.2103/expansion\">Casirivimab / Imdevimab</a></li>\n                  \n                    <li><a href=\"https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.3.3616.200.110.102.2119/expansion\">Molnupiravir</a></li>\n                  \n                    <li><a href=\"https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.3.3616.200.110.102.2081/expansion\">Remdesivir</a></li>\n                  \n                    <li><a href=\"https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.3.3616.200.110.102.2104/expansion\">Nirmatrelvir / Ritonavir</a></li>\n                  \n                    <li><a href=\"https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.3.3616.200.110.102.2105/expansion\">Bebtelovimab</a></li>\n                  \n                    <li><a href=\"https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1190.85/expansion\">Baloxavir</a></li>\n                  \n                    <li><a href=\"https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1190.86/expansion\">Peramivir</a></li>\n                  \n                    <li><a href=\"https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1190.87/expansion\">Zanamivir</a></li>\n                  \n                    <li><a href=\"https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.3.3616.200.110.102.2078/expansion\">Oseltamivir</a></li>\n                  \n                    <li><a href=\"https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.10.20.22.5.300/expansion\">Transmission Based Precaution Typesversion: null20240607)</a></li>\n                  \n                    <li><a href=\"https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1046.274/expansion\">NHSN Inpatient Encounter Class Codes</a></li>\n                  \n                </ul>\n                \n                \n                \n                \n                \n            </td>\n        </tr>\n        \n\n        \n        <tr>\n          <th scope=\"row\"><b>Parameters: </b></th>\n          <td style=\"padding-left: 4px;\">\n            <table class=\"grid-dict\">\n              <tr><th><b>Name</b></th><th><b>Type</b></th><th><b>Min</b></th><th><b>Max</b></th><th><b>In/Out</b></th></tr>\n              \n                <tr><th>Measurement Period</th><th>Period</th><th>0</th><th>1</th><th>In</th></tr>\n              \n                <tr><th>Patient</th><th>Patient</th><th>0</th><th>1</th><th>Out</th></tr>\n              \n                <tr><th>EncounterInpatient</th><th>Encounter</th><th>0</th><th>*</th><th>Out</th></tr>\n              \n                <tr><th>EncounterObservation</th><th>Encounter</th><th>0</th><th>*</th><th>Out</th></tr>\n              \n                <tr><th>Encounters with Patient Hospital Locations</th><th>Encounter</th><th>0</th><th>*</th><th>Out</th></tr>\n              \n                <tr><th>Initial Population</th><th>Encounter</th><th>0</th><th>*</th><th>Out</th></tr>\n              \n                <tr><th>COVID And Influenza Observation</th><th>Observation</th><th>0</th><th>*</th><th>Out</th></tr>\n              \n                <tr><th>RSV Observation</th><th>Observation</th><th>0</th><th>*</th><th>Out</th></tr>\n              \n                <tr><th>ACH Daily Observation</th><th>Observation</th><th>0</th><th>*</th><th>Out</th></tr>\n              \n                <tr><th>COVID And Influenza PRE Admission Observation</th><th>Observation</th><th>0</th><th>*</th><th>Out</th></tr>\n              \n                <tr><th>RSV PRE Admission Observation</th><th>Observation</th><th>0</th><th>*</th><th>Out</th></tr>\n              \n                <tr><th>COVID And Influenza DiagnosticReport</th><th>DiagnosticReport</th><th>0</th><th>*</th><th>Out</th></tr>\n              \n                <tr><th>RSV DiagnosticReport</th><th>DiagnosticReport</th><th>0</th><th>*</th><th>Out</th></tr>\n              \n                <tr><th>ACH Daily DiagnosticReport</th><th>DiagnosticReport</th><th>0</th><th>*</th><th>Out</th></tr>\n              \n                <tr><th>COVID And Influenza DiagnosticReport PRE Admission</th><th>DiagnosticReport</th><th>0</th><th>*</th><th>Out</th></tr>\n              \n                <tr><th>RSV DiagnosticReport PRE Admission</th><th>DiagnosticReport</th><th>0</th><th>*</th><th>Out</th></tr>\n              \n                <tr><th>DiagnosticReports</th><th>DiagnosticReport</th><th>0</th><th>*</th><th>Out</th></tr>\n              \n                <tr><th>Observations</th><th>Observation</th><th>0</th><th>*</th><th>Out</th></tr>\n              \n                <tr><th>COVID and Influenza DiagnosticReport Observations</th><th>Observation</th><th>0</th><th>*</th><th>Out</th></tr>\n              \n                <tr><th>COVID and Influenza DiagnosticReport Result from Lab</th><th>DiagnosticReport</th><th>0</th><th>*</th><th>Out</th></tr>\n              \n                <tr><th>RSV Observations</th><th>Observation</th><th>0</th><th>*</th><th>Out</th></tr>\n              \n                <tr><th>RSV DiagnosticReport Observations</th><th>DiagnosticReport</th><th>0</th><th>*</th><th>Out</th></tr>\n              \n                <tr><th>RSV DiagnosticReport Result from Lab</th><th>DiagnosticReport</th><th>0</th><th>*</th><th>Out</th></tr>\n              \n                <tr><th>ACH Daily DiagnosticReport Result from Lab</th><th>DiagnosticReport</th><th>0</th><th>*</th><th>Out</th></tr>\n              \n                <tr><th>COVID and Influenza DiagnosticReport Result from Lab PRE Admission</th><th>DiagnosticReport</th><th>0</th><th>*</th><th>Out</th></tr>\n              \n                <tr><th>RSV DiagnosticReport Result from Lab PRE Admission</th><th>DiagnosticReport</th><th>0</th><th>*</th><th>Out</th></tr>\n              \n                <tr><th>SDE IP Encounters</th><th>Encounter</th><th>0</th><th>*</th><th>Out</th></tr>\n              \n                <tr><th>Encounters</th><th>Encounter</th><th>0</th><th>*</th><th>Out</th></tr>\n              \n                <tr><th>SDE Encounter</th><th>Encounter</th><th>0</th><th>*</th><th>Out</th></tr>\n              \n                <tr><th>SDE Minimal Patient</th><th>Patient</th><th>0</th><th>1</th><th>Out</th></tr>\n              \n                <tr><th>SDE Location</th><th>Location</th><th>0</th><th>*</th><th>Out</th></tr>\n              \n                <tr><th>SDE Encounter Discharge Dispositions</th><th>Encounter</th><th>0</th><th>*</th><th>Out</th></tr>\n              \n                <tr><th>SDE ACH Daily Observation</th><th>Observation</th><th>0</th><th>*</th><th>Out</th></tr>\n              \n                <tr><th>SDE RSV PRE Admission Observation</th><th>Observation</th><th>0</th><th>*</th><th>Out</th></tr>\n              \n                <tr><th>SDE COVID And Influenza PRE Admission Observation</th><th>Observation</th><th>0</th><th>*</th><th>Out</th></tr>\n              \n                <tr><th>SDE ACH Daily Specimen</th><th>Specimen</th><th>0</th><th>*</th><th>Out</th></tr>\n              \n                <tr><th>SDE RSV Specimen</th><th>Specimen</th><th>0</th><th>*</th><th>Out</th></tr>\n              \n                <tr><th>SDE COVID And Influenza Specimen</th><th>Specimen</th><th>0</th><th>*</th><th>Out</th></tr>\n              \n                <tr><th>SDE ACH Daily DiagnosticReport</th><th>DiagnosticReport</th><th>0</th><th>*</th><th>Out</th></tr>\n              \n                <tr><th>SDE COVID And Influenza DiagnosticReport</th><th>DiagnosticReport</th><th>0</th><th>*</th><th>Out</th></tr>\n              \n                <tr><th>SDE RSV DiagnosticReport</th><th>DiagnosticReport</th><th>0</th><th>*</th><th>Out</th></tr>\n              \n                <tr><th>SDE ACH Daily DiagnosticReport Result from Lab</th><th>DiagnosticReport</th><th>0</th><th>*</th><th>Out</th></tr>\n              \n                <tr><th>SDE COVID and Influenza DiagnosticReport Result from Lab</th><th>DiagnosticReport</th><th>0</th><th>*</th><th>Out</th></tr>\n              \n                <tr><th>SDE RSV DiagnosticReport Result from Lab</th><th>DiagnosticReport</th><th>0</th><th>*</th><th>Out</th></tr>\n              \n                <tr><th>SDE ACH Daily ServiceRequest</th><th>ServiceRequest</th><th>0</th><th>*</th><th>Out</th></tr>\n              \n                <tr><th>SDE Isolation Precautions Implemented</th><th>Procedure</th><th>0</th><th>*</th><th>Out</th></tr>\n              \n                <tr><th>SDE Covid or Influenza Medication Administered</th><th>MedicationAdministration</th><th>0</th><th>*</th><th>Out</th></tr>\n              \n                <tr><th>SDE Covid or Influenza Medication Ordered</th><th>MedicationRequest</th><th>0</th><th>*</th><th>Out</th></tr>\n              \n                <tr><th>SDE Medication</th><th>Medication</th><th>0</th><th>*</th><th>Out</th></tr>\n              \n                <tr><th>SDE All Observations</th><th>Observation</th><th>0</th><th>*</th><th>Out</th></tr>\n              \n                <tr><th>SDE All ServiceRequests</th><th>ServiceRequest</th><th>0</th><th>*</th><th>Out</th></tr>\n              \n                <tr><th>SDE All Procedures</th><th>Procedure</th><th>0</th><th>*</th><th>Out</th></tr>\n              \n            </table>\n          </td>\n        </tr>\n        \n\n        \n        <tr>\n          <th scope=\"row\"><b>Data Requirements:</b></th>\n          <td style=\"padding-left: 4px;\">\n            <table class=\"grid-dict\">\n              <tr><th><b>Type</b></th><th><b>Profile</b></th><th><b>MS</b></th><th><b>Code Filter</b></th></tr>\n              \n                <tr>\n                  <th>Patient</th>\n                  <th>http://hl7.org/fhir/StructureDefinition/Patient</th>\n                  <th>;;;;;;;;;;;;;;;;;</th>\n                  <th>\n                    \n                  </th>\n                </tr>\n              \n                <tr>\n                  <th>Encounter</th>\n                  <th>http://hl7.org/fhir/StructureDefinition/Encounter</th>\n                  <th>;;;;;;;;;;;;;;;;;;;;;</th>\n                  <th>\n                    \n                      <b>code filter: </b>\n                      \n                      <br/>\n                      \n                      \n                      <span style=\"padding-left: 4px;\">\n                          <b>path: </b><span>type</span>\n                      </span>\n                      \n                      <br/>\n                      \n                      \n                      \n                      <span style=\"padding-left: 4px;\">\n                          <b>value set: </b><span>http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307</span>\n                      </span>\n                      \n                      \n                    \n                  </th>\n                </tr>\n              \n                <tr>\n                  <th>Encounter</th>\n                  <th>http://hl7.org/fhir/StructureDefinition/Encounter</th>\n                  <th>;;;;;;;;;;;;;;;;;;;;;</th>\n                  <th>\n                    \n                      <b>code filter: </b>\n                      \n                      <br/>\n                      \n                      \n                      <span style=\"padding-left: 4px;\">\n                          <b>path: </b><span>class</span>\n                      </span>\n                      \n                      <br/>\n                      \n                      \n                      \n                      <span style=\"padding-left: 4px;\">\n                          <b>value set: </b><span>http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1046.274</span>\n                      </span>\n                      \n                      \n                    \n                  </th>\n                </tr>\n              \n                <tr>\n                  <th>Encounter</th>\n                  <th>http://hl7.org/fhir/StructureDefinition/Encounter</th>\n                  <th>;;;;;;;;;;;;;;;;;;;;;</th>\n                  <th>\n                    \n                      <b>code filter: </b>\n                      \n                      <br/>\n                      \n                      \n                      <span style=\"padding-left: 4px;\">\n                          <b>path: </b><span>type</span>\n                      </span>\n                      \n                      <br/>\n                      \n                      \n                      \n                      <span style=\"padding-left: 4px;\">\n                          <b>value set: </b><span>http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1111.143</span>\n                      </span>\n                      \n                      \n                    \n                  </th>\n                </tr>\n              \n                <tr>\n                  <th>Encounter</th>\n                  <th>http://hl7.org/fhir/StructureDefinition/Encounter</th>\n                  <th>;;;;;;;;;;;;;;;;;;;;;</th>\n                  <th>\n                    \n                      <b>code filter: </b>\n                      \n                      <br/>\n                      \n                      \n                      <span style=\"padding-left: 4px;\">\n                          <b>path: </b><span>class</span>\n                      </span>\n                      \n                      <br/>\n                      \n                      \n                      \n                      \n                          \n                          <p style=\"margin-bottom: 5px;\">\n                              <b>system: </b> <span><a href=\"http://terminology.hl7.org/7.0.1/CodeSystem-v3-ActCode.html\">http://terminology.hl7.org/CodeSystem/v3-ActCode</a></span>\n                          </p>\n                          \n                          \n                          <p style=\"margin-bottom: 5px;\">\n                              <b>code: </b> <span>OBSENC</span>\n                          </p>\n                          \n                          \n                          <p style=\"margin-bottom: 5px;\">\n                              <b>display: </b> <span>observation encounter</span>\n                          </p>\n                          \n                      \n                    \n                  </th>\n                </tr>\n              \n                <tr>\n                  <th>Encounter</th>\n                  <th>http://hl7.org/fhir/StructureDefinition/Encounter</th>\n                  <th>;;;;;;;;;;;;;;;;;;;;;</th>\n                  <th>\n                    \n                  </th>\n                </tr>\n              \n                <tr>\n                  <th>Location</th>\n                  <th>http://hl7.org/fhir/StructureDefinition/Location</th>\n                  <th>;;;;;;;;;;;;;;;;;;</th>\n                  <th>\n                    \n                  </th>\n                </tr>\n              \n                <tr>\n                  <th>Observation</th>\n                  <th>http://hl7.org/fhir/StructureDefinition/Observation</th>\n                  <th>;;;;;;;;;;;;;;;;;;;;;;;;;;;</th>\n                  <th>\n                    \n                      <b>code filter: </b>\n                      \n                      <br/>\n                      \n                      \n                      <span style=\"padding-left: 4px;\">\n                          <b>path: </b><span>code</span>\n                      </span>\n                      \n                      <br/>\n                      \n                      \n                      \n                      <span style=\"padding-left: 4px;\">\n                          <b>value set: </b><span>http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.336|20250218</span>\n                      </span>\n                      \n                      \n                    \n                  </th>\n                </tr>\n              \n                <tr>\n                  <th>Observation</th>\n                  <th>http://hl7.org/fhir/StructureDefinition/Observation</th>\n                  <th>;;;;;;;;;;;;;;;;;;;;;;;;;;;</th>\n                  <th>\n                    \n                      <b>code filter: </b>\n                      \n                      <br/>\n                      \n                      \n                      <span style=\"padding-left: 4px;\">\n                          <b>path: </b><span>code</span>\n                      </span>\n                      \n                      <br/>\n                      \n                      \n                      \n                      <span style=\"padding-left: 4px;\">\n                          <b>value set: </b><span>http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.337</span>\n                      </span>\n                      \n                      \n                    \n                  </th>\n                </tr>\n              \n                <tr>\n                  <th>Observation</th>\n                  <th>http://hl7.org/fhir/StructureDefinition/Observation</th>\n                  <th>;;;;;;;;;;;;;;;;;;;;;;;;;;;</th>\n                  <th>\n                    \n                      <b>code filter: </b>\n                      \n                      <br/>\n                      \n                      \n                      <span style=\"padding-left: 4px;\">\n                          <b>path: </b><span>code</span>\n                      </span>\n                      \n                      <br/>\n                      \n                      \n                      \n                      <span style=\"padding-left: 4px;\">\n                          <b>value set: </b><span>http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1142|20250218</span>\n                      </span>\n                      \n                      \n                    \n                  </th>\n                </tr>\n              \n                <tr>\n                  <th>Observation</th>\n                  <th>http://hl7.org/fhir/StructureDefinition/Observation</th>\n                  <th>;;;;;;;;;;;;;;;;;;;;;;;;;;;</th>\n                  <th>\n                    \n                      <b>code filter: </b>\n                      \n                      <br/>\n                      \n                      \n                      <span style=\"padding-left: 4px;\">\n                          <b>path: </b><span>code</span>\n                      </span>\n                      \n                      <br/>\n                      \n                      \n                      \n                      <span style=\"padding-left: 4px;\">\n                          <b>value set: </b><span>http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1158|20240123</span>\n                      </span>\n                      \n                      \n                    \n                  </th>\n                </tr>\n              \n                <tr>\n                  <th>Observation</th>\n                  <th>http://hl7.org/fhir/StructureDefinition/Observation</th>\n                  <th>;;;;;;;;;;;;;;;;;;;;;;;;;;;</th>\n                  <th>\n                    \n                      <b>code filter: </b>\n                      \n                      <br/>\n                      \n                      \n                      <span style=\"padding-left: 4px;\">\n                          <b>path: </b><span>code</span>\n                      </span>\n                      \n                      <br/>\n                      \n                      \n                      \n                      <span style=\"padding-left: 4px;\">\n                          <b>value set: </b><span>http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1312|20250218</span>\n                      </span>\n                      \n                      \n                    \n                  </th>\n                </tr>\n              \n                <tr>\n                  <th>Observation</th>\n                  <th>http://hl7.org/fhir/StructureDefinition/Observation</th>\n                  <th>;;;;;;;;;;;;;;;;;;;;;;;;;;;</th>\n                  <th>\n                    \n                      <b>code filter: </b>\n                      \n                      <br/>\n                      \n                      \n                      <span style=\"padding-left: 4px;\">\n                          <b>path: </b><span>code</span>\n                      </span>\n                      \n                      <br/>\n                      \n                      \n                      \n                      <span style=\"padding-left: 4px;\">\n                          <b>value set: </b><span>http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1311</span>\n                      </span>\n                      \n                      \n                    \n                  </th>\n                </tr>\n              \n                <tr>\n                  <th>Observation</th>\n                  <th>http://hl7.org/fhir/StructureDefinition/Observation</th>\n                  <th>;;;;;;;;;;;;;;;;;;;;;;;;;;;</th>\n                  <th>\n                    \n                  </th>\n                </tr>\n              \n                <tr>\n                  <th>Specimen</th>\n                  <th>http://hl7.org/fhir/StructureDefinition/Specimen</th>\n                  <th>;;;;;;;;;;;;;;;</th>\n                  <th>\n                    \n                  </th>\n                </tr>\n              \n                <tr>\n                  <th>DiagnosticReport</th>\n                  <th>http://hl7.org/fhir/StructureDefinition/DiagnosticReport</th>\n                  <th>;;;;;;;;;;;;;;;;</th>\n                  <th>\n                    \n                      <b>code filter: </b>\n                      \n                      <br/>\n                      \n                      \n                      <span style=\"padding-left: 4px;\">\n                          <b>path: </b><span>code</span>\n                      </span>\n                      \n                      <br/>\n                      \n                      \n                      \n                      <span style=\"padding-left: 4px;\">\n                          <b>value set: </b><span>http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1142|20250218</span>\n                      </span>\n                      \n                      \n                    \n                  </th>\n                </tr>\n              \n                <tr>\n                  <th>DiagnosticReport</th>\n                  <th>http://hl7.org/fhir/StructureDefinition/DiagnosticReport</th>\n                  <th>;;;;;;;;;;;;;;;;</th>\n                  <th>\n                    \n                      <b>code filter: </b>\n                      \n                      <br/>\n                      \n                      \n                      <span style=\"padding-left: 4px;\">\n                          <b>path: </b><span>code</span>\n                      </span>\n                      \n                      <br/>\n                      \n                      \n                      \n                      <span style=\"padding-left: 4px;\">\n                          <b>value set: </b><span>http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1158|20240123</span>\n                      </span>\n                      \n                      \n                    \n                  </th>\n                </tr>\n              \n                <tr>\n                  <th>DiagnosticReport</th>\n                  <th>http://hl7.org/fhir/StructureDefinition/DiagnosticReport</th>\n                  <th>;;;;;;;;;;;;;;;;</th>\n                  <th>\n                    \n                      <b>code filter: </b>\n                      \n                      <br/>\n                      \n                      \n                      <span style=\"padding-left: 4px;\">\n                          <b>path: </b><span>code</span>\n                      </span>\n                      \n                      <br/>\n                      \n                      \n                      \n                      <span style=\"padding-left: 4px;\">\n                          <b>value set: </b><span>http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.336|20250218</span>\n                      </span>\n                      \n                      \n                    \n                  </th>\n                </tr>\n              \n                <tr>\n                  <th>DiagnosticReport</th>\n                  <th>http://hl7.org/fhir/StructureDefinition/DiagnosticReport</th>\n                  <th>;;;;;;;;;;;;;;;;</th>\n                  <th>\n                    \n                      <b>code filter: </b>\n                      \n                      <br/>\n                      \n                      \n                      <span style=\"padding-left: 4px;\">\n                          <b>path: </b><span>code</span>\n                      </span>\n                      \n                      <br/>\n                      \n                      \n                      \n                      <span style=\"padding-left: 4px;\">\n                          <b>value set: </b><span>http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.337</span>\n                      </span>\n                      \n                      \n                    \n                  </th>\n                </tr>\n              \n                <tr>\n                  <th>DiagnosticReport</th>\n                  <th>http://hl7.org/fhir/StructureDefinition/DiagnosticReport</th>\n                  <th>;;;;;;;;;;;;;;;;</th>\n                  <th>\n                    \n                      <b>code filter: </b>\n                      \n                      <br/>\n                      \n                      \n                      <span style=\"padding-left: 4px;\">\n                          <b>path: </b><span>code</span>\n                      </span>\n                      \n                      <br/>\n                      \n                      \n                      \n                      <span style=\"padding-left: 4px;\">\n                          <b>value set: </b><span>http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1312|20250218</span>\n                      </span>\n                      \n                      \n                    \n                  </th>\n                </tr>\n              \n                <tr>\n                  <th>DiagnosticReport</th>\n                  <th>http://hl7.org/fhir/StructureDefinition/DiagnosticReport</th>\n                  <th>;;;;;;;;;;;;;;;;</th>\n                  <th>\n                    \n                      <b>code filter: </b>\n                      \n                      <br/>\n                      \n                      \n                      <span style=\"padding-left: 4px;\">\n                          <b>path: </b><span>code</span>\n                      </span>\n                      \n                      <br/>\n                      \n                      \n                      \n                      <span style=\"padding-left: 4px;\">\n                          <b>value set: </b><span>http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1311</span>\n                      </span>\n                      \n                      \n                    \n                  </th>\n                </tr>\n              \n                <tr>\n                  <th>DiagnosticReport</th>\n                  <th>http://hl7.org/fhir/StructureDefinition/DiagnosticReport</th>\n                  <th>;;;;;;;;;;;;;;;;</th>\n                  <th>\n                    \n                  </th>\n                </tr>\n              \n                <tr>\n                  <th>ServiceRequest</th>\n                  <th>http://hl7.org/fhir/StructureDefinition/ServiceRequest</th>\n                  <th>;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;</th>\n                  <th>\n                    \n                      <b>code filter: </b>\n                      \n                      <br/>\n                      \n                      \n                      <span style=\"padding-left: 4px;\">\n                          <b>path: </b><span>code</span>\n                      </span>\n                      \n                      <br/>\n                      \n                      \n                      \n                      <span style=\"padding-left: 4px;\">\n                          <b>value set: </b><span>http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1142|20250218</span>\n                      </span>\n                      \n                      \n                    \n                  </th>\n                </tr>\n              \n                <tr>\n                  <th>ServiceRequest</th>\n                  <th>http://hl7.org/fhir/StructureDefinition/ServiceRequest</th>\n                  <th>;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;</th>\n                  <th>\n                    \n                      <b>code filter: </b>\n                      \n                      <br/>\n                      \n                      \n                      <span style=\"padding-left: 4px;\">\n                          <b>path: </b><span>code</span>\n                      </span>\n                      \n                      <br/>\n                      \n                      \n                      \n                      <span style=\"padding-left: 4px;\">\n                          <b>value set: </b><span>http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1158|20240123</span>\n                      </span>\n                      \n                      \n                    \n                  </th>\n                </tr>\n              \n                <tr>\n                  <th>ServiceRequest</th>\n                  <th>http://hl7.org/fhir/StructureDefinition/ServiceRequest</th>\n                  <th>;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;</th>\n                  <th>\n                    \n                      <b>code filter: </b>\n                      \n                      <br/>\n                      \n                      \n                      <span style=\"padding-left: 4px;\">\n                          <b>path: </b><span>code</span>\n                      </span>\n                      \n                      <br/>\n                      \n                      \n                      \n                      <span style=\"padding-left: 4px;\">\n                          <b>value set: </b><span>http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.336|20250218</span>\n                      </span>\n                      \n                      \n                    \n                  </th>\n                </tr>\n              \n                <tr>\n                  <th>ServiceRequest</th>\n                  <th>http://hl7.org/fhir/StructureDefinition/ServiceRequest</th>\n                  <th>;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;</th>\n                  <th>\n                    \n                      <b>code filter: </b>\n                      \n                      <br/>\n                      \n                      \n                      <span style=\"padding-left: 4px;\">\n                          <b>path: </b><span>code</span>\n                      </span>\n                      \n                      <br/>\n                      \n                      \n                      \n                      <span style=\"padding-left: 4px;\">\n                          <b>value set: </b><span>http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.337</span>\n                      </span>\n                      \n                      \n                    \n                  </th>\n                </tr>\n              \n                <tr>\n                  <th>ServiceRequest</th>\n                  <th>http://hl7.org/fhir/StructureDefinition/ServiceRequest</th>\n                  <th>;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;</th>\n                  <th>\n                    \n                      <b>code filter: </b>\n                      \n                      <br/>\n                      \n                      \n                      <span style=\"padding-left: 4px;\">\n                          <b>path: </b><span>code</span>\n                      </span>\n                      \n                      <br/>\n                      \n                      \n                      \n                      <span style=\"padding-left: 4px;\">\n                          <b>value set: </b><span>http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1312|20250218</span>\n                      </span>\n                      \n                      \n                    \n                  </th>\n                </tr>\n              \n                <tr>\n                  <th>ServiceRequest</th>\n                  <th>http://hl7.org/fhir/StructureDefinition/ServiceRequest</th>\n                  <th>;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;</th>\n                  <th>\n                    \n                      <b>code filter: </b>\n                      \n                      <br/>\n                      \n                      \n                      <span style=\"padding-left: 4px;\">\n                          <b>path: </b><span>code</span>\n                      </span>\n                      \n                      <br/>\n                      \n                      \n                      \n                      <span style=\"padding-left: 4px;\">\n                          <b>value set: </b><span>http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1311</span>\n                      </span>\n                      \n                      \n                    \n                  </th>\n                </tr>\n              \n                <tr>\n                  <th>ServiceRequest</th>\n                  <th>http://hl7.org/fhir/StructureDefinition/ServiceRequest</th>\n                  <th>;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;</th>\n                  <th>\n                    \n                  </th>\n                </tr>\n              \n                <tr>\n                  <th>Procedure</th>\n                  <th>http://hl7.org/fhir/StructureDefinition/Procedure</th>\n                  <th>;;;;;;;;;;;;;;;;;;;;;;;;;;;;;</th>\n                  <th>\n                    \n                      <b>code filter: </b>\n                      \n                      <br/>\n                      \n                      \n                      <span style=\"padding-left: 4px;\">\n                          <b>path: </b><span>code</span>\n                      </span>\n                      \n                      <br/>\n                      \n                      \n                      \n                      <span style=\"padding-left: 4px;\">\n                          <b>value set: </b><span>http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.10.20.22.5.300|20240607</span>\n                      </span>\n                      \n                      \n                    \n                  </th>\n                </tr>\n              \n                <tr>\n                  <th>Procedure</th>\n                  <th>http://hl7.org/fhir/StructureDefinition/Procedure</th>\n                  <th>;;;;;;;;;;;;;;;;;;;;;;;;;;;;;</th>\n                  <th>\n                    \n                  </th>\n                </tr>\n              \n                <tr>\n                  <th>Medication</th>\n                  <th>http://hl7.org/fhir/StructureDefinition/Medication</th>\n                  <th>;;;;;;;;;</th>\n                  <th>\n                    \n                      <b>code filter: </b>\n                      \n                      <br/>\n                      \n                      \n                      <span style=\"padding-left: 4px;\">\n                          <b>path: </b><span>id</span>\n                      </span>\n                      \n                      \n                      \n                      \n                    \n                  </th>\n                </tr>\n              \n                <tr>\n                  <th>MedicationAdministration</th>\n                  <th>http://hl7.org/fhir/StructureDefinition/MedicationAdministration</th>\n                  <th>;;;;;;;;;;;;;;;;;;;;</th>\n                  <th>\n                    \n                  </th>\n                </tr>\n              \n                <tr>\n                  <th>MedicationRequest</th>\n                  <th>http://hl7.org/fhir/StructureDefinition/MedicationRequest</th>\n                  <th>;;;;;;;;;;;;;;;;;;;;;</th>\n                  <th>\n                    \n                  </th>\n                </tr>\n              \n            </table>\n          </td>\n        </tr>\n        \n\n        \n        \n        <tr>\n          <td colspan=\"2\">\n            <table>\n              <tr><th><a id=\"cql-content\"><b>Content: </b></a> text/cql</th></tr>\n              <tr><td><pre><code class=\"language-cql\">library NHSNAcuteCareHospitalDailyInitialPopulation version '2.0.0-dev'\n\nusing FHIR version '4.0.1'\n\ninclude FHIRHelpers version '4.0.2' called FHIRHelpers\ninclude NHSNHelpers version '0.0.002' called NHSNHelpers\ninclude SharedResourceCreation version '0.1.010' called SharedResource\n\ncodesystem &quot;ActCode&quot;: 'http://terminology.hl7.org/CodeSystem/v3-ActCode' \ncodesystem &quot;LOINC&quot;: 'http://loinc.org' \ncodesystem &quot;Observation Category&quot;: 'http://terminology.hl7.org/CodeSystem/observation-category' \ncodesystem &quot;RXNORM&quot;: 'http://www.nlm.nih.gov/research/umls/rxnorm'\n\nvalueset &quot;Encounter Inpatient&quot;: 'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307' \nvalueset &quot;Inpatient, Emergency, and Observation Locations&quot;: 'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1046.265' \nvalueset &quot;Observation Services&quot;: 'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1111.143' \nvalueset &quot;Discharge Disposition&quot;: 'http://terminology.hl7.org/ValueSet/clinical-discharge-disposition'\n\n//COVID-19 lab tests\nvalueset &quot;COVID_19 (Tests for SARS_CoV_2 Nucleic Acid)&quot;: 'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1142'\nvalueset &quot;COVID_19 (Tests for SARS_CoV_2 Antigen)&quot;: 'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1158'\n\n//COVID-19 test results (unused)\nvalueset &quot;COVID_19 (Organism or Substance in Lab Results)&quot;: 'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1143'\n\n//Influenza lab tests\nvalueset &quot;Influenza (Tests for influenza A or B virus Nucleic Acid)&quot;: 'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.336'\nvalueset &quot;Influenza (Tests for influenza A or B virus Antigen)&quot;: 'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.337'\n\n//Influenza test Results (unused)\nvalueset &quot;Influenza (influenza A or B virus in Lab Results)&quot;: 'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.340'\n\n//RSV lab tests\nvalueset &quot;RSV (Tests for RSV Antigen)&quot;: 'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1311'\nvalueset &quot;RSV (Tests for RSV Nucleic Acid)&quot;: 'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1312'\n\n//RSV test results (unused)\nvalueset &quot;RSV (Organism or Substance in Lab Results)&quot;: 'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1308'\n\n//Test results shared among COVID-19, Influenza and RSV (unused)\nvalueset &quot;LIVD SARS CoV2 Test Result Codes&quot;: 'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1114.10'\n\n//COVID-19 medications\nvalueset &quot;Baricitinib&quot;: 'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3616.200.110.102.2046'\nvalueset &quot;Anakinra&quot;: 'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3616.200.110.102.2054'\nvalueset &quot;Sarilumab&quot;: 'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3616.200.110.102.2084'\nvalueset &quot;COVID19 RxNorm Value Set for Tocilizumab&quot;: 'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3616.200.110.102.2087'\nvalueset &quot;Casirivimab&quot;: 'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3616.200.110.102.2097'\nvalueset &quot;Imdevimab&quot;: 'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3616.200.110.102.2098'\nvalueset &quot;Bamlanivimab&quot;: 'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3616.200.110.102.2099'\nvalueset &quot;Etesevimab&quot;: 'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3616.200.110.102.2100'\nvalueset &quot;Sotrovimab&quot;: 'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3616.200.110.102.2101'\nvalueset &quot;Tofacitinib&quot;: 'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3616.200.110.102.2102'\nvalueset &quot;Casirivimab / Imdevimab&quot;: 'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3616.200.110.102.2103'\nvalueset &quot;Molnupiravir&quot;: 'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3616.200.110.102.2119'\nvalueset &quot;Remdesivir&quot;: 'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3616.200.110.102.2081'\nvalueset &quot;Nirmatrelvir / Ritonavir&quot;: 'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3616.200.110.102.2104'\nvalueset &quot;Bebtelovimab&quot;: 'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3616.200.110.102.2105'\n\n//Influenza medications\nvalueset &quot;Baloxavir&quot;: 'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1190.85'\nvalueset &quot;Peramivir&quot;: 'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1190.86'\nvalueset &quot;Zanamivir&quot;: 'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1190.87'\nvalueset &quot;Oseltamivir&quot;: 'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3616.200.110.102.2078'\n\n//Isolation Precautions\nvalueset &quot;Transmission Based Precaution Types&quot;: 'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.10.20.22.5.300'\n\n//Encounter Class Codes\nvalueset &quot;NHSN Inpatient Encounter Class Codes&quot;: 'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1046.274'\n\n//Observation Category Codes\ncode &quot;laboratory&quot;: 'laboratory' from &quot;Observation Category&quot; display 'Laboratory'\n\n//Observation Encounter Class Code\ncode &quot;observation encounter&quot;: 'OBSENC' from &quot;ActCode&quot; display 'observation encounter'\n\nparameter &quot;Measurement Period&quot; \n  default Interval[@2022-01-01T00:00:00.0, @2022-01-02T00:00:00.0)\n\ncontext Patient\n\n//----------------------------------\n// Initial Population\n//----------------------------------\ndefine &quot;Initial Population&quot;:\n  EncounterInpatient\n  union EncounterObservation\n  union &quot;Encounters with Patient Hospital Locations&quot;\n\ndefine &quot;EncounterInpatient&quot;:\n  ([Encounter: &quot;Encounter Inpatient&quot;]\n    union [Encounter: class in &quot;NHSN Inpatient Encounter Class Codes&quot;]) Encounters\n  where Encounters.status in {'in-progress', 'finished', 'triaged', 'onleave', 'entered-in-error'}\n    and Encounters.period overlaps &quot;Measurement Period&quot;\n\ndefine &quot;EncounterObservation&quot;:\n  ([Encounter: &quot;Observation Services&quot;]\n    union [Encounter: class in {&quot;observation encounter&quot;}]) Encounters\n  where Encounters.status in {'in-progress', 'finished', 'triaged', 'onleave', 'entered-in-error'}\n    and Encounters.period overlaps &quot;Measurement Period&quot;\n\ndefine &quot;Encounters with Patient Hospital Locations&quot;:\n  [Encounter] Encounters\n  where exists(\n    Encounters.location EncounterLocation\n    let types: NHSNHelpers.GetLocation(EncounterLocation.location).type\n    where exists(\n      types type\n      where type in &quot;Inpatient, Emergency, and Observation Locations&quot;\n    )\n    and EncounterLocation.period overlaps Encounters.period\n    and Encounters.status in {'in-progress', 'finished', 'triaged', 'onleave', 'entered-in-error' }\n    and Encounters.period overlaps &quot;Measurement Period&quot;\n  )\n\n\n//-----------------------------------------------\n// Logic related to Laboratory\n//-----------------------------------------------\n//Lab Observations\ndefine &quot;COVID And Influenza Observation&quot;:\n  ([Observation: &quot;Influenza (Tests for influenza A or B virus Nucleic Acid)&quot;] \n  union [Observation: &quot;Influenza (Tests for influenza A or B virus Antigen)&quot;]\n  union [Observation: &quot;COVID_19 (Tests for SARS_CoV_2 Nucleic Acid)&quot;]\n  union [Observation: &quot;COVID_19 (Tests for SARS_CoV_2 Antigen)&quot;]\n  ) Observations\n    where exists(Observations.category Category where Category ~ &quot;laboratory&quot;)\n      and Observations.status in {'final','registered','preliminary','partial'}\n      and exists(&quot;Initial Population&quot;)\n\ndefine &quot;RSV Observation&quot;:\n  ([Observation: &quot;RSV (Tests for RSV Nucleic Acid)&quot;]\n  union [Observation: &quot;RSV (Tests for RSV Antigen)&quot;]   \n  ) Observations\n    where exists(Observations.category Category where Category ~ &quot;laboratory&quot;)\n      and Observations.status in {'final','registered','preliminary','partial'}\n      and exists(&quot;Initial Population&quot;)\n\ndefine &quot;ACH Daily Observation&quot;:\n  &quot;RSV Observation&quot;\n  union &quot;COVID And Influenza Observation&quot;\n\n//further constrain COVID-19 and Influenza Observations for 14 day lookback\ndefine &quot;COVID And Influenza PRE Admission Observation&quot;:\n  &quot;COVID And Influenza Observation&quot; O \n   where exists( EncounterInpatient E \n    where (\n      NHSNHelpers.&quot;Normalize Interval&quot;(O.effective) 14 days or less on or before start of E.period\n      or NHSNHelpers.&quot;Normalize Interval&quot;(GetSpecimen(O.specimen).collection.collected) 14 days or less on or before start of E.period\n      )\n      and start of E.period during &quot;Measurement Period&quot;\n    )  \n\n//further constrain RSV observation for 8 day lookback\ndefine &quot;RSV PRE Admission Observation&quot;:\n  &quot;RSV Observation&quot; O \n  where exists(EncounterInpatient E \n    where (\n      NHSNHelpers.&quot;Normalize Interval&quot;(O.effective) 8 days or less on or before start of E.period\n      or NHSNHelpers.&quot;Normalize Interval&quot;(GetSpecimen(O.specimen).collection.collected) 8 days or less on or before start of E.period\n      )\n      and start of E.period during &quot;Measurement Period&quot;\n    )\n\n//Lab DiagnosticReport\ndefine &quot;COVID And Influenza DiagnosticReport&quot;:\n  ([DiagnosticReport: &quot;COVID_19 (Tests for SARS_CoV_2 Nucleic Acid)&quot;]\n    union [DiagnosticReport: &quot;COVID_19 (Tests for SARS_CoV_2 Antigen)&quot;]\n    union [DiagnosticReport: &quot;Influenza (Tests for influenza A or B virus Nucleic Acid)&quot;]\n    union [DiagnosticReport: &quot;Influenza (Tests for influenza A or B virus Antigen)&quot;]\n  ) Reports\n    where exists(&quot;Initial Population&quot;)\n      and Reports.status in {'final','registered','preliminary','partial'}\n\ndefine &quot;RSV DiagnosticReport&quot;:\n  ([DiagnosticReport: &quot;RSV (Tests for RSV Nucleic Acid)&quot;]\n    union [DiagnosticReport: &quot;RSV (Tests for RSV Antigen)&quot;]\n  ) Reports\n    where exists(&quot;Initial Population&quot;)\n      and Reports.status in {'final','registered','preliminary','partial'}\n\ndefine &quot;ACH Daily DiagnosticReport&quot;:\n  &quot;COVID And Influenza DiagnosticReport&quot;\n    union &quot;RSV DiagnosticReport&quot;\n\n//further constrain COVID-19 and Influenza with 14 day lookback \ndefine &quot;COVID And Influenza DiagnosticReport PRE Admission&quot;:\n  &quot;COVID And Influenza DiagnosticReport&quot; R \n  where exists(EncounterInpatient E \n    where (\n      NHSNHelpers.&quot;Normalize Interval&quot;(R.effective) 14 days or less on or before start of E.period)\n      and start of E.period during &quot;Measurement Period&quot;\n    )\n\n//further constrain RSV for 8 day lookback\ndefine &quot;RSV DiagnosticReport PRE Admission&quot;:\n  &quot;RSV DiagnosticReport&quot; R \n  where exists(EncounterInpatient E \n    where (\n      NHSNHelpers.&quot;Normalize Interval&quot;(R.effective) 8 days or less on or before start of E.period)\n      and start of E.period during &quot;Measurement Period&quot;\n    )\n\ndefine &quot;COVID and Influenza DiagnosticReport Result from Lab&quot;:\n  &quot;DiagnosticReports&quot; Reports\n    where exists(\n      &quot;COVID and Influenza DiagnosticReport Observations&quot; Observations\n      where Reports.result.references(Observations)\n    )\n    and Reports.status in {'final','registered','preliminary','partial'}\n    and exists(&quot;Initial Population&quot;)\n\ndefine &quot;COVID and Influenza DiagnosticReport Observations&quot;:\n  &quot;Observations&quot; Observations\n  where Observations.code in &quot;COVID_19 (Tests for SARS_CoV_2 Nucleic Acid)&quot;\n    or Observations.code in &quot;COVID_19 (Tests for SARS_CoV_2 Antigen)&quot;\n    or Observations.code in &quot;Influenza (Tests for influenza A or B virus Nucleic Acid)&quot;\n    or Observations.code in &quot;Influenza (Tests for influenza A or B virus Antigen)&quot;\n\n \ndefine &quot;RSV DiagnosticReport Result from Lab&quot;:\n  [DiagnosticReport] Reports\n    where exists(&quot;RSV DiagnosticReport Observations&quot;)\n      and Reports.status in {'final','registered','preliminary','partial'}\n      and exists(&quot;Initial Population&quot;)\n\ndefine &quot;RSV Observations&quot;:\n  &quot;Observations&quot; Observations\n  where Observations.code in &quot;RSV (Tests for RSV Nucleic Acid)&quot;\n    or Observations.code in &quot;RSV (Tests for RSV Antigen)&quot;\n    \ndefine &quot;RSV DiagnosticReport Observations&quot;:\n  &quot;DiagnosticReports&quot; Reports\n  where exists(\n    &quot;RSV Observations&quot; Observations\n    where Reports.result.references(Observations)\n  )\n\ndefine &quot;ACH Daily DiagnosticReport Result from Lab&quot;:\n  &quot;COVID and Influenza DiagnosticReport Result from Lab&quot;\n    union &quot;RSV DiagnosticReport Result from Lab&quot;\n\n//further constrain COVID-19 and Influenza with 14 day lookback\ndefine &quot;COVID and Influenza DiagnosticReport Result from Lab PRE Admission&quot;:\n  &quot;COVID and Influenza DiagnosticReport Result from Lab&quot; R \n  where exists(EncounterInpatient E \n    where (\n      NHSNHelpers.&quot;Normalize Interval&quot;(R.effective) 14 days or less on or before start of E.period)\n      and start of E.period during &quot;Measurement Period&quot;\n    )\n\n//further constrain RSV with 8 day lookback\ndefine &quot;RSV DiagnosticReport Result from Lab PRE Admission&quot;:\n  &quot;RSV DiagnosticReport Result from Lab&quot; R \n  where exists(EncounterInpatient E \n    where (\n      NHSNHelpers.&quot;Normalize Interval&quot;(R.effective) 8 days or less on or before start of E.period)\n      and start of E.period during &quot;Measurement Period&quot;\n    )\n    \n//----------------------------------\n// SDE\n//----------------------------------\ndefine &quot;SDE IP Encounters&quot;:\n  &quot;Initial Population&quot; IP\n  return SharedResource.EncounterResource(IP, \n  {FHIR.canonical{value: 'http://www.cdc.gov/nhsn/fhirportal/dqm/ig/StructureDefinition/ach-daily-encounter'}})\n\ndefine &quot;SDE Encounter&quot;: \n  &quot;Encounters&quot; Encounters\n  where not CheckIP(Encounters)\n  and exists(\n    &quot;Initial Population&quot; IP\n    where Encounters.period overlaps IP.period)\n  return SharedResource.EncounterResource(Encounters,\n  {FHIR.canonical{value: 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-encounter'}})\n\ndefine &quot;SDE Minimal Patient&quot;:\n  Patient p\n  where exists(&quot;Initial Population&quot;)\n  return SharedResource.PatientResource(p, \n  {FHIR.canonical{value: 'http://www.cdc.gov/nhsn/fhirportal/dqm/ig/StructureDefinition/cross-measure-patient'}})\n\ndefine &quot;SDE Location&quot;:\n  [Location] Locations\n  where exists(&quot;Initial Population&quot;)\n  return SharedResource.LocationResource(Locations,\n  {FHIR.canonical{value: 'http://www.cdc.gov/nhsn/fhirportal/dqm/ig/StructureDefinition/ach-daily-location'}})\n   \ndefine &quot;SDE Encounter Discharge Dispositions&quot;:\n\t&quot;Initial Population&quot; DischargeDispositions \n  where DischargeDispositions.hospitalization.dischargeDisposition in &quot;Discharge Disposition&quot;\n  return SharedResource.EncounterResource(DischargeDispositions,\n  {FHIR.canonical{value: 'http://www.cdc.gov/nhsn/fhirportal/dqm/ig/StructureDefinition/ach-daily-encounter'}})\n\n//return the Observation during the Measurement Period\ndefine &quot;SDE ACH Daily Observation&quot;:\n  &quot;ACH Daily Observation&quot; Observations\n    return ObservationLabResource(Observations,\n    {FHIR.canonical{value: 'http://www.cdc.gov/nhsn/fhirportal/dqm/ig/StructureDefinition/ach-daily-observation-lab'}})\n\n//return the RSV Observation Pre Admission    \ndefine &quot;SDE RSV PRE Admission Observation&quot;:\n  &quot;RSV PRE Admission Observation&quot; Observations\n    return ObservationLabResource(Observations, \n    {FHIR.canonical{value: 'http://www.cdc.gov/nhsn/fhirportal/dqm/ig/StructureDefinition/ach-daily-observation-lab'}})\n\n//return the COVID-19 and Influenza Observation Pre Admission\ndefine &quot;SDE COVID And Influenza PRE Admission Observation&quot;:\n  &quot;COVID And Influenza PRE Admission Observation&quot; Observations\n    return ObservationLabResource(Observations,\n    {FHIR.canonical{value: 'http://www.cdc.gov/nhsn/fhirportal/dqm/ig/StructureDefinition/ach-daily-observation-lab'}})\n\n//return the Specimen related to the Observation during the Measurement Period\ndefine &quot;SDE ACH Daily Specimen&quot;:\n  &quot;ACH Daily Observation&quot; ObservationWithSpecimen\n    let Specimen: GetSpecimen(ObservationWithSpecimen.specimen)\n    return SharedResource.SpecimenResource(Specimen,\n    {FHIR.canonical{value: 'http://www.cdc.gov/nhsn/fhirportal/dqm/ig/StructureDefinition/ach-daily-specimen'}})\n\n//return the Specimen related to the RSV Observation Pre Admission\ndefine &quot;SDE RSV Specimen&quot;:\n  &quot;RSV PRE Admission Observation&quot; ObservationWithSpecimen\n    let Specimen: GetSpecimen(ObservationWithSpecimen.specimen)\n    return SharedResource.SpecimenResource(Specimen,\n    {FHIR.canonical{value: 'http://www.cdc.gov/nhsn/fhirportal/dqm/ig/StructureDefinition/ach-daily-specimen'}})\n\n//return the Specimen related to the COVID-19 And Influenza Observation Pre Admission\ndefine &quot;SDE COVID And Influenza Specimen&quot;:\n  &quot;COVID And Influenza PRE Admission Observation&quot; ObservationWithSpecimen\n    let Specimen: GetSpecimen(ObservationWithSpecimen.specimen)\n    return SharedResource.SpecimenResource(Specimen,\n    {FHIR.canonical{value: 'http://www.cdc.gov/nhsn/fhirportal/dqm/ig/StructureDefinition/ach-daily-specimen'}})\n\n//return the DiagnosticReport during the Measurement Period\ndefine &quot;SDE ACH Daily DiagnosticReport&quot;:\n  &quot;ACH Daily DiagnosticReport&quot; Reports\n    return SharedResource.DiagnosticReportLabResource(Reports,\n    {FHIR.canonical{value: 'http://www.cdc.gov/nhsn/fhirportal/dqm/ig/StructureDefinition/ach-daily-diagnosticreport-lab'}})\n\n//return the COVID-19 And Influenza DiagnosticReport pre admission\ndefine &quot;SDE COVID And Influenza DiagnosticReport&quot;:\n  &quot;COVID And Influenza DiagnosticReport&quot; Reports\n    return SharedResource.DiagnosticReportLabResource(Reports,\n    {FHIR.canonical{value: 'http://www.cdc.gov/nhsn/fhirportal/dqm/ig/StructureDefinition/ach-daily-diagnosticreport-lab'}})\n\n//return the RSV DiagnosticReport pre admission\ndefine &quot;SDE RSV DiagnosticReport&quot;:\n  &quot;RSV DiagnosticReport&quot; Reports\n    return SharedResource.DiagnosticReportLabResource(Reports,\n    {FHIR.canonical{value: 'http://www.cdc.gov/nhsn/fhirportal/dqm/ig/StructureDefinition/ach-daily-diagnosticreport-lab'}})\n\n//return the DiagnosticReport based on the result during the Measurement Period    \ndefine &quot;SDE ACH Daily DiagnosticReport Result from Lab&quot;:\n  &quot;ACH Daily DiagnosticReport Result from Lab&quot; Reports\n    return SharedResource.DiagnosticReportLabResource(Reports,\n    {FHIR.canonical{value: 'http://www.cdc.gov/nhsn/fhirportal/dqm/ig/StructureDefinition/ach-daily-diagnosticreport-lab'}})\n\n//return the COVID-19 and Influenza DiagnosticReport based on the result pre admission\ndefine &quot;SDE COVID and Influenza DiagnosticReport Result from Lab&quot;:\n  &quot;COVID and Influenza DiagnosticReport Result from Lab&quot; Reports\n    return SharedResource.DiagnosticReportLabResource(Reports,\n    {FHIR.canonical{value: 'http://www.cdc.gov/nhsn/fhirportal/dqm/ig/StructureDefinition/ach-daily-diagnosticreport-lab'}})\n\n//return the RSV DiagnosticReport based on the result pre admission\ndefine &quot;SDE RSV DiagnosticReport Result from Lab&quot;:\n  &quot;RSV DiagnosticReport Result from Lab&quot; Reports\n    return SharedResource.DiagnosticReportLabResource(Reports,\n    {FHIR.canonical{value: 'http://www.cdc.gov/nhsn/fhirportal/dqm/ig/StructureDefinition/ach-daily-diagnosticreport-lab'}})\n  \ndefine &quot;SDE ACH Daily ServiceRequest&quot;:\n  ([ServiceRequest: &quot;COVID_19 (Tests for SARS_CoV_2 Nucleic Acid)&quot;] \n  union  [ServiceRequest: &quot;COVID_19 (Tests for SARS_CoV_2 Antigen)&quot;] \n  union  [ServiceRequest: &quot;Influenza (Tests for influenza A or B virus Nucleic Acid)&quot;]\n  union  [ServiceRequest: &quot;Influenza (Tests for influenza A or B virus Antigen)&quot;]\n  union  [ServiceRequest: &quot;RSV (Tests for RSV Nucleic Acid)&quot;]\n  union  [ServiceRequest: &quot;RSV (Tests for RSV Antigen)&quot;]\n  ) ServiceRequests\n    where ServiceRequests.intent ~ 'order'\n      and ServiceRequests.status ~ 'completed'\n      and exists(&quot;Initial Population&quot;)\n  return ServiceRequestResource(ServiceRequests,\n  {FHIR.canonical{value: 'http://www.cdc.gov/nhsn/fhirportal/dqm/ig/StructureDefinition/ach-daily-servicerequest'}})\n\ndefine &quot;SDE Isolation Precautions Implemented&quot;:\n  [Procedure: &quot;Transmission Based Precaution Types&quot;] IsolationPrecautions\n    where NHSNHelpers.&quot;Normalize Interval&quot;(IsolationPrecautions.performed) during &quot;Measurement Period&quot;\n    and exists(&quot;Initial Population&quot;)\n  return SharedResource.ProcedureResource(IsolationPrecautions,\n  {FHIR.canonical{value: 'http://www.cdc.gov/nhsn/fhirportal/dqm/ig/StructureDefinition/ach-daily-procedure'}})\n\ndefine &quot;SDE Covid or Influenza Medication Administered&quot;:\n  [MedicationAdministration] RPSMedAdmin\n    let Meds: GetMedicationCode(RPSMedAdmin.medication)\n   where (Meds in &quot;Anakinra&quot;\n            or Meds in &quot;Bamlanivimab&quot;\n            or Meds in &quot;Baloxavir&quot;\n            or Meds in &quot;Baricitinib&quot;\n            or Meds in &quot;Bebtelovimab&quot;\n            or Meds in &quot;Casirivimab&quot;\n            or Meds in &quot;Casirivimab / Imdevimab&quot;\n            or Meds in &quot;COVID19 RxNorm Value Set for Tocilizumab&quot;\n            or Meds in &quot;Etesevimab&quot;\n            or Meds in &quot;Imdevimab&quot;\n            or Meds in &quot;Molnupiravir&quot;\n            or Meds in &quot;Nirmatrelvir / Ritonavir&quot;\n            or Meds in &quot;Oseltamivir&quot;\n            or Meds in &quot;Peramivir&quot;\n            or Meds in &quot;Remdesivir&quot;\n            or Meds in &quot;Sarilumab&quot;\n            or Meds in &quot;Sotrovimab&quot;    \n            or Meds in &quot;Tofacitinib&quot;\n            or Meds in &quot;Zanamivir&quot;)\n      and RPSMedAdmin.status ~ 'completed'\n      and exists(&quot;Initial Population&quot;)\n      and NHSNHelpers.&quot;Normalize Interval&quot;(RPSMedAdmin.effective) during &quot;Measurement Period&quot;\n    return SharedResource.MedicationAdministrationResource(RPSMedAdmin,\n    {FHIR.canonical{value: 'http://www.cdc.gov/nhsn/fhirportal/dqm/ig/StructureDefinition/ach-daily-medicationadministration'}})\n\ndefine &quot;SDE Covid or Influenza Medication Ordered&quot;:\n  [MedicationRequest] RPSMedRequest\n    let Meds: GetMedicationCode(RPSMedRequest.medication)\n    where (Meds in &quot;Anakinra&quot;\n            or Meds in &quot;Baloxavir&quot;\n            or Meds in &quot;Bamlanivimab&quot;\n            or Meds in &quot;Baricitinib&quot;\n            or Meds in &quot;Bebtelovimab&quot;\n            or Meds in &quot;Casirivimab&quot;\n            or Meds in &quot;Casirivimab / Imdevimab&quot;\n            or Meds in &quot;COVID19 RxNorm Value Set for Tocilizumab&quot;\n            or Meds in &quot;Etesevimab&quot;\n            or Meds in &quot;Imdevimab&quot;\n            or Meds in &quot;Molnupiravir&quot;\n            or Meds in &quot;Nirmatrelvir / Ritonavir&quot;\n            or Meds in &quot;Oseltamivir&quot;\n            or Meds in &quot;Peramivir&quot;\n            or Meds in &quot;Remdesivir&quot;\n            or Meds in &quot;Sarilumab&quot;\n            or Meds in &quot;Sotrovimab&quot;    \n            or Meds in &quot;Tofacitinib&quot;\n            or Meds in &quot;Zanamivir&quot;)\n      and exists(&quot;Initial Population&quot;)\n      and NHSNHelpers.&quot;Normalize Interval&quot;(RPSMedRequest.authoredOn) during &quot;Measurement Period&quot;\n    return MedicationRequestResource(RPSMedRequest,\n    {FHIR.canonical{value: 'http://www.cdc.gov/nhsn/fhirportal/dqm/ig/StructureDefinition/ach-daily-medicationrequest'}})\n\ndefine &quot;SDE Medication&quot;:\n  (&quot;SDE Covid or Influenza Medication Ordered&quot;\n  union &quot;SDE Covid or Influenza Medication Administered&quot;) MedReqOrAdmin\n  where MedReqOrAdmin.medication is FHIR.Reference\n  return SharedResource.MedicationResource(GetMedicationFrom(MedReqOrAdmin.medication),\n  {FHIR.canonical{value: 'http://www.cdc.gov/nhsn/fhirportal/dqm/ig/StructureDefinition/ach-daily-medication'}})\n\n//To catch all isolation precautions\ndefine &quot;SDE All Observations&quot;:\n  &quot;Observations&quot; O\n  where exists(&quot;Initial Population&quot;)\n  return ObservationLabResource(O,\n  {FHIR.canonical{value: 'http://www.cdc.gov/nhsn/fhirportal/dqm/ig/StructureDefinition/ach-daily-observation'}})\n\n//To catch all isolation precautions\ndefine &quot;SDE All ServiceRequests&quot;:\n  [ServiceRequest] SR\n  where exists(&quot;Initial Population&quot;)\n  return ServiceRequestResource(SR,\n  {FHIR.canonical{value: 'http://www.cdc.gov/nhsn/fhirportal/dqm/ig/StructureDefinition/ach-daily-servicerequest'}})\n\n//To catch all isolation precautions\ndefine &quot;SDE All Procedures&quot;:\n  [Procedure] P\n  where exists(&quot;Initial Population&quot;)\n  return SharedResource.ProcedureResource(P,\n  {FHIR.canonical{value: 'http://www.cdc.gov/nhsn/fhirportal/dqm/ig/StructureDefinition/ach-daily-procedure'}})\n\n\n//-----------------------------------------------------\n//functions\n//-----------------------------------------------------\ndefine function &quot;CheckIP&quot;(encounter Encounter):\n  exists(&quot;Initial Population&quot; IP\n  where encounter.id = IP.id)\n\ndefine function &quot;GetMedication&quot;(reference Reference ):\n  singleton from (\n    [Medication: id in {NHSNHelpers.GetId(reference.reference)}]\n  )\n\ndefine function &quot;GetMedicationCode&quot;(choice Choice&lt;FHIR.CodeableConcept, FHIR.Reference&gt;):\n  case\n    when choice is FHIR.CodeableConcept then\n      choice as FHIR.CodeableConcept\n    when choice is FHIR.Reference then\n      GetMedication(choice as FHIR.Reference).code\n    else\n      null as FHIR.CodeableConcept\n  end\n\ndefine function &quot;GetMedicationFrom&quot;(choice Choice&lt;FHIR.CodeableConcept, FHIR.Reference&gt;):\n  case\n    when choice is FHIR.Reference then\n      GetMedication(choice as FHIR.Reference)\n    else\n      null\n  end\n\ndefine function &quot;GetSpecimen&quot;(reference FHIR.Reference):\n  singleton from (\n    [Specimen] Specimens\n    where Specimens.id = NHSNHelpers.GetId(reference.reference)\n  )\n\ndefine function &quot;GetEncounter&quot;(reference FHIR.Reference):\n  singleton from (\n    &quot;Encounters&quot; Encounters\n    where Encounters.id = NHSNHelpers.GetId(reference.reference)\n  )\n\ndefine fluent function references(reference FHIR.Reference, resource FHIR.Resource):\n  resource.id = Last(Split(reference.reference, '/'))\n\ndefine fluent function references(references List&lt;FHIR.Reference&gt;, resource FHIR.Resource):\n  exists(references R where R.references(resource))\n\n//Common Retrievals\ndefine &quot;Encounters&quot;:\n  [Encounter]\n\ndefine &quot;Observations&quot;:\n  [Observation]\n\ndefine &quot;DiagnosticReports&quot;:\n  [DiagnosticReport]\n\n //\n // Measure Specific Resource Creation Functions\n //\ndefine function MedicationRequestRepeat(repeat FHIR.Timing.Repeat):\n  repeat r\n  return FHIR.Timing.Repeat{\n    bounds: r.bounds,\n    count: r.count,\n    countMax: r.countMax,\n    &quot;duration&quot;: r.&quot;duration&quot;,\n    durationMax: r.durationMax,\n    durationUnit: r.durationUnit,\n    frequency: r.frequency,\n    frequencyMax: r.frequencyMax,\n    period: r.period,\n    periodMax: r.periodMax,\n    periodUnit: r.periodUnit,\n    dayOfWeek: r.dayOfWeek,\n    timeOfDay: r.timeOfDay,\n    &quot;when&quot;: r.&quot;when&quot;,\n    offset: r.offset\n  }\n\ndefine function MedicationRequestTiming(timing FHIR.Timing):\n  timing t\n  return FHIR.Timing{\n    event: t.event,\n    repeat: MedicationRequestRepeat(t.repeat),\n    code: t.code\n  }\n\ndefine function MedicationRequestDosageInstruction(dosageInstruction List&lt;FHIR.Dosage&gt;):\n  dosageInstruction dI\n  return FHIR.Dosage{\n    text: dI.text,\n    patientInstruction: dI.patientInstruction,\n    timing: MedicationRequestTiming(dI.timing),\n    asNeeded: dI.asNeeded,\n    site: dI.site,\n    route: dI.route,\n    method: dI.method,\n    doseAndRate: SharedResource.MedicationRequestDoseAndRate(dI.doseAndRate)\n  }\n\n define function MedicationRequestResource(medicationRequest MedicationRequest, profileURLs List&lt;FHIR.canonical&gt;):\n  medicationRequest m\n  return MedicationRequest{\n    id: FHIR.id {value: 'LCR-' + m.id},\n    meta: SharedResource.MetaElement(medicationRequest, profileURLs),\n    extension: m.extension,\n    status: m.status,\n    intent: m.intent,\n    category: m.category,\n    priority: m.priority,\n    doNotPerform: m.doNotPerform,\n    reported: m.reported,\n    medication: m.medication,\n    subject: m.subject,\n    encounter: m.encounter,\n    authoredOn: m.authoredOn,\n    requester: m.requester,\n    recorder: m.recorder,\n    reasonCode: m.reasonCode,\n    reasonReference: m.reasonReference,\n    instantiatesCanonical: m.instantiatesCanonical,\n    instantiatesUri: m.instantiatesUri,\n    courseOfTherapyType: m.courseOfTherapyType,\n    dosageInstruction: MedicationRequestDosageInstruction(m.dosageInstruction)\n  }\n\ndefine function ObservationLabCoding(coding List&lt;Coding&gt;):\n  coding c\n  return Coding{\n    system: c.system,\n    version: c.version,\n    code: c.code,\n    display: c.display,\n    userSelected: c.userSelected\n  }\n\ndefine function ObservationLabCategory(category List&lt;CodeableConcept&gt;):\n  category c\n  return CodeableConcept{\n    coding: ObservationLabCoding(c.coding),\n    text: c.text\n  }\n\ndefine function ObservationLabResource(observation Observation, profileURLs List&lt;FHIR.canonical&gt;):\n  observation o\n  return Observation{\n    id: FHIR.id {value: 'LCR-' + o.id},\n    meta: SharedResource.MetaElement(o, profileURLs),\n    extension: o.extension,\n    basedOn: o.basedOn,\n    partOf: o.partOf,\n    status: o.status,\n    category: ObservationLabCategory(o.category),\n    code: o.code,\n    subject: o.subject,\n    focus: o.focus,\n    encounter: o.encounter,\n    effective: o.effective,\n    issued: o.issued,\n    performer: o.performer,\n    value: o.value,\n    dataAbsentReason: o.dataAbsentReason,\n    interpretation: o.interpretation,\n    note: o.note,\n    bodySite: o.bodySite,\n    method: o.method,\n    specimen: o.specimen,\n    device: o.device,\n    referenceRange: SharedResource.ObservationReferenceRange(o.referenceRange),\n    hasMember: o.hasMember,\n    derivedFrom: o.derivedFrom,\n    component: SharedResource.ObservationComponent(o.component)\n  }\n\ndefine function &quot;GetProcedureExtensions&quot;(domainResource DomainResource):\n  domainResource.extension E\n    where E.url != 'http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-recorded'\n     return E\n\ndefine function ProcedureResource(procedure Procedure, profileURLs List&lt;FHIR.canonical&gt;):\n  procedure p\n  return Procedure{\n    id: FHIR.id {value: 'LCR-' + p.id},\n    meta: SharedResource.MetaElement(p, profileURLs),\n    extension: GetProcedureExtensions(p), \n    instantiatesCanonical: p.instantiatesCanonical,\n    instantiatesUri: p.instantiatesUri,\n    basedOn: p.basedOn,\n    partOf: p.partOf,\n    status: p.status,\n    statusReason: p.statusReason,\n    category: p.category,\n    code: p.code,\n    subject: p.subject,\n    encounter: p.encounter,\n    performed: p.performed,\n    recorder: p.recorder,\n    asserter: p.asserter,\n    performer: SharedResource.ProcedurePerformer(p.performer),\n    location: p.location,\n    reasonCode: p.reasonCode,\n    reasonReference: p.reasonReference,\n    bodySite: p.bodySite,\n    outcome: p.outcome,\n    report: p.report,\n    complication: p.complication,\n    complicationDetail: p.complicationDetail,\n    followUp: p.followUp,\n    note: p.note,\n    focalDevice: SharedResource.ProcedureFocalDevice(p.focalDevice),\n    usedReference: p.usedReference,\n    usedCode: p.usedCode\n  }\n\ndefine function ServiceRequestResource(serviceRequest ServiceRequest, profileURLs List&lt;FHIR.canonical&gt;):\n  serviceRequest sR\n  return ServiceRequest{\n    id: FHIR.id {value: 'LCR-' + sR.id},\n    meta: SharedResource.MetaElement(sR, profileURLs),\n    extension: sR.extension,\n    instantiatesCanonical: sR.instantiatesCanonical,\n    instantiatesUri: sR.instantiatesUri,\n    basedOn: sR.basedOn,\n    replaces: sR.replaces,\n    requisition: sR.requisition,\n    status: sR.status,\n    intent: sR.intent,\n    category: sR.category,\n    priority: sR.priority,\n    doNotPerform: sR.doNotPerform,\n    code: sR.code,\n    orderDetail: sR.orderDetail,\n    quantity: sR.quantity,\n    subject: sR.subject,\n    encounter: sR.encounter,\n    occurrence: sR.occurrence,\n    asNeeded: sR.asNeeded,\n    authoredOn: sR.authoredOn,\n    performerType: sR.performerType,\n    performer: sR.performer,\n    locationCode: sR.locationCode,\n    locationReference: sR.locationReference,\n    reasonCode: sR.reasonCode,\n    reasonReference: sR.reasonReference,\n    insurance: sR.insurance,\n    supportingInfo: sR.supportingInfo,\n    specimen: sR.specimen,\n    bodySite: sR.bodySite,\n    note: sR.note,\n    patientInstruction: sR.patientInstruction,\n    relevantHistory: sR.relevantHistory\n  }\n    \n    </code></pre></td></tr>\n            </table>\n          </td>\n        </tr>\n        \n        \n        \n    </table>\n</div>\n</div>"
+        },
         "url": "http://www.cdc.gov/nhsn/fhirportal/dqm/ig/Library/NHSNAcuteCareHospitalDailyInitialPopulation",
-        "version": "1.0.0-dev",
+        "version": "2.0.0-cibuild",
         "name": "NHSNAcuteCareHospitalDailyInitialPopulation",
+        "status": "draft",
         "type": {
           "coding": [
             {
@@ -427,6 +360,33 @@
             }
           ]
         },
+        "date": "2026-01-08T14:28:51+00:00",
+        "publisher": "CDC National Healthcare Safety Network (NHSN)",
+        "contact": [
+          {
+            "name": "CDC National Healthcare Safety Network (NHSN)",
+            "telecom": [
+              {
+                "system": "url",
+                "value": "http://www.cdc.gov/nhsn"
+              },
+              {
+                "system": "email",
+                "value": "nhsn@cdc.gov"
+              }
+            ]
+          }
+        ],
+        "jurisdiction": [
+          {
+            "coding": [
+              {
+                "system": "urn:iso:std:iso:3166",
+                "code": "US"
+              }
+            ]
+          }
+        ],
         "relatedArtifact": [
           {
             "type": "depends-on",
@@ -446,12 +406,12 @@
           {
             "type": "depends-on",
             "display": "Library SharedResource",
-            "resource": "http://www.cdc.gov/nhsn/fhirportal/dqm/ig/Library/SharedResourceCreation|0.1.009"
+            "resource": "http://www.cdc.gov/nhsn/fhirportal/dqm/ig/Library/SharedResourceCreation|0.1.010"
           },
           {
             "type": "depends-on",
             "display": "Code system ActCode",
-            "resource": "http://terminology.hl7.org/CodeSystem/v3-ActCode"
+            "resource": "http://terminology.hl7.org/CodeSystem/v3-ActCode|9.0.0"
           },
           {
             "type": "depends-on",
@@ -461,7 +421,7 @@
           {
             "type": "depends-on",
             "display": "Code system Observation Category",
-            "resource": "http://terminology.hl7.org/CodeSystem/observation-category"
+            "resource": "http://terminology.hl7.org/CodeSystem/observation-category|2.0.0"
           },
           {
             "type": "depends-on",
@@ -486,27 +446,27 @@
           {
             "type": "depends-on",
             "display": "Value set Discharge Disposition",
-            "resource": "http://terminology.hl7.org/ValueSet/encounter-discharge-disposition"
+            "resource": "http://terminology.hl7.org/ValueSet/encounter-discharge-disposition|1.0.1"
           },
           {
             "type": "depends-on",
             "display": "Value set COVID_19 (Tests for SARS_CoV_2 Nucleic Acid)",
-            "resource": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1142"
+            "resource": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1142|20250218"
           },
           {
             "type": "depends-on",
             "display": "Value set COVID_19 (Tests for SARS_CoV_2 Antigen)",
-            "resource": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1158"
+            "resource": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1158|20240123"
           },
           {
             "type": "depends-on",
             "display": "Value set COVID_19 (Organism or Substance in Lab Results)",
-            "resource": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1143"
+            "resource": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1143|20250218"
           },
           {
             "type": "depends-on",
             "display": "Value set Influenza (Tests for influenza A or B virus Nucleic Acid)",
-            "resource": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.336"
+            "resource": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.336|20250218"
           },
           {
             "type": "depends-on",
@@ -526,7 +486,7 @@
           {
             "type": "depends-on",
             "display": "Value set RSV (Tests for RSV Nucleic Acid)",
-            "resource": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1312"
+            "resource": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1312|20250218"
           },
           {
             "type": "depends-on",
@@ -636,7 +596,7 @@
           {
             "type": "depends-on",
             "display": "Value set Transmission Based Precaution Types",
-            "resource": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.10.20.22.5.300"
+            "resource": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.10.20.22.5.300|20240607"
           },
           {
             "type": "depends-on",
@@ -702,7 +662,7 @@
             "type": "Observation"
           },
           {
-            "name": "RPS Observation",
+            "name": "ACH Daily Observation",
             "use": "out",
             "min": 0,
             "max": "*",
@@ -737,7 +697,7 @@
             "type": "DiagnosticReport"
           },
           {
-            "name": "RPS DiagnosticReport",
+            "name": "ACH Daily DiagnosticReport",
             "use": "out",
             "min": 0,
             "max": "*",
@@ -807,7 +767,7 @@
             "type": "DiagnosticReport"
           },
           {
-            "name": "RPS DiagnosticReport Result from Lab",
+            "name": "ACH Daily DiagnosticReport Result from Lab",
             "use": "out",
             "min": 0,
             "max": "*",
@@ -870,7 +830,7 @@
             "type": "Encounter"
           },
           {
-            "name": "SDE RPSObservation",
+            "name": "SDE ACH Daily Observation",
             "use": "out",
             "min": 0,
             "max": "*",
@@ -891,7 +851,7 @@
             "type": "Observation"
           },
           {
-            "name": "SDE RPS Specimen",
+            "name": "SDE ACH Daily Specimen",
             "use": "out",
             "min": 0,
             "max": "*",
@@ -912,7 +872,7 @@
             "type": "Specimen"
           },
           {
-            "name": "SDE RPS DiagnosticReport",
+            "name": "SDE ACH Daily DiagnosticReport",
             "use": "out",
             "min": 0,
             "max": "*",
@@ -933,7 +893,7 @@
             "type": "DiagnosticReport"
           },
           {
-            "name": "SDE RPS DiagnosticReport Result from Lab",
+            "name": "SDE ACH Daily DiagnosticReport Result from Lab",
             "use": "out",
             "min": 0,
             "max": "*",
@@ -954,7 +914,7 @@
             "type": "DiagnosticReport"
           },
           {
-            "name": "SDE RPS ServiceRequest",
+            "name": "SDE ACH Daily ServiceRequest",
             "use": "out",
             "min": 0,
             "max": "*",
@@ -1274,7 +1234,7 @@
             "codeFilter": [
               {
                 "path": "code",
-                "valueSet": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.336"
+                "valueSet": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.336|20250218"
               }
             ]
           },
@@ -1356,7 +1316,7 @@
             "codeFilter": [
               {
                 "path": "code",
-                "valueSet": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1142"
+                "valueSet": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1142|20250218"
               }
             ]
           },
@@ -1397,7 +1357,7 @@
             "codeFilter": [
               {
                 "path": "code",
-                "valueSet": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1158"
+                "valueSet": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1158|20240123"
               }
             ]
           },
@@ -1438,7 +1398,7 @@
             "codeFilter": [
               {
                 "path": "code",
-                "valueSet": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1312"
+                "valueSet": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1312|20250218"
               }
             ]
           },
@@ -1567,7 +1527,7 @@
             "codeFilter": [
               {
                 "path": "code",
-                "valueSet": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1142"
+                "valueSet": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1142|20250218"
               }
             ]
           },
@@ -1597,7 +1557,7 @@
             "codeFilter": [
               {
                 "path": "code",
-                "valueSet": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1158"
+                "valueSet": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1158|20240123"
               }
             ]
           },
@@ -1627,7 +1587,7 @@
             "codeFilter": [
               {
                 "path": "code",
-                "valueSet": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.336"
+                "valueSet": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.336|20250218"
               }
             ]
           },
@@ -1687,7 +1647,7 @@
             "codeFilter": [
               {
                 "path": "code",
-                "valueSet": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1312"
+                "valueSet": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1312|20250218"
               }
             ]
           },
@@ -1789,7 +1749,7 @@
             "codeFilter": [
               {
                 "path": "code",
-                "valueSet": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1142"
+                "valueSet": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1142|20250218"
               }
             ]
           },
@@ -1837,7 +1797,7 @@
             "codeFilter": [
               {
                 "path": "code",
-                "valueSet": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1158"
+                "valueSet": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1158|20240123"
               }
             ]
           },
@@ -1885,7 +1845,7 @@
             "codeFilter": [
               {
                 "path": "code",
-                "valueSet": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.336"
+                "valueSet": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.336|20250218"
               }
             ]
           },
@@ -1981,7 +1941,7 @@
             "codeFilter": [
               {
                 "path": "code",
-                "valueSet": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1312"
+                "valueSet": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1312|20250218"
               }
             ]
           },
@@ -2114,7 +2074,7 @@
             "codeFilter": [
               {
                 "path": "code",
-                "valueSet": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.10.20.22.5.300"
+                "valueSet": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.10.20.22.5.300|20240607"
               }
             ]
           },
@@ -2238,7 +2198,8 @@
         "content": [
           {
             "contentType": "text/cql",
-            "data": "bGlicmFyeSBOSFNOQWN1dGVDYXJlSG9zcGl0YWxEYWlseUluaXRpYWxQb3B1bGF0aW9uIHZlcnNpb24gJzEuMC4wLWRldicKCnVzaW5nIEZISVIgdmVyc2lvbiAnNC4wLjEnCgppbmNsdWRlIEZISVJIZWxwZXJzIHZlcnNpb24gJzQuMC4yJyBjYWxsZWQgRkhJUkhlbHBlcnMKaW5jbHVkZSBOSFNOSGVscGVycyB2ZXJzaW9uICcwLjAuMDAyJyBjYWxsZWQgTkhTTkhlbHBlcnMKaW5jbHVkZSBTaGFyZWRSZXNvdXJjZUNyZWF0aW9uIHZlcnNpb24gJzAuMS4wMDknIGNhbGxlZCBTaGFyZWRSZXNvdXJjZQoKY29kZXN5c3RlbSAiQWN0Q29kZSI6ICdodHRwOi8vdGVybWlub2xvZ3kuaGw3Lm9yZy9Db2RlU3lzdGVtL3YzLUFjdENvZGUnIApjb2Rlc3lzdGVtICJMT0lOQyI6ICdodHRwOi8vbG9pbmMub3JnJyAKY29kZXN5c3RlbSAiT2JzZXJ2YXRpb24gQ2F0ZWdvcnkiOiAnaHR0cDovL3Rlcm1pbm9sb2d5LmhsNy5vcmcvQ29kZVN5c3RlbS9vYnNlcnZhdGlvbi1jYXRlZ29yeScgCmNvZGVzeXN0ZW0gIlJYTk9STSI6ICdodHRwOi8vd3d3Lm5sbS5uaWguZ292L3Jlc2VhcmNoL3VtbHMvcnhub3JtJwoKCnZhbHVlc2V0ICJFbmNvdW50ZXIgSW5wYXRpZW50IjogJ2h0dHA6Ly9jdHMubmxtLm5paC5nb3YvZmhpci9WYWx1ZVNldC8yLjE2Ljg0MC4xLjExMzg4My4zLjY2Ni41LjMwNycgCnZhbHVlc2V0ICJJbnBhdGllbnQsIEVtZXJnZW5jeSwgYW5kIE9ic2VydmF0aW9uIExvY2F0aW9ucyI6ICdodHRwOi8vY3RzLm5sbS5uaWguZ292L2ZoaXIvVmFsdWVTZXQvMi4xNi44NDAuMS4xMTM3NjIuMS40LjEwNDYuMjY1JyAKdmFsdWVzZXQgIk9ic2VydmF0aW9uIFNlcnZpY2VzIjogJ2h0dHA6Ly9jdHMubmxtLm5paC5nb3YvZmhpci9WYWx1ZVNldC8yLjE2Ljg0MC4xLjExMzc2Mi4xLjQuMTExMS4xNDMnIAp2YWx1ZXNldCAiRGlzY2hhcmdlIERpc3Bvc2l0aW9uIjogJ2h0dHA6Ly90ZXJtaW5vbG9neS5obDcub3JnL1ZhbHVlU2V0L2VuY291bnRlci1kaXNjaGFyZ2UtZGlzcG9zaXRpb24nCgovL0NPVklELTE5IGxhYiB0ZXN0cwp2YWx1ZXNldCAiQ09WSURfMTkgKFRlc3RzIGZvciBTQVJTX0NvVl8yIE51Y2xlaWMgQWNpZCkiOiAnaHR0cDovL2N0cy5ubG0ubmloLmdvdi9maGlyL1ZhbHVlU2V0LzIuMTYuODQwLjEuMTEzNzYyLjEuNC4xMTQ2LjExNDInCnZhbHVlc2V0ICJDT1ZJRF8xOSAoVGVzdHMgZm9yIFNBUlNfQ29WXzIgQW50aWdlbikiOiAnaHR0cDovL2N0cy5ubG0ubmloLmdvdi9maGlyL1ZhbHVlU2V0LzIuMTYuODQwLjEuMTEzNzYyLjEuNC4xMTQ2LjExNTgnCgovL0NPVklELTE5IHRlc3QgcmVzdWx0cyAodW51c2VkKQp2YWx1ZXNldCAiQ09WSURfMTkgKE9yZ2FuaXNtIG9yIFN1YnN0YW5jZSBpbiBMYWIgUmVzdWx0cykiOiAnaHR0cDovL2N0cy5ubG0ubmloLmdvdi9maGlyL1ZhbHVlU2V0LzIuMTYuODQwLjEuMTEzNzYyLjEuNC4xMTQ2LjExNDMnCgovL0luZmx1ZW56YSBsYWIgdGVzdHMKdmFsdWVzZXQgIkluZmx1ZW56YSAoVGVzdHMgZm9yIGluZmx1ZW56YSBBIG9yIEIgdmlydXMgTnVjbGVpYyBBY2lkKSI6ICdodHRwOi8vY3RzLm5sbS5uaWguZ292L2ZoaXIvVmFsdWVTZXQvMi4xNi44NDAuMS4xMTM3NjIuMS40LjExNDYuMzM2Jwp2YWx1ZXNldCAiSW5mbHVlbnphIChUZXN0cyBmb3IgaW5mbHVlbnphIEEgb3IgQiB2aXJ1cyBBbnRpZ2VuKSI6ICdodHRwOi8vY3RzLm5sbS5uaWguZ292L2ZoaXIvVmFsdWVTZXQvMi4xNi44NDAuMS4xMTM3NjIuMS40LjExNDYuMzM3JwoKLy9JbmZsdWVuemEgdGVzdCBSZXN1bHRzICh1bnVzZWQpCnZhbHVlc2V0ICJJbmZsdWVuemEgKGluZmx1ZW56YSBBIG9yIEIgdmlydXMgaW4gTGFiIFJlc3VsdHMpIjogJ2h0dHA6Ly9jdHMubmxtLm5paC5nb3YvZmhpci9WYWx1ZVNldC8yLjE2Ljg0MC4xLjExMzc2Mi4xLjQuMTE0Ni4zNDAnCgovL1JTViBsYWIgdGVzdHMKdmFsdWVzZXQgIlJTViAoVGVzdHMgZm9yIFJTViBBbnRpZ2VuKSI6ICdodHRwOi8vY3RzLm5sbS5uaWguZ292L2ZoaXIvVmFsdWVTZXQvMi4xNi44NDAuMS4xMTM3NjIuMS40LjExNDYuMTMxMScKdmFsdWVzZXQgIlJTViAoVGVzdHMgZm9yIFJTViBOdWNsZWljIEFjaWQpIjogJ2h0dHA6Ly9jdHMubmxtLm5paC5nb3YvZmhpci9WYWx1ZVNldC8yLjE2Ljg0MC4xLjExMzc2Mi4xLjQuMTE0Ni4xMzEyJwoKLy9SU1YgdGVzdCByZXN1bHRzICh1bnVzZWQpCnZhbHVlc2V0ICJSU1YgKE9yZ2FuaXNtIG9yIFN1YnN0YW5jZSBpbiBMYWIgUmVzdWx0cykiOiAnaHR0cDovL2N0cy5ubG0ubmloLmdvdi9maGlyL1ZhbHVlU2V0LzIuMTYuODQwLjEuMTEzNzYyLjEuNC4xMTQ2LjEzMDgnCgovL1Rlc3QgcmVzdWx0cyBzaGFyZWQgYW1vbmcgQ09WSUQtMTksIEluZmx1ZW56YSBhbmQgUlNWICh1bnVzZWQpCnZhbHVlc2V0ICJMSVZEIFNBUlMgQ29WMiBUZXN0IFJlc3VsdCBDb2RlcyI6ICdodHRwOi8vY3RzLm5sbS5uaWguZ292L2ZoaXIvVmFsdWVTZXQvMi4xNi44NDAuMS4xMTM3NjIuMS40LjExMTQuMTAnCgovL0NPVklELTE5IG1lZGljYXRpb25zCnZhbHVlc2V0ICJCYXJpY2l0aW5pYiI6ICdodHRwOi8vY3RzLm5sbS5uaWguZ292L2ZoaXIvVmFsdWVTZXQvMi4xNi44NDAuMS4xMTM4ODMuMy4zNjE2LjIwMC4xMTAuMTAyLjIwNDYnCnZhbHVlc2V0ICJBbmFraW5yYSI6ICdodHRwOi8vY3RzLm5sbS5uaWguZ292L2ZoaXIvVmFsdWVTZXQvMi4xNi44NDAuMS4xMTM4ODMuMy4zNjE2LjIwMC4xMTAuMTAyLjIwNTQnCnZhbHVlc2V0ICJTYXJpbHVtYWIiOiAnaHR0cDovL2N0cy5ubG0ubmloLmdvdi9maGlyL1ZhbHVlU2V0LzIuMTYuODQwLjEuMTEzODgzLjMuMzYxNi4yMDAuMTEwLjEwMi4yMDg0Jwp2YWx1ZXNldCAiQ09WSUQxOSBSeE5vcm0gVmFsdWUgU2V0IGZvciBUb2NpbGl6dW1hYiI6ICdodHRwOi8vY3RzLm5sbS5uaWguZ292L2ZoaXIvVmFsdWVTZXQvMi4xNi44NDAuMS4xMTM4ODMuMy4zNjE2LjIwMC4xMTAuMTAyLjIwODcnCnZhbHVlc2V0ICJDYXNpcml2aW1hYiI6ICdodHRwOi8vY3RzLm5sbS5uaWguZ292L2ZoaXIvVmFsdWVTZXQvMi4xNi44NDAuMS4xMTM4ODMuMy4zNjE2LjIwMC4xMTAuMTAyLjIwOTcnCnZhbHVlc2V0ICJJbWRldmltYWIiOiAnaHR0cDovL2N0cy5ubG0ubmloLmdvdi9maGlyL1ZhbHVlU2V0LzIuMTYuODQwLjEuMTEzODgzLjMuMzYxNi4yMDAuMTEwLjEwMi4yMDk4Jwp2YWx1ZXNldCAiQmFtbGFuaXZpbWFiIjogJ2h0dHA6Ly9jdHMubmxtLm5paC5nb3YvZmhpci9WYWx1ZVNldC8yLjE2Ljg0MC4xLjExMzg4My4zLjM2MTYuMjAwLjExMC4xMDIuMjA5OScKdmFsdWVzZXQgIkV0ZXNldmltYWIiOiAnaHR0cDovL2N0cy5ubG0ubmloLmdvdi9maGlyL1ZhbHVlU2V0LzIuMTYuODQwLjEuMTEzODgzLjMuMzYxNi4yMDAuMTEwLjEwMi4yMTAwJwp2YWx1ZXNldCAiU290cm92aW1hYiI6ICdodHRwOi8vY3RzLm5sbS5uaWguZ292L2ZoaXIvVmFsdWVTZXQvMi4xNi44NDAuMS4xMTM4ODMuMy4zNjE2LjIwMC4xMTAuMTAyLjIxMDEnCnZhbHVlc2V0ICJUb2ZhY2l0aW5pYiI6ICdodHRwOi8vY3RzLm5sbS5uaWguZ292L2ZoaXIvVmFsdWVTZXQvMi4xNi44NDAuMS4xMTM4ODMuMy4zNjE2LjIwMC4xMTAuMTAyLjIxMDInCnZhbHVlc2V0ICJDYXNpcml2aW1hYiAvIEltZGV2aW1hYiI6ICdodHRwOi8vY3RzLm5sbS5uaWguZ292L2ZoaXIvVmFsdWVTZXQvMi4xNi44NDAuMS4xMTM4ODMuMy4zNjE2LjIwMC4xMTAuMTAyLjIxMDMnCnZhbHVlc2V0ICJNb2xudXBpcmF2aXIiOiAnaHR0cDovL2N0cy5ubG0ubmloLmdvdi9maGlyL1ZhbHVlU2V0LzIuMTYuODQwLjEuMTEzODgzLjMuMzYxNi4yMDAuMTEwLjEwMi4yMTE5Jwp2YWx1ZXNldCAiUmVtZGVzaXZpciI6ICdodHRwOi8vY3RzLm5sbS5uaWguZ292L2ZoaXIvVmFsdWVTZXQvMi4xNi44NDAuMS4xMTM4ODMuMy4zNjE2LjIwMC4xMTAuMTAyLjIwODEnCnZhbHVlc2V0ICJOaXJtYXRyZWx2aXIgLyBSaXRvbmF2aXIiOiAnaHR0cDovL2N0cy5ubG0ubmloLmdvdi9maGlyL1ZhbHVlU2V0LzIuMTYuODQwLjEuMTEzODgzLjMuMzYxNi4yMDAuMTEwLjEwMi4yMTA0Jwp2YWx1ZXNldCAiQmVidGVsb3ZpbWFiIjogJ2h0dHA6Ly9jdHMubmxtLm5paC5nb3YvZmhpci9WYWx1ZVNldC8yLjE2Ljg0MC4xLjExMzg4My4zLjM2MTYuMjAwLjExMC4xMDIuMjEwNScKCi8vSW5mbHVlbnphIG1lZGljYXRpb25zCnZhbHVlc2V0ICJCYWxveGF2aXIiOiAnaHR0cDovL2N0cy5ubG0ubmloLmdvdi9maGlyL1ZhbHVlU2V0LzIuMTYuODQwLjEuMTEzNzYyLjEuNC4xMTkwLjg1Jwp2YWx1ZXNldCAiUGVyYW1pdmlyIjogJ2h0dHA6Ly9jdHMubmxtLm5paC5nb3YvZmhpci9WYWx1ZVNldC8yLjE2Ljg0MC4xLjExMzc2Mi4xLjQuMTE5MC44NicKdmFsdWVzZXQgIlphbmFtaXZpciI6ICdodHRwOi8vY3RzLm5sbS5uaWguZ292L2ZoaXIvVmFsdWVTZXQvMi4xNi44NDAuMS4xMTM3NjIuMS40LjExOTAuODcnCnZhbHVlc2V0ICJPc2VsdGFtaXZpciI6ICdodHRwOi8vY3RzLm5sbS5uaWguZ292L2ZoaXIvVmFsdWVTZXQvMi4xNi44NDAuMS4xMTM4ODMuMy4zNjE2LjIwMC4xMTAuMTAyLjIwNzgnCgovL0lzb2xhdGlvbiBQcmVjYXV0aW9ucwp2YWx1ZXNldCAiVHJhbnNtaXNzaW9uIEJhc2VkIFByZWNhdXRpb24gVHlwZXMiOiAnaHR0cDovL2N0cy5ubG0ubmloLmdvdi9maGlyL1ZhbHVlU2V0LzIuMTYuODQwLjEuMTEzODgzLjEwLjIwLjIyLjUuMzAwJwoKLy9FbmNvdW50ZXIgQ2xhc3MgQ29kZXMKdmFsdWVzZXQgIk5IU04gSW5wYXRpZW50IEVuY291bnRlciBDbGFzcyBDb2RlcyI6ICdodHRwOi8vY3RzLm5sbS5uaWguZ292L2ZoaXIvVmFsdWVTZXQvMi4xNi44NDAuMS4xMTM3NjIuMS40LjEwNDYuMjc0JwoKLy9PYnNlcnZhdGlvbiBDYXRlZ29yeSBDb2Rlcwpjb2RlICJsYWJvcmF0b3J5IjogJ2xhYm9yYXRvcnknIGZyb20gIk9ic2VydmF0aW9uIENhdGVnb3J5IiBkaXNwbGF5ICdMYWJvcmF0b3J5JwoKLy9PYnNlcnZhdGlvbiBFbmNvdW50ZXIgQ2xhc3MgQ29kZQpjb2RlICJvYnNlcnZhdGlvbiBlbmNvdW50ZXIiOiAnT0JTRU5DJyBmcm9tICJBY3RDb2RlIiBkaXNwbGF5ICdvYnNlcnZhdGlvbiBlbmNvdW50ZXInCgpwYXJhbWV0ZXIgIk1lYXN1cmVtZW50IFBlcmlvZCIgCiAgZGVmYXVsdCBJbnRlcnZhbFtAMjAyMi0wMS0wMVQwMDowMDowMC4wLCBAMjAyMi0wMS0wMlQwMDowMDowMC4wKQoKY29udGV4dCBQYXRpZW50CgovLy0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0KLy8gSW5pdGlhbCBQb3B1bGF0aW9uCi8vLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLQpkZWZpbmUgIkluaXRpYWwgUG9wdWxhdGlvbiI6CiAgRW5jb3VudGVySW5wYXRpZW50CiAgdW5pb24gRW5jb3VudGVyT2JzZXJ2YXRpb24KICB1bmlvbiAiRW5jb3VudGVycyB3aXRoIFBhdGllbnQgSG9zcGl0YWwgTG9jYXRpb25zIgoKZGVmaW5lICJFbmNvdW50ZXJJbnBhdGllbnQiOgogIChbRW5jb3VudGVyOiAiRW5jb3VudGVyIElucGF0aWVudCJdCiAgICB1bmlvbiBbRW5jb3VudGVyOiBjbGFzcyBpbiAiTkhTTiBJbnBhdGllbnQgRW5jb3VudGVyIENsYXNzIENvZGVzIl0pIEVuY291bnRlcnMKICB3aGVyZSBFbmNvdW50ZXJzLnN0YXR1cyBpbiB7J2luLXByb2dyZXNzJywgJ2ZpbmlzaGVkJywgJ3RyaWFnZWQnLCAnb25sZWF2ZScsICdlbnRlcmVkLWluLWVycm9yJ30KICAgIGFuZCBFbmNvdW50ZXJzLnBlcmlvZCBvdmVybGFwcyAiTWVhc3VyZW1lbnQgUGVyaW9kIgoKZGVmaW5lICJFbmNvdW50ZXJPYnNlcnZhdGlvbiI6CiAgKFtFbmNvdW50ZXI6ICJPYnNlcnZhdGlvbiBTZXJ2aWNlcyJdCiAgICB1bmlvbiBbRW5jb3VudGVyOiBjbGFzcyBpbiB7Im9ic2VydmF0aW9uIGVuY291bnRlciJ9XSkgRW5jb3VudGVycwogIHdoZXJlIEVuY291bnRlcnMuc3RhdHVzIGluIHsnaW4tcHJvZ3Jlc3MnLCAnZmluaXNoZWQnLCAndHJpYWdlZCcsICdvbmxlYXZlJywgJ2VudGVyZWQtaW4tZXJyb3InfQogICAgYW5kIEVuY291bnRlcnMucGVyaW9kIG92ZXJsYXBzICJNZWFzdXJlbWVudCBQZXJpb2QiCgpkZWZpbmUgIkVuY291bnRlcnMgd2l0aCBQYXRpZW50IEhvc3BpdGFsIExvY2F0aW9ucyI6CiAgW0VuY291bnRlcl0gRW5jb3VudGVycwogIHdoZXJlIGV4aXN0cygKICAgIEVuY291bnRlcnMubG9jYXRpb24gRW5jb3VudGVyTG9jYXRpb24KICAgIGxldCB0eXBlczogTkhTTkhlbHBlcnMuR2V0TG9jYXRpb24oRW5jb3VudGVyTG9jYXRpb24ubG9jYXRpb24pLnR5cGUKICAgIHdoZXJlIGV4aXN0cygKICAgICAgdHlwZXMgdHlwZQogICAgICB3aGVyZSB0eXBlIGluICJJbnBhdGllbnQsIEVtZXJnZW5jeSwgYW5kIE9ic2VydmF0aW9uIExvY2F0aW9ucyIKICAgICkKICAgIGFuZCBFbmNvdW50ZXJMb2NhdGlvbi5wZXJpb2Qgb3ZlcmxhcHMgRW5jb3VudGVycy5wZXJpb2QKICAgIGFuZCBFbmNvdW50ZXJzLnN0YXR1cyBpbiB7J2luLXByb2dyZXNzJywgJ2ZpbmlzaGVkJywgJ3RyaWFnZWQnLCAnb25sZWF2ZScsICdlbnRlcmVkLWluLWVycm9yJyB9CiAgICBhbmQgRW5jb3VudGVycy5wZXJpb2Qgb3ZlcmxhcHMgIk1lYXN1cmVtZW50IFBlcmlvZCIKICApCgoKLy8tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLQovLyBMb2dpYyByZWxhdGVkIHRvIExhYm9yYXRvcnkKLy8tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLQovL0xhYiBPYnNlcnZhdGlvbnMKZGVmaW5lICJDT1ZJRCBBbmQgSW5mbHVlbnphIE9ic2VydmF0aW9uIjoKICAoW09ic2VydmF0aW9uOiAiSW5mbHVlbnphIChUZXN0cyBmb3IgaW5mbHVlbnphIEEgb3IgQiB2aXJ1cyBOdWNsZWljIEFjaWQpIl0gCiAgdW5pb24gW09ic2VydmF0aW9uOiAiSW5mbHVlbnphIChUZXN0cyBmb3IgaW5mbHVlbnphIEEgb3IgQiB2aXJ1cyBBbnRpZ2VuKSJdCiAgdW5pb24gW09ic2VydmF0aW9uOiAiQ09WSURfMTkgKFRlc3RzIGZvciBTQVJTX0NvVl8yIE51Y2xlaWMgQWNpZCkiXQogIHVuaW9uIFtPYnNlcnZhdGlvbjogIkNPVklEXzE5IChUZXN0cyBmb3IgU0FSU19Db1ZfMiBBbnRpZ2VuKSJdCiAgKSBPYnNlcnZhdGlvbnMKICAgIHdoZXJlIGV4aXN0cyhPYnNlcnZhdGlvbnMuY2F0ZWdvcnkgQ2F0ZWdvcnkgd2hlcmUgQ2F0ZWdvcnkgfiAibGFib3JhdG9yeSIpCiAgICAgIGFuZCBPYnNlcnZhdGlvbnMuc3RhdHVzIGluIHsnZmluYWwnLCdyZWdpc3RlcmVkJywncHJlbGltaW5hcnknLCdwYXJ0aWFsJ30KICAgICAgYW5kIGV4aXN0cygiSW5pdGlhbCBQb3B1bGF0aW9uIikKCmRlZmluZSAiUlNWIE9ic2VydmF0aW9uIjoKICAoW09ic2VydmF0aW9uOiAiUlNWIChUZXN0cyBmb3IgUlNWIE51Y2xlaWMgQWNpZCkiXQogIHVuaW9uIFtPYnNlcnZhdGlvbjogIlJTViAoVGVzdHMgZm9yIFJTViBBbnRpZ2VuKSJdICAgCiAgKSBPYnNlcnZhdGlvbnMKICAgIHdoZXJlIGV4aXN0cyhPYnNlcnZhdGlvbnMuY2F0ZWdvcnkgQ2F0ZWdvcnkgd2hlcmUgQ2F0ZWdvcnkgfiAibGFib3JhdG9yeSIpCiAgICAgIGFuZCBPYnNlcnZhdGlvbnMuc3RhdHVzIGluIHsnZmluYWwnLCdyZWdpc3RlcmVkJywncHJlbGltaW5hcnknLCdwYXJ0aWFsJ30KICAgICAgYW5kIGV4aXN0cygiSW5pdGlhbCBQb3B1bGF0aW9uIikKCmRlZmluZSAiUlBTIE9ic2VydmF0aW9uIjoKICAiUlNWIE9ic2VydmF0aW9uIgogIHVuaW9uICJDT1ZJRCBBbmQgSW5mbHVlbnphIE9ic2VydmF0aW9uIgoKLy9mdXJ0aGVyIGNvbnN0cmFpbiBDT1ZJRC0xOSBhbmQgSW5mbHVlbnphIE9ic2VydmF0aW9ucyBmb3IgMTQgZGF5IGxvb2tiYWNrCmRlZmluZSAiQ09WSUQgQW5kIEluZmx1ZW56YSBQUkUgQWRtaXNzaW9uIE9ic2VydmF0aW9uIjoKICAiQ09WSUQgQW5kIEluZmx1ZW56YSBPYnNlcnZhdGlvbiIgTyAKICAgd2hlcmUgZXhpc3RzKCBFbmNvdW50ZXJJbnBhdGllbnQgRSAKICAgIHdoZXJlICgKICAgICAgTkhTTkhlbHBlcnMuIk5vcm1hbGl6ZSBJbnRlcnZhbCIoTy5lZmZlY3RpdmUpIDE0IGRheXMgb3IgbGVzcyBvbiBvciBiZWZvcmUgc3RhcnQgb2YgRS5wZXJpb2QKICAgICAgb3IgTkhTTkhlbHBlcnMuIk5vcm1hbGl6ZSBJbnRlcnZhbCIoR2V0U3BlY2ltZW4oTy5zcGVjaW1lbikuY29sbGVjdGlvbi5jb2xsZWN0ZWQpIDE0IGRheXMgb3IgbGVzcyBvbiBvciBiZWZvcmUgc3RhcnQgb2YgRS5wZXJpb2QKICAgICAgKQogICAgICBhbmQgc3RhcnQgb2YgRS5wZXJpb2QgZHVyaW5nICJNZWFzdXJlbWVudCBQZXJpb2QiCiAgICApICAKCi8vZnVydGhlciBjb25zdHJhaW4gUlNWIG9ic2VydmF0aW9uIGZvciA4IGRheSBsb29rYmFjawpkZWZpbmUgIlJTViBQUkUgQWRtaXNzaW9uIE9ic2VydmF0aW9uIjoKICAiUlNWIE9ic2VydmF0aW9uIiBPIAogIHdoZXJlIGV4aXN0cyhFbmNvdW50ZXJJbnBhdGllbnQgRSAKICAgIHdoZXJlICgKICAgICAgTkhTTkhlbHBlcnMuIk5vcm1hbGl6ZSBJbnRlcnZhbCIoTy5lZmZlY3RpdmUpIDggZGF5cyBvciBsZXNzIG9uIG9yIGJlZm9yZSBzdGFydCBvZiBFLnBlcmlvZAogICAgICBvciBOSFNOSGVscGVycy4iTm9ybWFsaXplIEludGVydmFsIihHZXRTcGVjaW1lbihPLnNwZWNpbWVuKS5jb2xsZWN0aW9uLmNvbGxlY3RlZCkgOCBkYXlzIG9yIGxlc3Mgb24gb3IgYmVmb3JlIHN0YXJ0IG9mIEUucGVyaW9kCiAgICAgICkKICAgICAgYW5kIHN0YXJ0IG9mIEUucGVyaW9kIGR1cmluZyAiTWVhc3VyZW1lbnQgUGVyaW9kIgogICAgKQoKLy9MYWIgRGlhZ25vc3RpY1JlcG9ydApkZWZpbmUgIkNPVklEIEFuZCBJbmZsdWVuemEgRGlhZ25vc3RpY1JlcG9ydCI6CiAgKFtEaWFnbm9zdGljUmVwb3J0OiAiQ09WSURfMTkgKFRlc3RzIGZvciBTQVJTX0NvVl8yIE51Y2xlaWMgQWNpZCkiXQogICAgdW5pb24gW0RpYWdub3N0aWNSZXBvcnQ6ICJDT1ZJRF8xOSAoVGVzdHMgZm9yIFNBUlNfQ29WXzIgQW50aWdlbikiXQogICAgdW5pb24gW0RpYWdub3N0aWNSZXBvcnQ6ICJJbmZsdWVuemEgKFRlc3RzIGZvciBpbmZsdWVuemEgQSBvciBCIHZpcnVzIE51Y2xlaWMgQWNpZCkiXQogICAgdW5pb24gW0RpYWdub3N0aWNSZXBvcnQ6ICJJbmZsdWVuemEgKFRlc3RzIGZvciBpbmZsdWVuemEgQSBvciBCIHZpcnVzIEFudGlnZW4pIl0KICApIFJlcG9ydHMKICAgIHdoZXJlIGV4aXN0cygiSW5pdGlhbCBQb3B1bGF0aW9uIikKICAgICAgYW5kIFJlcG9ydHMuc3RhdHVzIGluIHsnZmluYWwnLCdyZWdpc3RlcmVkJywncHJlbGltaW5hcnknLCdwYXJ0aWFsJ30KCmRlZmluZSAiUlNWIERpYWdub3N0aWNSZXBvcnQiOgogIChbRGlhZ25vc3RpY1JlcG9ydDogIlJTViAoVGVzdHMgZm9yIFJTViBOdWNsZWljIEFjaWQpIl0KICAgIHVuaW9uIFtEaWFnbm9zdGljUmVwb3J0OiAiUlNWIChUZXN0cyBmb3IgUlNWIEFudGlnZW4pIl0KICApIFJlcG9ydHMKICAgIHdoZXJlIGV4aXN0cygiSW5pdGlhbCBQb3B1bGF0aW9uIikKICAgICAgYW5kIFJlcG9ydHMuc3RhdHVzIGluIHsnZmluYWwnLCdyZWdpc3RlcmVkJywncHJlbGltaW5hcnknLCdwYXJ0aWFsJ30KCmRlZmluZSAiUlBTIERpYWdub3N0aWNSZXBvcnQiOgogICJDT1ZJRCBBbmQgSW5mbHVlbnphIERpYWdub3N0aWNSZXBvcnQiCiAgICB1bmlvbiAiUlNWIERpYWdub3N0aWNSZXBvcnQiCgovL2Z1cnRoZXIgY29uc3RyYWluIENPVklELTE5IGFuZCBJbmZsdWVuemEgd2l0aCAxNCBkYXkgbG9va2JhY2sgCmRlZmluZSAiQ09WSUQgQW5kIEluZmx1ZW56YSBEaWFnbm9zdGljUmVwb3J0IFBSRSBBZG1pc3Npb24iOgogICJDT1ZJRCBBbmQgSW5mbHVlbnphIERpYWdub3N0aWNSZXBvcnQiIFIgCiAgd2hlcmUgZXhpc3RzKEVuY291bnRlcklucGF0aWVudCBFIAogICAgd2hlcmUgKAogICAgICBOSFNOSGVscGVycy4iTm9ybWFsaXplIEludGVydmFsIihSLmVmZmVjdGl2ZSkgMTQgZGF5cyBvciBsZXNzIG9uIG9yIGJlZm9yZSBzdGFydCBvZiBFLnBlcmlvZCkKICAgICAgYW5kIHN0YXJ0IG9mIEUucGVyaW9kIGR1cmluZyAiTWVhc3VyZW1lbnQgUGVyaW9kIgogICAgKQoKLy9mdXJ0aGVyIGNvbnN0cmFpbiBSU1YgZm9yIDggZGF5IGxvb2tiYWNrCmRlZmluZSAiUlNWIERpYWdub3N0aWNSZXBvcnQgUFJFIEFkbWlzc2lvbiI6CiAgIlJTViBEaWFnbm9zdGljUmVwb3J0IiBSIAogIHdoZXJlIGV4aXN0cyhFbmNvdW50ZXJJbnBhdGllbnQgRSAKICAgIHdoZXJlICgKICAgICAgTkhTTkhlbHBlcnMuIk5vcm1hbGl6ZSBJbnRlcnZhbCIoUi5lZmZlY3RpdmUpIDggZGF5cyBvciBsZXNzIG9uIG9yIGJlZm9yZSBzdGFydCBvZiBFLnBlcmlvZCkKICAgICAgYW5kIHN0YXJ0IG9mIEUucGVyaW9kIGR1cmluZyAiTWVhc3VyZW1lbnQgUGVyaW9kIgogICAgKQoKZGVmaW5lICJDT1ZJRCBhbmQgSW5mbHVlbnphIERpYWdub3N0aWNSZXBvcnQgUmVzdWx0IGZyb20gTGFiIjoKICAiRGlhZ25vc3RpY1JlcG9ydHMiIFJlcG9ydHMKICAgIHdoZXJlIGV4aXN0cygKICAgICAgIkNPVklEIGFuZCBJbmZsdWVuemEgRGlhZ25vc3RpY1JlcG9ydCBPYnNlcnZhdGlvbnMiIE9ic2VydmF0aW9ucwogICAgICB3aGVyZSBSZXBvcnRzLnJlc3VsdC5yZWZlcmVuY2VzKE9ic2VydmF0aW9ucykKICAgICkKICAgIGFuZCBSZXBvcnRzLnN0YXR1cyBpbiB7J2ZpbmFsJywncmVnaXN0ZXJlZCcsJ3ByZWxpbWluYXJ5JywncGFydGlhbCd9CiAgICBhbmQgZXhpc3RzKCJJbml0aWFsIFBvcHVsYXRpb24iKQoKZGVmaW5lICJDT1ZJRCBhbmQgSW5mbHVlbnphIERpYWdub3N0aWNSZXBvcnQgT2JzZXJ2YXRpb25zIjoKICAiT2JzZXJ2YXRpb25zIiBPYnNlcnZhdGlvbnMKICB3aGVyZSBPYnNlcnZhdGlvbnMuY29kZSBpbiAiQ09WSURfMTkgKFRlc3RzIGZvciBTQVJTX0NvVl8yIE51Y2xlaWMgQWNpZCkiCiAgICBvciBPYnNlcnZhdGlvbnMuY29kZSBpbiAiQ09WSURfMTkgKFRlc3RzIGZvciBTQVJTX0NvVl8yIEFudGlnZW4pIgogICAgb3IgT2JzZXJ2YXRpb25zLmNvZGUgaW4gIkluZmx1ZW56YSAoVGVzdHMgZm9yIGluZmx1ZW56YSBBIG9yIEIgdmlydXMgTnVjbGVpYyBBY2lkKSIKICAgIG9yIE9ic2VydmF0aW9ucy5jb2RlIGluICJJbmZsdWVuemEgKFRlc3RzIGZvciBpbmZsdWVuemEgQSBvciBCIHZpcnVzIEFudGlnZW4pIgoKIApkZWZpbmUgIlJTViBEaWFnbm9zdGljUmVwb3J0IFJlc3VsdCBmcm9tIExhYiI6CiAgW0RpYWdub3N0aWNSZXBvcnRdIFJlcG9ydHMKICAgIHdoZXJlIGV4aXN0cygiUlNWIERpYWdub3N0aWNSZXBvcnQgT2JzZXJ2YXRpb25zIikKICAgICAgYW5kIFJlcG9ydHMuc3RhdHVzIGluIHsnZmluYWwnLCdyZWdpc3RlcmVkJywncHJlbGltaW5hcnknLCdwYXJ0aWFsJ30KICAgICAgYW5kIGV4aXN0cygiSW5pdGlhbCBQb3B1bGF0aW9uIikKCmRlZmluZSAiUlNWIE9ic2VydmF0aW9ucyI6CiAgIk9ic2VydmF0aW9ucyIgT2JzZXJ2YXRpb25zCiAgd2hlcmUgT2JzZXJ2YXRpb25zLmNvZGUgaW4gIlJTViAoVGVzdHMgZm9yIFJTViBOdWNsZWljIEFjaWQpIgogICAgb3IgT2JzZXJ2YXRpb25zLmNvZGUgaW4gIlJTViAoVGVzdHMgZm9yIFJTViBBbnRpZ2VuKSIKICAgIApkZWZpbmUgIlJTViBEaWFnbm9zdGljUmVwb3J0IE9ic2VydmF0aW9ucyI6CiAgIkRpYWdub3N0aWNSZXBvcnRzIiBSZXBvcnRzCiAgd2hlcmUgZXhpc3RzKAogICAgIlJTViBPYnNlcnZhdGlvbnMiIE9ic2VydmF0aW9ucwogICAgd2hlcmUgUmVwb3J0cy5yZXN1bHQucmVmZXJlbmNlcyhPYnNlcnZhdGlvbnMpCiAgKQoKZGVmaW5lICJSUFMgRGlhZ25vc3RpY1JlcG9ydCBSZXN1bHQgZnJvbSBMYWIiOgogICJDT1ZJRCBhbmQgSW5mbHVlbnphIERpYWdub3N0aWNSZXBvcnQgUmVzdWx0IGZyb20gTGFiIgogICAgdW5pb24gIlJTViBEaWFnbm9zdGljUmVwb3J0IFJlc3VsdCBmcm9tIExhYiIKCi8vZnVydGhlciBjb25zdHJhaW4gQ09WSUQtMTkgYW5kIEluZmx1ZW56YSB3aXRoIDE0IGRheSBsb29rYmFjawpkZWZpbmUgIkNPVklEIGFuZCBJbmZsdWVuemEgRGlhZ25vc3RpY1JlcG9ydCBSZXN1bHQgZnJvbSBMYWIgUFJFIEFkbWlzc2lvbiI6CiAgIkNPVklEIGFuZCBJbmZsdWVuemEgRGlhZ25vc3RpY1JlcG9ydCBSZXN1bHQgZnJvbSBMYWIiIFIgCiAgd2hlcmUgZXhpc3RzKEVuY291bnRlcklucGF0aWVudCBFIAogICAgd2hlcmUgKAogICAgICBOSFNOSGVscGVycy4iTm9ybWFsaXplIEludGVydmFsIihSLmVmZmVjdGl2ZSkgMTQgZGF5cyBvciBsZXNzIG9uIG9yIGJlZm9yZSBzdGFydCBvZiBFLnBlcmlvZCkKICAgICAgYW5kIHN0YXJ0IG9mIEUucGVyaW9kIGR1cmluZyAiTWVhc3VyZW1lbnQgUGVyaW9kIgogICAgKQoKLy9mdXJ0aGVyIGNvbnN0cmFpbiBSU1Ygd2l0aCA4IGRheSBsb29rYmFjawpkZWZpbmUgIlJTViBEaWFnbm9zdGljUmVwb3J0IFJlc3VsdCBmcm9tIExhYiBQUkUgQWRtaXNzaW9uIjoKICAiUlNWIERpYWdub3N0aWNSZXBvcnQgUmVzdWx0IGZyb20gTGFiIiBSIAogIHdoZXJlIGV4aXN0cyhFbmNvdW50ZXJJbnBhdGllbnQgRSAKICAgIHdoZXJlICgKICAgICAgTkhTTkhlbHBlcnMuIk5vcm1hbGl6ZSBJbnRlcnZhbCIoUi5lZmZlY3RpdmUpIDggZGF5cyBvciBsZXNzIG9uIG9yIGJlZm9yZSBzdGFydCBvZiBFLnBlcmlvZCkKICAgICAgYW5kIHN0YXJ0IG9mIEUucGVyaW9kIGR1cmluZyAiTWVhc3VyZW1lbnQgUGVyaW9kIgogICAgKQogICAgCi8vLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLQovLyBTREUKLy8tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tCmRlZmluZSAiU0RFIElQIEVuY291bnRlcnMiOgogICJJbml0aWFsIFBvcHVsYXRpb24iIElQCiAgcmV0dXJuIFNoYXJlZFJlc291cmNlLkVuY291bnRlclJlc291cmNlKElQLCAKICB7RkhJUi5jYW5vbmljYWx7dmFsdWU6ICdodHRwOi8vd3d3LmNkYy5nb3Yvbmhzbi9maGlycG9ydGFsL2RxbS9pZy9TdHJ1Y3R1cmVEZWZpbml0aW9uL2FjaC1kYWlseS1lbmNvdW50ZXInfX0pCgpkZWZpbmUgIlNERSBFbmNvdW50ZXIiOiAKICAiRW5jb3VudGVycyIgRW5jb3VudGVycwogIHdoZXJlIG5vdCBDaGVja0lQKEVuY291bnRlcnMpCiAgYW5kIGV4aXN0cygKICAgICJJbml0aWFsIFBvcHVsYXRpb24iIElQCiAgICB3aGVyZSBFbmNvdW50ZXJzLnBlcmlvZCBvdmVybGFwcyBJUC5wZXJpb2QpCiAgcmV0dXJuIFNoYXJlZFJlc291cmNlLkVuY291bnRlclJlc291cmNlKEVuY291bnRlcnMsCiAge0ZISVIuY2Fub25pY2Fse3ZhbHVlOiAnaHR0cDovL2hsNy5vcmcvZmhpci91cy9jb3JlL1N0cnVjdHVyZURlZmluaXRpb24vdXMtY29yZS1lbmNvdW50ZXInfX0pCgpkZWZpbmUgIlNERSBNaW5pbWFsIFBhdGllbnQiOgogIFBhdGllbnQgcAogIHdoZXJlIGV4aXN0cygiSW5pdGlhbCBQb3B1bGF0aW9uIikKICByZXR1cm4gU2hhcmVkUmVzb3VyY2UuUGF0aWVudFJlc291cmNlKHAsIAogIHtGSElSLmNhbm9uaWNhbHt2YWx1ZTogJ2h0dHA6Ly93d3cuY2RjLmdvdi9uaHNuL2ZoaXJwb3J0YWwvZHFtL2lnL1N0cnVjdHVyZURlZmluaXRpb24vY3Jvc3MtbWVhc3VyZS1wYXRpZW50J319KQoKZGVmaW5lICJTREUgTG9jYXRpb24iOgogIFtMb2NhdGlvbl0gTG9jYXRpb25zCiAgd2hlcmUgZXhpc3RzKCJJbml0aWFsIFBvcHVsYXRpb24iKQogIHJldHVybiBTaGFyZWRSZXNvdXJjZS5Mb2NhdGlvblJlc291cmNlKExvY2F0aW9ucywKICB7RkhJUi5jYW5vbmljYWx7dmFsdWU6ICdodHRwOi8vd3d3LmNkYy5nb3Yvbmhzbi9maGlycG9ydGFsL2RxbS9pZy9TdHJ1Y3R1cmVEZWZpbml0aW9uL2FjaC1kYWlseS1sb2NhdGlvbid9fSkKICAgCmRlZmluZSAiU0RFIEVuY291bnRlciBEaXNjaGFyZ2UgRGlzcG9zaXRpb25zIjoKCSJJbml0aWFsIFBvcHVsYXRpb24iIERpc2NoYXJnZURpc3Bvc2l0aW9ucyAKICB3aGVyZSBEaXNjaGFyZ2VEaXNwb3NpdGlvbnMuaG9zcGl0YWxpemF0aW9uLmRpc2NoYXJnZURpc3Bvc2l0aW9uIGluICJEaXNjaGFyZ2UgRGlzcG9zaXRpb24iCiAgcmV0dXJuIFNoYXJlZFJlc291cmNlLkVuY291bnRlclJlc291cmNlKERpc2NoYXJnZURpc3Bvc2l0aW9ucywKICB7RkhJUi5jYW5vbmljYWx7dmFsdWU6ICdodHRwOi8vd3d3LmNkYy5nb3Yvbmhzbi9maGlycG9ydGFsL2RxbS9pZy9TdHJ1Y3R1cmVEZWZpbml0aW9uL2FjaC1kYWlseS1lbmNvdW50ZXInfX0pCgovL3JldHVybiB0aGUgT2JzZXJ2YXRpb24gZHVyaW5nIHRoZSBNZWFzdXJlbWVudCBQZXJpb2QKZGVmaW5lICJTREUgUlBTT2JzZXJ2YXRpb24iOgogICJSUFMgT2JzZXJ2YXRpb24iIE9ic2VydmF0aW9ucwogICAgcmV0dXJuIFNoYXJlZFJlc291cmNlLk9ic2VydmF0aW9uTGFiUmVzb3VyY2UoT2JzZXJ2YXRpb25zLAogICAge0ZISVIuY2Fub25pY2Fse3ZhbHVlOiAnaHR0cDovL3d3dy5jZGMuZ292L25oc24vZmhpcnBvcnRhbC9kcW0vaWcvU3RydWN0dXJlRGVmaW5pdGlvbi9hY2gtZGFpbHktb2JzZXJ2YXRpb24tbGFiJ319KQoKLy9yZXR1cm4gdGhlIFJTViBPYnNlcnZhdGlvbiBQcmUgQWRtaXNzaW9uICAgIApkZWZpbmUgIlNERSBSU1YgUFJFIEFkbWlzc2lvbiBPYnNlcnZhdGlvbiI6CiAgIlJTViBQUkUgQWRtaXNzaW9uIE9ic2VydmF0aW9uIiBPYnNlcnZhdGlvbnMKICAgIHJldHVybiBTaGFyZWRSZXNvdXJjZS5PYnNlcnZhdGlvbkxhYlJlc291cmNlKE9ic2VydmF0aW9ucywgCiAgICB7RkhJUi5jYW5vbmljYWx7dmFsdWU6ICdodHRwOi8vd3d3LmNkYy5nb3Yvbmhzbi9maGlycG9ydGFsL2RxbS9pZy9TdHJ1Y3R1cmVEZWZpbml0aW9uL2FjaC1kYWlseS1vYnNlcnZhdGlvbi1sYWInfX0pCgovL3JldHVybiB0aGUgQ09WSUQtMTkgYW5kIEluZmx1ZW56YSBPYnNlcnZhdGlvbiBQcmUgQWRtaXNzaW9uCmRlZmluZSAiU0RFIENPVklEIEFuZCBJbmZsdWVuemEgUFJFIEFkbWlzc2lvbiBPYnNlcnZhdGlvbiI6CiAgIkNPVklEIEFuZCBJbmZsdWVuemEgUFJFIEFkbWlzc2lvbiBPYnNlcnZhdGlvbiIgT2JzZXJ2YXRpb25zCiAgICByZXR1cm4gU2hhcmVkUmVzb3VyY2UuT2JzZXJ2YXRpb25MYWJSZXNvdXJjZShPYnNlcnZhdGlvbnMsCiAgICB7RkhJUi5jYW5vbmljYWx7dmFsdWU6ICdodHRwOi8vd3d3LmNkYy5nb3Yvbmhzbi9maGlycG9ydGFsL2RxbS9pZy9TdHJ1Y3R1cmVEZWZpbml0aW9uL2FjaC1kYWlseS1vYnNlcnZhdGlvbi1sYWInfX0pCgovL3JldHVybiB0aGUgU3BlY2ltZW4gcmVsYXRlZCB0byB0aGUgT2JzZXJ2YXRpb24gZHVyaW5nIHRoZSBNZWFzdXJlbWVudCBQZXJpb2QKZGVmaW5lICJTREUgUlBTIFNwZWNpbWVuIjoKICAiUlBTIE9ic2VydmF0aW9uIiBPYnNlcnZhdGlvbldpdGhTcGVjaW1lbgogICAgbGV0IFNwZWNpbWVuOiBHZXRTcGVjaW1lbihPYnNlcnZhdGlvbldpdGhTcGVjaW1lbi5zcGVjaW1lbikKICAgIHJldHVybiBTaGFyZWRSZXNvdXJjZS5TcGVjaW1lblJlc291cmNlKFNwZWNpbWVuLAogICAge0ZISVIuY2Fub25pY2Fse3ZhbHVlOiAnaHR0cDovL3d3dy5jZGMuZ292L25oc24vZmhpcnBvcnRhbC9kcW0vaWcvU3RydWN0dXJlRGVmaW5pdGlvbi9hY2gtZGFpbHktc3BlY2ltZW4nfX0pCgovL3JldHVybiB0aGUgU3BlY2ltZW4gcmVsYXRlZCB0byB0aGUgUlNWIE9ic2VydmF0aW9uIFByZSBBZG1pc3Npb24KZGVmaW5lICJTREUgUlNWIFNwZWNpbWVuIjoKICAiUlNWIFBSRSBBZG1pc3Npb24gT2JzZXJ2YXRpb24iIE9ic2VydmF0aW9uV2l0aFNwZWNpbWVuCiAgICBsZXQgU3BlY2ltZW46IEdldFNwZWNpbWVuKE9ic2VydmF0aW9uV2l0aFNwZWNpbWVuLnNwZWNpbWVuKQogICAgcmV0dXJuIFNoYXJlZFJlc291cmNlLlNwZWNpbWVuUmVzb3VyY2UoU3BlY2ltZW4sCiAgICB7RkhJUi5jYW5vbmljYWx7dmFsdWU6ICdodHRwOi8vd3d3LmNkYy5nb3Yvbmhzbi9maGlycG9ydGFsL2RxbS9pZy9TdHJ1Y3R1cmVEZWZpbml0aW9uL2FjaC1kYWlseS1zcGVjaW1lbid9fSkKCi8vcmV0dXJuIHRoZSBTcGVjaW1lbiByZWxhdGVkIHRvIHRoZSBDT1ZJRC0xOSBBbmQgSW5mbHVlbnphIE9ic2VydmF0aW9uIFByZSBBZG1pc3Npb24KZGVmaW5lICJTREUgQ09WSUQgQW5kIEluZmx1ZW56YSBTcGVjaW1lbiI6CiAgIkNPVklEIEFuZCBJbmZsdWVuemEgUFJFIEFkbWlzc2lvbiBPYnNlcnZhdGlvbiIgT2JzZXJ2YXRpb25XaXRoU3BlY2ltZW4KICAgIGxldCBTcGVjaW1lbjogR2V0U3BlY2ltZW4oT2JzZXJ2YXRpb25XaXRoU3BlY2ltZW4uc3BlY2ltZW4pCiAgICByZXR1cm4gU2hhcmVkUmVzb3VyY2UuU3BlY2ltZW5SZXNvdXJjZShTcGVjaW1lbiwKICAgIHtGSElSLmNhbm9uaWNhbHt2YWx1ZTogJ2h0dHA6Ly93d3cuY2RjLmdvdi9uaHNuL2ZoaXJwb3J0YWwvZHFtL2lnL1N0cnVjdHVyZURlZmluaXRpb24vYWNoLWRhaWx5LXNwZWNpbWVuJ319KQoKLy9yZXR1cm4gdGhlIERpYWdub3N0aWNSZXBvcnQgZHVyaW5nIHRoZSBNZWFzdXJlbWVudCBQZXJpb2QKZGVmaW5lICJTREUgUlBTIERpYWdub3N0aWNSZXBvcnQiOgogICJSUFMgRGlhZ25vc3RpY1JlcG9ydCIgUmVwb3J0cwogICAgcmV0dXJuIFNoYXJlZFJlc291cmNlLkRpYWdub3N0aWNSZXBvcnRMYWJSZXNvdXJjZShSZXBvcnRzLAogICAge0ZISVIuY2Fub25pY2Fse3ZhbHVlOiAnaHR0cDovL3d3dy5jZGMuZ292L25oc24vZmhpcnBvcnRhbC9kcW0vaWcvU3RydWN0dXJlRGVmaW5pdGlvbi9hY2gtZGFpbHktZGlhZ25vc3RpY3JlcG9ydC1sYWInfX0pCgovL3JldHVybiB0aGUgQ09WSUQtMTkgQW5kIEluZmx1ZW56YSBEaWFnbm9zdGljUmVwb3J0IHByZSBhZG1pc3Npb24KZGVmaW5lICJTREUgQ09WSUQgQW5kIEluZmx1ZW56YSBEaWFnbm9zdGljUmVwb3J0IjoKICAiQ09WSUQgQW5kIEluZmx1ZW56YSBEaWFnbm9zdGljUmVwb3J0IiBSZXBvcnRzCiAgICByZXR1cm4gU2hhcmVkUmVzb3VyY2UuRGlhZ25vc3RpY1JlcG9ydExhYlJlc291cmNlKFJlcG9ydHMsCiAgICB7RkhJUi5jYW5vbmljYWx7dmFsdWU6ICdodHRwOi8vd3d3LmNkYy5nb3Yvbmhzbi9maGlycG9ydGFsL2RxbS9pZy9TdHJ1Y3R1cmVEZWZpbml0aW9uL2FjaC1kYWlseS1kaWFnbm9zdGljcmVwb3J0LWxhYid9fSkKCi8vcmV0dXJuIHRoZSBSU1YgRGlhZ25vc3RpY1JlcG9ydCBwcmUgYWRtaXNzaW9uCmRlZmluZSAiU0RFIFJTViBEaWFnbm9zdGljUmVwb3J0IjoKICAiUlNWIERpYWdub3N0aWNSZXBvcnQiIFJlcG9ydHMKICAgIHJldHVybiBTaGFyZWRSZXNvdXJjZS5EaWFnbm9zdGljUmVwb3J0TGFiUmVzb3VyY2UoUmVwb3J0cywKICAgIHtGSElSLmNhbm9uaWNhbHt2YWx1ZTogJ2h0dHA6Ly93d3cuY2RjLmdvdi9uaHNuL2ZoaXJwb3J0YWwvZHFtL2lnL1N0cnVjdHVyZURlZmluaXRpb24vYWNoLWRhaWx5LWRpYWdub3N0aWNyZXBvcnQtbGFiJ319KQoKLy9yZXR1cm4gdGhlIERpYWdub3N0aWNSZXBvcnQgYmFzZWQgb24gdGhlIHJlc3VsdCBkdXJpbmcgdGhlIE1lYXN1cmVtZW50IFBlcmlvZCAgICAKZGVmaW5lICJTREUgUlBTIERpYWdub3N0aWNSZXBvcnQgUmVzdWx0IGZyb20gTGFiIjoKICAiUlBTIERpYWdub3N0aWNSZXBvcnQgUmVzdWx0IGZyb20gTGFiIiBSZXBvcnRzCiAgICByZXR1cm4gU2hhcmVkUmVzb3VyY2UuRGlhZ25vc3RpY1JlcG9ydExhYlJlc291cmNlKFJlcG9ydHMsCiAgICB7RkhJUi5jYW5vbmljYWx7dmFsdWU6ICdodHRwOi8vd3d3LmNkYy5nb3Yvbmhzbi9maGlycG9ydGFsL2RxbS9pZy9TdHJ1Y3R1cmVEZWZpbml0aW9uL2FjaC1kYWlseS1kaWFnbm9zdGljcmVwb3J0LWxhYid9fSkKCi8vcmV0dXJuIHRoZSBDT1ZJRC0xOSBhbmQgSW5mbHVlbnphIERpYWdub3N0aWNSZXBvcnQgYmFzZWQgb24gdGhlIHJlc3VsdCBwcmUgYWRtaXNzaW9uCmRlZmluZSAiU0RFIENPVklEIGFuZCBJbmZsdWVuemEgRGlhZ25vc3RpY1JlcG9ydCBSZXN1bHQgZnJvbSBMYWIiOgogICJDT1ZJRCBhbmQgSW5mbHVlbnphIERpYWdub3N0aWNSZXBvcnQgUmVzdWx0IGZyb20gTGFiIiBSZXBvcnRzCiAgICByZXR1cm4gU2hhcmVkUmVzb3VyY2UuRGlhZ25vc3RpY1JlcG9ydExhYlJlc291cmNlKFJlcG9ydHMsCiAgICB7RkhJUi5jYW5vbmljYWx7dmFsdWU6ICdodHRwOi8vd3d3LmNkYy5nb3Yvbmhzbi9maGlycG9ydGFsL2RxbS9pZy9TdHJ1Y3R1cmVEZWZpbml0aW9uL2FjaC1kYWlseS1kaWFnbm9zdGljcmVwb3J0LWxhYid9fSkKCi8vcmV0dXJuIHRoZSBSU1YgRGlhZ25vc3RpY1JlcG9ydCBiYXNlZCBvbiB0aGUgcmVzdWx0IHByZSBhZG1pc3Npb24KZGVmaW5lICJTREUgUlNWIERpYWdub3N0aWNSZXBvcnQgUmVzdWx0IGZyb20gTGFiIjoKICAiUlNWIERpYWdub3N0aWNSZXBvcnQgUmVzdWx0IGZyb20gTGFiIiBSZXBvcnRzCiAgICByZXR1cm4gU2hhcmVkUmVzb3VyY2UuRGlhZ25vc3RpY1JlcG9ydExhYlJlc291cmNlKFJlcG9ydHMsCiAgICB7RkhJUi5jYW5vbmljYWx7dmFsdWU6ICdodHRwOi8vd3d3LmNkYy5nb3Yvbmhzbi9maGlycG9ydGFsL2RxbS9pZy9TdHJ1Y3R1cmVEZWZpbml0aW9uL2FjaC1kYWlseS1kaWFnbm9zdGljcmVwb3J0LWxhYid9fSkKICAKZGVmaW5lICJTREUgUlBTIFNlcnZpY2VSZXF1ZXN0IjoKICAoW1NlcnZpY2VSZXF1ZXN0OiAiQ09WSURfMTkgKFRlc3RzIGZvciBTQVJTX0NvVl8yIE51Y2xlaWMgQWNpZCkiXSAKICB1bmlvbiAgW1NlcnZpY2VSZXF1ZXN0OiAiQ09WSURfMTkgKFRlc3RzIGZvciBTQVJTX0NvVl8yIEFudGlnZW4pIl0gCiAgdW5pb24gIFtTZXJ2aWNlUmVxdWVzdDogIkluZmx1ZW56YSAoVGVzdHMgZm9yIGluZmx1ZW56YSBBIG9yIEIgdmlydXMgTnVjbGVpYyBBY2lkKSJdCiAgdW5pb24gIFtTZXJ2aWNlUmVxdWVzdDogIkluZmx1ZW56YSAoVGVzdHMgZm9yIGluZmx1ZW56YSBBIG9yIEIgdmlydXMgQW50aWdlbikiXQogIHVuaW9uICBbU2VydmljZVJlcXVlc3Q6ICJSU1YgKFRlc3RzIGZvciBSU1YgTnVjbGVpYyBBY2lkKSJdCiAgdW5pb24gIFtTZXJ2aWNlUmVxdWVzdDogIlJTViAoVGVzdHMgZm9yIFJTViBBbnRpZ2VuKSJdCiAgKSBTZXJ2aWNlUmVxdWVzdHMKICAgIHdoZXJlIFNlcnZpY2VSZXF1ZXN0cy5pbnRlbnQgfiAnb3JkZXInCiAgICAgIGFuZCBTZXJ2aWNlUmVxdWVzdHMuc3RhdHVzIH4gJ2NvbXBsZXRlZCcKICAgICAgYW5kIGV4aXN0cygiSW5pdGlhbCBQb3B1bGF0aW9uIikKICByZXR1cm4gU2hhcmVkUmVzb3VyY2UuU2VydmljZVJlcXVlc3RSZXNvdXJjZShTZXJ2aWNlUmVxdWVzdHMsCiAge0ZISVIuY2Fub25pY2Fse3ZhbHVlOiAnaHR0cDovL3d3dy5jZGMuZ292L25oc24vZmhpcnBvcnRhbC9kcW0vaWcvU3RydWN0dXJlRGVmaW5pdGlvbi9hY2gtZGFpbHktc2VydmljZXJlcXVlc3QnfX0pCgpkZWZpbmUgIlNERSBJc29sYXRpb24gUHJlY2F1dGlvbnMgSW1wbGVtZW50ZWQiOgogIFtQcm9jZWR1cmU6ICJUcmFuc21pc3Npb24gQmFzZWQgUHJlY2F1dGlvbiBUeXBlcyJdIElzb2xhdGlvblByZWNhdXRpb25zCiAgICB3aGVyZSBOSFNOSGVscGVycy4iTm9ybWFsaXplIEludGVydmFsIihJc29sYXRpb25QcmVjYXV0aW9ucy5wZXJmb3JtZWQpIGR1cmluZyAiTWVhc3VyZW1lbnQgUGVyaW9kIgogICAgYW5kIGV4aXN0cygiSW5pdGlhbCBQb3B1bGF0aW9uIikKICByZXR1cm4gU2hhcmVkUmVzb3VyY2UuUHJvY2VkdXJlUmVzb3VyY2UoSXNvbGF0aW9uUHJlY2F1dGlvbnMsCiAge0ZISVIuY2Fub25pY2Fse3ZhbHVlOiAnaHR0cDovL3d3dy5jZGMuZ292L25oc24vZmhpcnBvcnRhbC9kcW0vaWcvU3RydWN0dXJlRGVmaW5pdGlvbi9hY2gtZGFpbHktcHJvY2VkdXJlJ319KQoKZGVmaW5lICJTREUgQ292aWQgb3IgSW5mbHVlbnphIE1lZGljYXRpb24gQWRtaW5pc3RlcmVkIjoKICBbTWVkaWNhdGlvbkFkbWluaXN0cmF0aW9uXSBSUFNNZWRBZG1pbgogICAgbGV0IE1lZHM6IEdldE1lZGljYXRpb25Db2RlKFJQU01lZEFkbWluLm1lZGljYXRpb24pCiAgIHdoZXJlIChNZWRzIGluICJBbmFraW5yYSIKICAgICAgICAgICAgb3IgTWVkcyBpbiAiQmFtbGFuaXZpbWFiIgogICAgICAgICAgICBvciBNZWRzIGluICJCYWxveGF2aXIiCiAgICAgICAgICAgIG9yIE1lZHMgaW4gIkJhcmljaXRpbmliIgogICAgICAgICAgICBvciBNZWRzIGluICJCZWJ0ZWxvdmltYWIiCiAgICAgICAgICAgIG9yIE1lZHMgaW4gIkNhc2lyaXZpbWFiIgogICAgICAgICAgICBvciBNZWRzIGluICJDYXNpcml2aW1hYiAvIEltZGV2aW1hYiIKICAgICAgICAgICAgb3IgTWVkcyBpbiAiQ09WSUQxOSBSeE5vcm0gVmFsdWUgU2V0IGZvciBUb2NpbGl6dW1hYiIKICAgICAgICAgICAgb3IgTWVkcyBpbiAiRXRlc2V2aW1hYiIKICAgICAgICAgICAgb3IgTWVkcyBpbiAiSW1kZXZpbWFiIgogICAgICAgICAgICBvciBNZWRzIGluICJNb2xudXBpcmF2aXIiCiAgICAgICAgICAgIG9yIE1lZHMgaW4gIk5pcm1hdHJlbHZpciAvIFJpdG9uYXZpciIKICAgICAgICAgICAgb3IgTWVkcyBpbiAiT3NlbHRhbWl2aXIiCiAgICAgICAgICAgIG9yIE1lZHMgaW4gIlBlcmFtaXZpciIKICAgICAgICAgICAgb3IgTWVkcyBpbiAiUmVtZGVzaXZpciIKICAgICAgICAgICAgb3IgTWVkcyBpbiAiU2FyaWx1bWFiIgogICAgICAgICAgICBvciBNZWRzIGluICJTb3Ryb3ZpbWFiIiAgICAKICAgICAgICAgICAgb3IgTWVkcyBpbiAiVG9mYWNpdGluaWIiCiAgICAgICAgICAgIG9yIE1lZHMgaW4gIlphbmFtaXZpciIpCiAgICAgIGFuZCBSUFNNZWRBZG1pbi5zdGF0dXMgfiAnY29tcGxldGVkJwogICAgICBhbmQgZXhpc3RzKCJJbml0aWFsIFBvcHVsYXRpb24iKQogICAgICBhbmQgTkhTTkhlbHBlcnMuIk5vcm1hbGl6ZSBJbnRlcnZhbCIoUlBTTWVkQWRtaW4uZWZmZWN0aXZlKSBkdXJpbmcgIk1lYXN1cmVtZW50IFBlcmlvZCIKICAgIHJldHVybiBTaGFyZWRSZXNvdXJjZS5NZWRpY2F0aW9uQWRtaW5pc3RyYXRpb25SZXNvdXJjZShSUFNNZWRBZG1pbiwKICAgIHtGSElSLmNhbm9uaWNhbHt2YWx1ZTogJ2h0dHA6Ly93d3cuY2RjLmdvdi9uaHNuL2ZoaXJwb3J0YWwvZHFtL2lnL1N0cnVjdHVyZURlZmluaXRpb24vYWNoLWRhaWx5LW1lZGljYXRpb25hZG1pbmlzdHJhdGlvbid9fSkKCmRlZmluZSAiU0RFIENvdmlkIG9yIEluZmx1ZW56YSBNZWRpY2F0aW9uIE9yZGVyZWQiOgogIFtNZWRpY2F0aW9uUmVxdWVzdF0gUlBTTWVkUmVxdWVzdAogICAgbGV0IE1lZHM6IEdldE1lZGljYXRpb25Db2RlKFJQU01lZFJlcXVlc3QubWVkaWNhdGlvbikKICAgIHdoZXJlIChNZWRzIGluICJBbmFraW5yYSIKICAgICAgICAgICAgb3IgTWVkcyBpbiAiQmFsb3hhdmlyIgogICAgICAgICAgICBvciBNZWRzIGluICJCYW1sYW5pdmltYWIiCiAgICAgICAgICAgIG9yIE1lZHMgaW4gIkJhcmljaXRpbmliIgogICAgICAgICAgICBvciBNZWRzIGluICJCZWJ0ZWxvdmltYWIiCiAgICAgICAgICAgIG9yIE1lZHMgaW4gIkNhc2lyaXZpbWFiIgogICAgICAgICAgICBvciBNZWRzIGluICJDYXNpcml2aW1hYiAvIEltZGV2aW1hYiIKICAgICAgICAgICAgb3IgTWVkcyBpbiAiQ09WSUQxOSBSeE5vcm0gVmFsdWUgU2V0IGZvciBUb2NpbGl6dW1hYiIKICAgICAgICAgICAgb3IgTWVkcyBpbiAiRXRlc2V2aW1hYiIKICAgICAgICAgICAgb3IgTWVkcyBpbiAiSW1kZXZpbWFiIgogICAgICAgICAgICBvciBNZWRzIGluICJNb2xudXBpcmF2aXIiCiAgICAgICAgICAgIG9yIE1lZHMgaW4gIk5pcm1hdHJlbHZpciAvIFJpdG9uYXZpciIKICAgICAgICAgICAgb3IgTWVkcyBpbiAiT3NlbHRhbWl2aXIiCiAgICAgICAgICAgIG9yIE1lZHMgaW4gIlBlcmFtaXZpciIKICAgICAgICAgICAgb3IgTWVkcyBpbiAiUmVtZGVzaXZpciIKICAgICAgICAgICAgb3IgTWVkcyBpbiAiU2FyaWx1bWFiIgogICAgICAgICAgICBvciBNZWRzIGluICJTb3Ryb3ZpbWFiIiAgICAKICAgICAgICAgICAgb3IgTWVkcyBpbiAiVG9mYWNpdGluaWIiCiAgICAgICAgICAgIG9yIE1lZHMgaW4gIlphbmFtaXZpciIpCiAgICAgIGFuZCBleGlzdHMoIkluaXRpYWwgUG9wdWxhdGlvbiIpCiAgICAgIGFuZCBOSFNOSGVscGVycy4iTm9ybWFsaXplIEludGVydmFsIihSUFNNZWRSZXF1ZXN0LmF1dGhvcmVkT24pIGR1cmluZyAiTWVhc3VyZW1lbnQgUGVyaW9kIgogICAgcmV0dXJuIFNoYXJlZFJlc291cmNlLk1lZGljYXRpb25SZXF1ZXN0UmVzb3VyY2UoUlBTTWVkUmVxdWVzdCwKICAgIHtGSElSLmNhbm9uaWNhbHt2YWx1ZTogJ2h0dHA6Ly93d3cuY2RjLmdvdi9uaHNuL2ZoaXJwb3J0YWwvZHFtL2lnL1N0cnVjdHVyZURlZmluaXRpb24vYWNoLWRhaWx5LW1lZGljYXRpb25yZXF1ZXN0J319KQoKZGVmaW5lICJTREUgTWVkaWNhdGlvbiI6CiAgKCJTREUgQ292aWQgb3IgSW5mbHVlbnphIE1lZGljYXRpb24gT3JkZXJlZCIKICB1bmlvbiAiU0RFIENvdmlkIG9yIEluZmx1ZW56YSBNZWRpY2F0aW9uIEFkbWluaXN0ZXJlZCIpIE1lZFJlcU9yQWRtaW4KICB3aGVyZSBNZWRSZXFPckFkbWluLm1lZGljYXRpb24gaXMgRkhJUi5SZWZlcmVuY2UKICByZXR1cm4gU2hhcmVkUmVzb3VyY2UuTWVkaWNhdGlvblJlc291cmNlKEdldE1lZGljYXRpb25Gcm9tKE1lZFJlcU9yQWRtaW4ubWVkaWNhdGlvbiksCiAge0ZISVIuY2Fub25pY2Fse3ZhbHVlOiAnaHR0cDovL3d3dy5jZGMuZ292L25oc24vZmhpcnBvcnRhbC9kcW0vaWcvU3RydWN0dXJlRGVmaW5pdGlvbi9hY2gtZGFpbHktbWVkaWNhdGlvbid9fSkKCi8vVG8gY2F0Y2ggYWxsIGlzb2xhdGlvbiBwcmVjYXV0aW9ucwpkZWZpbmUgIlNERSBBbGwgT2JzZXJ2YXRpb25zIjoKICAiT2JzZXJ2YXRpb25zIiBPCiAgd2hlcmUgZXhpc3RzKCJJbml0aWFsIFBvcHVsYXRpb24iKQogIHJldHVybiBTaGFyZWRSZXNvdXJjZS5PYnNlcnZhdGlvbkxhYlJlc291cmNlKE8sCiAge0ZISVIuY2Fub25pY2Fse3ZhbHVlOiAnaHR0cDovL3d3dy5jZGMuZ292L25oc24vZmhpcnBvcnRhbC9kcW0vaWcvU3RydWN0dXJlRGVmaW5pdGlvbi9hY2gtZGFpbHktb2JzZXJ2YXRpb24nfX0pCgovL1RvIGNhdGNoIGFsbCBpc29sYXRpb24gcHJlY2F1dGlvbnMKZGVmaW5lICJTREUgQWxsIFNlcnZpY2VSZXF1ZXN0cyI6CiAgW1NlcnZpY2VSZXF1ZXN0XSBTUgogIHdoZXJlIGV4aXN0cygiSW5pdGlhbCBQb3B1bGF0aW9uIikKICByZXR1cm4gU2hhcmVkUmVzb3VyY2UuU2VydmljZVJlcXVlc3RSZXNvdXJjZShTUiwKICB7RkhJUi5jYW5vbmljYWx7dmFsdWU6ICdodHRwOi8vd3d3LmNkYy5nb3Yvbmhzbi9maGlycG9ydGFsL2RxbS9pZy9TdHJ1Y3R1cmVEZWZpbml0aW9uL2FjaC1kYWlseS1zZXJ2aWNlcmVxdWVzdCd9fSkKCi8vVG8gY2F0Y2ggYWxsIGlzb2xhdGlvbiBwcmVjYXV0aW9ucwpkZWZpbmUgIlNERSBBbGwgUHJvY2VkdXJlcyI6CiAgW1Byb2NlZHVyZV0gUAogIHdoZXJlIGV4aXN0cygiSW5pdGlhbCBQb3B1bGF0aW9uIikKICByZXR1cm4gU2hhcmVkUmVzb3VyY2UuUHJvY2VkdXJlUmVzb3VyY2UoUCwKICB7RkhJUi5jYW5vbmljYWx7dmFsdWU6ICdodHRwOi8vd3d3LmNkYy5nb3Yvbmhzbi9maGlycG9ydGFsL2RxbS9pZy9TdHJ1Y3R1cmVEZWZpbml0aW9uL2FjaC1kYWlseS1wcm9jZWR1cmUnfX0pCgoKLy8tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLQovL2Z1bmN0aW9ucwovLy0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tCmRlZmluZSBmdW5jdGlvbiAiQ2hlY2tJUCIoZW5jb3VudGVyIEVuY291bnRlcik6CiAgZXhpc3RzKCJJbml0aWFsIFBvcHVsYXRpb24iIElQCiAgd2hlcmUgZW5jb3VudGVyLmlkID0gSVAuaWQpCgpkZWZpbmUgZnVuY3Rpb24gIkdldE1lZGljYXRpb24iKHJlZmVyZW5jZSBSZWZlcmVuY2UgKToKICBzaW5nbGV0b24gZnJvbSAoCiAgICBbTWVkaWNhdGlvbjogaWQgaW4ge05IU05IZWxwZXJzLkdldElkKHJlZmVyZW5jZS5yZWZlcmVuY2UpfV0KICApCgpkZWZpbmUgZnVuY3Rpb24gIkdldE1lZGljYXRpb25Db2RlIihjaG9pY2UgQ2hvaWNlPEZISVIuQ29kZWFibGVDb25jZXB0LCBGSElSLlJlZmVyZW5jZT4pOgogIGNhc2UKICAgIHdoZW4gY2hvaWNlIGlzIEZISVIuQ29kZWFibGVDb25jZXB0IHRoZW4KICAgICAgY2hvaWNlIGFzIEZISVIuQ29kZWFibGVDb25jZXB0CiAgICB3aGVuIGNob2ljZSBpcyBGSElSLlJlZmVyZW5jZSB0aGVuCiAgICAgIEdldE1lZGljYXRpb24oY2hvaWNlIGFzIEZISVIuUmVmZXJlbmNlKS5jb2RlCiAgICBlbHNlCiAgICAgIG51bGwgYXMgRkhJUi5Db2RlYWJsZUNvbmNlcHQKICBlbmQKCmRlZmluZSBmdW5jdGlvbiAiR2V0TWVkaWNhdGlvbkZyb20iKGNob2ljZSBDaG9pY2U8RkhJUi5Db2RlYWJsZUNvbmNlcHQsIEZISVIuUmVmZXJlbmNlPik6CiAgY2FzZQogICAgd2hlbiBjaG9pY2UgaXMgRkhJUi5SZWZlcmVuY2UgdGhlbgogICAgICBHZXRNZWRpY2F0aW9uKGNob2ljZSBhcyBGSElSLlJlZmVyZW5jZSkKICAgIGVsc2UKICAgICAgbnVsbAogIGVuZAoKZGVmaW5lIGZ1bmN0aW9uICJHZXRTcGVjaW1lbiIocmVmZXJlbmNlIEZISVIuUmVmZXJlbmNlKToKICBzaW5nbGV0b24gZnJvbSAoCiAgICBbU3BlY2ltZW5dIFNwZWNpbWVucwogICAgd2hlcmUgU3BlY2ltZW5zLmlkID0gTkhTTkhlbHBlcnMuR2V0SWQocmVmZXJlbmNlLnJlZmVyZW5jZSkKICApCgpkZWZpbmUgZnVuY3Rpb24gIkdldEVuY291bnRlciIocmVmZXJlbmNlIEZISVIuUmVmZXJlbmNlKToKICBzaW5nbGV0b24gZnJvbSAoCiAgICAiRW5jb3VudGVycyIgRW5jb3VudGVycwogICAgd2hlcmUgRW5jb3VudGVycy5pZCA9IE5IU05IZWxwZXJzLkdldElkKHJlZmVyZW5jZS5yZWZlcmVuY2UpCiAgKQoKZGVmaW5lIGZsdWVudCBmdW5jdGlvbiByZWZlcmVuY2VzKHJlZmVyZW5jZSBGSElSLlJlZmVyZW5jZSwgcmVzb3VyY2UgRkhJUi5SZXNvdXJjZSk6CiAgcmVzb3VyY2UuaWQgPSBMYXN0KFNwbGl0KHJlZmVyZW5jZS5yZWZlcmVuY2UsICcvJykpCgpkZWZpbmUgZmx1ZW50IGZ1bmN0aW9uIHJlZmVyZW5jZXMocmVmZXJlbmNlcyBMaXN0PEZISVIuUmVmZXJlbmNlPiwgcmVzb3VyY2UgRkhJUi5SZXNvdXJjZSk6CiAgZXhpc3RzKHJlZmVyZW5jZXMgUiB3aGVyZSBSLnJlZmVyZW5jZXMocmVzb3VyY2UpKQoKLy9Db21tb24gUmV0cmlldmFscwpkZWZpbmUgIkVuY291bnRlcnMiOgogIFtFbmNvdW50ZXJdCgpkZWZpbmUgIk9ic2VydmF0aW9ucyI6CiAgW09ic2VydmF0aW9uXQoKZGVmaW5lICJEaWFnbm9zdGljUmVwb3J0cyI6CiAgW0RpYWdub3N0aWNSZXBvcnRd"
+            "data": "bGlicmFyeSBOSFNOQWN1dGVDYXJlSG9zcGl0YWxEYWlseUluaXRpYWxQb3B1bGF0aW9uIHZlcnNpb24gJzIuMC4wLWRldicKCnVzaW5nIEZISVIgdmVyc2lvbiAnNC4wLjEnCgppbmNsdWRlIEZISVJIZWxwZXJzIHZlcnNpb24gJzQuMC4yJyBjYWxsZWQgRkhJUkhlbHBlcnMKaW5jbHVkZSBOSFNOSGVscGVycyB2ZXJzaW9uICcwLjAuMDAyJyBjYWxsZWQgTkhTTkhlbHBlcnMKaW5jbHVkZSBTaGFyZWRSZXNvdXJjZUNyZWF0aW9uIHZlcnNpb24gJzAuMS4wMTAnIGNhbGxlZCBTaGFyZWRSZXNvdXJjZQoKY29kZXN5c3RlbSAiQWN0Q29kZSI6ICdodHRwOi8vdGVybWlub2xvZ3kuaGw3Lm9yZy9Db2RlU3lzdGVtL3YzLUFjdENvZGUnIApjb2Rlc3lzdGVtICJMT0lOQyI6ICdodHRwOi8vbG9pbmMub3JnJyAKY29kZXN5c3RlbSAiT2JzZXJ2YXRpb24gQ2F0ZWdvcnkiOiAnaHR0cDovL3Rlcm1pbm9sb2d5LmhsNy5vcmcvQ29kZVN5c3RlbS9vYnNlcnZhdGlvbi1jYXRlZ29yeScgCmNvZGVzeXN0ZW0gIlJYTk9STSI6ICdodHRwOi8vd3d3Lm5sbS5uaWguZ292L3Jlc2VhcmNoL3VtbHMvcnhub3JtJwoKdmFsdWVzZXQgIkVuY291bnRlciBJbnBhdGllbnQiOiAnaHR0cDovL2N0cy5ubG0ubmloLmdvdi9maGlyL1ZhbHVlU2V0LzIuMTYuODQwLjEuMTEzODgzLjMuNjY2LjUuMzA3JyAKdmFsdWVzZXQgIklucGF0aWVudCwgRW1lcmdlbmN5LCBhbmQgT2JzZXJ2YXRpb24gTG9jYXRpb25zIjogJ2h0dHA6Ly9jdHMubmxtLm5paC5nb3YvZmhpci9WYWx1ZVNldC8yLjE2Ljg0MC4xLjExMzc2Mi4xLjQuMTA0Ni4yNjUnIAp2YWx1ZXNldCAiT2JzZXJ2YXRpb24gU2VydmljZXMiOiAnaHR0cDovL2N0cy5ubG0ubmloLmdvdi9maGlyL1ZhbHVlU2V0LzIuMTYuODQwLjEuMTEzNzYyLjEuNC4xMTExLjE0MycgCnZhbHVlc2V0ICJEaXNjaGFyZ2UgRGlzcG9zaXRpb24iOiAnaHR0cDovL3Rlcm1pbm9sb2d5LmhsNy5vcmcvVmFsdWVTZXQvY2xpbmljYWwtZGlzY2hhcmdlLWRpc3Bvc2l0aW9uJwoKLy9DT1ZJRC0xOSBsYWIgdGVzdHMKdmFsdWVzZXQgIkNPVklEXzE5IChUZXN0cyBmb3IgU0FSU19Db1ZfMiBOdWNsZWljIEFjaWQpIjogJ2h0dHA6Ly9jdHMubmxtLm5paC5nb3YvZmhpci9WYWx1ZVNldC8yLjE2Ljg0MC4xLjExMzc2Mi4xLjQuMTE0Ni4xMTQyJwp2YWx1ZXNldCAiQ09WSURfMTkgKFRlc3RzIGZvciBTQVJTX0NvVl8yIEFudGlnZW4pIjogJ2h0dHA6Ly9jdHMubmxtLm5paC5nb3YvZmhpci9WYWx1ZVNldC8yLjE2Ljg0MC4xLjExMzc2Mi4xLjQuMTE0Ni4xMTU4JwoKLy9DT1ZJRC0xOSB0ZXN0IHJlc3VsdHMgKHVudXNlZCkKdmFsdWVzZXQgIkNPVklEXzE5IChPcmdhbmlzbSBvciBTdWJzdGFuY2UgaW4gTGFiIFJlc3VsdHMpIjogJ2h0dHA6Ly9jdHMubmxtLm5paC5nb3YvZmhpci9WYWx1ZVNldC8yLjE2Ljg0MC4xLjExMzc2Mi4xLjQuMTE0Ni4xMTQzJwoKLy9JbmZsdWVuemEgbGFiIHRlc3RzCnZhbHVlc2V0ICJJbmZsdWVuemEgKFRlc3RzIGZvciBpbmZsdWVuemEgQSBvciBCIHZpcnVzIE51Y2xlaWMgQWNpZCkiOiAnaHR0cDovL2N0cy5ubG0ubmloLmdvdi9maGlyL1ZhbHVlU2V0LzIuMTYuODQwLjEuMTEzNzYyLjEuNC4xMTQ2LjMzNicKdmFsdWVzZXQgIkluZmx1ZW56YSAoVGVzdHMgZm9yIGluZmx1ZW56YSBBIG9yIEIgdmlydXMgQW50aWdlbikiOiAnaHR0cDovL2N0cy5ubG0ubmloLmdvdi9maGlyL1ZhbHVlU2V0LzIuMTYuODQwLjEuMTEzNzYyLjEuNC4xMTQ2LjMzNycKCi8vSW5mbHVlbnphIHRlc3QgUmVzdWx0cyAodW51c2VkKQp2YWx1ZXNldCAiSW5mbHVlbnphIChpbmZsdWVuemEgQSBvciBCIHZpcnVzIGluIExhYiBSZXN1bHRzKSI6ICdodHRwOi8vY3RzLm5sbS5uaWguZ292L2ZoaXIvVmFsdWVTZXQvMi4xNi44NDAuMS4xMTM3NjIuMS40LjExNDYuMzQwJwoKLy9SU1YgbGFiIHRlc3RzCnZhbHVlc2V0ICJSU1YgKFRlc3RzIGZvciBSU1YgQW50aWdlbikiOiAnaHR0cDovL2N0cy5ubG0ubmloLmdvdi9maGlyL1ZhbHVlU2V0LzIuMTYuODQwLjEuMTEzNzYyLjEuNC4xMTQ2LjEzMTEnCnZhbHVlc2V0ICJSU1YgKFRlc3RzIGZvciBSU1YgTnVjbGVpYyBBY2lkKSI6ICdodHRwOi8vY3RzLm5sbS5uaWguZ292L2ZoaXIvVmFsdWVTZXQvMi4xNi44NDAuMS4xMTM3NjIuMS40LjExNDYuMTMxMicKCi8vUlNWIHRlc3QgcmVzdWx0cyAodW51c2VkKQp2YWx1ZXNldCAiUlNWIChPcmdhbmlzbSBvciBTdWJzdGFuY2UgaW4gTGFiIFJlc3VsdHMpIjogJ2h0dHA6Ly9jdHMubmxtLm5paC5nb3YvZmhpci9WYWx1ZVNldC8yLjE2Ljg0MC4xLjExMzc2Mi4xLjQuMTE0Ni4xMzA4JwoKLy9UZXN0IHJlc3VsdHMgc2hhcmVkIGFtb25nIENPVklELTE5LCBJbmZsdWVuemEgYW5kIFJTViAodW51c2VkKQp2YWx1ZXNldCAiTElWRCBTQVJTIENvVjIgVGVzdCBSZXN1bHQgQ29kZXMiOiAnaHR0cDovL2N0cy5ubG0ubmloLmdvdi9maGlyL1ZhbHVlU2V0LzIuMTYuODQwLjEuMTEzNzYyLjEuNC4xMTE0LjEwJwoKLy9DT1ZJRC0xOSBtZWRpY2F0aW9ucwp2YWx1ZXNldCAiQmFyaWNpdGluaWIiOiAnaHR0cDovL2N0cy5ubG0ubmloLmdvdi9maGlyL1ZhbHVlU2V0LzIuMTYuODQwLjEuMTEzODgzLjMuMzYxNi4yMDAuMTEwLjEwMi4yMDQ2Jwp2YWx1ZXNldCAiQW5ha2lucmEiOiAnaHR0cDovL2N0cy5ubG0ubmloLmdvdi9maGlyL1ZhbHVlU2V0LzIuMTYuODQwLjEuMTEzODgzLjMuMzYxNi4yMDAuMTEwLjEwMi4yMDU0Jwp2YWx1ZXNldCAiU2FyaWx1bWFiIjogJ2h0dHA6Ly9jdHMubmxtLm5paC5nb3YvZmhpci9WYWx1ZVNldC8yLjE2Ljg0MC4xLjExMzg4My4zLjM2MTYuMjAwLjExMC4xMDIuMjA4NCcKdmFsdWVzZXQgIkNPVklEMTkgUnhOb3JtIFZhbHVlIFNldCBmb3IgVG9jaWxpenVtYWIiOiAnaHR0cDovL2N0cy5ubG0ubmloLmdvdi9maGlyL1ZhbHVlU2V0LzIuMTYuODQwLjEuMTEzODgzLjMuMzYxNi4yMDAuMTEwLjEwMi4yMDg3Jwp2YWx1ZXNldCAiQ2FzaXJpdmltYWIiOiAnaHR0cDovL2N0cy5ubG0ubmloLmdvdi9maGlyL1ZhbHVlU2V0LzIuMTYuODQwLjEuMTEzODgzLjMuMzYxNi4yMDAuMTEwLjEwMi4yMDk3Jwp2YWx1ZXNldCAiSW1kZXZpbWFiIjogJ2h0dHA6Ly9jdHMubmxtLm5paC5nb3YvZmhpci9WYWx1ZVNldC8yLjE2Ljg0MC4xLjExMzg4My4zLjM2MTYuMjAwLjExMC4xMDIuMjA5OCcKdmFsdWVzZXQgIkJhbWxhbml2aW1hYiI6ICdodHRwOi8vY3RzLm5sbS5uaWguZ292L2ZoaXIvVmFsdWVTZXQvMi4xNi44NDAuMS4xMTM4ODMuMy4zNjE2LjIwMC4xMTAuMTAyLjIwOTknCnZhbHVlc2V0ICJFdGVzZXZpbWFiIjogJ2h0dHA6Ly9jdHMubmxtLm5paC5nb3YvZmhpci9WYWx1ZVNldC8yLjE2Ljg0MC4xLjExMzg4My4zLjM2MTYuMjAwLjExMC4xMDIuMjEwMCcKdmFsdWVzZXQgIlNvdHJvdmltYWIiOiAnaHR0cDovL2N0cy5ubG0ubmloLmdvdi9maGlyL1ZhbHVlU2V0LzIuMTYuODQwLjEuMTEzODgzLjMuMzYxNi4yMDAuMTEwLjEwMi4yMTAxJwp2YWx1ZXNldCAiVG9mYWNpdGluaWIiOiAnaHR0cDovL2N0cy5ubG0ubmloLmdvdi9maGlyL1ZhbHVlU2V0LzIuMTYuODQwLjEuMTEzODgzLjMuMzYxNi4yMDAuMTEwLjEwMi4yMTAyJwp2YWx1ZXNldCAiQ2FzaXJpdmltYWIgLyBJbWRldmltYWIiOiAnaHR0cDovL2N0cy5ubG0ubmloLmdvdi9maGlyL1ZhbHVlU2V0LzIuMTYuODQwLjEuMTEzODgzLjMuMzYxNi4yMDAuMTEwLjEwMi4yMTAzJwp2YWx1ZXNldCAiTW9sbnVwaXJhdmlyIjogJ2h0dHA6Ly9jdHMubmxtLm5paC5nb3YvZmhpci9WYWx1ZVNldC8yLjE2Ljg0MC4xLjExMzg4My4zLjM2MTYuMjAwLjExMC4xMDIuMjExOScKdmFsdWVzZXQgIlJlbWRlc2l2aXIiOiAnaHR0cDovL2N0cy5ubG0ubmloLmdvdi9maGlyL1ZhbHVlU2V0LzIuMTYuODQwLjEuMTEzODgzLjMuMzYxNi4yMDAuMTEwLjEwMi4yMDgxJwp2YWx1ZXNldCAiTmlybWF0cmVsdmlyIC8gUml0b25hdmlyIjogJ2h0dHA6Ly9jdHMubmxtLm5paC5nb3YvZmhpci9WYWx1ZVNldC8yLjE2Ljg0MC4xLjExMzg4My4zLjM2MTYuMjAwLjExMC4xMDIuMjEwNCcKdmFsdWVzZXQgIkJlYnRlbG92aW1hYiI6ICdodHRwOi8vY3RzLm5sbS5uaWguZ292L2ZoaXIvVmFsdWVTZXQvMi4xNi44NDAuMS4xMTM4ODMuMy4zNjE2LjIwMC4xMTAuMTAyLjIxMDUnCgovL0luZmx1ZW56YSBtZWRpY2F0aW9ucwp2YWx1ZXNldCAiQmFsb3hhdmlyIjogJ2h0dHA6Ly9jdHMubmxtLm5paC5nb3YvZmhpci9WYWx1ZVNldC8yLjE2Ljg0MC4xLjExMzc2Mi4xLjQuMTE5MC44NScKdmFsdWVzZXQgIlBlcmFtaXZpciI6ICdodHRwOi8vY3RzLm5sbS5uaWguZ292L2ZoaXIvVmFsdWVTZXQvMi4xNi44NDAuMS4xMTM3NjIuMS40LjExOTAuODYnCnZhbHVlc2V0ICJaYW5hbWl2aXIiOiAnaHR0cDovL2N0cy5ubG0ubmloLmdvdi9maGlyL1ZhbHVlU2V0LzIuMTYuODQwLjEuMTEzNzYyLjEuNC4xMTkwLjg3Jwp2YWx1ZXNldCAiT3NlbHRhbWl2aXIiOiAnaHR0cDovL2N0cy5ubG0ubmloLmdvdi9maGlyL1ZhbHVlU2V0LzIuMTYuODQwLjEuMTEzODgzLjMuMzYxNi4yMDAuMTEwLjEwMi4yMDc4JwoKLy9Jc29sYXRpb24gUHJlY2F1dGlvbnMKdmFsdWVzZXQgIlRyYW5zbWlzc2lvbiBCYXNlZCBQcmVjYXV0aW9uIFR5cGVzIjogJ2h0dHA6Ly9jdHMubmxtLm5paC5nb3YvZmhpci9WYWx1ZVNldC8yLjE2Ljg0MC4xLjExMzg4My4xMC4yMC4yMi41LjMwMCcKCi8vRW5jb3VudGVyIENsYXNzIENvZGVzCnZhbHVlc2V0ICJOSFNOIElucGF0aWVudCBFbmNvdW50ZXIgQ2xhc3MgQ29kZXMiOiAnaHR0cDovL2N0cy5ubG0ubmloLmdvdi9maGlyL1ZhbHVlU2V0LzIuMTYuODQwLjEuMTEzNzYyLjEuNC4xMDQ2LjI3NCcKCi8vT2JzZXJ2YXRpb24gQ2F0ZWdvcnkgQ29kZXMKY29kZSAibGFib3JhdG9yeSI6ICdsYWJvcmF0b3J5JyBmcm9tICJPYnNlcnZhdGlvbiBDYXRlZ29yeSIgZGlzcGxheSAnTGFib3JhdG9yeScKCi8vT2JzZXJ2YXRpb24gRW5jb3VudGVyIENsYXNzIENvZGUKY29kZSAib2JzZXJ2YXRpb24gZW5jb3VudGVyIjogJ09CU0VOQycgZnJvbSAiQWN0Q29kZSIgZGlzcGxheSAnb2JzZXJ2YXRpb24gZW5jb3VudGVyJwoKcGFyYW1ldGVyICJNZWFzdXJlbWVudCBQZXJpb2QiIAogIGRlZmF1bHQgSW50ZXJ2YWxbQDIwMjItMDEtMDFUMDA6MDA6MDAuMCwgQDIwMjItMDEtMDJUMDA6MDA6MDAuMCkKCmNvbnRleHQgUGF0aWVudAoKLy8tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tCi8vIEluaXRpYWwgUG9wdWxhdGlvbgovLy0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0KZGVmaW5lICJJbml0aWFsIFBvcHVsYXRpb24iOgogIEVuY291bnRlcklucGF0aWVudAogIHVuaW9uIEVuY291bnRlck9ic2VydmF0aW9uCiAgdW5pb24gIkVuY291bnRlcnMgd2l0aCBQYXRpZW50IEhvc3BpdGFsIExvY2F0aW9ucyIKCmRlZmluZSAiRW5jb3VudGVySW5wYXRpZW50IjoKICAoW0VuY291bnRlcjogIkVuY291bnRlciBJbnBhdGllbnQiXQogICAgdW5pb24gW0VuY291bnRlcjogY2xhc3MgaW4gIk5IU04gSW5wYXRpZW50IEVuY291bnRlciBDbGFzcyBDb2RlcyJdKSBFbmNvdW50ZXJzCiAgd2hlcmUgRW5jb3VudGVycy5zdGF0dXMgaW4geydpbi1wcm9ncmVzcycsICdmaW5pc2hlZCcsICd0cmlhZ2VkJywgJ29ubGVhdmUnLCAnZW50ZXJlZC1pbi1lcnJvcid9CiAgICBhbmQgRW5jb3VudGVycy5wZXJpb2Qgb3ZlcmxhcHMgIk1lYXN1cmVtZW50IFBlcmlvZCIKCmRlZmluZSAiRW5jb3VudGVyT2JzZXJ2YXRpb24iOgogIChbRW5jb3VudGVyOiAiT2JzZXJ2YXRpb24gU2VydmljZXMiXQogICAgdW5pb24gW0VuY291bnRlcjogY2xhc3MgaW4geyJvYnNlcnZhdGlvbiBlbmNvdW50ZXIifV0pIEVuY291bnRlcnMKICB3aGVyZSBFbmNvdW50ZXJzLnN0YXR1cyBpbiB7J2luLXByb2dyZXNzJywgJ2ZpbmlzaGVkJywgJ3RyaWFnZWQnLCAnb25sZWF2ZScsICdlbnRlcmVkLWluLWVycm9yJ30KICAgIGFuZCBFbmNvdW50ZXJzLnBlcmlvZCBvdmVybGFwcyAiTWVhc3VyZW1lbnQgUGVyaW9kIgoKZGVmaW5lICJFbmNvdW50ZXJzIHdpdGggUGF0aWVudCBIb3NwaXRhbCBMb2NhdGlvbnMiOgogIFtFbmNvdW50ZXJdIEVuY291bnRlcnMKICB3aGVyZSBleGlzdHMoCiAgICBFbmNvdW50ZXJzLmxvY2F0aW9uIEVuY291bnRlckxvY2F0aW9uCiAgICBsZXQgdHlwZXM6IE5IU05IZWxwZXJzLkdldExvY2F0aW9uKEVuY291bnRlckxvY2F0aW9uLmxvY2F0aW9uKS50eXBlCiAgICB3aGVyZSBleGlzdHMoCiAgICAgIHR5cGVzIHR5cGUKICAgICAgd2hlcmUgdHlwZSBpbiAiSW5wYXRpZW50LCBFbWVyZ2VuY3ksIGFuZCBPYnNlcnZhdGlvbiBMb2NhdGlvbnMiCiAgICApCiAgICBhbmQgRW5jb3VudGVyTG9jYXRpb24ucGVyaW9kIG92ZXJsYXBzIEVuY291bnRlcnMucGVyaW9kCiAgICBhbmQgRW5jb3VudGVycy5zdGF0dXMgaW4geydpbi1wcm9ncmVzcycsICdmaW5pc2hlZCcsICd0cmlhZ2VkJywgJ29ubGVhdmUnLCAnZW50ZXJlZC1pbi1lcnJvcicgfQogICAgYW5kIEVuY291bnRlcnMucGVyaW9kIG92ZXJsYXBzICJNZWFzdXJlbWVudCBQZXJpb2QiCiAgKQoKCi8vLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0KLy8gTG9naWMgcmVsYXRlZCB0byBMYWJvcmF0b3J5Ci8vLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0KLy9MYWIgT2JzZXJ2YXRpb25zCmRlZmluZSAiQ09WSUQgQW5kIEluZmx1ZW56YSBPYnNlcnZhdGlvbiI6CiAgKFtPYnNlcnZhdGlvbjogIkluZmx1ZW56YSAoVGVzdHMgZm9yIGluZmx1ZW56YSBBIG9yIEIgdmlydXMgTnVjbGVpYyBBY2lkKSJdIAogIHVuaW9uIFtPYnNlcnZhdGlvbjogIkluZmx1ZW56YSAoVGVzdHMgZm9yIGluZmx1ZW56YSBBIG9yIEIgdmlydXMgQW50aWdlbikiXQogIHVuaW9uIFtPYnNlcnZhdGlvbjogIkNPVklEXzE5IChUZXN0cyBmb3IgU0FSU19Db1ZfMiBOdWNsZWljIEFjaWQpIl0KICB1bmlvbiBbT2JzZXJ2YXRpb246ICJDT1ZJRF8xOSAoVGVzdHMgZm9yIFNBUlNfQ29WXzIgQW50aWdlbikiXQogICkgT2JzZXJ2YXRpb25zCiAgICB3aGVyZSBleGlzdHMoT2JzZXJ2YXRpb25zLmNhdGVnb3J5IENhdGVnb3J5IHdoZXJlIENhdGVnb3J5IH4gImxhYm9yYXRvcnkiKQogICAgICBhbmQgT2JzZXJ2YXRpb25zLnN0YXR1cyBpbiB7J2ZpbmFsJywncmVnaXN0ZXJlZCcsJ3ByZWxpbWluYXJ5JywncGFydGlhbCd9CiAgICAgIGFuZCBleGlzdHMoIkluaXRpYWwgUG9wdWxhdGlvbiIpCgpkZWZpbmUgIlJTViBPYnNlcnZhdGlvbiI6CiAgKFtPYnNlcnZhdGlvbjogIlJTViAoVGVzdHMgZm9yIFJTViBOdWNsZWljIEFjaWQpIl0KICB1bmlvbiBbT2JzZXJ2YXRpb246ICJSU1YgKFRlc3RzIGZvciBSU1YgQW50aWdlbikiXSAgIAogICkgT2JzZXJ2YXRpb25zCiAgICB3aGVyZSBleGlzdHMoT2JzZXJ2YXRpb25zLmNhdGVnb3J5IENhdGVnb3J5IHdoZXJlIENhdGVnb3J5IH4gImxhYm9yYXRvcnkiKQogICAgICBhbmQgT2JzZXJ2YXRpb25zLnN0YXR1cyBpbiB7J2ZpbmFsJywncmVnaXN0ZXJlZCcsJ3ByZWxpbWluYXJ5JywncGFydGlhbCd9CiAgICAgIGFuZCBleGlzdHMoIkluaXRpYWwgUG9wdWxhdGlvbiIpCgpkZWZpbmUgIkFDSCBEYWlseSBPYnNlcnZhdGlvbiI6CiAgIlJTViBPYnNlcnZhdGlvbiIKICB1bmlvbiAiQ09WSUQgQW5kIEluZmx1ZW56YSBPYnNlcnZhdGlvbiIKCi8vZnVydGhlciBjb25zdHJhaW4gQ09WSUQtMTkgYW5kIEluZmx1ZW56YSBPYnNlcnZhdGlvbnMgZm9yIDE0IGRheSBsb29rYmFjawpkZWZpbmUgIkNPVklEIEFuZCBJbmZsdWVuemEgUFJFIEFkbWlzc2lvbiBPYnNlcnZhdGlvbiI6CiAgIkNPVklEIEFuZCBJbmZsdWVuemEgT2JzZXJ2YXRpb24iIE8gCiAgIHdoZXJlIGV4aXN0cyggRW5jb3VudGVySW5wYXRpZW50IEUgCiAgICB3aGVyZSAoCiAgICAgIE5IU05IZWxwZXJzLiJOb3JtYWxpemUgSW50ZXJ2YWwiKE8uZWZmZWN0aXZlKSAxNCBkYXlzIG9yIGxlc3Mgb24gb3IgYmVmb3JlIHN0YXJ0IG9mIEUucGVyaW9kCiAgICAgIG9yIE5IU05IZWxwZXJzLiJOb3JtYWxpemUgSW50ZXJ2YWwiKEdldFNwZWNpbWVuKE8uc3BlY2ltZW4pLmNvbGxlY3Rpb24uY29sbGVjdGVkKSAxNCBkYXlzIG9yIGxlc3Mgb24gb3IgYmVmb3JlIHN0YXJ0IG9mIEUucGVyaW9kCiAgICAgICkKICAgICAgYW5kIHN0YXJ0IG9mIEUucGVyaW9kIGR1cmluZyAiTWVhc3VyZW1lbnQgUGVyaW9kIgogICAgKSAgCgovL2Z1cnRoZXIgY29uc3RyYWluIFJTViBvYnNlcnZhdGlvbiBmb3IgOCBkYXkgbG9va2JhY2sKZGVmaW5lICJSU1YgUFJFIEFkbWlzc2lvbiBPYnNlcnZhdGlvbiI6CiAgIlJTViBPYnNlcnZhdGlvbiIgTyAKICB3aGVyZSBleGlzdHMoRW5jb3VudGVySW5wYXRpZW50IEUgCiAgICB3aGVyZSAoCiAgICAgIE5IU05IZWxwZXJzLiJOb3JtYWxpemUgSW50ZXJ2YWwiKE8uZWZmZWN0aXZlKSA4IGRheXMgb3IgbGVzcyBvbiBvciBiZWZvcmUgc3RhcnQgb2YgRS5wZXJpb2QKICAgICAgb3IgTkhTTkhlbHBlcnMuIk5vcm1hbGl6ZSBJbnRlcnZhbCIoR2V0U3BlY2ltZW4oTy5zcGVjaW1lbikuY29sbGVjdGlvbi5jb2xsZWN0ZWQpIDggZGF5cyBvciBsZXNzIG9uIG9yIGJlZm9yZSBzdGFydCBvZiBFLnBlcmlvZAogICAgICApCiAgICAgIGFuZCBzdGFydCBvZiBFLnBlcmlvZCBkdXJpbmcgIk1lYXN1cmVtZW50IFBlcmlvZCIKICAgICkKCi8vTGFiIERpYWdub3N0aWNSZXBvcnQKZGVmaW5lICJDT1ZJRCBBbmQgSW5mbHVlbnphIERpYWdub3N0aWNSZXBvcnQiOgogIChbRGlhZ25vc3RpY1JlcG9ydDogIkNPVklEXzE5IChUZXN0cyBmb3IgU0FSU19Db1ZfMiBOdWNsZWljIEFjaWQpIl0KICAgIHVuaW9uIFtEaWFnbm9zdGljUmVwb3J0OiAiQ09WSURfMTkgKFRlc3RzIGZvciBTQVJTX0NvVl8yIEFudGlnZW4pIl0KICAgIHVuaW9uIFtEaWFnbm9zdGljUmVwb3J0OiAiSW5mbHVlbnphIChUZXN0cyBmb3IgaW5mbHVlbnphIEEgb3IgQiB2aXJ1cyBOdWNsZWljIEFjaWQpIl0KICAgIHVuaW9uIFtEaWFnbm9zdGljUmVwb3J0OiAiSW5mbHVlbnphIChUZXN0cyBmb3IgaW5mbHVlbnphIEEgb3IgQiB2aXJ1cyBBbnRpZ2VuKSJdCiAgKSBSZXBvcnRzCiAgICB3aGVyZSBleGlzdHMoIkluaXRpYWwgUG9wdWxhdGlvbiIpCiAgICAgIGFuZCBSZXBvcnRzLnN0YXR1cyBpbiB7J2ZpbmFsJywncmVnaXN0ZXJlZCcsJ3ByZWxpbWluYXJ5JywncGFydGlhbCd9CgpkZWZpbmUgIlJTViBEaWFnbm9zdGljUmVwb3J0IjoKICAoW0RpYWdub3N0aWNSZXBvcnQ6ICJSU1YgKFRlc3RzIGZvciBSU1YgTnVjbGVpYyBBY2lkKSJdCiAgICB1bmlvbiBbRGlhZ25vc3RpY1JlcG9ydDogIlJTViAoVGVzdHMgZm9yIFJTViBBbnRpZ2VuKSJdCiAgKSBSZXBvcnRzCiAgICB3aGVyZSBleGlzdHMoIkluaXRpYWwgUG9wdWxhdGlvbiIpCiAgICAgIGFuZCBSZXBvcnRzLnN0YXR1cyBpbiB7J2ZpbmFsJywncmVnaXN0ZXJlZCcsJ3ByZWxpbWluYXJ5JywncGFydGlhbCd9CgpkZWZpbmUgIkFDSCBEYWlseSBEaWFnbm9zdGljUmVwb3J0IjoKICAiQ09WSUQgQW5kIEluZmx1ZW56YSBEaWFnbm9zdGljUmVwb3J0IgogICAgdW5pb24gIlJTViBEaWFnbm9zdGljUmVwb3J0IgoKLy9mdXJ0aGVyIGNvbnN0cmFpbiBDT1ZJRC0xOSBhbmQgSW5mbHVlbnphIHdpdGggMTQgZGF5IGxvb2tiYWNrIApkZWZpbmUgIkNPVklEIEFuZCBJbmZsdWVuemEgRGlhZ25vc3RpY1JlcG9ydCBQUkUgQWRtaXNzaW9uIjoKICAiQ09WSUQgQW5kIEluZmx1ZW56YSBEaWFnbm9zdGljUmVwb3J0IiBSIAogIHdoZXJlIGV4aXN0cyhFbmNvdW50ZXJJbnBhdGllbnQgRSAKICAgIHdoZXJlICgKICAgICAgTkhTTkhlbHBlcnMuIk5vcm1hbGl6ZSBJbnRlcnZhbCIoUi5lZmZlY3RpdmUpIDE0IGRheXMgb3IgbGVzcyBvbiBvciBiZWZvcmUgc3RhcnQgb2YgRS5wZXJpb2QpCiAgICAgIGFuZCBzdGFydCBvZiBFLnBlcmlvZCBkdXJpbmcgIk1lYXN1cmVtZW50IFBlcmlvZCIKICAgICkKCi8vZnVydGhlciBjb25zdHJhaW4gUlNWIGZvciA4IGRheSBsb29rYmFjawpkZWZpbmUgIlJTViBEaWFnbm9zdGljUmVwb3J0IFBSRSBBZG1pc3Npb24iOgogICJSU1YgRGlhZ25vc3RpY1JlcG9ydCIgUiAKICB3aGVyZSBleGlzdHMoRW5jb3VudGVySW5wYXRpZW50IEUgCiAgICB3aGVyZSAoCiAgICAgIE5IU05IZWxwZXJzLiJOb3JtYWxpemUgSW50ZXJ2YWwiKFIuZWZmZWN0aXZlKSA4IGRheXMgb3IgbGVzcyBvbiBvciBiZWZvcmUgc3RhcnQgb2YgRS5wZXJpb2QpCiAgICAgIGFuZCBzdGFydCBvZiBFLnBlcmlvZCBkdXJpbmcgIk1lYXN1cmVtZW50IFBlcmlvZCIKICAgICkKCmRlZmluZSAiQ09WSUQgYW5kIEluZmx1ZW56YSBEaWFnbm9zdGljUmVwb3J0IFJlc3VsdCBmcm9tIExhYiI6CiAgIkRpYWdub3N0aWNSZXBvcnRzIiBSZXBvcnRzCiAgICB3aGVyZSBleGlzdHMoCiAgICAgICJDT1ZJRCBhbmQgSW5mbHVlbnphIERpYWdub3N0aWNSZXBvcnQgT2JzZXJ2YXRpb25zIiBPYnNlcnZhdGlvbnMKICAgICAgd2hlcmUgUmVwb3J0cy5yZXN1bHQucmVmZXJlbmNlcyhPYnNlcnZhdGlvbnMpCiAgICApCiAgICBhbmQgUmVwb3J0cy5zdGF0dXMgaW4geydmaW5hbCcsJ3JlZ2lzdGVyZWQnLCdwcmVsaW1pbmFyeScsJ3BhcnRpYWwnfQogICAgYW5kIGV4aXN0cygiSW5pdGlhbCBQb3B1bGF0aW9uIikKCmRlZmluZSAiQ09WSUQgYW5kIEluZmx1ZW56YSBEaWFnbm9zdGljUmVwb3J0IE9ic2VydmF0aW9ucyI6CiAgIk9ic2VydmF0aW9ucyIgT2JzZXJ2YXRpb25zCiAgd2hlcmUgT2JzZXJ2YXRpb25zLmNvZGUgaW4gIkNPVklEXzE5IChUZXN0cyBmb3IgU0FSU19Db1ZfMiBOdWNsZWljIEFjaWQpIgogICAgb3IgT2JzZXJ2YXRpb25zLmNvZGUgaW4gIkNPVklEXzE5IChUZXN0cyBmb3IgU0FSU19Db1ZfMiBBbnRpZ2VuKSIKICAgIG9yIE9ic2VydmF0aW9ucy5jb2RlIGluICJJbmZsdWVuemEgKFRlc3RzIGZvciBpbmZsdWVuemEgQSBvciBCIHZpcnVzIE51Y2xlaWMgQWNpZCkiCiAgICBvciBPYnNlcnZhdGlvbnMuY29kZSBpbiAiSW5mbHVlbnphIChUZXN0cyBmb3IgaW5mbHVlbnphIEEgb3IgQiB2aXJ1cyBBbnRpZ2VuKSIKCiAKZGVmaW5lICJSU1YgRGlhZ25vc3RpY1JlcG9ydCBSZXN1bHQgZnJvbSBMYWIiOgogIFtEaWFnbm9zdGljUmVwb3J0XSBSZXBvcnRzCiAgICB3aGVyZSBleGlzdHMoIlJTViBEaWFnbm9zdGljUmVwb3J0IE9ic2VydmF0aW9ucyIpCiAgICAgIGFuZCBSZXBvcnRzLnN0YXR1cyBpbiB7J2ZpbmFsJywncmVnaXN0ZXJlZCcsJ3ByZWxpbWluYXJ5JywncGFydGlhbCd9CiAgICAgIGFuZCBleGlzdHMoIkluaXRpYWwgUG9wdWxhdGlvbiIpCgpkZWZpbmUgIlJTViBPYnNlcnZhdGlvbnMiOgogICJPYnNlcnZhdGlvbnMiIE9ic2VydmF0aW9ucwogIHdoZXJlIE9ic2VydmF0aW9ucy5jb2RlIGluICJSU1YgKFRlc3RzIGZvciBSU1YgTnVjbGVpYyBBY2lkKSIKICAgIG9yIE9ic2VydmF0aW9ucy5jb2RlIGluICJSU1YgKFRlc3RzIGZvciBSU1YgQW50aWdlbikiCiAgICAKZGVmaW5lICJSU1YgRGlhZ25vc3RpY1JlcG9ydCBPYnNlcnZhdGlvbnMiOgogICJEaWFnbm9zdGljUmVwb3J0cyIgUmVwb3J0cwogIHdoZXJlIGV4aXN0cygKICAgICJSU1YgT2JzZXJ2YXRpb25zIiBPYnNlcnZhdGlvbnMKICAgIHdoZXJlIFJlcG9ydHMucmVzdWx0LnJlZmVyZW5jZXMoT2JzZXJ2YXRpb25zKQogICkKCmRlZmluZSAiQUNIIERhaWx5IERpYWdub3N0aWNSZXBvcnQgUmVzdWx0IGZyb20gTGFiIjoKICAiQ09WSUQgYW5kIEluZmx1ZW56YSBEaWFnbm9zdGljUmVwb3J0IFJlc3VsdCBmcm9tIExhYiIKICAgIHVuaW9uICJSU1YgRGlhZ25vc3RpY1JlcG9ydCBSZXN1bHQgZnJvbSBMYWIiCgovL2Z1cnRoZXIgY29uc3RyYWluIENPVklELTE5IGFuZCBJbmZsdWVuemEgd2l0aCAxNCBkYXkgbG9va2JhY2sKZGVmaW5lICJDT1ZJRCBhbmQgSW5mbHVlbnphIERpYWdub3N0aWNSZXBvcnQgUmVzdWx0IGZyb20gTGFiIFBSRSBBZG1pc3Npb24iOgogICJDT1ZJRCBhbmQgSW5mbHVlbnphIERpYWdub3N0aWNSZXBvcnQgUmVzdWx0IGZyb20gTGFiIiBSIAogIHdoZXJlIGV4aXN0cyhFbmNvdW50ZXJJbnBhdGllbnQgRSAKICAgIHdoZXJlICgKICAgICAgTkhTTkhlbHBlcnMuIk5vcm1hbGl6ZSBJbnRlcnZhbCIoUi5lZmZlY3RpdmUpIDE0IGRheXMgb3IgbGVzcyBvbiBvciBiZWZvcmUgc3RhcnQgb2YgRS5wZXJpb2QpCiAgICAgIGFuZCBzdGFydCBvZiBFLnBlcmlvZCBkdXJpbmcgIk1lYXN1cmVtZW50IFBlcmlvZCIKICAgICkKCi8vZnVydGhlciBjb25zdHJhaW4gUlNWIHdpdGggOCBkYXkgbG9va2JhY2sKZGVmaW5lICJSU1YgRGlhZ25vc3RpY1JlcG9ydCBSZXN1bHQgZnJvbSBMYWIgUFJFIEFkbWlzc2lvbiI6CiAgIlJTViBEaWFnbm9zdGljUmVwb3J0IFJlc3VsdCBmcm9tIExhYiIgUiAKICB3aGVyZSBleGlzdHMoRW5jb3VudGVySW5wYXRpZW50IEUgCiAgICB3aGVyZSAoCiAgICAgIE5IU05IZWxwZXJzLiJOb3JtYWxpemUgSW50ZXJ2YWwiKFIuZWZmZWN0aXZlKSA4IGRheXMgb3IgbGVzcyBvbiBvciBiZWZvcmUgc3RhcnQgb2YgRS5wZXJpb2QpCiAgICAgIGFuZCBzdGFydCBvZiBFLnBlcmlvZCBkdXJpbmcgIk1lYXN1cmVtZW50IFBlcmlvZCIKICAgICkKICAgIAovLy0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0KLy8gU0RFCi8vLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLQpkZWZpbmUgIlNERSBJUCBFbmNvdW50ZXJzIjoKICAiSW5pdGlhbCBQb3B1bGF0aW9uIiBJUAogIHJldHVybiBTaGFyZWRSZXNvdXJjZS5FbmNvdW50ZXJSZXNvdXJjZShJUCwgCiAge0ZISVIuY2Fub25pY2Fse3ZhbHVlOiAnaHR0cDovL3d3dy5jZGMuZ292L25oc24vZmhpcnBvcnRhbC9kcW0vaWcvU3RydWN0dXJlRGVmaW5pdGlvbi9hY2gtZGFpbHktZW5jb3VudGVyJ319KQoKZGVmaW5lICJTREUgRW5jb3VudGVyIjogCiAgIkVuY291bnRlcnMiIEVuY291bnRlcnMKICB3aGVyZSBub3QgQ2hlY2tJUChFbmNvdW50ZXJzKQogIGFuZCBleGlzdHMoCiAgICAiSW5pdGlhbCBQb3B1bGF0aW9uIiBJUAogICAgd2hlcmUgRW5jb3VudGVycy5wZXJpb2Qgb3ZlcmxhcHMgSVAucGVyaW9kKQogIHJldHVybiBTaGFyZWRSZXNvdXJjZS5FbmNvdW50ZXJSZXNvdXJjZShFbmNvdW50ZXJzLAogIHtGSElSLmNhbm9uaWNhbHt2YWx1ZTogJ2h0dHA6Ly9obDcub3JnL2ZoaXIvdXMvY29yZS9TdHJ1Y3R1cmVEZWZpbml0aW9uL3VzLWNvcmUtZW5jb3VudGVyJ319KQoKZGVmaW5lICJTREUgTWluaW1hbCBQYXRpZW50IjoKICBQYXRpZW50IHAKICB3aGVyZSBleGlzdHMoIkluaXRpYWwgUG9wdWxhdGlvbiIpCiAgcmV0dXJuIFNoYXJlZFJlc291cmNlLlBhdGllbnRSZXNvdXJjZShwLCAKICB7RkhJUi5jYW5vbmljYWx7dmFsdWU6ICdodHRwOi8vd3d3LmNkYy5nb3Yvbmhzbi9maGlycG9ydGFsL2RxbS9pZy9TdHJ1Y3R1cmVEZWZpbml0aW9uL2Nyb3NzLW1lYXN1cmUtcGF0aWVudCd9fSkKCmRlZmluZSAiU0RFIExvY2F0aW9uIjoKICBbTG9jYXRpb25dIExvY2F0aW9ucwogIHdoZXJlIGV4aXN0cygiSW5pdGlhbCBQb3B1bGF0aW9uIikKICByZXR1cm4gU2hhcmVkUmVzb3VyY2UuTG9jYXRpb25SZXNvdXJjZShMb2NhdGlvbnMsCiAge0ZISVIuY2Fub25pY2Fse3ZhbHVlOiAnaHR0cDovL3d3dy5jZGMuZ292L25oc24vZmhpcnBvcnRhbC9kcW0vaWcvU3RydWN0dXJlRGVmaW5pdGlvbi9hY2gtZGFpbHktbG9jYXRpb24nfX0pCiAgIApkZWZpbmUgIlNERSBFbmNvdW50ZXIgRGlzY2hhcmdlIERpc3Bvc2l0aW9ucyI6CgkiSW5pdGlhbCBQb3B1bGF0aW9uIiBEaXNjaGFyZ2VEaXNwb3NpdGlvbnMgCiAgd2hlcmUgRGlzY2hhcmdlRGlzcG9zaXRpb25zLmhvc3BpdGFsaXphdGlvbi5kaXNjaGFyZ2VEaXNwb3NpdGlvbiBpbiAiRGlzY2hhcmdlIERpc3Bvc2l0aW9uIgogIHJldHVybiBTaGFyZWRSZXNvdXJjZS5FbmNvdW50ZXJSZXNvdXJjZShEaXNjaGFyZ2VEaXNwb3NpdGlvbnMsCiAge0ZISVIuY2Fub25pY2Fse3ZhbHVlOiAnaHR0cDovL3d3dy5jZGMuZ292L25oc24vZmhpcnBvcnRhbC9kcW0vaWcvU3RydWN0dXJlRGVmaW5pdGlvbi9hY2gtZGFpbHktZW5jb3VudGVyJ319KQoKLy9yZXR1cm4gdGhlIE9ic2VydmF0aW9uIGR1cmluZyB0aGUgTWVhc3VyZW1lbnQgUGVyaW9kCmRlZmluZSAiU0RFIEFDSCBEYWlseSBPYnNlcnZhdGlvbiI6CiAgIkFDSCBEYWlseSBPYnNlcnZhdGlvbiIgT2JzZXJ2YXRpb25zCiAgICByZXR1cm4gT2JzZXJ2YXRpb25MYWJSZXNvdXJjZShPYnNlcnZhdGlvbnMsCiAgICB7RkhJUi5jYW5vbmljYWx7dmFsdWU6ICdodHRwOi8vd3d3LmNkYy5nb3Yvbmhzbi9maGlycG9ydGFsL2RxbS9pZy9TdHJ1Y3R1cmVEZWZpbml0aW9uL2FjaC1kYWlseS1vYnNlcnZhdGlvbi1sYWInfX0pCgovL3JldHVybiB0aGUgUlNWIE9ic2VydmF0aW9uIFByZSBBZG1pc3Npb24gICAgCmRlZmluZSAiU0RFIFJTViBQUkUgQWRtaXNzaW9uIE9ic2VydmF0aW9uIjoKICAiUlNWIFBSRSBBZG1pc3Npb24gT2JzZXJ2YXRpb24iIE9ic2VydmF0aW9ucwogICAgcmV0dXJuIE9ic2VydmF0aW9uTGFiUmVzb3VyY2UoT2JzZXJ2YXRpb25zLCAKICAgIHtGSElSLmNhbm9uaWNhbHt2YWx1ZTogJ2h0dHA6Ly93d3cuY2RjLmdvdi9uaHNuL2ZoaXJwb3J0YWwvZHFtL2lnL1N0cnVjdHVyZURlZmluaXRpb24vYWNoLWRhaWx5LW9ic2VydmF0aW9uLWxhYid9fSkKCi8vcmV0dXJuIHRoZSBDT1ZJRC0xOSBhbmQgSW5mbHVlbnphIE9ic2VydmF0aW9uIFByZSBBZG1pc3Npb24KZGVmaW5lICJTREUgQ09WSUQgQW5kIEluZmx1ZW56YSBQUkUgQWRtaXNzaW9uIE9ic2VydmF0aW9uIjoKICAiQ09WSUQgQW5kIEluZmx1ZW56YSBQUkUgQWRtaXNzaW9uIE9ic2VydmF0aW9uIiBPYnNlcnZhdGlvbnMKICAgIHJldHVybiBPYnNlcnZhdGlvbkxhYlJlc291cmNlKE9ic2VydmF0aW9ucywKICAgIHtGSElSLmNhbm9uaWNhbHt2YWx1ZTogJ2h0dHA6Ly93d3cuY2RjLmdvdi9uaHNuL2ZoaXJwb3J0YWwvZHFtL2lnL1N0cnVjdHVyZURlZmluaXRpb24vYWNoLWRhaWx5LW9ic2VydmF0aW9uLWxhYid9fSkKCi8vcmV0dXJuIHRoZSBTcGVjaW1lbiByZWxhdGVkIHRvIHRoZSBPYnNlcnZhdGlvbiBkdXJpbmcgdGhlIE1lYXN1cmVtZW50IFBlcmlvZApkZWZpbmUgIlNERSBBQ0ggRGFpbHkgU3BlY2ltZW4iOgogICJBQ0ggRGFpbHkgT2JzZXJ2YXRpb24iIE9ic2VydmF0aW9uV2l0aFNwZWNpbWVuCiAgICBsZXQgU3BlY2ltZW46IEdldFNwZWNpbWVuKE9ic2VydmF0aW9uV2l0aFNwZWNpbWVuLnNwZWNpbWVuKQogICAgcmV0dXJuIFNoYXJlZFJlc291cmNlLlNwZWNpbWVuUmVzb3VyY2UoU3BlY2ltZW4sCiAgICB7RkhJUi5jYW5vbmljYWx7dmFsdWU6ICdodHRwOi8vd3d3LmNkYy5nb3Yvbmhzbi9maGlycG9ydGFsL2RxbS9pZy9TdHJ1Y3R1cmVEZWZpbml0aW9uL2FjaC1kYWlseS1zcGVjaW1lbid9fSkKCi8vcmV0dXJuIHRoZSBTcGVjaW1lbiByZWxhdGVkIHRvIHRoZSBSU1YgT2JzZXJ2YXRpb24gUHJlIEFkbWlzc2lvbgpkZWZpbmUgIlNERSBSU1YgU3BlY2ltZW4iOgogICJSU1YgUFJFIEFkbWlzc2lvbiBPYnNlcnZhdGlvbiIgT2JzZXJ2YXRpb25XaXRoU3BlY2ltZW4KICAgIGxldCBTcGVjaW1lbjogR2V0U3BlY2ltZW4oT2JzZXJ2YXRpb25XaXRoU3BlY2ltZW4uc3BlY2ltZW4pCiAgICByZXR1cm4gU2hhcmVkUmVzb3VyY2UuU3BlY2ltZW5SZXNvdXJjZShTcGVjaW1lbiwKICAgIHtGSElSLmNhbm9uaWNhbHt2YWx1ZTogJ2h0dHA6Ly93d3cuY2RjLmdvdi9uaHNuL2ZoaXJwb3J0YWwvZHFtL2lnL1N0cnVjdHVyZURlZmluaXRpb24vYWNoLWRhaWx5LXNwZWNpbWVuJ319KQoKLy9yZXR1cm4gdGhlIFNwZWNpbWVuIHJlbGF0ZWQgdG8gdGhlIENPVklELTE5IEFuZCBJbmZsdWVuemEgT2JzZXJ2YXRpb24gUHJlIEFkbWlzc2lvbgpkZWZpbmUgIlNERSBDT1ZJRCBBbmQgSW5mbHVlbnphIFNwZWNpbWVuIjoKICAiQ09WSUQgQW5kIEluZmx1ZW56YSBQUkUgQWRtaXNzaW9uIE9ic2VydmF0aW9uIiBPYnNlcnZhdGlvbldpdGhTcGVjaW1lbgogICAgbGV0IFNwZWNpbWVuOiBHZXRTcGVjaW1lbihPYnNlcnZhdGlvbldpdGhTcGVjaW1lbi5zcGVjaW1lbikKICAgIHJldHVybiBTaGFyZWRSZXNvdXJjZS5TcGVjaW1lblJlc291cmNlKFNwZWNpbWVuLAogICAge0ZISVIuY2Fub25pY2Fse3ZhbHVlOiAnaHR0cDovL3d3dy5jZGMuZ292L25oc24vZmhpcnBvcnRhbC9kcW0vaWcvU3RydWN0dXJlRGVmaW5pdGlvbi9hY2gtZGFpbHktc3BlY2ltZW4nfX0pCgovL3JldHVybiB0aGUgRGlhZ25vc3RpY1JlcG9ydCBkdXJpbmcgdGhlIE1lYXN1cmVtZW50IFBlcmlvZApkZWZpbmUgIlNERSBBQ0ggRGFpbHkgRGlhZ25vc3RpY1JlcG9ydCI6CiAgIkFDSCBEYWlseSBEaWFnbm9zdGljUmVwb3J0IiBSZXBvcnRzCiAgICByZXR1cm4gU2hhcmVkUmVzb3VyY2UuRGlhZ25vc3RpY1JlcG9ydExhYlJlc291cmNlKFJlcG9ydHMsCiAgICB7RkhJUi5jYW5vbmljYWx7dmFsdWU6ICdodHRwOi8vd3d3LmNkYy5nb3Yvbmhzbi9maGlycG9ydGFsL2RxbS9pZy9TdHJ1Y3R1cmVEZWZpbml0aW9uL2FjaC1kYWlseS1kaWFnbm9zdGljcmVwb3J0LWxhYid9fSkKCi8vcmV0dXJuIHRoZSBDT1ZJRC0xOSBBbmQgSW5mbHVlbnphIERpYWdub3N0aWNSZXBvcnQgcHJlIGFkbWlzc2lvbgpkZWZpbmUgIlNERSBDT1ZJRCBBbmQgSW5mbHVlbnphIERpYWdub3N0aWNSZXBvcnQiOgogICJDT1ZJRCBBbmQgSW5mbHVlbnphIERpYWdub3N0aWNSZXBvcnQiIFJlcG9ydHMKICAgIHJldHVybiBTaGFyZWRSZXNvdXJjZS5EaWFnbm9zdGljUmVwb3J0TGFiUmVzb3VyY2UoUmVwb3J0cywKICAgIHtGSElSLmNhbm9uaWNhbHt2YWx1ZTogJ2h0dHA6Ly93d3cuY2RjLmdvdi9uaHNuL2ZoaXJwb3J0YWwvZHFtL2lnL1N0cnVjdHVyZURlZmluaXRpb24vYWNoLWRhaWx5LWRpYWdub3N0aWNyZXBvcnQtbGFiJ319KQoKLy9yZXR1cm4gdGhlIFJTViBEaWFnbm9zdGljUmVwb3J0IHByZSBhZG1pc3Npb24KZGVmaW5lICJTREUgUlNWIERpYWdub3N0aWNSZXBvcnQiOgogICJSU1YgRGlhZ25vc3RpY1JlcG9ydCIgUmVwb3J0cwogICAgcmV0dXJuIFNoYXJlZFJlc291cmNlLkRpYWdub3N0aWNSZXBvcnRMYWJSZXNvdXJjZShSZXBvcnRzLAogICAge0ZISVIuY2Fub25pY2Fse3ZhbHVlOiAnaHR0cDovL3d3dy5jZGMuZ292L25oc24vZmhpcnBvcnRhbC9kcW0vaWcvU3RydWN0dXJlRGVmaW5pdGlvbi9hY2gtZGFpbHktZGlhZ25vc3RpY3JlcG9ydC1sYWInfX0pCgovL3JldHVybiB0aGUgRGlhZ25vc3RpY1JlcG9ydCBiYXNlZCBvbiB0aGUgcmVzdWx0IGR1cmluZyB0aGUgTWVhc3VyZW1lbnQgUGVyaW9kICAgIApkZWZpbmUgIlNERSBBQ0ggRGFpbHkgRGlhZ25vc3RpY1JlcG9ydCBSZXN1bHQgZnJvbSBMYWIiOgogICJBQ0ggRGFpbHkgRGlhZ25vc3RpY1JlcG9ydCBSZXN1bHQgZnJvbSBMYWIiIFJlcG9ydHMKICAgIHJldHVybiBTaGFyZWRSZXNvdXJjZS5EaWFnbm9zdGljUmVwb3J0TGFiUmVzb3VyY2UoUmVwb3J0cywKICAgIHtGSElSLmNhbm9uaWNhbHt2YWx1ZTogJ2h0dHA6Ly93d3cuY2RjLmdvdi9uaHNuL2ZoaXJwb3J0YWwvZHFtL2lnL1N0cnVjdHVyZURlZmluaXRpb24vYWNoLWRhaWx5LWRpYWdub3N0aWNyZXBvcnQtbGFiJ319KQoKLy9yZXR1cm4gdGhlIENPVklELTE5IGFuZCBJbmZsdWVuemEgRGlhZ25vc3RpY1JlcG9ydCBiYXNlZCBvbiB0aGUgcmVzdWx0IHByZSBhZG1pc3Npb24KZGVmaW5lICJTREUgQ09WSUQgYW5kIEluZmx1ZW56YSBEaWFnbm9zdGljUmVwb3J0IFJlc3VsdCBmcm9tIExhYiI6CiAgIkNPVklEIGFuZCBJbmZsdWVuemEgRGlhZ25vc3RpY1JlcG9ydCBSZXN1bHQgZnJvbSBMYWIiIFJlcG9ydHMKICAgIHJldHVybiBTaGFyZWRSZXNvdXJjZS5EaWFnbm9zdGljUmVwb3J0TGFiUmVzb3VyY2UoUmVwb3J0cywKICAgIHtGSElSLmNhbm9uaWNhbHt2YWx1ZTogJ2h0dHA6Ly93d3cuY2RjLmdvdi9uaHNuL2ZoaXJwb3J0YWwvZHFtL2lnL1N0cnVjdHVyZURlZmluaXRpb24vYWNoLWRhaWx5LWRpYWdub3N0aWNyZXBvcnQtbGFiJ319KQoKLy9yZXR1cm4gdGhlIFJTViBEaWFnbm9zdGljUmVwb3J0IGJhc2VkIG9uIHRoZSByZXN1bHQgcHJlIGFkbWlzc2lvbgpkZWZpbmUgIlNERSBSU1YgRGlhZ25vc3RpY1JlcG9ydCBSZXN1bHQgZnJvbSBMYWIiOgogICJSU1YgRGlhZ25vc3RpY1JlcG9ydCBSZXN1bHQgZnJvbSBMYWIiIFJlcG9ydHMKICAgIHJldHVybiBTaGFyZWRSZXNvdXJjZS5EaWFnbm9zdGljUmVwb3J0TGFiUmVzb3VyY2UoUmVwb3J0cywKICAgIHtGSElSLmNhbm9uaWNhbHt2YWx1ZTogJ2h0dHA6Ly93d3cuY2RjLmdvdi9uaHNuL2ZoaXJwb3J0YWwvZHFtL2lnL1N0cnVjdHVyZURlZmluaXRpb24vYWNoLWRhaWx5LWRpYWdub3N0aWNyZXBvcnQtbGFiJ319KQogIApkZWZpbmUgIlNERSBBQ0ggRGFpbHkgU2VydmljZVJlcXVlc3QiOgogIChbU2VydmljZVJlcXVlc3Q6ICJDT1ZJRF8xOSAoVGVzdHMgZm9yIFNBUlNfQ29WXzIgTnVjbGVpYyBBY2lkKSJdIAogIHVuaW9uICBbU2VydmljZVJlcXVlc3Q6ICJDT1ZJRF8xOSAoVGVzdHMgZm9yIFNBUlNfQ29WXzIgQW50aWdlbikiXSAKICB1bmlvbiAgW1NlcnZpY2VSZXF1ZXN0OiAiSW5mbHVlbnphIChUZXN0cyBmb3IgaW5mbHVlbnphIEEgb3IgQiB2aXJ1cyBOdWNsZWljIEFjaWQpIl0KICB1bmlvbiAgW1NlcnZpY2VSZXF1ZXN0OiAiSW5mbHVlbnphIChUZXN0cyBmb3IgaW5mbHVlbnphIEEgb3IgQiB2aXJ1cyBBbnRpZ2VuKSJdCiAgdW5pb24gIFtTZXJ2aWNlUmVxdWVzdDogIlJTViAoVGVzdHMgZm9yIFJTViBOdWNsZWljIEFjaWQpIl0KICB1bmlvbiAgW1NlcnZpY2VSZXF1ZXN0OiAiUlNWIChUZXN0cyBmb3IgUlNWIEFudGlnZW4pIl0KICApIFNlcnZpY2VSZXF1ZXN0cwogICAgd2hlcmUgU2VydmljZVJlcXVlc3RzLmludGVudCB+ICdvcmRlcicKICAgICAgYW5kIFNlcnZpY2VSZXF1ZXN0cy5zdGF0dXMgfiAnY29tcGxldGVkJwogICAgICBhbmQgZXhpc3RzKCJJbml0aWFsIFBvcHVsYXRpb24iKQogIHJldHVybiBTZXJ2aWNlUmVxdWVzdFJlc291cmNlKFNlcnZpY2VSZXF1ZXN0cywKICB7RkhJUi5jYW5vbmljYWx7dmFsdWU6ICdodHRwOi8vd3d3LmNkYy5nb3Yvbmhzbi9maGlycG9ydGFsL2RxbS9pZy9TdHJ1Y3R1cmVEZWZpbml0aW9uL2FjaC1kYWlseS1zZXJ2aWNlcmVxdWVzdCd9fSkKCmRlZmluZSAiU0RFIElzb2xhdGlvbiBQcmVjYXV0aW9ucyBJbXBsZW1lbnRlZCI6CiAgW1Byb2NlZHVyZTogIlRyYW5zbWlzc2lvbiBCYXNlZCBQcmVjYXV0aW9uIFR5cGVzIl0gSXNvbGF0aW9uUHJlY2F1dGlvbnMKICAgIHdoZXJlIE5IU05IZWxwZXJzLiJOb3JtYWxpemUgSW50ZXJ2YWwiKElzb2xhdGlvblByZWNhdXRpb25zLnBlcmZvcm1lZCkgZHVyaW5nICJNZWFzdXJlbWVudCBQZXJpb2QiCiAgICBhbmQgZXhpc3RzKCJJbml0aWFsIFBvcHVsYXRpb24iKQogIHJldHVybiBTaGFyZWRSZXNvdXJjZS5Qcm9jZWR1cmVSZXNvdXJjZShJc29sYXRpb25QcmVjYXV0aW9ucywKICB7RkhJUi5jYW5vbmljYWx7dmFsdWU6ICdodHRwOi8vd3d3LmNkYy5nb3Yvbmhzbi9maGlycG9ydGFsL2RxbS9pZy9TdHJ1Y3R1cmVEZWZpbml0aW9uL2FjaC1kYWlseS1wcm9jZWR1cmUnfX0pCgpkZWZpbmUgIlNERSBDb3ZpZCBvciBJbmZsdWVuemEgTWVkaWNhdGlvbiBBZG1pbmlzdGVyZWQiOgogIFtNZWRpY2F0aW9uQWRtaW5pc3RyYXRpb25dIFJQU01lZEFkbWluCiAgICBsZXQgTWVkczogR2V0TWVkaWNhdGlvbkNvZGUoUlBTTWVkQWRtaW4ubWVkaWNhdGlvbikKICAgd2hlcmUgKE1lZHMgaW4gIkFuYWtpbnJhIgogICAgICAgICAgICBvciBNZWRzIGluICJCYW1sYW5pdmltYWIiCiAgICAgICAgICAgIG9yIE1lZHMgaW4gIkJhbG94YXZpciIKICAgICAgICAgICAgb3IgTWVkcyBpbiAiQmFyaWNpdGluaWIiCiAgICAgICAgICAgIG9yIE1lZHMgaW4gIkJlYnRlbG92aW1hYiIKICAgICAgICAgICAgb3IgTWVkcyBpbiAiQ2FzaXJpdmltYWIiCiAgICAgICAgICAgIG9yIE1lZHMgaW4gIkNhc2lyaXZpbWFiIC8gSW1kZXZpbWFiIgogICAgICAgICAgICBvciBNZWRzIGluICJDT1ZJRDE5IFJ4Tm9ybSBWYWx1ZSBTZXQgZm9yIFRvY2lsaXp1bWFiIgogICAgICAgICAgICBvciBNZWRzIGluICJFdGVzZXZpbWFiIgogICAgICAgICAgICBvciBNZWRzIGluICJJbWRldmltYWIiCiAgICAgICAgICAgIG9yIE1lZHMgaW4gIk1vbG51cGlyYXZpciIKICAgICAgICAgICAgb3IgTWVkcyBpbiAiTmlybWF0cmVsdmlyIC8gUml0b25hdmlyIgogICAgICAgICAgICBvciBNZWRzIGluICJPc2VsdGFtaXZpciIKICAgICAgICAgICAgb3IgTWVkcyBpbiAiUGVyYW1pdmlyIgogICAgICAgICAgICBvciBNZWRzIGluICJSZW1kZXNpdmlyIgogICAgICAgICAgICBvciBNZWRzIGluICJTYXJpbHVtYWIiCiAgICAgICAgICAgIG9yIE1lZHMgaW4gIlNvdHJvdmltYWIiICAgIAogICAgICAgICAgICBvciBNZWRzIGluICJUb2ZhY2l0aW5pYiIKICAgICAgICAgICAgb3IgTWVkcyBpbiAiWmFuYW1pdmlyIikKICAgICAgYW5kIFJQU01lZEFkbWluLnN0YXR1cyB+ICdjb21wbGV0ZWQnCiAgICAgIGFuZCBleGlzdHMoIkluaXRpYWwgUG9wdWxhdGlvbiIpCiAgICAgIGFuZCBOSFNOSGVscGVycy4iTm9ybWFsaXplIEludGVydmFsIihSUFNNZWRBZG1pbi5lZmZlY3RpdmUpIGR1cmluZyAiTWVhc3VyZW1lbnQgUGVyaW9kIgogICAgcmV0dXJuIFNoYXJlZFJlc291cmNlLk1lZGljYXRpb25BZG1pbmlzdHJhdGlvblJlc291cmNlKFJQU01lZEFkbWluLAogICAge0ZISVIuY2Fub25pY2Fse3ZhbHVlOiAnaHR0cDovL3d3dy5jZGMuZ292L25oc24vZmhpcnBvcnRhbC9kcW0vaWcvU3RydWN0dXJlRGVmaW5pdGlvbi9hY2gtZGFpbHktbWVkaWNhdGlvbmFkbWluaXN0cmF0aW9uJ319KQoKZGVmaW5lICJTREUgQ292aWQgb3IgSW5mbHVlbnphIE1lZGljYXRpb24gT3JkZXJlZCI6CiAgW01lZGljYXRpb25SZXF1ZXN0XSBSUFNNZWRSZXF1ZXN0CiAgICBsZXQgTWVkczogR2V0TWVkaWNhdGlvbkNvZGUoUlBTTWVkUmVxdWVzdC5tZWRpY2F0aW9uKQogICAgd2hlcmUgKE1lZHMgaW4gIkFuYWtpbnJhIgogICAgICAgICAgICBvciBNZWRzIGluICJCYWxveGF2aXIiCiAgICAgICAgICAgIG9yIE1lZHMgaW4gIkJhbWxhbml2aW1hYiIKICAgICAgICAgICAgb3IgTWVkcyBpbiAiQmFyaWNpdGluaWIiCiAgICAgICAgICAgIG9yIE1lZHMgaW4gIkJlYnRlbG92aW1hYiIKICAgICAgICAgICAgb3IgTWVkcyBpbiAiQ2FzaXJpdmltYWIiCiAgICAgICAgICAgIG9yIE1lZHMgaW4gIkNhc2lyaXZpbWFiIC8gSW1kZXZpbWFiIgogICAgICAgICAgICBvciBNZWRzIGluICJDT1ZJRDE5IFJ4Tm9ybSBWYWx1ZSBTZXQgZm9yIFRvY2lsaXp1bWFiIgogICAgICAgICAgICBvciBNZWRzIGluICJFdGVzZXZpbWFiIgogICAgICAgICAgICBvciBNZWRzIGluICJJbWRldmltYWIiCiAgICAgICAgICAgIG9yIE1lZHMgaW4gIk1vbG51cGlyYXZpciIKICAgICAgICAgICAgb3IgTWVkcyBpbiAiTmlybWF0cmVsdmlyIC8gUml0b25hdmlyIgogICAgICAgICAgICBvciBNZWRzIGluICJPc2VsdGFtaXZpciIKICAgICAgICAgICAgb3IgTWVkcyBpbiAiUGVyYW1pdmlyIgogICAgICAgICAgICBvciBNZWRzIGluICJSZW1kZXNpdmlyIgogICAgICAgICAgICBvciBNZWRzIGluICJTYXJpbHVtYWIiCiAgICAgICAgICAgIG9yIE1lZHMgaW4gIlNvdHJvdmltYWIiICAgIAogICAgICAgICAgICBvciBNZWRzIGluICJUb2ZhY2l0aW5pYiIKICAgICAgICAgICAgb3IgTWVkcyBpbiAiWmFuYW1pdmlyIikKICAgICAgYW5kIGV4aXN0cygiSW5pdGlhbCBQb3B1bGF0aW9uIikKICAgICAgYW5kIE5IU05IZWxwZXJzLiJOb3JtYWxpemUgSW50ZXJ2YWwiKFJQU01lZFJlcXVlc3QuYXV0aG9yZWRPbikgZHVyaW5nICJNZWFzdXJlbWVudCBQZXJpb2QiCiAgICByZXR1cm4gTWVkaWNhdGlvblJlcXVlc3RSZXNvdXJjZShSUFNNZWRSZXF1ZXN0LAogICAge0ZISVIuY2Fub25pY2Fse3ZhbHVlOiAnaHR0cDovL3d3dy5jZGMuZ292L25oc24vZmhpcnBvcnRhbC9kcW0vaWcvU3RydWN0dXJlRGVmaW5pdGlvbi9hY2gtZGFpbHktbWVkaWNhdGlvbnJlcXVlc3QnfX0pCgpkZWZpbmUgIlNERSBNZWRpY2F0aW9uIjoKICAoIlNERSBDb3ZpZCBvciBJbmZsdWVuemEgTWVkaWNhdGlvbiBPcmRlcmVkIgogIHVuaW9uICJTREUgQ292aWQgb3IgSW5mbHVlbnphIE1lZGljYXRpb24gQWRtaW5pc3RlcmVkIikgTWVkUmVxT3JBZG1pbgogIHdoZXJlIE1lZFJlcU9yQWRtaW4ubWVkaWNhdGlvbiBpcyBGSElSLlJlZmVyZW5jZQogIHJldHVybiBTaGFyZWRSZXNvdXJjZS5NZWRpY2F0aW9uUmVzb3VyY2UoR2V0TWVkaWNhdGlvbkZyb20oTWVkUmVxT3JBZG1pbi5tZWRpY2F0aW9uKSwKICB7RkhJUi5jYW5vbmljYWx7dmFsdWU6ICdodHRwOi8vd3d3LmNkYy5nb3Yvbmhzbi9maGlycG9ydGFsL2RxbS9pZy9TdHJ1Y3R1cmVEZWZpbml0aW9uL2FjaC1kYWlseS1tZWRpY2F0aW9uJ319KQoKLy9UbyBjYXRjaCBhbGwgaXNvbGF0aW9uIHByZWNhdXRpb25zCmRlZmluZSAiU0RFIEFsbCBPYnNlcnZhdGlvbnMiOgogICJPYnNlcnZhdGlvbnMiIE8KICB3aGVyZSBleGlzdHMoIkluaXRpYWwgUG9wdWxhdGlvbiIpCiAgcmV0dXJuIE9ic2VydmF0aW9uTGFiUmVzb3VyY2UoTywKICB7RkhJUi5jYW5vbmljYWx7dmFsdWU6ICdodHRwOi8vd3d3LmNkYy5nb3Yvbmhzbi9maGlycG9ydGFsL2RxbS9pZy9TdHJ1Y3R1cmVEZWZpbml0aW9uL2FjaC1kYWlseS1vYnNlcnZhdGlvbid9fSkKCi8vVG8gY2F0Y2ggYWxsIGlzb2xhdGlvbiBwcmVjYXV0aW9ucwpkZWZpbmUgIlNERSBBbGwgU2VydmljZVJlcXVlc3RzIjoKICBbU2VydmljZVJlcXVlc3RdIFNSCiAgd2hlcmUgZXhpc3RzKCJJbml0aWFsIFBvcHVsYXRpb24iKQogIHJldHVybiBTZXJ2aWNlUmVxdWVzdFJlc291cmNlKFNSLAogIHtGSElSLmNhbm9uaWNhbHt2YWx1ZTogJ2h0dHA6Ly93d3cuY2RjLmdvdi9uaHNuL2ZoaXJwb3J0YWwvZHFtL2lnL1N0cnVjdHVyZURlZmluaXRpb24vYWNoLWRhaWx5LXNlcnZpY2VyZXF1ZXN0J319KQoKLy9UbyBjYXRjaCBhbGwgaXNvbGF0aW9uIHByZWNhdXRpb25zCmRlZmluZSAiU0RFIEFsbCBQcm9jZWR1cmVzIjoKICBbUHJvY2VkdXJlXSBQCiAgd2hlcmUgZXhpc3RzKCJJbml0aWFsIFBvcHVsYXRpb24iKQogIHJldHVybiBTaGFyZWRSZXNvdXJjZS5Qcm9jZWR1cmVSZXNvdXJjZShQLAogIHtGSElSLmNhbm9uaWNhbHt2YWx1ZTogJ2h0dHA6Ly93d3cuY2RjLmdvdi9uaHNuL2ZoaXJwb3J0YWwvZHFtL2lnL1N0cnVjdHVyZURlZmluaXRpb24vYWNoLWRhaWx5LXByb2NlZHVyZSd9fSkKCgovLy0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tCi8vZnVuY3Rpb25zCi8vLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0KZGVmaW5lIGZ1bmN0aW9uICJDaGVja0lQIihlbmNvdW50ZXIgRW5jb3VudGVyKToKICBleGlzdHMoIkluaXRpYWwgUG9wdWxhdGlvbiIgSVAKICB3aGVyZSBlbmNvdW50ZXIuaWQgPSBJUC5pZCkKCmRlZmluZSBmdW5jdGlvbiAiR2V0TWVkaWNhdGlvbiIocmVmZXJlbmNlIFJlZmVyZW5jZSApOgogIHNpbmdsZXRvbiBmcm9tICgKICAgIFtNZWRpY2F0aW9uOiBpZCBpbiB7TkhTTkhlbHBlcnMuR2V0SWQocmVmZXJlbmNlLnJlZmVyZW5jZSl9XQogICkKCmRlZmluZSBmdW5jdGlvbiAiR2V0TWVkaWNhdGlvbkNvZGUiKGNob2ljZSBDaG9pY2U8RkhJUi5Db2RlYWJsZUNvbmNlcHQsIEZISVIuUmVmZXJlbmNlPik6CiAgY2FzZQogICAgd2hlbiBjaG9pY2UgaXMgRkhJUi5Db2RlYWJsZUNvbmNlcHQgdGhlbgogICAgICBjaG9pY2UgYXMgRkhJUi5Db2RlYWJsZUNvbmNlcHQKICAgIHdoZW4gY2hvaWNlIGlzIEZISVIuUmVmZXJlbmNlIHRoZW4KICAgICAgR2V0TWVkaWNhdGlvbihjaG9pY2UgYXMgRkhJUi5SZWZlcmVuY2UpLmNvZGUKICAgIGVsc2UKICAgICAgbnVsbCBhcyBGSElSLkNvZGVhYmxlQ29uY2VwdAogIGVuZAoKZGVmaW5lIGZ1bmN0aW9uICJHZXRNZWRpY2F0aW9uRnJvbSIoY2hvaWNlIENob2ljZTxGSElSLkNvZGVhYmxlQ29uY2VwdCwgRkhJUi5SZWZlcmVuY2U+KToKICBjYXNlCiAgICB3aGVuIGNob2ljZSBpcyBGSElSLlJlZmVyZW5jZSB0aGVuCiAgICAgIEdldE1lZGljYXRpb24oY2hvaWNlIGFzIEZISVIuUmVmZXJlbmNlKQogICAgZWxzZQogICAgICBudWxsCiAgZW5kCgpkZWZpbmUgZnVuY3Rpb24gIkdldFNwZWNpbWVuIihyZWZlcmVuY2UgRkhJUi5SZWZlcmVuY2UpOgogIHNpbmdsZXRvbiBmcm9tICgKICAgIFtTcGVjaW1lbl0gU3BlY2ltZW5zCiAgICB3aGVyZSBTcGVjaW1lbnMuaWQgPSBOSFNOSGVscGVycy5HZXRJZChyZWZlcmVuY2UucmVmZXJlbmNlKQogICkKCmRlZmluZSBmdW5jdGlvbiAiR2V0RW5jb3VudGVyIihyZWZlcmVuY2UgRkhJUi5SZWZlcmVuY2UpOgogIHNpbmdsZXRvbiBmcm9tICgKICAgICJFbmNvdW50ZXJzIiBFbmNvdW50ZXJzCiAgICB3aGVyZSBFbmNvdW50ZXJzLmlkID0gTkhTTkhlbHBlcnMuR2V0SWQocmVmZXJlbmNlLnJlZmVyZW5jZSkKICApCgpkZWZpbmUgZmx1ZW50IGZ1bmN0aW9uIHJlZmVyZW5jZXMocmVmZXJlbmNlIEZISVIuUmVmZXJlbmNlLCByZXNvdXJjZSBGSElSLlJlc291cmNlKToKICByZXNvdXJjZS5pZCA9IExhc3QoU3BsaXQocmVmZXJlbmNlLnJlZmVyZW5jZSwgJy8nKSkKCmRlZmluZSBmbHVlbnQgZnVuY3Rpb24gcmVmZXJlbmNlcyhyZWZlcmVuY2VzIExpc3Q8RkhJUi5SZWZlcmVuY2U+LCByZXNvdXJjZSBGSElSLlJlc291cmNlKToKICBleGlzdHMocmVmZXJlbmNlcyBSIHdoZXJlIFIucmVmZXJlbmNlcyhyZXNvdXJjZSkpCgovL0NvbW1vbiBSZXRyaWV2YWxzCmRlZmluZSAiRW5jb3VudGVycyI6CiAgW0VuY291bnRlcl0KCmRlZmluZSAiT2JzZXJ2YXRpb25zIjoKICBbT2JzZXJ2YXRpb25dCgpkZWZpbmUgIkRpYWdub3N0aWNSZXBvcnRzIjoKICBbRGlhZ25vc3RpY1JlcG9ydF0KCiAvLwogLy8gTWVhc3VyZSBTcGVjaWZpYyBSZXNvdXJjZSBDcmVhdGlvbiBGdW5jdGlvbnMKIC8vCmRlZmluZSBmdW5jdGlvbiBNZWRpY2F0aW9uUmVxdWVzdFJlcGVhdChyZXBlYXQgRkhJUi5UaW1pbmcuUmVwZWF0KToKICByZXBlYXQgcgogIHJldHVybiBGSElSLlRpbWluZy5SZXBlYXR7CiAgICBib3VuZHM6IHIuYm91bmRzLAogICAgY291bnQ6IHIuY291bnQsCiAgICBjb3VudE1heDogci5jb3VudE1heCwKICAgICJkdXJhdGlvbiI6IHIuImR1cmF0aW9uIiwKICAgIGR1cmF0aW9uTWF4OiByLmR1cmF0aW9uTWF4LAogICAgZHVyYXRpb25Vbml0OiByLmR1cmF0aW9uVW5pdCwKICAgIGZyZXF1ZW5jeTogci5mcmVxdWVuY3ksCiAgICBmcmVxdWVuY3lNYXg6IHIuZnJlcXVlbmN5TWF4LAogICAgcGVyaW9kOiByLnBlcmlvZCwKICAgIHBlcmlvZE1heDogci5wZXJpb2RNYXgsCiAgICBwZXJpb2RVbml0OiByLnBlcmlvZFVuaXQsCiAgICBkYXlPZldlZWs6IHIuZGF5T2ZXZWVrLAogICAgdGltZU9mRGF5OiByLnRpbWVPZkRheSwKICAgICJ3aGVuIjogci4id2hlbiIsCiAgICBvZmZzZXQ6IHIub2Zmc2V0CiAgfQoKZGVmaW5lIGZ1bmN0aW9uIE1lZGljYXRpb25SZXF1ZXN0VGltaW5nKHRpbWluZyBGSElSLlRpbWluZyk6CiAgdGltaW5nIHQKICByZXR1cm4gRkhJUi5UaW1pbmd7CiAgICBldmVudDogdC5ldmVudCwKICAgIHJlcGVhdDogTWVkaWNhdGlvblJlcXVlc3RSZXBlYXQodC5yZXBlYXQpLAogICAgY29kZTogdC5jb2RlCiAgfQoKZGVmaW5lIGZ1bmN0aW9uIE1lZGljYXRpb25SZXF1ZXN0RG9zYWdlSW5zdHJ1Y3Rpb24oZG9zYWdlSW5zdHJ1Y3Rpb24gTGlzdDxGSElSLkRvc2FnZT4pOgogIGRvc2FnZUluc3RydWN0aW9uIGRJCiAgcmV0dXJuIEZISVIuRG9zYWdlewogICAgdGV4dDogZEkudGV4dCwKICAgIHBhdGllbnRJbnN0cnVjdGlvbjogZEkucGF0aWVudEluc3RydWN0aW9uLAogICAgdGltaW5nOiBNZWRpY2F0aW9uUmVxdWVzdFRpbWluZyhkSS50aW1pbmcpLAogICAgYXNOZWVkZWQ6IGRJLmFzTmVlZGVkLAogICAgc2l0ZTogZEkuc2l0ZSwKICAgIHJvdXRlOiBkSS5yb3V0ZSwKICAgIG1ldGhvZDogZEkubWV0aG9kLAogICAgZG9zZUFuZFJhdGU6IFNoYXJlZFJlc291cmNlLk1lZGljYXRpb25SZXF1ZXN0RG9zZUFuZFJhdGUoZEkuZG9zZUFuZFJhdGUpCiAgfQoKIGRlZmluZSBmdW5jdGlvbiBNZWRpY2F0aW9uUmVxdWVzdFJlc291cmNlKG1lZGljYXRpb25SZXF1ZXN0IE1lZGljYXRpb25SZXF1ZXN0LCBwcm9maWxlVVJMcyBMaXN0PEZISVIuY2Fub25pY2FsPik6CiAgbWVkaWNhdGlvblJlcXVlc3QgbQogIHJldHVybiBNZWRpY2F0aW9uUmVxdWVzdHsKICAgIGlkOiBGSElSLmlkIHt2YWx1ZTogJ0xDUi0nICsgbS5pZH0sCiAgICBtZXRhOiBTaGFyZWRSZXNvdXJjZS5NZXRhRWxlbWVudChtZWRpY2F0aW9uUmVxdWVzdCwgcHJvZmlsZVVSTHMpLAogICAgZXh0ZW5zaW9uOiBtLmV4dGVuc2lvbiwKICAgIHN0YXR1czogbS5zdGF0dXMsCiAgICBpbnRlbnQ6IG0uaW50ZW50LAogICAgY2F0ZWdvcnk6IG0uY2F0ZWdvcnksCiAgICBwcmlvcml0eTogbS5wcmlvcml0eSwKICAgIGRvTm90UGVyZm9ybTogbS5kb05vdFBlcmZvcm0sCiAgICByZXBvcnRlZDogbS5yZXBvcnRlZCwKICAgIG1lZGljYXRpb246IG0ubWVkaWNhdGlvbiwKICAgIHN1YmplY3Q6IG0uc3ViamVjdCwKICAgIGVuY291bnRlcjogbS5lbmNvdW50ZXIsCiAgICBhdXRob3JlZE9uOiBtLmF1dGhvcmVkT24sCiAgICByZXF1ZXN0ZXI6IG0ucmVxdWVzdGVyLAogICAgcmVjb3JkZXI6IG0ucmVjb3JkZXIsCiAgICByZWFzb25Db2RlOiBtLnJlYXNvbkNvZGUsCiAgICByZWFzb25SZWZlcmVuY2U6IG0ucmVhc29uUmVmZXJlbmNlLAogICAgaW5zdGFudGlhdGVzQ2Fub25pY2FsOiBtLmluc3RhbnRpYXRlc0Nhbm9uaWNhbCwKICAgIGluc3RhbnRpYXRlc1VyaTogbS5pbnN0YW50aWF0ZXNVcmksCiAgICBjb3Vyc2VPZlRoZXJhcHlUeXBlOiBtLmNvdXJzZU9mVGhlcmFweVR5cGUsCiAgICBkb3NhZ2VJbnN0cnVjdGlvbjogTWVkaWNhdGlvblJlcXVlc3REb3NhZ2VJbnN0cnVjdGlvbihtLmRvc2FnZUluc3RydWN0aW9uKQogIH0KCmRlZmluZSBmdW5jdGlvbiBPYnNlcnZhdGlvbkxhYkNvZGluZyhjb2RpbmcgTGlzdDxDb2Rpbmc+KToKICBjb2RpbmcgYwogIHJldHVybiBDb2Rpbmd7CiAgICBzeXN0ZW06IGMuc3lzdGVtLAogICAgdmVyc2lvbjogYy52ZXJzaW9uLAogICAgY29kZTogYy5jb2RlLAogICAgZGlzcGxheTogYy5kaXNwbGF5LAogICAgdXNlclNlbGVjdGVkOiBjLnVzZXJTZWxlY3RlZAogIH0KCmRlZmluZSBmdW5jdGlvbiBPYnNlcnZhdGlvbkxhYkNhdGVnb3J5KGNhdGVnb3J5IExpc3Q8Q29kZWFibGVDb25jZXB0Pik6CiAgY2F0ZWdvcnkgYwogIHJldHVybiBDb2RlYWJsZUNvbmNlcHR7CiAgICBjb2Rpbmc6IE9ic2VydmF0aW9uTGFiQ29kaW5nKGMuY29kaW5nKSwKICAgIHRleHQ6IGMudGV4dAogIH0KCmRlZmluZSBmdW5jdGlvbiBPYnNlcnZhdGlvbkxhYlJlc291cmNlKG9ic2VydmF0aW9uIE9ic2VydmF0aW9uLCBwcm9maWxlVVJMcyBMaXN0PEZISVIuY2Fub25pY2FsPik6CiAgb2JzZXJ2YXRpb24gbwogIHJldHVybiBPYnNlcnZhdGlvbnsKICAgIGlkOiBGSElSLmlkIHt2YWx1ZTogJ0xDUi0nICsgby5pZH0sCiAgICBtZXRhOiBTaGFyZWRSZXNvdXJjZS5NZXRhRWxlbWVudChvLCBwcm9maWxlVVJMcyksCiAgICBleHRlbnNpb246IG8uZXh0ZW5zaW9uLAogICAgYmFzZWRPbjogby5iYXNlZE9uLAogICAgcGFydE9mOiBvLnBhcnRPZiwKICAgIHN0YXR1czogby5zdGF0dXMsCiAgICBjYXRlZ29yeTogT2JzZXJ2YXRpb25MYWJDYXRlZ29yeShvLmNhdGVnb3J5KSwKICAgIGNvZGU6IG8uY29kZSwKICAgIHN1YmplY3Q6IG8uc3ViamVjdCwKICAgIGZvY3VzOiBvLmZvY3VzLAogICAgZW5jb3VudGVyOiBvLmVuY291bnRlciwKICAgIGVmZmVjdGl2ZTogby5lZmZlY3RpdmUsCiAgICBpc3N1ZWQ6IG8uaXNzdWVkLAogICAgcGVyZm9ybWVyOiBvLnBlcmZvcm1lciwKICAgIHZhbHVlOiBvLnZhbHVlLAogICAgZGF0YUFic2VudFJlYXNvbjogby5kYXRhQWJzZW50UmVhc29uLAogICAgaW50ZXJwcmV0YXRpb246IG8uaW50ZXJwcmV0YXRpb24sCiAgICBub3RlOiBvLm5vdGUsCiAgICBib2R5U2l0ZTogby5ib2R5U2l0ZSwKICAgIG1ldGhvZDogby5tZXRob2QsCiAgICBzcGVjaW1lbjogby5zcGVjaW1lbiwKICAgIGRldmljZTogby5kZXZpY2UsCiAgICByZWZlcmVuY2VSYW5nZTogU2hhcmVkUmVzb3VyY2UuT2JzZXJ2YXRpb25SZWZlcmVuY2VSYW5nZShvLnJlZmVyZW5jZVJhbmdlKSwKICAgIGhhc01lbWJlcjogby5oYXNNZW1iZXIsCiAgICBkZXJpdmVkRnJvbTogby5kZXJpdmVkRnJvbSwKICAgIGNvbXBvbmVudDogU2hhcmVkUmVzb3VyY2UuT2JzZXJ2YXRpb25Db21wb25lbnQoby5jb21wb25lbnQpCiAgfQoKZGVmaW5lIGZ1bmN0aW9uICJHZXRQcm9jZWR1cmVFeHRlbnNpb25zIihkb21haW5SZXNvdXJjZSBEb21haW5SZXNvdXJjZSk6CiAgZG9tYWluUmVzb3VyY2UuZXh0ZW5zaW9uIEUKICAgIHdoZXJlIEUudXJsICE9ICdodHRwOi8vaGw3Lm9yZy9maGlyL3VzL3FpY29yZS9TdHJ1Y3R1cmVEZWZpbml0aW9uL3FpY29yZS1yZWNvcmRlZCcKICAgICByZXR1cm4gRQoKZGVmaW5lIGZ1bmN0aW9uIFByb2NlZHVyZVJlc291cmNlKHByb2NlZHVyZSBQcm9jZWR1cmUsIHByb2ZpbGVVUkxzIExpc3Q8RkhJUi5jYW5vbmljYWw+KToKICBwcm9jZWR1cmUgcAogIHJldHVybiBQcm9jZWR1cmV7CiAgICBpZDogRkhJUi5pZCB7dmFsdWU6ICdMQ1ItJyArIHAuaWR9LAogICAgbWV0YTogU2hhcmVkUmVzb3VyY2UuTWV0YUVsZW1lbnQocCwgcHJvZmlsZVVSTHMpLAogICAgZXh0ZW5zaW9uOiBHZXRQcm9jZWR1cmVFeHRlbnNpb25zKHApLCAKICAgIGluc3RhbnRpYXRlc0Nhbm9uaWNhbDogcC5pbnN0YW50aWF0ZXNDYW5vbmljYWwsCiAgICBpbnN0YW50aWF0ZXNVcmk6IHAuaW5zdGFudGlhdGVzVXJpLAogICAgYmFzZWRPbjogcC5iYXNlZE9uLAogICAgcGFydE9mOiBwLnBhcnRPZiwKICAgIHN0YXR1czogcC5zdGF0dXMsCiAgICBzdGF0dXNSZWFzb246IHAuc3RhdHVzUmVhc29uLAogICAgY2F0ZWdvcnk6IHAuY2F0ZWdvcnksCiAgICBjb2RlOiBwLmNvZGUsCiAgICBzdWJqZWN0OiBwLnN1YmplY3QsCiAgICBlbmNvdW50ZXI6IHAuZW5jb3VudGVyLAogICAgcGVyZm9ybWVkOiBwLnBlcmZvcm1lZCwKICAgIHJlY29yZGVyOiBwLnJlY29yZGVyLAogICAgYXNzZXJ0ZXI6IHAuYXNzZXJ0ZXIsCiAgICBwZXJmb3JtZXI6IFNoYXJlZFJlc291cmNlLlByb2NlZHVyZVBlcmZvcm1lcihwLnBlcmZvcm1lciksCiAgICBsb2NhdGlvbjogcC5sb2NhdGlvbiwKICAgIHJlYXNvbkNvZGU6IHAucmVhc29uQ29kZSwKICAgIHJlYXNvblJlZmVyZW5jZTogcC5yZWFzb25SZWZlcmVuY2UsCiAgICBib2R5U2l0ZTogcC5ib2R5U2l0ZSwKICAgIG91dGNvbWU6IHAub3V0Y29tZSwKICAgIHJlcG9ydDogcC5yZXBvcnQsCiAgICBjb21wbGljYXRpb246IHAuY29tcGxpY2F0aW9uLAogICAgY29tcGxpY2F0aW9uRGV0YWlsOiBwLmNvbXBsaWNhdGlvbkRldGFpbCwKICAgIGZvbGxvd1VwOiBwLmZvbGxvd1VwLAogICAgbm90ZTogcC5ub3RlLAogICAgZm9jYWxEZXZpY2U6IFNoYXJlZFJlc291cmNlLlByb2NlZHVyZUZvY2FsRGV2aWNlKHAuZm9jYWxEZXZpY2UpLAogICAgdXNlZFJlZmVyZW5jZTogcC51c2VkUmVmZXJlbmNlLAogICAgdXNlZENvZGU6IHAudXNlZENvZGUKICB9CgpkZWZpbmUgZnVuY3Rpb24gU2VydmljZVJlcXVlc3RSZXNvdXJjZShzZXJ2aWNlUmVxdWVzdCBTZXJ2aWNlUmVxdWVzdCwgcHJvZmlsZVVSTHMgTGlzdDxGSElSLmNhbm9uaWNhbD4pOgogIHNlcnZpY2VSZXF1ZXN0IHNSCiAgcmV0dXJuIFNlcnZpY2VSZXF1ZXN0ewogICAgaWQ6IEZISVIuaWQge3ZhbHVlOiAnTENSLScgKyBzUi5pZH0sCiAgICBtZXRhOiBTaGFyZWRSZXNvdXJjZS5NZXRhRWxlbWVudChzUiwgcHJvZmlsZVVSTHMpLAogICAgZXh0ZW5zaW9uOiBzUi5leHRlbnNpb24sCiAgICBpbnN0YW50aWF0ZXNDYW5vbmljYWw6IHNSLmluc3RhbnRpYXRlc0Nhbm9uaWNhbCwKICAgIGluc3RhbnRpYXRlc1VyaTogc1IuaW5zdGFudGlhdGVzVXJpLAogICAgYmFzZWRPbjogc1IuYmFzZWRPbiwKICAgIHJlcGxhY2VzOiBzUi5yZXBsYWNlcywKICAgIHJlcXVpc2l0aW9uOiBzUi5yZXF1aXNpdGlvbiwKICAgIHN0YXR1czogc1Iuc3RhdHVzLAogICAgaW50ZW50OiBzUi5pbnRlbnQsCiAgICBjYXRlZ29yeTogc1IuY2F0ZWdvcnksCiAgICBwcmlvcml0eTogc1IucHJpb3JpdHksCiAgICBkb05vdFBlcmZvcm06IHNSLmRvTm90UGVyZm9ybSwKICAgIGNvZGU6IHNSLmNvZGUsCiAgICBvcmRlckRldGFpbDogc1Iub3JkZXJEZXRhaWwsCiAgICBxdWFudGl0eTogc1IucXVhbnRpdHksCiAgICBzdWJqZWN0OiBzUi5zdWJqZWN0LAogICAgZW5jb3VudGVyOiBzUi5lbmNvdW50ZXIsCiAgICBvY2N1cnJlbmNlOiBzUi5vY2N1cnJlbmNlLAogICAgYXNOZWVkZWQ6IHNSLmFzTmVlZGVkLAogICAgYXV0aG9yZWRPbjogc1IuYXV0aG9yZWRPbiwKICAgIHBlcmZvcm1lclR5cGU6IHNSLnBlcmZvcm1lclR5cGUsCiAgICBwZXJmb3JtZXI6IHNSLnBlcmZvcm1lciwKICAgIGxvY2F0aW9uQ29kZTogc1IubG9jYXRpb25Db2RlLAogICAgbG9jYXRpb25SZWZlcmVuY2U6IHNSLmxvY2F0aW9uUmVmZXJlbmNlLAogICAgcmVhc29uQ29kZTogc1IucmVhc29uQ29kZSwKICAgIHJlYXNvblJlZmVyZW5jZTogc1IucmVhc29uUmVmZXJlbmNlLAogICAgaW5zdXJhbmNlOiBzUi5pbnN1cmFuY2UsCiAgICBzdXBwb3J0aW5nSW5mbzogc1Iuc3VwcG9ydGluZ0luZm8sCiAgICBzcGVjaW1lbjogc1Iuc3BlY2ltZW4sCiAgICBib2R5U2l0ZTogc1IuYm9keVNpdGUsCiAgICBub3RlOiBzUi5ub3RlLAogICAgcGF0aWVudEluc3RydWN0aW9uOiBzUi5wYXRpZW50SW5zdHJ1Y3Rpb24sCiAgICByZWxldmFudEhpc3Rvcnk6IHNSLnJlbGV2YW50SGlzdG9yeQogIH0KICAgIAogICAg",
+            "url": "http://www.cdc.gov/nhsn/fhirportal/dqm/ig/Library-NHSNAcuteCareHospitalDailyInitialPopulation.cql"
           }
         ]
       },
@@ -8463,6 +8424,10 @@
       "resource": {
         "resourceType": "Library",
         "id": "SharedResourceCreation",
+        "text": {
+          "status": "extensions",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n<div>\n    <table class=\"grid dict\">\n        \n        \n\n        \n        \n        <tr>\n            <th scope=\"row\"><b>Id: </b></th>\n            <td style=\"padding-left: 4px;\">SharedResourceCreation</td>\n        </tr>\n        \n\n        \n        \n        <tr>\n            <th scope=\"row\"><b>Version: </b></th>\n            <td style=\"padding-left: 4px;\">2.0.0-cibuild</td>\n        </tr>\n        \n\n        \n        <tr>\n            <th scope=\"row\"><b>Url: </b></th>\n            <td style=\"padding-left: 4px;\"><a href=\"Library-SharedResourceCreation.html\">SharedResourceCreation</a></td>\n        </tr>\n        \n\n        \n\n        \n\n        \n        <tr>\n            <th scope=\"row\"><b>Status: </b></th>\n            <td style=\"padding-left: 4px;\">draft</td>\n        </tr>\n        \n\n        \n\n        \n        <tr>\n            <th scope=\"row\"><b>Type: </b></th>\n            <td style=\"padding-left: 4px;\">\n                \n                    \n                        \n                        <p style=\"margin-bottom: 5px;\">\n                            <b>system: </b> <span><a href=\"http://terminology.hl7.org/7.0.1/CodeSystem-library-type.html\">http://terminology.hl7.org/CodeSystem/library-type</a></span>\n                        </p>\n                        \n                        \n                        <p style=\"margin-bottom: 5px;\">\n                            <b>code: </b> <span>logic-library</span>\n                        </p>\n                        \n                        \n                    \n                \n                \n            </td>\n        </tr>\n        \n\n        \n\n        \n        <tr>\n            <th scope=\"row\"><b>Date: </b></th>\n            <td style=\"padding-left: 4px;\">2026-01-08 14:28:51+0000</td>\n        </tr>\n        \n\n        \n        <tr>\n            <th scope=\"row\"><b>Publisher: </b></th>\n            <td style=\"padding-left: 4px;\">CDC National Healthcare Safety Network (NHSN)</td>\n        </tr>\n        \n\n        \n\n        \n\n        \n\n        \n\n        \n        <tr>\n            <th scope=\"row\"><b>Jurisdiction: </b></th>\n            <td style=\"padding-left: 4px;\">US</td>\n        </tr>\n        \n\n        \n\n        \n\n        \n\n        \n\n        \n\n        \n\n        \n        <tr>\n            <th scope=\"row\"><b>Related Artifacts: </b></th>\n            <td style=\"padding-left: 4px;\">\n                \n                \n                \n                <p><b>Dependencies</b></p>\n                <ul>\n                  \n                    <li><a href=\"http://fhir.org/guides/cqf/common/4.0.1/4.0.1/Library-FHIR-ModelInfo.html\">http://fhir.org/guides/cqf/common/Library/FHIR-ModelInfo|4.0.1</a></li>\n                  \n                    <li><code>http://www.cdc.gov/nhsn/fhirportal/dqm/ig/Library/FHIRHelpers|4.0.2</code></li>\n                  \n                </ul>\n                \n                \n                \n                \n                \n            </td>\n        </tr>\n        \n\n        \n\n        \n\n        \n        \n        <tr>\n          <td colspan=\"2\">\n            <table>\n              <tr><th><a id=\"cql-content\"><b>Content: </b></a> text/cql</th></tr>\n              <tr><td><pre><code class=\"language-cql\">library SharedResourceCreation version '0.1.010'\n\ninclude FHIRHelpers version '4.0.2'\n\nusing FHIR version '4.0.1'\n\ndefine function &quot;GetPatientExtensions&quot;(domainResource DomainResource):\n  domainResource.extension E\n  where E.url = 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-race'\n    or E.url = 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity'\n    or E.url = 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-tribal-affiliation'\n    or E.url = 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-birthsex'\n    or E.url = 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-sex'\n    or E.url = 'http://www.cdc.gov/nhsn/fhirportal/dqm/ig/StructureDefinition/link-original-resource-id-extension'\n  return E\n\ndefine function &quot;MetaElement&quot;(resource Resource, profileURLs List&lt;FHIR.canonical&gt;):\n  resource r\n  return FHIR.Meta{\n    extension: r.meta.extension,\n    versionId: r.meta.versionId,\n    lastUpdated: r.meta.lastUpdated,\n    profile: profileURLs,\n    security: r.meta.security,\n    tag: r.meta.tag\n  }\n\ndefine function ConditionStage(stage List&lt;FHIR.Condition.Stage&gt;):\n  stage s\n  return FHIR.Condition.Stage{\n    summary: s.summary,\n    assessment: s.assessment,\n    type: s.type\n  }\n\ndefine function ConditionEvidence(evidence List&lt;FHIR.Condition.Evidence&gt;):\n  evidence e\n  return FHIR.Condition.Evidence{\n    code: e.code,\n    detail: e.detail\n  }\n\ndefine function ConditionResource(condition Condition, profileURLs List&lt;FHIR.canonical&gt;):\n  condition c\n  return Condition{\n    id: FHIR.id {value: 'LCR-' + c.id},\n    meta: MetaElement(c, profileURLs),\n    extension: c.extension,\n    clinicalStatus: c.clinicalStatus,\n    verificationStatus: c.verificationStatus,\n    category: c.category,\n    severity: c.severity,\n    code: c.code,\n    bodySite: c.bodySite,\n    subject: c.subject,\n    encounter: c.encounter,\n    onset: c.onset,\n    abatement: c.abatement,\n    recordedDate: c.recordedDate,\n    stage: ConditionStage(c.stage),\n    evidence: ConditionEvidence(c.evidence),\n    note: c.note\n  }\n\ndefine function CoverageClass(class List&lt;FHIR.Coverage.Class&gt;):\n  class c\n  return FHIR.Coverage.Class{\n    value: c.value,\n    name: c.name\n  }\n\ndefine function CoverageResource(coverage Coverage, profileURLs List&lt;FHIR.canonical&gt;):\n  coverage c\n  return Coverage{\n    id: FHIR.id{value: 'LCR-' + c.id},\n    meta: MetaElement(c, profileURLs),\n    extension: c.extension,\n    status: c.status,\n    type: c.type,\n    policyHolder: c.policyHolder,\n    subscriber: c.subscriber,\n    subscriberId: c.subscriberId,\n    beneficiary: c.beneficiary,\n    dependent: c.dependent,\n    relationship: c.relationship,\n    period: c.period,\n    payor: c.payor,\n    class: CoverageClass(c.class),\n    order: c.order,\n    network: c.network,\n    subrogation: c.subrogation,\n    contract: c.contract\n  }\n\ndefine function DiagnosticReportCoding(coding List&lt;Coding&gt;):\n  coding c\n  return Coding{\n    system: c.system,\n    version: c.version,\n    code: c.code,\n    display: c.display,\n    userSelected: c.userSelected\n  }\n\ndefine function DiagnosticReportCategory(category List&lt;CodeableConcept&gt;):\n  category c\n  return CodeableConcept{\n    coding: DiagnosticReportCoding(c.coding)\n  }\n\ndefine function DiagnosticReportLabResource(diagnosticReport DiagnosticReport, profileURLs List&lt;FHIR.canonical&gt;):\n  diagnosticReport d\n  return DiagnosticReport{\n    id: FHIR.id{value: 'LCR-' + d.id},\n    meta: MetaElement(d, profileURLs),\n    extension: d.extension,\n    basedOn: d.basedOn,\n    status: d.status,\n    category: DiagnosticReportCategory(d.category),\n    code: d.code,\n    subject: d.subject,\n    encounter: d.encounter,\n    effective: d.effective,\n    issued: d.issued,\n    performer: d.performer,\n    resultsInterpreter: d.resultsInterpreter,\n    specimen: d.specimen,\n    result: d.result,\n    conclusion: d.conclusion,\n    conclusionCode: d.conclusionCode\n  }\n\ndefine function EncounterIdentifier(identifier List&lt;FHIR.Identifier&gt;):\n  identifier i\n  return FHIR.Identifier{\n    use: i.use,\n    type: i.type,\n    system: i.system,\n    value: i.value,\n    period: i.period\n  }\n\ndefine function EncounterStatusHistory(statusHistory List&lt;FHIR.Encounter.StatusHistory&gt;):\n  statusHistory sH\n  return FHIR.Encounter.StatusHistory{\n    status: sH.status,\n    period: sH.period\n  }\n\ndefine function EncounterClassHistory(classHistory List&lt;FHIR.Encounter.ClassHistory&gt;):\n  classHistory cH\n  return FHIR.Encounter.ClassHistory{\n    class: cH.class,\n    period: cH.period\n  }\n\n/*No longer needed but saving for potential future use\ndefine function EncounterParticipant(participant List&lt;FHIR.Encounter.Participant&gt;):\n  participant p\n  return FHIR.Encounter.Participant{\n    type: p.type,\n    period: p.period,\n    individual: p.individual\n  }*/\n\ndefine function EncounterDiagnosis(diagnosis List&lt;FHIR.Encounter.Diagnosis&gt;):\n  diagnosis d\n  return FHIR.Encounter.Diagnosis{\n    condition: d.condition,\n    use: d.use,\n    rank: d.rank\n  }\n\ndefine function EncounterHospitalization(hospitalization FHIR.Encounter.Hospitalization):\n  hospitalization h\n  return FHIR.Encounter.Hospitalization{\n    preAdmissionIdentifier: h.preAdmissionIdentifier,\n    origin: h.origin,\n    admitSource: h.admitSource,\n    reAdmission: h.reAdmission,\n    dietPreference: h.dietPreference,\n    specialCourtesy: h.specialCourtesy,\n    specialArrangement: h.specialArrangement,\n    destination: h.destination,\n    dischargeDisposition: h.dischargeDisposition\n  }\n\ndefine function EncounterLocation(location List&lt;FHIR.Encounter.Location&gt;):\n  location l\n  return FHIR.Encounter.Location{\n    location: l.location,\n    status: l.status,\n    physicalType: l.physicalType,\n    period: l.period\n  }\n\ndefine function EncounterResource(encounter Encounter, profileURLs List&lt;FHIR.canonical&gt;):\n  encounter e\n  return Encounter{\n    id: FHIR.id{value: 'LCR-' + e.id},\n    meta: MetaElement(e, profileURLs),\n    extension: e.extension,\n    identifier: EncounterIdentifier(e.identifier),\n    status: e.status,\n    statusHistory: EncounterStatusHistory(e.statusHistory),\n    class: e.class,\n    classHistory: EncounterClassHistory(e.classHistory),\n    type: e.type,\n    serviceType: e.serviceType,\n    priority: e.priority,\n    subject: e.subject,\n    period: e.period,\n    length: e.length,\n    reasonCode: e.reasonCode,\n    reasonReference: e.reasonReference,\n    diagnosis: EncounterDiagnosis(e.diagnosis),\n    account: e.account,\n    hospitalization: EncounterHospitalization(e.hospitalization),\n    location: EncounterLocation(e.location),\n    partOf: e.partOf\n  }\n\ndefine function ObservationLabCoding(coding List&lt;Coding&gt;):\n  coding c\n  return Coding{\n    id: c.id,\n    extension: c.extension,\n    system: c.system,\n    version: c.version,\n    code: c.code,\n    display: c.display,\n    userSelected: c.userSelected\n  }\n\ndefine function ObservationLabCategory(category List&lt;CodeableConcept&gt;):\n  category c\n  return CodeableConcept{\n    coding: ObservationLabCoding(c.coding),\n    text: c.text\n  }\n\ndefine function ObservationReferenceRange(referenceRange List&lt;FHIR.Observation.ReferenceRange&gt;):\n  referenceRange rR\n  return FHIR.Observation.ReferenceRange{\n    low: rR.low,\n    high: rR.high,\n    type: rR.type,\n    appliesTo: rR.appliesTo,\n    age: rR.age,\n    text: rR.text\n  }\n\ndefine function ObservationComponent(component List&lt;FHIR.Observation.Component&gt;):\n  component c\n  return FHIR.Observation.Component{\n    code: c.code,\n    value: c.value,\n    dataAbsentReason: c.dataAbsentReason,\n    interpretation: c.interpretation,\n    referenceRange: c.referenceRange\n  }\n\ndefine function ObservationLabResource(observation Observation, profileURLs List&lt;FHIR.canonical&gt;):\n  observation o\n  return Observation{\n    id: FHIR.id {value: 'LCR-' + o.id},\n    meta: MetaElement(o, profileURLs),\n    extension: o.extension,\n    basedOn: o.basedOn,\n    partOf: o.partOf,\n    status: o.status,\n    category: ObservationLabCategory(o.category),\n    code: o.code,\n    subject: o.subject,\n    focus: o.focus,\n    encounter: o.encounter,\n    effective: o.effective,\n    issued: o.issued,\n    performer: o.performer,\n    value: o.value,\n    dataAbsentReason: o.dataAbsentReason,\n    interpretation: o.interpretation,\n    note: o.note,\n    bodySite: o.bodySite,\n    method: o.method,\n    specimen: o.specimen,\n    device: o.device,\n    referenceRange: ObservationReferenceRange(o.referenceRange),\n    hasMember: o.hasMember,\n    derivedFrom: o.derivedFrom,\n    component: ObservationComponent(o.component)\n  }\n\ndefine function LocationAddress(address FHIR.Address):\n  address a\n  return FHIR.Address{\n    use: a.use,\n    type: a.type,\n    text: a.text,\n    line: a.line,\n    city: a.city,\n    district: a.district,\n    state: a.state,\n    postalCode: a.postalCode,\n    country: a.country,\n    period: a.period\n  }\n\ndefine function LocationPosition(position FHIR.Location.Position):\n  position p\n  return FHIR.Location.Position{\n    longitude: p.longitude,\n    latitude: p.latitude,\n    altitude: p.altitude\n  }\n\ndefine function LocationHoursOfOperation(hoursOfOperation List&lt;FHIR.Location.HoursOfOperation&gt;):\n  hoursOfOperation hOO\n  return FHIR.Location.HoursOfOperation{\n    daysOfWeek: hOO.daysOfWeek,\n    allDay: hOO.allDay,\n    openingTime: hOO.openingTime,\n    closingTime: hOO.closingTime\n  }\n\ndefine function LocationResource(location Location, profileURLs List&lt;FHIR.canonical&gt;):\n  location l\n  return Location{\n    id: FHIR.id {value: 'LCR-' + l.id},\n    meta: MetaElement(l, profileURLs),\n    extension: l.extension,\n    status: l.status,\n    operationalStatus: l.operationalStatus,\n    name: l.name,\n    alias: l.alias,\n    description: l.description,\n    mode: l.mode,\n    type: l.type,\n    telecom: l.telecom,\n    address: LocationAddress(l.address),\n    physicalType: l.physicalType,\n    position: LocationPosition(l.position),\n    managingOrganization: l.managingOrganization,\n    partOf: l.partOf,\n    hoursOfOperation: LocationHoursOfOperation(l.hoursOfOperation),\n    availabilityExceptions: l.availabilityExceptions,\n    endpoint: l.endpoint\n  }\n\ndefine function MedicationIngredient(ingredient List&lt;FHIR.Medication.Ingredient&gt;):\n  ingredient i\n  return FHIR.Medication.Ingredient{\n    item: i.item,\n    strength: i.strength\n  }\n\ndefine function MedicationBatch(batch FHIR.Medication.Batch):\n  batch b\n  return FHIR.Medication.Batch{\n    lotNumber: b.lotNumber,\n    expirationDate: b.expirationDate\n  }\n\ndefine function MedicationResource(medication Medication, profileURLs List&lt;FHIR.canonical&gt;):\n  medication m\n  return Medication{\n    id: FHIR.id {value: 'LCR-' + m.id},\n    meta: MetaElement(m, profileURLs),\n    extension: m.extension,\n    code: m.code,\n    status: m.status,\n    manufacturer: m.manufacturer,\n    form: m.form,\n    amount: m.amount,\n    ingredient: MedicationIngredient(m.ingredient),\n    batch: MedicationBatch(m.batch)\n  }\n\ndefine function MedicationAdministrationPerformer(performer List&lt;FHIR.MedicationAdministration.Performer&gt;):\n  performer p\n  return FHIR.MedicationAdministration.Performer{\n    function: p.function,\n    actor: p.actor\n  }\n\ndefine function MedicationAdministrationDosage(dosage FHIR.MedicationAdministration.Dosage):\n  dosage d\n  return FHIR.MedicationAdministration.Dosage{\n    text: d.text,\n    site: d.site,\n    route: d.route,\n    method: d.method,\n    dose: d.dose,\n    rate: d.rate\n  }\n\ndefine function MedicationAdministrationResource(medicationAdministration MedicationAdministration, profileURLs List&lt;FHIR.canonical&gt;):\n  medicationAdministration m\n  return MedicationAdministration{\n    id: FHIR.id {value: 'LCR-' + m.id},\n    meta: MetaElement(m, profileURLs),\n    extension: m.extension,\n    instantiates: m.instantiates,\n    partOf: m.partOf,\n    status: m.status,\n    statusReason: m.statusReason,\n    category: m.category,\n    medication: m.medication,\n    subject: m.subject,\n    context: m.context,\n    supportingInformation: m.supportingInformation,\n    effective: m.effective,\n    performer: MedicationAdministrationPerformer(m.performer),\n    reasonCode: m.reasonCode,\n    reasonReference: m.reasonReference,\n    request: m.request,\n    device: m.device,\n    note: m.note,\n    dosage: MedicationAdministrationDosage(m.dosage),\n    eventHistory: m.eventHistory\n  }\n\ndefine function MedicationRequestDoseAndRate(doseAndRate List&lt;FHIR.Dosage.DoseAndRate&gt;):\n  doseAndRate dR\n  return FHIR.Dosage.DoseAndRate{\n    type: dR.type,\n    dose: dR.dose,\n    rate: dR.rate\n  }\n\ndefine function MedicationRequestDosageInstruction(dosageInstruction List&lt;FHIR.Dosage&gt;):\n  dosageInstruction dI\n  return FHIR.Dosage{\n    text: dI.text,\n    patientInstruction: dI.patientInstruction,\n    timing: dI.timing,\n    asNeeded: dI.asNeeded,\n    site: dI.site,\n    route: dI.route,\n    method: dI.method,\n    doseAndRate: MedicationRequestDoseAndRate(dI.doseAndRate)\n  }\n\ndefine function MedicationRequestResource(medicationRequest MedicationRequest, profileURLs List&lt;FHIR.canonical&gt;):\n  medicationRequest m\n  return MedicationRequest{\n    id: FHIR.id {value: 'LCR-' + m.id},\n    meta: MetaElement(medicationRequest, profileURLs),\n    extension: m.extension,\n    status: m.status,\n    statusReason: m.statusReason,\n    intent: m.intent,\n    category: m.category,\n    priority: m.priority,\n    doNotPerform: m.doNotPerform,\n    reported: m.reported,\n    medication: m.medication,\n    subject: m.subject,\n    encounter: m.encounter,\n    authoredOn: m.authoredOn,\n    requester: m.requester,\n    recorder: m.recorder,\n    reasonCode: m.reasonCode,\n    reasonReference: m.reasonReference,\n    instantiatesCanonical: m.instantiatesCanonical,\n    instantiatesUri: m.instantiatesUri,\n    courseOfTherapyType: m.courseOfTherapyType,\n    dosageInstruction: MedicationRequestDosageInstruction(m.dosageInstruction)\n  }\n\n/* No longer needed but saving in case it's useful later\ndefine function PatientIdentifier(identifier List&lt;FHIR.Identifier&gt;):\n  identifier i\n  return FHIR.Identifier{\n    id: i.id,\n    extension: i.extension,\n    use: i.use,\n    type: i.type,\n    system: i.system,\n    value: i.value,\n    period: i.period,\n    assigner: i.assigner\n  }*/\n\ndefine function PatientName(name List&lt;FHIR.HumanName&gt;):\n  name n\n  return FHIR.HumanName{\n    id: n.id,\n    extension: n.extension,\n    use: n.use,\n    text: n.text,\n    family: n.family,\n    given: n.given,\n    prefix: n.prefix,\n    suffix: n.suffix,\n    period: n.period\n  }\n\ndefine function PatientTelecom(telecom List&lt;FHIR.ContactPoint&gt;):\n  telecom t\n  return FHIR.ContactPoint{\n    system: t.system,\n    value: t.value,\n    use: t.use,\n    rank: t.rank,\n    period: t.period\n  }\n\ndefine function PatientAddress(address List&lt;FHIR.Address&gt;):\n  address a\n  return FHIR.Address{\n    use: a.use,\n    type: a.type,\n    text: a.text,\n    line: a.line,\n    city: a.city,\n    district: a.district,\n    state: a.state,\n    postalCode: a.postalCode,\n    country: a.country,\n    period: a.period\n  }\n\ndefine function PatientContact(contact List&lt;FHIR.Patient.Contact&gt;):\n  contact c\n  return FHIR.Patient.Contact{\n    relationship: c.relationship,\n    name: c.name,\n    telecom: c.telecom,\n    address: c.address,\n    gender: c.gender,\n    organization: c.organization,\n    period: c.period\n  }\n\ndefine function PatientCommunication(communication List&lt;FHIR.Patient.Communication&gt;):\n  communication c\n  return FHIR.Patient.Communication{\n    language: c.language,\n    preferred: c.preferred\n  }\n\ndefine function PatientLink(link List&lt;FHIR.Patient.Link&gt;):\n  link l\n  return FHIR.Patient.Link{\n    extension: l.extension,\n    modifierExtension: l.modifierExtension,\n    other: l.other,\n    type: l.type\n  }\n\ndefine function PatientResource(patient Patient, profileURLs List&lt;FHIR.canonical&gt;):\n  patient p\n  return Patient{\n    id: FHIR.id{value: 'LCR-' + p.id},\n    meta: MetaElement(p, profileURLs),\n    extension: GetPatientExtensions(p),\n    identifier: p.identifier,\n    active: p.active,\n    name: PatientName(p.name),\n    telecom: PatientTelecom(p.telecom),\n    gender: p.gender,\n    birthDate: p.birthDate,\n    deceased: p.deceased,\n    address: PatientAddress(p.address),\n    maritalStatus: p.maritalStatus,\n    multipleBirth: p.multipleBirth,\n    contact: PatientContact(p.contact),\n    communication: PatientCommunication(p.communication),\n    link: PatientLink(p.link)\n  }\n\ndefine function ProcedurePerformer(performer List&lt;FHIR.Procedure.Performer&gt;):\n  performer p\n  return FHIR.Procedure.Performer{\n    function: p.function,\n    actor: p.actor,\n    onBehalfOf: p.onBehalfOf\n  }\n\ndefine function ProcedureFocalDevice(device List&lt;FHIR.Procedure.FocalDevice&gt;):\n  device d\n  return FHIR.Procedure.FocalDevice{\n    action: d.action,\n    manipulated: d.manipulated\n  }\n\ndefine function ProcedureResource(procedure Procedure, profileURLs List&lt;FHIR.canonical&gt;):\n  procedure p\n  return Procedure{\n    id: FHIR.id {value: 'LCR-' + p.id},\n    meta: MetaElement(p, profileURLs),\n    extension: p.extension,\n    instantiatesCanonical: p.instantiatesCanonical,\n    instantiatesUri: p.instantiatesUri,\n    basedOn: p.basedOn,\n    partOf: p.partOf,\n    status: p.status,\n    statusReason: p.statusReason,\n    category: p.category,\n    code: p.code,\n    subject: p.subject,\n    encounter: p.encounter,\n    performed: p.performed,\n    recorder: p.recorder,\n    asserter: p.asserter,\n    performer: ProcedurePerformer(p.performer),\n    location: p.location,\n    reasonCode: p.reasonCode,\n    reasonReference: p.reasonReference,\n    bodySite: p.bodySite,\n    outcome: p.outcome,\n    report: p.report,\n    complication: p.complication,\n    complicationDetail: p.complicationDetail,\n    followUp: p.followUp,\n    note: p.note,\n    focalDevice: ProcedureFocalDevice(p.focalDevice),\n    usedReference: p.usedReference,\n    usedCode: p.usedCode\n  }\n\ndefine function ServiceRequestResource(serviceRequest ServiceRequest, profileURLs List&lt;FHIR.canonical&gt;):\n  serviceRequest sR\n  return ServiceRequest{\n    id: FHIR.id {value: 'LCR-' + sR.id},\n    meta: MetaElement(sR, profileURLs),\n    extension: sR.extension,\n    instantiatesCanonical: sR.instantiatesCanonical,\n    instantiatesUri: sR.instantiatesUri,\n    basedOn: sR.basedOn,\n    replaces: sR.replaces,\n    requisition: sR.requisition,\n    status: sR.status,\n    intent: sR.intent,\n    category: sR.category,\n    priority: sR.priority,\n    doNotPerform: sR.doNotPerform,\n    code: sR.code,\n    orderDetail: sR.orderDetail,\n    quantity: sR.quantity,\n    subject: sR.subject,\n    encounter: sR.encounter,\n    occurrence: sR.occurrence,\n    asNeeded: sR.asNeeded,\n    authoredOn: sR.authoredOn,\n    requester: sR.requester,\n    performerType: sR.performerType,\n    performer: sR.performer,\n    locationCode: sR.locationCode,\n    locationReference: sR.locationReference,\n    reasonCode: sR.reasonCode,\n    reasonReference: sR.reasonReference,\n    insurance: sR.insurance,\n    supportingInfo: sR.supportingInfo,\n    specimen: sR.specimen,\n    bodySite: sR.bodySite,\n    note: sR.note,\n    patientInstruction: sR.patientInstruction,\n    relevantHistory: sR.relevantHistory\n  }\n\ndefine function SpecimenCollection(collection FHIR.Specimen.Collection):\n  collection c\n  return FHIR.Specimen.Collection{\n    collector: c.collector,\n    collected: c.collected,\n    &quot;duration&quot;: c.&quot;duration&quot;,\n    quantity: c.quantity,\n    method: c.method,\n    bodySite: c.bodySite,\n    fastingStatus: c.fastingStatus\n  }\n\ndefine function SpecimenProcessing(processing List&lt;FHIR.Specimen.Processing&gt;):\n  processing p\n  return FHIR.Specimen.Processing{\n    description: p.description,\n    procedure: p.procedure,\n    additive: p.additive,\n    time: p.time\n  }\n\ndefine function SpecimenContainer(container List&lt;FHIR.Specimen.Container&gt;):\n  container c\n  return FHIR.Specimen.Container{\n    description: c.description,\n    type: c.type,\n    capacity: c.capacity,\n    specimenQuantity: c.specimenQuantity,\n    additive: c.additive\n  }\n\ndefine function SpecimenResource(specimen Specimen, profileURLs List&lt;FHIR.canonical&gt;):\n  specimen s\n  return Specimen{\n    id: FHIR.id {value: 'LCR-' + s.id},\n    meta: MetaElement(s, profileURLs),\n    extension: s.extension,\n    identifier: s.identifier,\n    accessionIdentifier: s.accessionIdentifier,\n    status: s.status,\n    type: s.type,\n    subject: s.subject,\n    receivedTime: s.receivedTime,\n    parent: s.parent,\n    request: s.request,\n    collection: SpecimenCollection(s.collection),\n    processing: SpecimenProcessing(s.processing),\n    container: SpecimenContainer(s.container),\n    condition: s.condition,\n    note: s.note\n  }\n\ndefine function &quot;OperationOutcomeResource&quot;(errorId String, resourceId FHIR.id, message String):\n  OperationOutcome{\n      id: FHIR.id{value: errorId},\n      issue: {\n          FHIR.OperationOutcome.Issue{\n          severity: FHIR.IssueSeverity{value: 'error'},\n          code: FHIR.IssueType{value: 'exception'},\n          details: \n              FHIR.CodeableConcept{\n                  coding: {\n                      Coding{\n                      system: uri{value: 'https://lantanagroup.com/validation-error'},\n                      code: code{value: 'Error'},\n                      display: string{value: 'Resource ' + resourceId + ' failed validation: ' + message}\n                      }\n                  }\n              }\n          }\n      }\n  }</code></pre></td></tr>\n            </table>\n          </td>\n        </tr>\n        \n        \n        \n    </table>\n</div>\n</div>"
+        },
         "contained": [
           {
             "resourceType": "Parameters",
@@ -8533,11 +8498,18 @@
             "valueReference": {
               "reference": "#options"
             }
+          },
+          {
+            "url": "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-softwaresystem",
+            "valueReference": {
+              "reference": "Device/cqf-tooling"
+            }
           }
         ],
         "url": "http://www.cdc.gov/nhsn/fhirportal/dqm/ig/Library/SharedResourceCreation",
-        "version": "0.1.009",
+        "version": "0.1.010",
         "name": "SharedResourceCreation",
+        "status": "draft",
         "type": {
           "coding": [
             {
@@ -8546,6 +8518,33 @@
             }
           ]
         },
+        "date": "2026-01-08T14:28:51+00:00",
+        "publisher": "CDC National Healthcare Safety Network (NHSN)",
+        "contact": [
+          {
+            "name": "CDC National Healthcare Safety Network (NHSN)",
+            "telecom": [
+              {
+                "system": "url",
+                "value": "http://www.cdc.gov/nhsn"
+              },
+              {
+                "system": "email",
+                "value": "nhsn@cdc.gov"
+              }
+            ]
+          }
+        ],
+        "jurisdiction": [
+          {
+            "coding": [
+              {
+                "system": "urn:iso:std:iso:3166",
+                "code": "US"
+              }
+            ]
+          }
+        ],
         "relatedArtifact": [
           {
             "type": "depends-on",
@@ -8561,7 +8560,8 @@
         "content": [
           {
             "contentType": "text/cql",
-            "data": "bGlicmFyeSBTaGFyZWRSZXNvdXJjZUNyZWF0aW9uIHZlcnNpb24gJzAuMS4wMDknCgppbmNsdWRlIEZISVJIZWxwZXJzIHZlcnNpb24gJzQuMC4yJwoKdXNpbmcgRkhJUiB2ZXJzaW9uICc0LjAuMScKCmRlZmluZSBmdW5jdGlvbiAiR2V0SWRFeHRlbnNpb25zIihkb21haW5SZXNvdXJjZSBEb21haW5SZXNvdXJjZSk6CiAgZG9tYWluUmVzb3VyY2UuZXh0ZW5zaW9uIEUKICB3aGVyZSBFLnVybC52YWx1ZSA9ICdodHRwOi8vd3d3LmNkYy5nb3Yvbmhzbi9maGlycG9ydGFsL2RxbS9pZy9TdHJ1Y3R1cmVEZWZpbml0aW9uL2xpbmstb3JpZ2luYWwtcmVzb3VyY2UtaWQtZXh0ZW5zaW9uJwogIHJldHVybiBFCgpkZWZpbmUgZnVuY3Rpb24gIkdldFBhdGllbnRFeHRlbnNpb25zIihkb21haW5SZXNvdXJjZSBEb21haW5SZXNvdXJjZSk6CiAgZG9tYWluUmVzb3VyY2UuZXh0ZW5zaW9uIEUKICB3aGVyZSBFLnVybC52YWx1ZSA9ICdodHRwOi8vaGw3Lm9yZy9maGlyL3VzL2NvcmUvU3RydWN0dXJlRGVmaW5pdGlvbi91cy1jb3JlLXJhY2UnCiAgICBvciBFLnVybC52YWx1ZSA9ICdodHRwOi8vaGw3Lm9yZy9maGlyL3VzL2NvcmUvU3RydWN0dXJlRGVmaW5pdGlvbi91cy1jb3JlLWV0aG5pY2l0eScKICAgIG9yIEUudXJsLnZhbHVlID0gJ2h0dHA6Ly9obDcub3JnL2ZoaXIvdXMvY29yZS9TdHJ1Y3R1cmVEZWZpbml0aW9uL3VzLWNvcmUtYmlydGhzZXgnCiAgICBvciBFLnVybC52YWx1ZSA9ICdodHRwOi8vd3d3LmNkYy5nb3Yvbmhzbi9maGlycG9ydGFsL2RxbS9pZy9TdHJ1Y3R1cmVEZWZpbml0aW9uL2xpbmstb3JpZ2luYWwtcmVzb3VyY2UtaWQtZXh0ZW5zaW9uJwogIHJldHVybiBFCgpkZWZpbmUgZnVuY3Rpb24gIk1ldGFFbGVtZW50IihyZXNvdXJjZSBSZXNvdXJjZSwgcHJvZmlsZVVSTHMgTGlzdDxGSElSLmNhbm9uaWNhbD4pOgogIHJlc291cmNlIHIKICByZXR1cm4gRkhJUi5NZXRhewogICAgZXh0ZW5zaW9uOiByLm1ldGEuZXh0ZW5zaW9uLAogICAgdmVyc2lvbklkOiByLm1ldGEudmVyc2lvbklkLAogICAgbGFzdFVwZGF0ZWQ6IHIubWV0YS5sYXN0VXBkYXRlZCwKICAgIHByb2ZpbGU6IHByb2ZpbGVVUkxzLAogICAgc2VjdXJpdHk6IHIubWV0YS5zZWN1cml0eSwKICAgIHRhZzogci5tZXRhLnRhZwogIH0KCmRlZmluZSBmdW5jdGlvbiBDb25kaXRpb25TdGFnZShzdGFnZSBMaXN0PEZISVIuQ29uZGl0aW9uLlN0YWdlPik6CiAgc3RhZ2UgcwogIHJldHVybiBGSElSLkNvbmRpdGlvbi5TdGFnZXsKICAgIHN1bW1hcnk6IHMuc3VtbWFyeSwKICAgIGFzc2Vzc21lbnQ6IHMuYXNzZXNzbWVudCwKICAgIHR5cGU6IHMudHlwZQogIH0KCmRlZmluZSBmdW5jdGlvbiBDb25kaXRpb25FdmlkZW5jZShldmlkZW5jZSBMaXN0PEZISVIuQ29uZGl0aW9uLkV2aWRlbmNlPik6CiAgZXZpZGVuY2UgZQogIHJldHVybiBGSElSLkNvbmRpdGlvbi5FdmlkZW5jZXsKICAgIGNvZGU6IGUuY29kZSwKICAgIGRldGFpbDogZS5kZXRhaWwKICB9CgpkZWZpbmUgZnVuY3Rpb24gQ29uZGl0aW9uUmVzb3VyY2UoY29uZGl0aW9uIENvbmRpdGlvbiwgcHJvZmlsZVVSTHMgTGlzdDxGSElSLmNhbm9uaWNhbD4pOgogIGNvbmRpdGlvbiBjCiAgcmV0dXJuIENvbmRpdGlvbnsKICAgIGlkOiBGSElSLmlkIHt2YWx1ZTogJ0xDUi0nICsgYy5pZH0sCiAgICBtZXRhOiBNZXRhRWxlbWVudChjLCBwcm9maWxlVVJMcyksCiAgICBleHRlbnNpb246IGMuZXh0ZW5zaW9uLAogICAgY2xpbmljYWxTdGF0dXM6IGMuY2xpbmljYWxTdGF0dXMsCiAgICB2ZXJpZmljYXRpb25TdGF0dXM6IGMudmVyaWZpY2F0aW9uU3RhdHVzLAogICAgY2F0ZWdvcnk6IGMuY2F0ZWdvcnksCiAgICBzZXZlcml0eTogYy5zZXZlcml0eSwKICAgIGNvZGU6IGMuY29kZSwKICAgIGJvZHlTaXRlOiBjLmJvZHlTaXRlLAogICAgc3ViamVjdDogYy5zdWJqZWN0LAogICAgZW5jb3VudGVyOiBjLmVuY291bnRlciwKICAgIG9uc2V0OiBjLm9uc2V0LAogICAgYWJhdGVtZW50OiBjLmFiYXRlbWVudCwKICAgIHJlY29yZGVkRGF0ZTogYy5yZWNvcmRlZERhdGUsCiAgICBzdGFnZTogQ29uZGl0aW9uU3RhZ2UoYy5zdGFnZSksCiAgICBldmlkZW5jZTogQ29uZGl0aW9uRXZpZGVuY2UoYy5ldmlkZW5jZSksCiAgICBub3RlOiBjLm5vdGUKICB9CgpkZWZpbmUgZnVuY3Rpb24gQ292ZXJhZ2VDbGFzcyhjbGFzcyBMaXN0PEZISVIuQ292ZXJhZ2UuQ2xhc3M+KToKICBjbGFzcyBjCiAgcmV0dXJuIEZISVIuQ292ZXJhZ2UuQ2xhc3N7CiAgICB2YWx1ZTogYy52YWx1ZSwKICAgIG5hbWU6IGMubmFtZQogIH0KCmRlZmluZSBmdW5jdGlvbiBDb3ZlcmFnZVJlc291cmNlKGNvdmVyYWdlIENvdmVyYWdlLCBwcm9maWxlVVJMcyBMaXN0PEZISVIuY2Fub25pY2FsPik6CiAgY292ZXJhZ2UgYwogIHJldHVybiBDb3ZlcmFnZXsKICAgIGlkOiBGSElSLmlke3ZhbHVlOiAnTENSLScgKyBjLmlkfSwKICAgIG1ldGE6IE1ldGFFbGVtZW50KGMsIHByb2ZpbGVVUkxzKSwKICAgIGV4dGVuc2lvbjogYy5leHRlbnNpb24sCiAgICBzdGF0dXM6IGMuc3RhdHVzLAogICAgdHlwZTogYy50eXBlLAogICAgcG9saWN5SG9sZGVyOiBjLnBvbGljeUhvbGRlciwKICAgIHN1YnNjcmliZXI6IGMuc3Vic2NyaWJlciwKICAgIHN1YnNjcmliZXJJZDogYy5zdWJzY3JpYmVySWQsCiAgICBiZW5lZmljaWFyeTogYy5iZW5lZmljaWFyeSwKICAgIGRlcGVuZGVudDogYy5kZXBlbmRlbnQsCiAgICByZWxhdGlvbnNoaXA6IGMucmVsYXRpb25zaGlwLAogICAgcGVyaW9kOiBjLnBlcmlvZCwKICAgIHBheW9yOiBjLnBheW9yLAogICAgY2xhc3M6IENvdmVyYWdlQ2xhc3MoYy5jbGFzcyksCiAgICBvcmRlcjogYy5vcmRlciwKICAgIG5ldHdvcms6IGMubmV0d29yaywKICAgIHN1YnJvZ2F0aW9uOiBjLnN1YnJvZ2F0aW9uLAogICAgY29udHJhY3Q6IGMuY29udHJhY3QKICB9CgpkZWZpbmUgZnVuY3Rpb24gRGlhZ25vc3RpY1JlcG9ydENvZGluZyhjb2RpbmcgTGlzdDxDb2Rpbmc+KToKICBjb2RpbmcgYwogIHJldHVybiBDb2Rpbmd7CiAgICBzeXN0ZW06IGMuc3lzdGVtLAogICAgdmVyc2lvbjogYy52ZXJzaW9uLAogICAgY29kZTogYy5jb2RlLAogICAgZGlzcGxheTogYy5kaXNwbGF5LAogICAgdXNlclNlbGVjdGVkOiBjLnVzZXJTZWxlY3RlZAogIH0KCmRlZmluZSBmdW5jdGlvbiBEaWFnbm9zdGljUmVwb3J0Q2F0ZWdvcnkoY2F0ZWdvcnkgTGlzdDxDb2RlYWJsZUNvbmNlcHQ+KToKICBjYXRlZ29yeSBjCiAgcmV0dXJuIENvZGVhYmxlQ29uY2VwdHsKICAgIGNvZGluZzogRGlhZ25vc3RpY1JlcG9ydENvZGluZyhjLmNvZGluZykKICB9CgpkZWZpbmUgZnVuY3Rpb24gRGlhZ25vc3RpY1JlcG9ydExhYlJlc291cmNlKGRpYWdub3N0aWNSZXBvcnQgRGlhZ25vc3RpY1JlcG9ydCwgcHJvZmlsZVVSTHMgTGlzdDxGSElSLmNhbm9uaWNhbD4pOgogIGRpYWdub3N0aWNSZXBvcnQgZAogIHJldHVybiBEaWFnbm9zdGljUmVwb3J0ewogICAgaWQ6IEZISVIuaWR7dmFsdWU6ICdMQ1ItJyArIGQuaWR9LAogICAgbWV0YTogTWV0YUVsZW1lbnQoZCwgcHJvZmlsZVVSTHMpLAogICAgZXh0ZW5zaW9uOiBkLmV4dGVuc2lvbiwKICAgIGJhc2VkT246IGQuYmFzZWRPbiwKICAgIHN0YXR1czogZC5zdGF0dXMsCiAgICBjYXRlZ29yeTogRGlhZ25vc3RpY1JlcG9ydENhdGVnb3J5KGQuY2F0ZWdvcnkpLAogICAgY29kZTogZC5jb2RlLAogICAgc3ViamVjdDogZC5zdWJqZWN0LAogICAgZW5jb3VudGVyOiBkLmVuY291bnRlciwKICAgIGVmZmVjdGl2ZTogZC5lZmZlY3RpdmUsCiAgICBpc3N1ZWQ6IGQuaXNzdWVkLAogICAgcGVyZm9ybWVyOiBkLnBlcmZvcm1lciwKICAgIHJlc3VsdHNJbnRlcnByZXRlcjogZC5yZXN1bHRzSW50ZXJwcmV0ZXIsCiAgICBzcGVjaW1lbjogZC5zcGVjaW1lbiwKICAgIHJlc3VsdDogZC5yZXN1bHQsCiAgICBjb25jbHVzaW9uOiBkLmNvbmNsdXNpb24sCiAgICBjb25jbHVzaW9uQ29kZTogZC5jb25jbHVzaW9uQ29kZQogIH0KCmRlZmluZSBmdW5jdGlvbiBFbmNvdW50ZXJJZGVudGlmaWVyKGlkZW50aWZpZXIgTGlzdDxGSElSLklkZW50aWZpZXI+KToKICBpZGVudGlmaWVyIGkKICByZXR1cm4gRkhJUi5JZGVudGlmaWVyewogICAgdXNlOiBpLnVzZSwKICAgIHR5cGU6IGkudHlwZSwKICAgIHN5c3RlbTogaS5zeXN0ZW0sCiAgICB2YWx1ZTogaS52YWx1ZSwKICAgIHBlcmlvZDogaS5wZXJpb2QKICB9CgpkZWZpbmUgZnVuY3Rpb24gRW5jb3VudGVyU3RhdHVzSGlzdG9yeShzdGF0dXNIaXN0b3J5IExpc3Q8RkhJUi5FbmNvdW50ZXIuU3RhdHVzSGlzdG9yeT4pOgogIHN0YXR1c0hpc3Rvcnkgc0gKICByZXR1cm4gRkhJUi5FbmNvdW50ZXIuU3RhdHVzSGlzdG9yeXsKICAgIHN0YXR1czogc0guc3RhdHVzLAogICAgcGVyaW9kOiBzSC5wZXJpb2QKICB9CgpkZWZpbmUgZnVuY3Rpb24gRW5jb3VudGVyQ2xhc3NIaXN0b3J5KGNsYXNzSGlzdG9yeSBMaXN0PEZISVIuRW5jb3VudGVyLkNsYXNzSGlzdG9yeT4pOgogIGNsYXNzSGlzdG9yeSBjSAogIHJldHVybiBGSElSLkVuY291bnRlci5DbGFzc0hpc3Rvcnl7CiAgICBjbGFzczogY0guY2xhc3MsCiAgICBwZXJpb2Q6IGNILnBlcmlvZAogIH0KCi8qTm8gbG9uZ2VyIG5lZWRlZCBidXQgc2F2aW5nIGZvciBwb3RlbnRpYWwgZnV0dXJlIHVzZQpkZWZpbmUgZnVuY3Rpb24gRW5jb3VudGVyUGFydGljaXBhbnQocGFydGljaXBhbnQgTGlzdDxGSElSLkVuY291bnRlci5QYXJ0aWNpcGFudD4pOgogIHBhcnRpY2lwYW50IHAKICByZXR1cm4gRkhJUi5FbmNvdW50ZXIuUGFydGljaXBhbnR7CiAgICB0eXBlOiBwLnR5cGUsCiAgICBwZXJpb2Q6IHAucGVyaW9kLAogICAgaW5kaXZpZHVhbDogcC5pbmRpdmlkdWFsCiAgfSovCgpkZWZpbmUgZnVuY3Rpb24gRW5jb3VudGVyRGlhZ25vc2lzKGRpYWdub3NpcyBMaXN0PEZISVIuRW5jb3VudGVyLkRpYWdub3Npcz4pOgogIGRpYWdub3NpcyBkCiAgcmV0dXJuIEZISVIuRW5jb3VudGVyLkRpYWdub3Npc3sKICAgIGNvbmRpdGlvbjogZC5jb25kaXRpb24sCiAgICB1c2U6IGQudXNlLAogICAgcmFuazogZC5yYW5rCiAgfQoKZGVmaW5lIGZ1bmN0aW9uIEVuY291bnRlckhvc3BpdGFsaXphdGlvbihob3NwaXRhbGl6YXRpb24gRkhJUi5FbmNvdW50ZXIuSG9zcGl0YWxpemF0aW9uKToKICBob3NwaXRhbGl6YXRpb24gaAogIHJldHVybiBGSElSLkVuY291bnRlci5Ib3NwaXRhbGl6YXRpb257CiAgICBwcmVBZG1pc3Npb25JZGVudGlmaWVyOiBoLnByZUFkbWlzc2lvbklkZW50aWZpZXIsCiAgICBvcmlnaW46IGgub3JpZ2luLAogICAgYWRtaXRTb3VyY2U6IGguYWRtaXRTb3VyY2UsCiAgICByZUFkbWlzc2lvbjogaC5yZUFkbWlzc2lvbiwKICAgIGRpZXRQcmVmZXJlbmNlOiBoLmRpZXRQcmVmZXJlbmNlLAogICAgc3BlY2lhbENvdXJ0ZXN5OiBoLnNwZWNpYWxDb3VydGVzeSwKICAgIHNwZWNpYWxBcnJhbmdlbWVudDogaC5zcGVjaWFsQXJyYW5nZW1lbnQsCiAgICBkZXN0aW5hdGlvbjogaC5kZXN0aW5hdGlvbiwKICAgIGRpc2NoYXJnZURpc3Bvc2l0aW9uOiBoLmRpc2NoYXJnZURpc3Bvc2l0aW9uCiAgfQoKZGVmaW5lIGZ1bmN0aW9uIEVuY291bnRlckxvY2F0aW9uKGxvY2F0aW9uIExpc3Q8RkhJUi5FbmNvdW50ZXIuTG9jYXRpb24+KToKICBsb2NhdGlvbiBsCiAgcmV0dXJuIEZISVIuRW5jb3VudGVyLkxvY2F0aW9uewogICAgbG9jYXRpb246IGwubG9jYXRpb24sCiAgICBzdGF0dXM6IGwuc3RhdHVzLAogICAgcGh5c2ljYWxUeXBlOiBsLnBoeXNpY2FsVHlwZSwKICAgIHBlcmlvZDogbC5wZXJpb2QKICB9CgpkZWZpbmUgZnVuY3Rpb24gRW5jb3VudGVyUmVzb3VyY2UoZW5jb3VudGVyIEVuY291bnRlciwgcHJvZmlsZVVSTHMgTGlzdDxGSElSLmNhbm9uaWNhbD4pOgogIGVuY291bnRlciBlCiAgcmV0dXJuIEVuY291bnRlcnsKICAgIGlkOiBGSElSLmlke3ZhbHVlOiAnTENSLScgKyBlLmlkfSwKICAgIG1ldGE6IE1ldGFFbGVtZW50KGUsIHByb2ZpbGVVUkxzKSwKICAgIGV4dGVuc2lvbjogZS5leHRlbnNpb24sCiAgICBpZGVudGlmaWVyOiBFbmNvdW50ZXJJZGVudGlmaWVyKGUuaWRlbnRpZmllciksCiAgICBzdGF0dXM6IGUuc3RhdHVzLAogICAgc3RhdHVzSGlzdG9yeTogRW5jb3VudGVyU3RhdHVzSGlzdG9yeShlLnN0YXR1c0hpc3RvcnkpLAogICAgY2xhc3M6IGUuY2xhc3MsCiAgICBjbGFzc0hpc3Rvcnk6IEVuY291bnRlckNsYXNzSGlzdG9yeShlLmNsYXNzSGlzdG9yeSksCiAgICB0eXBlOiBlLnR5cGUsCiAgICBzZXJ2aWNlVHlwZTogZS5zZXJ2aWNlVHlwZSwKICAgIHByaW9yaXR5OiBlLnByaW9yaXR5LAogICAgc3ViamVjdDogZS5zdWJqZWN0LAogICAgcGVyaW9kOiBlLnBlcmlvZCwKICAgIGxlbmd0aDogZS5sZW5ndGgsCiAgICByZWFzb25Db2RlOiBlLnJlYXNvbkNvZGUsCiAgICByZWFzb25SZWZlcmVuY2U6IGUucmVhc29uUmVmZXJlbmNlLAogICAgZGlhZ25vc2lzOiBFbmNvdW50ZXJEaWFnbm9zaXMoZS5kaWFnbm9zaXMpLAogICAgYWNjb3VudDogZS5hY2NvdW50LAogICAgaG9zcGl0YWxpemF0aW9uOiBFbmNvdW50ZXJIb3NwaXRhbGl6YXRpb24oZS5ob3NwaXRhbGl6YXRpb24pLAogICAgbG9jYXRpb246IEVuY291bnRlckxvY2F0aW9uKGUubG9jYXRpb24pLAogICAgcGFydE9mOiBlLnBhcnRPZgogIH0KCmRlZmluZSBmdW5jdGlvbiBPYnNlcnZhdGlvbkxhYkNvZGluZyhjb2RpbmcgTGlzdDxDb2Rpbmc+KToKICBjb2RpbmcgYwogIHJldHVybiBDb2Rpbmd7CiAgICBpZDogYy5pZCwKICAgIGV4dGVuc2lvbjogYy5leHRlbnNpb24sCiAgICBzeXN0ZW06IGMuc3lzdGVtLAogICAgdmVyc2lvbjogYy52ZXJzaW9uLAogICAgY29kZTogYy5jb2RlLAogICAgZGlzcGxheTogYy5kaXNwbGF5LAogICAgdXNlclNlbGVjdGVkOiBjLnVzZXJTZWxlY3RlZAogIH0KCmRlZmluZSBmdW5jdGlvbiBPYnNlcnZhdGlvbkxhYkNhdGVnb3J5KGNhdGVnb3J5IExpc3Q8Q29kZWFibGVDb25jZXB0Pik6CiAgY2F0ZWdvcnkgYwogIHJldHVybiBDb2RlYWJsZUNvbmNlcHR7CiAgICBjb2Rpbmc6IE9ic2VydmF0aW9uTGFiQ29kaW5nKGMuY29kaW5nKSwKICAgIHRleHQ6IGMudGV4dAogIH0KCmRlZmluZSBmdW5jdGlvbiBPYnNlcnZhdGlvblJlZmVyZW5jZVJhbmdlKHJlZmVyZW5jZVJhbmdlIExpc3Q8RkhJUi5PYnNlcnZhdGlvbi5SZWZlcmVuY2VSYW5nZT4pOgogIHJlZmVyZW5jZVJhbmdlIHJSCiAgcmV0dXJuIEZISVIuT2JzZXJ2YXRpb24uUmVmZXJlbmNlUmFuZ2V7CiAgICBsb3c6IHJSLmxvdywKICAgIGhpZ2g6IHJSLmhpZ2gsCiAgICB0eXBlOiByUi50eXBlLAogICAgYXBwbGllc1RvOiByUi5hcHBsaWVzVG8sCiAgICBhZ2U6IHJSLmFnZSwKICAgIHRleHQ6IHJSLnRleHQKICB9CgpkZWZpbmUgZnVuY3Rpb24gT2JzZXJ2YXRpb25Db21wb25lbnQoY29tcG9uZW50IExpc3Q8RkhJUi5PYnNlcnZhdGlvbi5Db21wb25lbnQ+KToKICBjb21wb25lbnQgYwogIHJldHVybiBGSElSLk9ic2VydmF0aW9uLkNvbXBvbmVudHsKICAgIGNvZGU6IGMuY29kZSwKICAgIHZhbHVlOiBjLnZhbHVlLAogICAgZGF0YUFic2VudFJlYXNvbjogYy5kYXRhQWJzZW50UmVhc29uLAogICAgaW50ZXJwcmV0YXRpb246IGMuaW50ZXJwcmV0YXRpb24sCiAgICByZWZlcmVuY2VSYW5nZTogYy5yZWZlcmVuY2VSYW5nZQogIH0KCmRlZmluZSBmdW5jdGlvbiBPYnNlcnZhdGlvbkxhYlJlc291cmNlKG9ic2VydmF0aW9uIE9ic2VydmF0aW9uLCBwcm9maWxlVVJMcyBMaXN0PEZISVIuY2Fub25pY2FsPik6CiAgb2JzZXJ2YXRpb24gbwogIHJldHVybiBPYnNlcnZhdGlvbnsKICAgIGlkOiBGSElSLmlkIHt2YWx1ZTogJ0xDUi0nICsgby5pZH0sCiAgICBtZXRhOiBNZXRhRWxlbWVudChvLCBwcm9maWxlVVJMcyksCiAgICBleHRlbnNpb246IG8uZXh0ZW5zaW9uLAogICAgYmFzZWRPbjogby5iYXNlZE9uLAogICAgcGFydE9mOiBvLnBhcnRPZiwKICAgIHN0YXR1czogby5zdGF0dXMsCiAgICBjYXRlZ29yeTogT2JzZXJ2YXRpb25MYWJDYXRlZ29yeShvLmNhdGVnb3J5KSwKICAgIGNvZGU6IG8uY29kZSwKICAgIHN1YmplY3Q6IG8uc3ViamVjdCwKICAgIGZvY3VzOiBvLmZvY3VzLAogICAgZW5jb3VudGVyOiBvLmVuY291bnRlciwKICAgIGVmZmVjdGl2ZTogby5lZmZlY3RpdmUsCiAgICBpc3N1ZWQ6IG8uaXNzdWVkLAogICAgcGVyZm9ybWVyOiBvLnBlcmZvcm1lciwKICAgIHZhbHVlOiBvLnZhbHVlLAogICAgZGF0YUFic2VudFJlYXNvbjogby5kYXRhQWJzZW50UmVhc29uLAogICAgaW50ZXJwcmV0YXRpb246IG8uaW50ZXJwcmV0YXRpb24sCiAgICBub3RlOiBvLm5vdGUsCiAgICBib2R5U2l0ZTogby5ib2R5U2l0ZSwKICAgIG1ldGhvZDogby5tZXRob2QsCiAgICBzcGVjaW1lbjogby5zcGVjaW1lbiwKICAgIGRldmljZTogby5kZXZpY2UsCiAgICByZWZlcmVuY2VSYW5nZTogT2JzZXJ2YXRpb25SZWZlcmVuY2VSYW5nZShvLnJlZmVyZW5jZVJhbmdlKSwKICAgIGhhc01lbWJlcjogby5oYXNNZW1iZXIsCiAgICBkZXJpdmVkRnJvbTogby5kZXJpdmVkRnJvbSwKICAgIGNvbXBvbmVudDogT2JzZXJ2YXRpb25Db21wb25lbnQoby5jb21wb25lbnQpCiAgfQoKZGVmaW5lIGZ1bmN0aW9uIExvY2F0aW9uQWRkcmVzcyhhZGRyZXNzIEZISVIuQWRkcmVzcyk6CiAgYWRkcmVzcyBhCiAgcmV0dXJuIEZISVIuQWRkcmVzc3sKICAgIHVzZTogYS51c2UsCiAgICB0eXBlOiBhLnR5cGUsCiAgICB0ZXh0OiBhLnRleHQsCiAgICBsaW5lOiBhLmxpbmUsCiAgICBjaXR5OiBhLmNpdHksCiAgICBkaXN0cmljdDogYS5kaXN0cmljdCwKICAgIHN0YXRlOiBhLnN0YXRlLAogICAgcG9zdGFsQ29kZTogYS5wb3N0YWxDb2RlLAogICAgY291bnRyeTogYS5jb3VudHJ5LAogICAgcGVyaW9kOiBhLnBlcmlvZAogIH0KCmRlZmluZSBmdW5jdGlvbiBMb2NhdGlvblBvc2l0aW9uKHBvc2l0aW9uIEZISVIuTG9jYXRpb24uUG9zaXRpb24pOgogIHBvc2l0aW9uIHAKICByZXR1cm4gRkhJUi5Mb2NhdGlvbi5Qb3NpdGlvbnsKICAgIGxvbmdpdHVkZTogcC5sb25naXR1ZGUsCiAgICBsYXRpdHVkZTogcC5sYXRpdHVkZSwKICAgIGFsdGl0dWRlOiBwLmFsdGl0dWRlCiAgfQoKZGVmaW5lIGZ1bmN0aW9uIExvY2F0aW9uSG91cnNPZk9wZXJhdGlvbihob3Vyc09mT3BlcmF0aW9uIExpc3Q8RkhJUi5Mb2NhdGlvbi5Ib3Vyc09mT3BlcmF0aW9uPik6CiAgaG91cnNPZk9wZXJhdGlvbiBoT08KICByZXR1cm4gRkhJUi5Mb2NhdGlvbi5Ib3Vyc09mT3BlcmF0aW9uewogICAgZGF5c09mV2VlazogaE9PLmRheXNPZldlZWssCiAgICBhbGxEYXk6IGhPTy5hbGxEYXksCiAgICBvcGVuaW5nVGltZTogaE9PLm9wZW5pbmdUaW1lLAogICAgY2xvc2luZ1RpbWU6IGhPTy5jbG9zaW5nVGltZQogIH0KCmRlZmluZSBmdW5jdGlvbiBMb2NhdGlvblJlc291cmNlKGxvY2F0aW9uIExvY2F0aW9uLCBwcm9maWxlVVJMcyBMaXN0PEZISVIuY2Fub25pY2FsPik6CiAgbG9jYXRpb24gbAogIHJldHVybiBMb2NhdGlvbnsKICAgIGlkOiBGSElSLmlkIHt2YWx1ZTogJ0xDUi0nICsgbC5pZH0sCiAgICBtZXRhOiBNZXRhRWxlbWVudChsLCBwcm9maWxlVVJMcyksCiAgICBleHRlbnNpb246IGwuZXh0ZW5zaW9uLAogICAgc3RhdHVzOiBsLnN0YXR1cywKICAgIG9wZXJhdGlvbmFsU3RhdHVzOiBsLm9wZXJhdGlvbmFsU3RhdHVzLAogICAgbmFtZTogbC5uYW1lLAogICAgYWxpYXM6IGwuYWxpYXMsCiAgICBkZXNjcmlwdGlvbjogbC5kZXNjcmlwdGlvbiwKICAgIG1vZGU6IGwubW9kZSwKICAgIHR5cGU6IGwudHlwZSwKICAgIHRlbGVjb206IGwudGVsZWNvbSwKICAgIGFkZHJlc3M6IExvY2F0aW9uQWRkcmVzcyhsLmFkZHJlc3MpLAogICAgcGh5c2ljYWxUeXBlOiBsLnBoeXNpY2FsVHlwZSwKICAgIHBvc2l0aW9uOiBMb2NhdGlvblBvc2l0aW9uKGwucG9zaXRpb24pLAogICAgbWFuYWdpbmdPcmdhbml6YXRpb246IGwubWFuYWdpbmdPcmdhbml6YXRpb24sCiAgICBwYXJ0T2Y6IGwucGFydE9mLAogICAgaG91cnNPZk9wZXJhdGlvbjogTG9jYXRpb25Ib3Vyc09mT3BlcmF0aW9uKGwuaG91cnNPZk9wZXJhdGlvbiksCiAgICBhdmFpbGFiaWxpdHlFeGNlcHRpb25zOiBsLmF2YWlsYWJpbGl0eUV4Y2VwdGlvbnMsCiAgICBlbmRwb2ludDogbC5lbmRwb2ludAogIH0KCmRlZmluZSBmdW5jdGlvbiBNZWRpY2F0aW9uSW5ncmVkaWVudChpbmdyZWRpZW50IExpc3Q8RkhJUi5NZWRpY2F0aW9uLkluZ3JlZGllbnQ+KToKICBpbmdyZWRpZW50IGkKICByZXR1cm4gRkhJUi5NZWRpY2F0aW9uLkluZ3JlZGllbnR7CiAgICBpdGVtOiBpLml0ZW0sCiAgICBzdHJlbmd0aDogaS5zdHJlbmd0aAogIH0KCmRlZmluZSBmdW5jdGlvbiBNZWRpY2F0aW9uQmF0Y2goYmF0Y2ggRkhJUi5NZWRpY2F0aW9uLkJhdGNoKToKICBiYXRjaCBiCiAgcmV0dXJuIEZISVIuTWVkaWNhdGlvbi5CYXRjaHsKICAgIGxvdE51bWJlcjogYi5sb3ROdW1iZXIsCiAgICBleHBpcmF0aW9uRGF0ZTogYi5leHBpcmF0aW9uRGF0ZQogIH0KCmRlZmluZSBmdW5jdGlvbiBNZWRpY2F0aW9uUmVzb3VyY2UobWVkaWNhdGlvbiBNZWRpY2F0aW9uLCBwcm9maWxlVVJMcyBMaXN0PEZISVIuY2Fub25pY2FsPik6CiAgbWVkaWNhdGlvbiBtCiAgcmV0dXJuIE1lZGljYXRpb257CiAgICBpZDogRkhJUi5pZCB7dmFsdWU6ICdMQ1ItJyArIG0uaWR9LAogICAgbWV0YTogTWV0YUVsZW1lbnQobSwgcHJvZmlsZVVSTHMpLAogICAgZXh0ZW5zaW9uOiBtLmV4dGVuc2lvbiwKICAgIGNvZGU6IG0uY29kZSwKICAgIHN0YXR1czogbS5zdGF0dXMsCiAgICBtYW51ZmFjdHVyZXI6IG0ubWFudWZhY3R1cmVyLAogICAgZm9ybTogbS5mb3JtLAogICAgYW1vdW50OiBtLmFtb3VudCwKICAgIGluZ3JlZGllbnQ6IE1lZGljYXRpb25JbmdyZWRpZW50KG0uaW5ncmVkaWVudCksCiAgICBiYXRjaDogTWVkaWNhdGlvbkJhdGNoKG0uYmF0Y2gpCiAgfQoKZGVmaW5lIGZ1bmN0aW9uIE1lZGljYXRpb25BZG1pbmlzdHJhdGlvblBlcmZvcm1lcihwZXJmb3JtZXIgTGlzdDxGSElSLk1lZGljYXRpb25BZG1pbmlzdHJhdGlvbi5QZXJmb3JtZXI+KToKICBwZXJmb3JtZXIgcAogIHJldHVybiBGSElSLk1lZGljYXRpb25BZG1pbmlzdHJhdGlvbi5QZXJmb3JtZXJ7CiAgICBmdW5jdGlvbjogcC5mdW5jdGlvbiwKICAgIGFjdG9yOiBwLmFjdG9yCiAgfQoKZGVmaW5lIGZ1bmN0aW9uIE1lZGljYXRpb25BZG1pbmlzdHJhdGlvbkRvc2FnZShkb3NhZ2UgRkhJUi5NZWRpY2F0aW9uQWRtaW5pc3RyYXRpb24uRG9zYWdlKToKICBkb3NhZ2UgZAogIHJldHVybiBGSElSLk1lZGljYXRpb25BZG1pbmlzdHJhdGlvbi5Eb3NhZ2V7CiAgICB0ZXh0OiBkLnRleHQsCiAgICBzaXRlOiBkLnNpdGUsCiAgICByb3V0ZTogZC5yb3V0ZSwKICAgIG1ldGhvZDogZC5tZXRob2QsCiAgICBkb3NlOiBkLmRvc2UsCiAgICByYXRlOiBkLnJhdGUKICB9CgpkZWZpbmUgZnVuY3Rpb24gTWVkaWNhdGlvbkFkbWluaXN0cmF0aW9uUmVzb3VyY2UobWVkaWNhdGlvbkFkbWluaXN0cmF0aW9uIE1lZGljYXRpb25BZG1pbmlzdHJhdGlvbiwgcHJvZmlsZVVSTHMgTGlzdDxGSElSLmNhbm9uaWNhbD4pOgogIG1lZGljYXRpb25BZG1pbmlzdHJhdGlvbiBtCiAgcmV0dXJuIE1lZGljYXRpb25BZG1pbmlzdHJhdGlvbnsKICAgIGlkOiBGSElSLmlkIHt2YWx1ZTogJ0xDUi0nICsgbS5pZH0sCiAgICBtZXRhOiBNZXRhRWxlbWVudChtLCBwcm9maWxlVVJMcyksCiAgICBleHRlbnNpb246IG0uZXh0ZW5zaW9uLAogICAgaW5zdGFudGlhdGVzOiBtLmluc3RhbnRpYXRlcywKICAgIHBhcnRPZjogbS5wYXJ0T2YsCiAgICBzdGF0dXM6IG0uc3RhdHVzLAogICAgc3RhdHVzUmVhc29uOiBtLnN0YXR1c1JlYXNvbiwKICAgIGNhdGVnb3J5OiBtLmNhdGVnb3J5LAogICAgbWVkaWNhdGlvbjogbS5tZWRpY2F0aW9uLAogICAgc3ViamVjdDogbS5zdWJqZWN0LAogICAgY29udGV4dDogbS5jb250ZXh0LAogICAgc3VwcG9ydGluZ0luZm9ybWF0aW9uOiBtLnN1cHBvcnRpbmdJbmZvcm1hdGlvbiwKICAgIGVmZmVjdGl2ZTogbS5lZmZlY3RpdmUsCiAgICBwZXJmb3JtZXI6IE1lZGljYXRpb25BZG1pbmlzdHJhdGlvblBlcmZvcm1lcihtLnBlcmZvcm1lciksCiAgICByZWFzb25Db2RlOiBtLnJlYXNvbkNvZGUsCiAgICByZWFzb25SZWZlcmVuY2U6IG0ucmVhc29uUmVmZXJlbmNlLAogICAgcmVxdWVzdDogbS5yZXF1ZXN0LAogICAgZGV2aWNlOiBtLmRldmljZSwKICAgIG5vdGU6IG0ubm90ZSwKICAgIGRvc2FnZTogTWVkaWNhdGlvbkFkbWluaXN0cmF0aW9uRG9zYWdlKG0uZG9zYWdlKSwKICAgIGV2ZW50SGlzdG9yeTogbS5ldmVudEhpc3RvcnkKICB9CgpkZWZpbmUgZnVuY3Rpb24gTWVkaWNhdGlvblJlcXVlc3REb3NlQW5kUmF0ZShkb3NlQW5kUmF0ZSBMaXN0PEZISVIuRG9zYWdlLkRvc2VBbmRSYXRlPik6CiAgZG9zZUFuZFJhdGUgZFIKICByZXR1cm4gRkhJUi5Eb3NhZ2UuRG9zZUFuZFJhdGV7CiAgICB0eXBlOiBkUi50eXBlLAogICAgZG9zZTogZFIuZG9zZSwKICAgIHJhdGU6IGRSLnJhdGUKICB9CgpkZWZpbmUgZnVuY3Rpb24gTWVkaWNhdGlvblJlcXVlc3REb3NhZ2VJbnN0cnVjdGlvbihkb3NhZ2VJbnN0cnVjdGlvbiBMaXN0PEZISVIuRG9zYWdlPik6CiAgZG9zYWdlSW5zdHJ1Y3Rpb24gZEkKICByZXR1cm4gRkhJUi5Eb3NhZ2V7CiAgICB0ZXh0OiBkSS50ZXh0LAogICAgcGF0aWVudEluc3RydWN0aW9uOiBkSS5wYXRpZW50SW5zdHJ1Y3Rpb24sCiAgICB0aW1pbmc6IGRJLnRpbWluZywKICAgIGFzTmVlZGVkOiBkSS5hc05lZWRlZCwKICAgIHNpdGU6IGRJLnNpdGUsCiAgICByb3V0ZTogZEkucm91dGUsCiAgICBtZXRob2Q6IGRJLm1ldGhvZCwKICAgIGRvc2VBbmRSYXRlOiBNZWRpY2F0aW9uUmVxdWVzdERvc2VBbmRSYXRlKGRJLmRvc2VBbmRSYXRlKQogIH0KCmRlZmluZSBmdW5jdGlvbiBNZWRpY2F0aW9uUmVxdWVzdFJlc291cmNlKG1lZGljYXRpb25SZXF1ZXN0IE1lZGljYXRpb25SZXF1ZXN0LCBwcm9maWxlVVJMcyBMaXN0PEZISVIuY2Fub25pY2FsPik6CiAgbWVkaWNhdGlvblJlcXVlc3QgbQogIHJldHVybiBNZWRpY2F0aW9uUmVxdWVzdHsKICAgIGlkOiBGSElSLmlkIHt2YWx1ZTogJ0xDUi0nICsgbS5pZH0sCiAgICBtZXRhOiBNZXRhRWxlbWVudChtZWRpY2F0aW9uUmVxdWVzdCwgcHJvZmlsZVVSTHMpLAogICAgZXh0ZW5zaW9uOiBtLmV4dGVuc2lvbiwKICAgIHN0YXR1czogbS5zdGF0dXMsCiAgICBzdGF0dXNSZWFzb246IG0uc3RhdHVzUmVhc29uLAogICAgaW50ZW50OiBtLmludGVudCwKICAgIGNhdGVnb3J5OiBtLmNhdGVnb3J5LAogICAgcHJpb3JpdHk6IG0ucHJpb3JpdHksCiAgICBkb05vdFBlcmZvcm06IG0uZG9Ob3RQZXJmb3JtLAogICAgcmVwb3J0ZWQ6IG0ucmVwb3J0ZWQsCiAgICBtZWRpY2F0aW9uOiBtLm1lZGljYXRpb24sCiAgICBzdWJqZWN0OiBtLnN1YmplY3QsCiAgICBlbmNvdW50ZXI6IG0uZW5jb3VudGVyLAogICAgYXV0aG9yZWRPbjogbS5hdXRob3JlZE9uLAogICAgcmVxdWVzdGVyOiBtLnJlcXVlc3RlciwKICAgIHJlY29yZGVyOiBtLnJlY29yZGVyLAogICAgcmVhc29uQ29kZTogbS5yZWFzb25Db2RlLAogICAgcmVhc29uUmVmZXJlbmNlOiBtLnJlYXNvblJlZmVyZW5jZSwKICAgIGluc3RhbnRpYXRlc0Nhbm9uaWNhbDogbS5pbnN0YW50aWF0ZXNDYW5vbmljYWwsCiAgICBpbnN0YW50aWF0ZXNVcmk6IG0uaW5zdGFudGlhdGVzVXJpLAogICAgY291cnNlT2ZUaGVyYXB5VHlwZTogbS5jb3Vyc2VPZlRoZXJhcHlUeXBlLAogICAgZG9zYWdlSW5zdHJ1Y3Rpb246IE1lZGljYXRpb25SZXF1ZXN0RG9zYWdlSW5zdHJ1Y3Rpb24obS5kb3NhZ2VJbnN0cnVjdGlvbikKICB9CgovKiBObyBsb25nZXIgbmVlZGVkIGJ1dCBzYXZpbmcgaW4gY2FzZSBpdCdzIHVzZWZ1bCBsYXRlcgpkZWZpbmUgZnVuY3Rpb24gUGF0aWVudElkZW50aWZpZXIoaWRlbnRpZmllciBMaXN0PEZISVIuSWRlbnRpZmllcj4pOgogIGlkZW50aWZpZXIgaQogIHJldHVybiBGSElSLklkZW50aWZpZXJ7CiAgICBpZDogaS5pZCwKICAgIGV4dGVuc2lvbjogaS5leHRlbnNpb24sCiAgICB1c2U6IGkudXNlLAogICAgdHlwZTogaS50eXBlLAogICAgc3lzdGVtOiBpLnN5c3RlbSwKICAgIHZhbHVlOiBpLnZhbHVlLAogICAgcGVyaW9kOiBpLnBlcmlvZCwKICAgIGFzc2lnbmVyOiBpLmFzc2lnbmVyCiAgfSovCgpkZWZpbmUgZnVuY3Rpb24gUGF0aWVudE5hbWUobmFtZSBMaXN0PEZISVIuSHVtYW5OYW1lPik6CiAgbmFtZSBuCiAgcmV0dXJuIEZISVIuSHVtYW5OYW1lewogICAgaWQ6IG4uaWQsCiAgICBleHRlbnNpb246IG4uZXh0ZW5zaW9uLAogICAgdXNlOiBuLnVzZSwKICAgIHRleHQ6IG4udGV4dCwKICAgIGZhbWlseTogbi5mYW1pbHksCiAgICBnaXZlbjogbi5naXZlbiwKICAgIHByZWZpeDogbi5wcmVmaXgsCiAgICBzdWZmaXg6IG4uc3VmZml4LAogICAgcGVyaW9kOiBuLnBlcmlvZAogIH0KCmRlZmluZSBmdW5jdGlvbiBQYXRpZW50VGVsZWNvbSh0ZWxlY29tIExpc3Q8RkhJUi5Db250YWN0UG9pbnQ+KToKICB0ZWxlY29tIHQKICByZXR1cm4gRkhJUi5Db250YWN0UG9pbnR7CiAgICBzeXN0ZW06IHQuc3lzdGVtLAogICAgdmFsdWU6IHQudmFsdWUsCiAgICB1c2U6IHQudXNlLAogICAgcmFuazogdC5yYW5rLAogICAgcGVyaW9kOiB0LnBlcmlvZAogIH0KCmRlZmluZSBmdW5jdGlvbiBQYXRpZW50QWRkcmVzcyhhZGRyZXNzIExpc3Q8RkhJUi5BZGRyZXNzPik6CiAgYWRkcmVzcyBhCiAgcmV0dXJuIEZISVIuQWRkcmVzc3sKICAgIGlkOiBhLmlkLAogICAgZXh0ZW5zaW9uOiBhLmV4dGVuc2lvbiwKICAgIHVzZTogYS51c2UsCiAgICB0eXBlOiBhLnR5cGUsCiAgICB0ZXh0OiBhLnRleHQsCiAgICBsaW5lOiBhLmxpbmUsCiAgICBjaXR5OiBhLmNpdHksCiAgICBkaXN0cmljdDogYS5kaXN0cmljdCwKICAgIHN0YXRlOiBhLnN0YXRlLAogICAgcG9zdGFsQ29kZTogYS5wb3N0YWxDb2RlLAogICAgY291bnRyeTogYS5jb3VudHJ5LAogICAgcGVyaW9kOiBhLnBlcmlvZAogIH0KCmRlZmluZSBmdW5jdGlvbiBQYXRpZW50Q29udGFjdChjb250YWN0IExpc3Q8RkhJUi5QYXRpZW50LkNvbnRhY3Q+KToKICBjb250YWN0IGMKICByZXR1cm4gRkhJUi5QYXRpZW50LkNvbnRhY3R7CiAgICBpZDogYy5pZCwKICAgIGV4dGVuc2lvbjogYy5leHRlbnNpb24sCiAgICByZWxhdGlvbnNoaXA6IGMucmVsYXRpb25zaGlwLAogICAgbmFtZTogYy5uYW1lLAogICAgdGVsZWNvbTogYy50ZWxlY29tLAogICAgYWRkcmVzczogYy5hZGRyZXNzLAogICAgZ2VuZGVyOiBjLmdlbmRlciwKICAgIG9yZ2FuaXphdGlvbjogYy5vcmdhbml6YXRpb24sCiAgICBwZXJpb2Q6IGMucGVyaW9kCiAgfQoKZGVmaW5lIGZ1bmN0aW9uIFBhdGllbnRDb21tdW5pY2F0aW9uKGNvbW11bmljYXRpb24gTGlzdDxGSElSLlBhdGllbnQuQ29tbXVuaWNhdGlvbj4pOgogIGNvbW11bmljYXRpb24gYwogIHJldHVybiBGSElSLlBhdGllbnQuQ29tbXVuaWNhdGlvbnsKICAgIGlkOiBjLmlkLAogICAgZXh0ZW5zaW9uOiBjLmV4dGVuc2lvbiwKICAgIGxhbmd1YWdlOiBjLmxhbmd1YWdlLAogICAgcHJlZmVycmVkOiBjLnByZWZlcnJlZAogIH0KCmRlZmluZSBmdW5jdGlvbiBQYXRpZW50TGluayhsaW5rIExpc3Q8RkhJUi5QYXRpZW50Lkxpbms+KToKICBsaW5rIGwKICByZXR1cm4gRkhJUi5QYXRpZW50Lkxpbmt7CiAgICBpZDogbC5pZCwKICAgIGV4dGVuc2lvbjogbC5leHRlbnNpb24sCiAgICBtb2RpZmllckV4dGVuc2lvbjogbC5tb2RpZmllckV4dGVuc2lvbiwKICAgIG90aGVyOiBsLm90aGVyLAogICAgdHlwZTogbC50eXBlCiAgfQoKZGVmaW5lIGZ1bmN0aW9uIFBhdGllbnRSZXNvdXJjZShwYXRpZW50IFBhdGllbnQsIHByb2ZpbGVVUkxzIExpc3Q8RkhJUi5jYW5vbmljYWw+KToKICBwYXRpZW50IHAKICByZXR1cm4gUGF0aWVudHsKICAgIGlkOiBGSElSLmlke3ZhbHVlOiAnTENSLScgKyBwLmlkfSwKICAgIG1ldGE6IE1ldGFFbGVtZW50KHAsIHByb2ZpbGVVUkxzKSwKICAgIGV4dGVuc2lvbjogR2V0UGF0aWVudEV4dGVuc2lvbnMocCkgdW5pb24gR2V0SWRFeHRlbnNpb25zKHApLAogICAgaWRlbnRpZmllcjogcC5pZGVudGlmaWVyLAogICAgYWN0aXZlOiBwLmFjdGl2ZSwKICAgIG5hbWU6IFBhdGllbnROYW1lKHAubmFtZSksCiAgICB0ZWxlY29tOiBQYXRpZW50VGVsZWNvbShwLnRlbGVjb20pLAogICAgZ2VuZGVyOiBwLmdlbmRlciwKICAgIGJpcnRoRGF0ZTogcC5iaXJ0aERhdGUsCiAgICBkZWNlYXNlZDogcC5kZWNlYXNlZCwKICAgIGFkZHJlc3M6IFBhdGllbnRBZGRyZXNzKHAuYWRkcmVzcyksCiAgICBtYXJpdGFsU3RhdHVzOiBwLm1hcml0YWxTdGF0dXMsCiAgICBtdWx0aXBsZUJpcnRoOiBwLm11bHRpcGxlQmlydGgsCiAgICBwaG90bzogcC5waG90bywKICAgIGNvbnRhY3Q6IFBhdGllbnRDb250YWN0KHAuY29udGFjdCksCiAgICBjb21tdW5pY2F0aW9uOiBQYXRpZW50Q29tbXVuaWNhdGlvbihwLmNvbW11bmljYXRpb24pLAogICAgZ2VuZXJhbFByYWN0aXRpb25lcjogcC5nZW5lcmFsUHJhY3RpdGlvbmVyLAogICAgbWFuYWdpbmdPcmdhbml6YXRpb246IHAubWFuYWdpbmdPcmdhbml6YXRpb24sCiAgICBsaW5rOiBQYXRpZW50TGluayhwLmxpbmspCiAgfQoKZGVmaW5lIGZ1bmN0aW9uIFByb2NlZHVyZVBlcmZvcm1lcihwZXJmb3JtZXIgTGlzdDxGSElSLlByb2NlZHVyZS5QZXJmb3JtZXI+KToKICBwZXJmb3JtZXIgcAogIHJldHVybiBGSElSLlByb2NlZHVyZS5QZXJmb3JtZXJ7CiAgICBmdW5jdGlvbjogcC5mdW5jdGlvbiwKICAgIGFjdG9yOiBwLmFjdG9yLAogICAgb25CZWhhbGZPZjogcC5vbkJlaGFsZk9mCiAgfQoKZGVmaW5lIGZ1bmN0aW9uIFByb2NlZHVyZUZvY2FsRGV2aWNlKGRldmljZSBMaXN0PEZISVIuUHJvY2VkdXJlLkZvY2FsRGV2aWNlPik6CiAgZGV2aWNlIGQKICByZXR1cm4gRkhJUi5Qcm9jZWR1cmUuRm9jYWxEZXZpY2V7CiAgICBhY3Rpb246IGQuYWN0aW9uLAogICAgbWFuaXB1bGF0ZWQ6IGQubWFuaXB1bGF0ZWQKICB9CgpkZWZpbmUgZnVuY3Rpb24gUHJvY2VkdXJlUmVzb3VyY2UocHJvY2VkdXJlIFByb2NlZHVyZSwgcHJvZmlsZVVSTHMgTGlzdDxGSElSLmNhbm9uaWNhbD4pOgogIHByb2NlZHVyZSBwCiAgcmV0dXJuIFByb2NlZHVyZXsKICAgIGlkOiBGSElSLmlkIHt2YWx1ZTogJ0xDUi0nICsgcC5pZH0sCiAgICBtZXRhOiBNZXRhRWxlbWVudChwLCBwcm9maWxlVVJMcyksCiAgICBleHRlbnNpb246IHAuZXh0ZW5zaW9uLAogICAgaW5zdGFudGlhdGVzQ2Fub25pY2FsOiBwLmluc3RhbnRpYXRlc0Nhbm9uaWNhbCwKICAgIGluc3RhbnRpYXRlc1VyaTogcC5pbnN0YW50aWF0ZXNVcmksCiAgICBiYXNlZE9uOiBwLmJhc2VkT24sCiAgICBwYXJ0T2Y6IHAucGFydE9mLAogICAgc3RhdHVzOiBwLnN0YXR1cywKICAgIHN0YXR1c1JlYXNvbjogcC5zdGF0dXNSZWFzb24sCiAgICBjYXRlZ29yeTogcC5jYXRlZ29yeSwKICAgIGNvZGU6IHAuY29kZSwKICAgIHN1YmplY3Q6IHAuc3ViamVjdCwKICAgIGVuY291bnRlcjogcC5lbmNvdW50ZXIsCiAgICBwZXJmb3JtZWQ6IHAucGVyZm9ybWVkLAogICAgcmVjb3JkZXI6IHAucmVjb3JkZXIsCiAgICBhc3NlcnRlcjogcC5hc3NlcnRlciwKICAgIHBlcmZvcm1lcjogUHJvY2VkdXJlUGVyZm9ybWVyKHAucGVyZm9ybWVyKSwKICAgIGxvY2F0aW9uOiBwLmxvY2F0aW9uLAogICAgcmVhc29uQ29kZTogcC5yZWFzb25Db2RlLAogICAgcmVhc29uUmVmZXJlbmNlOiBwLnJlYXNvblJlZmVyZW5jZSwKICAgIGJvZHlTaXRlOiBwLmJvZHlTaXRlLAogICAgb3V0Y29tZTogcC5vdXRjb21lLAogICAgcmVwb3J0OiBwLnJlcG9ydCwKICAgIGNvbXBsaWNhdGlvbjogcC5jb21wbGljYXRpb24sCiAgICBjb21wbGljYXRpb25EZXRhaWw6IHAuY29tcGxpY2F0aW9uRGV0YWlsLAogICAgZm9sbG93VXA6IHAuZm9sbG93VXAsCiAgICBub3RlOiBwLm5vdGUsCiAgICBmb2NhbERldmljZTogUHJvY2VkdXJlRm9jYWxEZXZpY2UocC5mb2NhbERldmljZSksCiAgICB1c2VkUmVmZXJlbmNlOiBwLnVzZWRSZWZlcmVuY2UsCiAgICB1c2VkQ29kZTogcC51c2VkQ29kZQogIH0KCmRlZmluZSBmdW5jdGlvbiBTZXJ2aWNlUmVxdWVzdFJlc291cmNlKHNlcnZpY2VSZXF1ZXN0IFNlcnZpY2VSZXF1ZXN0LCBwcm9maWxlVVJMcyBMaXN0PEZISVIuY2Fub25pY2FsPik6CiAgc2VydmljZVJlcXVlc3Qgc1IKICByZXR1cm4gU2VydmljZVJlcXVlc3R7CiAgICBpZDogRkhJUi5pZCB7dmFsdWU6ICdMQ1ItJyArIHNSLmlkfSwKICAgIG1ldGE6IE1ldGFFbGVtZW50KHNSLCBwcm9maWxlVVJMcyksCiAgICBleHRlbnNpb246IHNSLmV4dGVuc2lvbiwKICAgIGluc3RhbnRpYXRlc0Nhbm9uaWNhbDogc1IuaW5zdGFudGlhdGVzQ2Fub25pY2FsLAogICAgaW5zdGFudGlhdGVzVXJpOiBzUi5pbnN0YW50aWF0ZXNVcmksCiAgICBiYXNlZE9uOiBzUi5iYXNlZE9uLAogICAgcmVwbGFjZXM6IHNSLnJlcGxhY2VzLAogICAgcmVxdWlzaXRpb246IHNSLnJlcXVpc2l0aW9uLAogICAgc3RhdHVzOiBzUi5zdGF0dXMsCiAgICBpbnRlbnQ6IHNSLmludGVudCwKICAgIGNhdGVnb3J5OiBzUi5jYXRlZ29yeSwKICAgIHByaW9yaXR5OiBzUi5wcmlvcml0eSwKICAgIGRvTm90UGVyZm9ybTogc1IuZG9Ob3RQZXJmb3JtLAogICAgY29kZTogc1IuY29kZSwKICAgIG9yZGVyRGV0YWlsOiBzUi5vcmRlckRldGFpbCwKICAgIHF1YW50aXR5OiBzUi5xdWFudGl0eSwKICAgIHN1YmplY3Q6IHNSLnN1YmplY3QsCiAgICBlbmNvdW50ZXI6IHNSLmVuY291bnRlciwKICAgIG9jY3VycmVuY2U6IHNSLm9jY3VycmVuY2UsCiAgICBhc05lZWRlZDogc1IuYXNOZWVkZWQsCiAgICBhdXRob3JlZE9uOiBzUi5hdXRob3JlZE9uLAogICAgcmVxdWVzdGVyOiBzUi5yZXF1ZXN0ZXIsCiAgICBwZXJmb3JtZXJUeXBlOiBzUi5wZXJmb3JtZXJUeXBlLAogICAgcGVyZm9ybWVyOiBzUi5wZXJmb3JtZXIsCiAgICBsb2NhdGlvbkNvZGU6IHNSLmxvY2F0aW9uQ29kZSwKICAgIGxvY2F0aW9uUmVmZXJlbmNlOiBzUi5sb2NhdGlvblJlZmVyZW5jZSwKICAgIHJlYXNvbkNvZGU6IHNSLnJlYXNvbkNvZGUsCiAgICByZWFzb25SZWZlcmVuY2U6IHNSLnJlYXNvblJlZmVyZW5jZSwKICAgIGluc3VyYW5jZTogc1IuaW5zdXJhbmNlLAogICAgc3VwcG9ydGluZ0luZm86IHNSLnN1cHBvcnRpbmdJbmZvLAogICAgc3BlY2ltZW46IHNSLnNwZWNpbWVuLAogICAgYm9keVNpdGU6IHNSLmJvZHlTaXRlLAogICAgbm90ZTogc1Iubm90ZSwKICAgIHBhdGllbnRJbnN0cnVjdGlvbjogc1IucGF0aWVudEluc3RydWN0aW9uLAogICAgcmVsZXZhbnRIaXN0b3J5OiBzUi5yZWxldmFudEhpc3RvcnkKICB9CgpkZWZpbmUgZnVuY3Rpb24gU3BlY2ltZW5Db2xsZWN0aW9uKGNvbGxlY3Rpb24gRkhJUi5TcGVjaW1lbi5Db2xsZWN0aW9uKToKICBjb2xsZWN0aW9uIGMKICByZXR1cm4gRkhJUi5TcGVjaW1lbi5Db2xsZWN0aW9uewogICAgY29sbGVjdG9yOiBjLmNvbGxlY3RvciwKICAgIGNvbGxlY3RlZDogYy5jb2xsZWN0ZWQsCiAgICAiZHVyYXRpb24iOiBjLiJkdXJhdGlvbiIsCiAgICBxdWFudGl0eTogYy5xdWFudGl0eSwKICAgIG1ldGhvZDogYy5tZXRob2QsCiAgICBib2R5U2l0ZTogYy5ib2R5U2l0ZSwKICAgIGZhc3RpbmdTdGF0dXM6IGMuZmFzdGluZ1N0YXR1cwogIH0KCmRlZmluZSBmdW5jdGlvbiBTcGVjaW1lblByb2Nlc3NpbmcocHJvY2Vzc2luZyBMaXN0PEZISVIuU3BlY2ltZW4uUHJvY2Vzc2luZz4pOgogIHByb2Nlc3NpbmcgcAogIHJldHVybiBGSElSLlNwZWNpbWVuLlByb2Nlc3Npbmd7CiAgICBkZXNjcmlwdGlvbjogcC5kZXNjcmlwdGlvbiwKICAgIHByb2NlZHVyZTogcC5wcm9jZWR1cmUsCiAgICBhZGRpdGl2ZTogcC5hZGRpdGl2ZSwKICAgIHRpbWU6IHAudGltZQogIH0KCmRlZmluZSBmdW5jdGlvbiBTcGVjaW1lbkNvbnRhaW5lcihjb250YWluZXIgTGlzdDxGSElSLlNwZWNpbWVuLkNvbnRhaW5lcj4pOgogIGNvbnRhaW5lciBjCiAgcmV0dXJuIEZISVIuU3BlY2ltZW4uQ29udGFpbmVyewogICAgZGVzY3JpcHRpb246IGMuZGVzY3JpcHRpb24sCiAgICB0eXBlOiBjLnR5cGUsCiAgICBjYXBhY2l0eTogYy5jYXBhY2l0eSwKICAgIHNwZWNpbWVuUXVhbnRpdHk6IGMuc3BlY2ltZW5RdWFudGl0eSwKICAgIGFkZGl0aXZlOiBjLmFkZGl0aXZlCiAgfQoKZGVmaW5lIGZ1bmN0aW9uIFNwZWNpbWVuUmVzb3VyY2Uoc3BlY2ltZW4gU3BlY2ltZW4sIHByb2ZpbGVVUkxzIExpc3Q8RkhJUi5jYW5vbmljYWw+KToKICBzcGVjaW1lbiBzCiAgcmV0dXJuIFNwZWNpbWVuewogICAgaWQ6IEZISVIuaWQge3ZhbHVlOiAnTENSLScgKyBzLmlkfSwKICAgIG1ldGE6IE1ldGFFbGVtZW50KHMsIHByb2ZpbGVVUkxzKSwKICAgIGV4dGVuc2lvbjogcy5leHRlbnNpb24sCiAgICBpZGVudGlmaWVyOiBzLmlkZW50aWZpZXIsCiAgICBhY2Nlc3Npb25JZGVudGlmaWVyOiBzLmFjY2Vzc2lvbklkZW50aWZpZXIsCiAgICBzdGF0dXM6IHMuc3RhdHVzLAogICAgdHlwZTogcy50eXBlLAogICAgc3ViamVjdDogcy5zdWJqZWN0LAogICAgcmVjZWl2ZWRUaW1lOiBzLnJlY2VpdmVkVGltZSwKICAgIHBhcmVudDogcy5wYXJlbnQsCiAgICByZXF1ZXN0OiBzLnJlcXVlc3QsCiAgICBjb2xsZWN0aW9uOiBTcGVjaW1lbkNvbGxlY3Rpb24ocy5jb2xsZWN0aW9uKSwKICAgIHByb2Nlc3Npbmc6IFNwZWNpbWVuUHJvY2Vzc2luZyhzLnByb2Nlc3NpbmcpLAogICAgY29udGFpbmVyOiBTcGVjaW1lbkNvbnRhaW5lcihzLmNvbnRhaW5lciksCiAgICBjb25kaXRpb246IHMuY29uZGl0aW9uLAogICAgbm90ZTogcy5ub3RlCiAgfQoKZGVmaW5lIGZ1bmN0aW9uICJPcGVyYXRpb25PdXRjb21lUmVzb3VyY2UiKGVycm9ySWQgU3RyaW5nLCByZXNvdXJjZUlkIEZISVIuaWQsIG1lc3NhZ2UgU3RyaW5nKToKICBPcGVyYXRpb25PdXRjb21lewogICAgICBpZDogRkhJUi5pZHt2YWx1ZTogZXJyb3JJZH0sCiAgICAgIGlzc3VlOiB7CiAgICAgICAgICBGSElSLk9wZXJhdGlvbk91dGNvbWUuSXNzdWV7CiAgICAgICAgICBzZXZlcml0eTogRkhJUi5Jc3N1ZVNldmVyaXR5e3ZhbHVlOiAnZXJyb3InfSwKICAgICAgICAgIGNvZGU6IEZISVIuSXNzdWVUeXBle3ZhbHVlOiAnZXhjZXB0aW9uJ30sCiAgICAgICAgICBkZXRhaWxzOiAKICAgICAgICAgICAgICBGSElSLkNvZGVhYmxlQ29uY2VwdHsKICAgICAgICAgICAgICAgICAgY29kaW5nOiB7CiAgICAgICAgICAgICAgICAgICAgICBDb2Rpbmd7CiAgICAgICAgICAgICAgICAgICAgICBzeXN0ZW06IHVyaXt2YWx1ZTogJ2h0dHBzOi8vbGFudGFuYWdyb3VwLmNvbS92YWxpZGF0aW9uLWVycm9yJ30sCiAgICAgICAgICAgICAgICAgICAgICBjb2RlOiBjb2Rle3ZhbHVlOiAnRXJyb3InfSwKICAgICAgICAgICAgICAgICAgICAgIGRpc3BsYXk6IHN0cmluZ3t2YWx1ZTogJ1Jlc291cmNlICcgKyByZXNvdXJjZUlkICsgJyBmYWlsZWQgdmFsaWRhdGlvbjogJyArIG1lc3NhZ2V9CiAgICAgICAgICAgICAgICAgICAgICB9CiAgICAgICAgICAgICAgICAgIH0KICAgICAgICAgICAgICB9CiAgICAgICAgICB9CiAgICAgIH0KICB9"
+            "data": "bGlicmFyeSBTaGFyZWRSZXNvdXJjZUNyZWF0aW9uIHZlcnNpb24gJzAuMS4wMTAnCgppbmNsdWRlIEZISVJIZWxwZXJzIHZlcnNpb24gJzQuMC4yJwoKdXNpbmcgRkhJUiB2ZXJzaW9uICc0LjAuMScKCmRlZmluZSBmdW5jdGlvbiAiR2V0UGF0aWVudEV4dGVuc2lvbnMiKGRvbWFpblJlc291cmNlIERvbWFpblJlc291cmNlKToKICBkb21haW5SZXNvdXJjZS5leHRlbnNpb24gRQogIHdoZXJlIEUudXJsID0gJ2h0dHA6Ly9obDcub3JnL2ZoaXIvdXMvY29yZS9TdHJ1Y3R1cmVEZWZpbml0aW9uL3VzLWNvcmUtcmFjZScKICAgIG9yIEUudXJsID0gJ2h0dHA6Ly9obDcub3JnL2ZoaXIvdXMvY29yZS9TdHJ1Y3R1cmVEZWZpbml0aW9uL3VzLWNvcmUtZXRobmljaXR5JwogICAgb3IgRS51cmwgPSAnaHR0cDovL2hsNy5vcmcvZmhpci91cy9jb3JlL1N0cnVjdHVyZURlZmluaXRpb24vdXMtY29yZS10cmliYWwtYWZmaWxpYXRpb24nCiAgICBvciBFLnVybCA9ICdodHRwOi8vaGw3Lm9yZy9maGlyL3VzL2NvcmUvU3RydWN0dXJlRGVmaW5pdGlvbi91cy1jb3JlLWJpcnRoc2V4JwogICAgb3IgRS51cmwgPSAnaHR0cDovL2hsNy5vcmcvZmhpci91cy9jb3JlL1N0cnVjdHVyZURlZmluaXRpb24vdXMtY29yZS1zZXgnCiAgICBvciBFLnVybCA9ICdodHRwOi8vd3d3LmNkYy5nb3Yvbmhzbi9maGlycG9ydGFsL2RxbS9pZy9TdHJ1Y3R1cmVEZWZpbml0aW9uL2xpbmstb3JpZ2luYWwtcmVzb3VyY2UtaWQtZXh0ZW5zaW9uJwogIHJldHVybiBFCgpkZWZpbmUgZnVuY3Rpb24gIk1ldGFFbGVtZW50IihyZXNvdXJjZSBSZXNvdXJjZSwgcHJvZmlsZVVSTHMgTGlzdDxGSElSLmNhbm9uaWNhbD4pOgogIHJlc291cmNlIHIKICByZXR1cm4gRkhJUi5NZXRhewogICAgZXh0ZW5zaW9uOiByLm1ldGEuZXh0ZW5zaW9uLAogICAgdmVyc2lvbklkOiByLm1ldGEudmVyc2lvbklkLAogICAgbGFzdFVwZGF0ZWQ6IHIubWV0YS5sYXN0VXBkYXRlZCwKICAgIHByb2ZpbGU6IHByb2ZpbGVVUkxzLAogICAgc2VjdXJpdHk6IHIubWV0YS5zZWN1cml0eSwKICAgIHRhZzogci5tZXRhLnRhZwogIH0KCmRlZmluZSBmdW5jdGlvbiBDb25kaXRpb25TdGFnZShzdGFnZSBMaXN0PEZISVIuQ29uZGl0aW9uLlN0YWdlPik6CiAgc3RhZ2UgcwogIHJldHVybiBGSElSLkNvbmRpdGlvbi5TdGFnZXsKICAgIHN1bW1hcnk6IHMuc3VtbWFyeSwKICAgIGFzc2Vzc21lbnQ6IHMuYXNzZXNzbWVudCwKICAgIHR5cGU6IHMudHlwZQogIH0KCmRlZmluZSBmdW5jdGlvbiBDb25kaXRpb25FdmlkZW5jZShldmlkZW5jZSBMaXN0PEZISVIuQ29uZGl0aW9uLkV2aWRlbmNlPik6CiAgZXZpZGVuY2UgZQogIHJldHVybiBGSElSLkNvbmRpdGlvbi5FdmlkZW5jZXsKICAgIGNvZGU6IGUuY29kZSwKICAgIGRldGFpbDogZS5kZXRhaWwKICB9CgpkZWZpbmUgZnVuY3Rpb24gQ29uZGl0aW9uUmVzb3VyY2UoY29uZGl0aW9uIENvbmRpdGlvbiwgcHJvZmlsZVVSTHMgTGlzdDxGSElSLmNhbm9uaWNhbD4pOgogIGNvbmRpdGlvbiBjCiAgcmV0dXJuIENvbmRpdGlvbnsKICAgIGlkOiBGSElSLmlkIHt2YWx1ZTogJ0xDUi0nICsgYy5pZH0sCiAgICBtZXRhOiBNZXRhRWxlbWVudChjLCBwcm9maWxlVVJMcyksCiAgICBleHRlbnNpb246IGMuZXh0ZW5zaW9uLAogICAgY2xpbmljYWxTdGF0dXM6IGMuY2xpbmljYWxTdGF0dXMsCiAgICB2ZXJpZmljYXRpb25TdGF0dXM6IGMudmVyaWZpY2F0aW9uU3RhdHVzLAogICAgY2F0ZWdvcnk6IGMuY2F0ZWdvcnksCiAgICBzZXZlcml0eTogYy5zZXZlcml0eSwKICAgIGNvZGU6IGMuY29kZSwKICAgIGJvZHlTaXRlOiBjLmJvZHlTaXRlLAogICAgc3ViamVjdDogYy5zdWJqZWN0LAogICAgZW5jb3VudGVyOiBjLmVuY291bnRlciwKICAgIG9uc2V0OiBjLm9uc2V0LAogICAgYWJhdGVtZW50OiBjLmFiYXRlbWVudCwKICAgIHJlY29yZGVkRGF0ZTogYy5yZWNvcmRlZERhdGUsCiAgICBzdGFnZTogQ29uZGl0aW9uU3RhZ2UoYy5zdGFnZSksCiAgICBldmlkZW5jZTogQ29uZGl0aW9uRXZpZGVuY2UoYy5ldmlkZW5jZSksCiAgICBub3RlOiBjLm5vdGUKICB9CgpkZWZpbmUgZnVuY3Rpb24gQ292ZXJhZ2VDbGFzcyhjbGFzcyBMaXN0PEZISVIuQ292ZXJhZ2UuQ2xhc3M+KToKICBjbGFzcyBjCiAgcmV0dXJuIEZISVIuQ292ZXJhZ2UuQ2xhc3N7CiAgICB2YWx1ZTogYy52YWx1ZSwKICAgIG5hbWU6IGMubmFtZQogIH0KCmRlZmluZSBmdW5jdGlvbiBDb3ZlcmFnZVJlc291cmNlKGNvdmVyYWdlIENvdmVyYWdlLCBwcm9maWxlVVJMcyBMaXN0PEZISVIuY2Fub25pY2FsPik6CiAgY292ZXJhZ2UgYwogIHJldHVybiBDb3ZlcmFnZXsKICAgIGlkOiBGSElSLmlke3ZhbHVlOiAnTENSLScgKyBjLmlkfSwKICAgIG1ldGE6IE1ldGFFbGVtZW50KGMsIHByb2ZpbGVVUkxzKSwKICAgIGV4dGVuc2lvbjogYy5leHRlbnNpb24sCiAgICBzdGF0dXM6IGMuc3RhdHVzLAogICAgdHlwZTogYy50eXBlLAogICAgcG9saWN5SG9sZGVyOiBjLnBvbGljeUhvbGRlciwKICAgIHN1YnNjcmliZXI6IGMuc3Vic2NyaWJlciwKICAgIHN1YnNjcmliZXJJZDogYy5zdWJzY3JpYmVySWQsCiAgICBiZW5lZmljaWFyeTogYy5iZW5lZmljaWFyeSwKICAgIGRlcGVuZGVudDogYy5kZXBlbmRlbnQsCiAgICByZWxhdGlvbnNoaXA6IGMucmVsYXRpb25zaGlwLAogICAgcGVyaW9kOiBjLnBlcmlvZCwKICAgIHBheW9yOiBjLnBheW9yLAogICAgY2xhc3M6IENvdmVyYWdlQ2xhc3MoYy5jbGFzcyksCiAgICBvcmRlcjogYy5vcmRlciwKICAgIG5ldHdvcms6IGMubmV0d29yaywKICAgIHN1YnJvZ2F0aW9uOiBjLnN1YnJvZ2F0aW9uLAogICAgY29udHJhY3Q6IGMuY29udHJhY3QKICB9CgpkZWZpbmUgZnVuY3Rpb24gRGlhZ25vc3RpY1JlcG9ydENvZGluZyhjb2RpbmcgTGlzdDxDb2Rpbmc+KToKICBjb2RpbmcgYwogIHJldHVybiBDb2Rpbmd7CiAgICBzeXN0ZW06IGMuc3lzdGVtLAogICAgdmVyc2lvbjogYy52ZXJzaW9uLAogICAgY29kZTogYy5jb2RlLAogICAgZGlzcGxheTogYy5kaXNwbGF5LAogICAgdXNlclNlbGVjdGVkOiBjLnVzZXJTZWxlY3RlZAogIH0KCmRlZmluZSBmdW5jdGlvbiBEaWFnbm9zdGljUmVwb3J0Q2F0ZWdvcnkoY2F0ZWdvcnkgTGlzdDxDb2RlYWJsZUNvbmNlcHQ+KToKICBjYXRlZ29yeSBjCiAgcmV0dXJuIENvZGVhYmxlQ29uY2VwdHsKICAgIGNvZGluZzogRGlhZ25vc3RpY1JlcG9ydENvZGluZyhjLmNvZGluZykKICB9CgpkZWZpbmUgZnVuY3Rpb24gRGlhZ25vc3RpY1JlcG9ydExhYlJlc291cmNlKGRpYWdub3N0aWNSZXBvcnQgRGlhZ25vc3RpY1JlcG9ydCwgcHJvZmlsZVVSTHMgTGlzdDxGSElSLmNhbm9uaWNhbD4pOgogIGRpYWdub3N0aWNSZXBvcnQgZAogIHJldHVybiBEaWFnbm9zdGljUmVwb3J0ewogICAgaWQ6IEZISVIuaWR7dmFsdWU6ICdMQ1ItJyArIGQuaWR9LAogICAgbWV0YTogTWV0YUVsZW1lbnQoZCwgcHJvZmlsZVVSTHMpLAogICAgZXh0ZW5zaW9uOiBkLmV4dGVuc2lvbiwKICAgIGJhc2VkT246IGQuYmFzZWRPbiwKICAgIHN0YXR1czogZC5zdGF0dXMsCiAgICBjYXRlZ29yeTogRGlhZ25vc3RpY1JlcG9ydENhdGVnb3J5KGQuY2F0ZWdvcnkpLAogICAgY29kZTogZC5jb2RlLAogICAgc3ViamVjdDogZC5zdWJqZWN0LAogICAgZW5jb3VudGVyOiBkLmVuY291bnRlciwKICAgIGVmZmVjdGl2ZTogZC5lZmZlY3RpdmUsCiAgICBpc3N1ZWQ6IGQuaXNzdWVkLAogICAgcGVyZm9ybWVyOiBkLnBlcmZvcm1lciwKICAgIHJlc3VsdHNJbnRlcnByZXRlcjogZC5yZXN1bHRzSW50ZXJwcmV0ZXIsCiAgICBzcGVjaW1lbjogZC5zcGVjaW1lbiwKICAgIHJlc3VsdDogZC5yZXN1bHQsCiAgICBjb25jbHVzaW9uOiBkLmNvbmNsdXNpb24sCiAgICBjb25jbHVzaW9uQ29kZTogZC5jb25jbHVzaW9uQ29kZQogIH0KCmRlZmluZSBmdW5jdGlvbiBFbmNvdW50ZXJJZGVudGlmaWVyKGlkZW50aWZpZXIgTGlzdDxGSElSLklkZW50aWZpZXI+KToKICBpZGVudGlmaWVyIGkKICByZXR1cm4gRkhJUi5JZGVudGlmaWVyewogICAgdXNlOiBpLnVzZSwKICAgIHR5cGU6IGkudHlwZSwKICAgIHN5c3RlbTogaS5zeXN0ZW0sCiAgICB2YWx1ZTogaS52YWx1ZSwKICAgIHBlcmlvZDogaS5wZXJpb2QKICB9CgpkZWZpbmUgZnVuY3Rpb24gRW5jb3VudGVyU3RhdHVzSGlzdG9yeShzdGF0dXNIaXN0b3J5IExpc3Q8RkhJUi5FbmNvdW50ZXIuU3RhdHVzSGlzdG9yeT4pOgogIHN0YXR1c0hpc3Rvcnkgc0gKICByZXR1cm4gRkhJUi5FbmNvdW50ZXIuU3RhdHVzSGlzdG9yeXsKICAgIHN0YXR1czogc0guc3RhdHVzLAogICAgcGVyaW9kOiBzSC5wZXJpb2QKICB9CgpkZWZpbmUgZnVuY3Rpb24gRW5jb3VudGVyQ2xhc3NIaXN0b3J5KGNsYXNzSGlzdG9yeSBMaXN0PEZISVIuRW5jb3VudGVyLkNsYXNzSGlzdG9yeT4pOgogIGNsYXNzSGlzdG9yeSBjSAogIHJldHVybiBGSElSLkVuY291bnRlci5DbGFzc0hpc3Rvcnl7CiAgICBjbGFzczogY0guY2xhc3MsCiAgICBwZXJpb2Q6IGNILnBlcmlvZAogIH0KCi8qTm8gbG9uZ2VyIG5lZWRlZCBidXQgc2F2aW5nIGZvciBwb3RlbnRpYWwgZnV0dXJlIHVzZQpkZWZpbmUgZnVuY3Rpb24gRW5jb3VudGVyUGFydGljaXBhbnQocGFydGljaXBhbnQgTGlzdDxGSElSLkVuY291bnRlci5QYXJ0aWNpcGFudD4pOgogIHBhcnRpY2lwYW50IHAKICByZXR1cm4gRkhJUi5FbmNvdW50ZXIuUGFydGljaXBhbnR7CiAgICB0eXBlOiBwLnR5cGUsCiAgICBwZXJpb2Q6IHAucGVyaW9kLAogICAgaW5kaXZpZHVhbDogcC5pbmRpdmlkdWFsCiAgfSovCgpkZWZpbmUgZnVuY3Rpb24gRW5jb3VudGVyRGlhZ25vc2lzKGRpYWdub3NpcyBMaXN0PEZISVIuRW5jb3VudGVyLkRpYWdub3Npcz4pOgogIGRpYWdub3NpcyBkCiAgcmV0dXJuIEZISVIuRW5jb3VudGVyLkRpYWdub3Npc3sKICAgIGNvbmRpdGlvbjogZC5jb25kaXRpb24sCiAgICB1c2U6IGQudXNlLAogICAgcmFuazogZC5yYW5rCiAgfQoKZGVmaW5lIGZ1bmN0aW9uIEVuY291bnRlckhvc3BpdGFsaXphdGlvbihob3NwaXRhbGl6YXRpb24gRkhJUi5FbmNvdW50ZXIuSG9zcGl0YWxpemF0aW9uKToKICBob3NwaXRhbGl6YXRpb24gaAogIHJldHVybiBGSElSLkVuY291bnRlci5Ib3NwaXRhbGl6YXRpb257CiAgICBwcmVBZG1pc3Npb25JZGVudGlmaWVyOiBoLnByZUFkbWlzc2lvbklkZW50aWZpZXIsCiAgICBvcmlnaW46IGgub3JpZ2luLAogICAgYWRtaXRTb3VyY2U6IGguYWRtaXRTb3VyY2UsCiAgICByZUFkbWlzc2lvbjogaC5yZUFkbWlzc2lvbiwKICAgIGRpZXRQcmVmZXJlbmNlOiBoLmRpZXRQcmVmZXJlbmNlLAogICAgc3BlY2lhbENvdXJ0ZXN5OiBoLnNwZWNpYWxDb3VydGVzeSwKICAgIHNwZWNpYWxBcnJhbmdlbWVudDogaC5zcGVjaWFsQXJyYW5nZW1lbnQsCiAgICBkZXN0aW5hdGlvbjogaC5kZXN0aW5hdGlvbiwKICAgIGRpc2NoYXJnZURpc3Bvc2l0aW9uOiBoLmRpc2NoYXJnZURpc3Bvc2l0aW9uCiAgfQoKZGVmaW5lIGZ1bmN0aW9uIEVuY291bnRlckxvY2F0aW9uKGxvY2F0aW9uIExpc3Q8RkhJUi5FbmNvdW50ZXIuTG9jYXRpb24+KToKICBsb2NhdGlvbiBsCiAgcmV0dXJuIEZISVIuRW5jb3VudGVyLkxvY2F0aW9uewogICAgbG9jYXRpb246IGwubG9jYXRpb24sCiAgICBzdGF0dXM6IGwuc3RhdHVzLAogICAgcGh5c2ljYWxUeXBlOiBsLnBoeXNpY2FsVHlwZSwKICAgIHBlcmlvZDogbC5wZXJpb2QKICB9CgpkZWZpbmUgZnVuY3Rpb24gRW5jb3VudGVyUmVzb3VyY2UoZW5jb3VudGVyIEVuY291bnRlciwgcHJvZmlsZVVSTHMgTGlzdDxGSElSLmNhbm9uaWNhbD4pOgogIGVuY291bnRlciBlCiAgcmV0dXJuIEVuY291bnRlcnsKICAgIGlkOiBGSElSLmlke3ZhbHVlOiAnTENSLScgKyBlLmlkfSwKICAgIG1ldGE6IE1ldGFFbGVtZW50KGUsIHByb2ZpbGVVUkxzKSwKICAgIGV4dGVuc2lvbjogZS5leHRlbnNpb24sCiAgICBpZGVudGlmaWVyOiBFbmNvdW50ZXJJZGVudGlmaWVyKGUuaWRlbnRpZmllciksCiAgICBzdGF0dXM6IGUuc3RhdHVzLAogICAgc3RhdHVzSGlzdG9yeTogRW5jb3VudGVyU3RhdHVzSGlzdG9yeShlLnN0YXR1c0hpc3RvcnkpLAogICAgY2xhc3M6IGUuY2xhc3MsCiAgICBjbGFzc0hpc3Rvcnk6IEVuY291bnRlckNsYXNzSGlzdG9yeShlLmNsYXNzSGlzdG9yeSksCiAgICB0eXBlOiBlLnR5cGUsCiAgICBzZXJ2aWNlVHlwZTogZS5zZXJ2aWNlVHlwZSwKICAgIHByaW9yaXR5OiBlLnByaW9yaXR5LAogICAgc3ViamVjdDogZS5zdWJqZWN0LAogICAgcGVyaW9kOiBlLnBlcmlvZCwKICAgIGxlbmd0aDogZS5sZW5ndGgsCiAgICByZWFzb25Db2RlOiBlLnJlYXNvbkNvZGUsCiAgICByZWFzb25SZWZlcmVuY2U6IGUucmVhc29uUmVmZXJlbmNlLAogICAgZGlhZ25vc2lzOiBFbmNvdW50ZXJEaWFnbm9zaXMoZS5kaWFnbm9zaXMpLAogICAgYWNjb3VudDogZS5hY2NvdW50LAogICAgaG9zcGl0YWxpemF0aW9uOiBFbmNvdW50ZXJIb3NwaXRhbGl6YXRpb24oZS5ob3NwaXRhbGl6YXRpb24pLAogICAgbG9jYXRpb246IEVuY291bnRlckxvY2F0aW9uKGUubG9jYXRpb24pLAogICAgcGFydE9mOiBlLnBhcnRPZgogIH0KCmRlZmluZSBmdW5jdGlvbiBPYnNlcnZhdGlvbkxhYkNvZGluZyhjb2RpbmcgTGlzdDxDb2Rpbmc+KToKICBjb2RpbmcgYwogIHJldHVybiBDb2Rpbmd7CiAgICBpZDogYy5pZCwKICAgIGV4dGVuc2lvbjogYy5leHRlbnNpb24sCiAgICBzeXN0ZW06IGMuc3lzdGVtLAogICAgdmVyc2lvbjogYy52ZXJzaW9uLAogICAgY29kZTogYy5jb2RlLAogICAgZGlzcGxheTogYy5kaXNwbGF5LAogICAgdXNlclNlbGVjdGVkOiBjLnVzZXJTZWxlY3RlZAogIH0KCmRlZmluZSBmdW5jdGlvbiBPYnNlcnZhdGlvbkxhYkNhdGVnb3J5KGNhdGVnb3J5IExpc3Q8Q29kZWFibGVDb25jZXB0Pik6CiAgY2F0ZWdvcnkgYwogIHJldHVybiBDb2RlYWJsZUNvbmNlcHR7CiAgICBjb2Rpbmc6IE9ic2VydmF0aW9uTGFiQ29kaW5nKGMuY29kaW5nKSwKICAgIHRleHQ6IGMudGV4dAogIH0KCmRlZmluZSBmdW5jdGlvbiBPYnNlcnZhdGlvblJlZmVyZW5jZVJhbmdlKHJlZmVyZW5jZVJhbmdlIExpc3Q8RkhJUi5PYnNlcnZhdGlvbi5SZWZlcmVuY2VSYW5nZT4pOgogIHJlZmVyZW5jZVJhbmdlIHJSCiAgcmV0dXJuIEZISVIuT2JzZXJ2YXRpb24uUmVmZXJlbmNlUmFuZ2V7CiAgICBsb3c6IHJSLmxvdywKICAgIGhpZ2g6IHJSLmhpZ2gsCiAgICB0eXBlOiByUi50eXBlLAogICAgYXBwbGllc1RvOiByUi5hcHBsaWVzVG8sCiAgICBhZ2U6IHJSLmFnZSwKICAgIHRleHQ6IHJSLnRleHQKICB9CgpkZWZpbmUgZnVuY3Rpb24gT2JzZXJ2YXRpb25Db21wb25lbnQoY29tcG9uZW50IExpc3Q8RkhJUi5PYnNlcnZhdGlvbi5Db21wb25lbnQ+KToKICBjb21wb25lbnQgYwogIHJldHVybiBGSElSLk9ic2VydmF0aW9uLkNvbXBvbmVudHsKICAgIGNvZGU6IGMuY29kZSwKICAgIHZhbHVlOiBjLnZhbHVlLAogICAgZGF0YUFic2VudFJlYXNvbjogYy5kYXRhQWJzZW50UmVhc29uLAogICAgaW50ZXJwcmV0YXRpb246IGMuaW50ZXJwcmV0YXRpb24sCiAgICByZWZlcmVuY2VSYW5nZTogYy5yZWZlcmVuY2VSYW5nZQogIH0KCmRlZmluZSBmdW5jdGlvbiBPYnNlcnZhdGlvbkxhYlJlc291cmNlKG9ic2VydmF0aW9uIE9ic2VydmF0aW9uLCBwcm9maWxlVVJMcyBMaXN0PEZISVIuY2Fub25pY2FsPik6CiAgb2JzZXJ2YXRpb24gbwogIHJldHVybiBPYnNlcnZhdGlvbnsKICAgIGlkOiBGSElSLmlkIHt2YWx1ZTogJ0xDUi0nICsgby5pZH0sCiAgICBtZXRhOiBNZXRhRWxlbWVudChvLCBwcm9maWxlVVJMcyksCiAgICBleHRlbnNpb246IG8uZXh0ZW5zaW9uLAogICAgYmFzZWRPbjogby5iYXNlZE9uLAogICAgcGFydE9mOiBvLnBhcnRPZiwKICAgIHN0YXR1czogby5zdGF0dXMsCiAgICBjYXRlZ29yeTogT2JzZXJ2YXRpb25MYWJDYXRlZ29yeShvLmNhdGVnb3J5KSwKICAgIGNvZGU6IG8uY29kZSwKICAgIHN1YmplY3Q6IG8uc3ViamVjdCwKICAgIGZvY3VzOiBvLmZvY3VzLAogICAgZW5jb3VudGVyOiBvLmVuY291bnRlciwKICAgIGVmZmVjdGl2ZTogby5lZmZlY3RpdmUsCiAgICBpc3N1ZWQ6IG8uaXNzdWVkLAogICAgcGVyZm9ybWVyOiBvLnBlcmZvcm1lciwKICAgIHZhbHVlOiBvLnZhbHVlLAogICAgZGF0YUFic2VudFJlYXNvbjogby5kYXRhQWJzZW50UmVhc29uLAogICAgaW50ZXJwcmV0YXRpb246IG8uaW50ZXJwcmV0YXRpb24sCiAgICBub3RlOiBvLm5vdGUsCiAgICBib2R5U2l0ZTogby5ib2R5U2l0ZSwKICAgIG1ldGhvZDogby5tZXRob2QsCiAgICBzcGVjaW1lbjogby5zcGVjaW1lbiwKICAgIGRldmljZTogby5kZXZpY2UsCiAgICByZWZlcmVuY2VSYW5nZTogT2JzZXJ2YXRpb25SZWZlcmVuY2VSYW5nZShvLnJlZmVyZW5jZVJhbmdlKSwKICAgIGhhc01lbWJlcjogby5oYXNNZW1iZXIsCiAgICBkZXJpdmVkRnJvbTogby5kZXJpdmVkRnJvbSwKICAgIGNvbXBvbmVudDogT2JzZXJ2YXRpb25Db21wb25lbnQoby5jb21wb25lbnQpCiAgfQoKZGVmaW5lIGZ1bmN0aW9uIExvY2F0aW9uQWRkcmVzcyhhZGRyZXNzIEZISVIuQWRkcmVzcyk6CiAgYWRkcmVzcyBhCiAgcmV0dXJuIEZISVIuQWRkcmVzc3sKICAgIHVzZTogYS51c2UsCiAgICB0eXBlOiBhLnR5cGUsCiAgICB0ZXh0OiBhLnRleHQsCiAgICBsaW5lOiBhLmxpbmUsCiAgICBjaXR5OiBhLmNpdHksCiAgICBkaXN0cmljdDogYS5kaXN0cmljdCwKICAgIHN0YXRlOiBhLnN0YXRlLAogICAgcG9zdGFsQ29kZTogYS5wb3N0YWxDb2RlLAogICAgY291bnRyeTogYS5jb3VudHJ5LAogICAgcGVyaW9kOiBhLnBlcmlvZAogIH0KCmRlZmluZSBmdW5jdGlvbiBMb2NhdGlvblBvc2l0aW9uKHBvc2l0aW9uIEZISVIuTG9jYXRpb24uUG9zaXRpb24pOgogIHBvc2l0aW9uIHAKICByZXR1cm4gRkhJUi5Mb2NhdGlvbi5Qb3NpdGlvbnsKICAgIGxvbmdpdHVkZTogcC5sb25naXR1ZGUsCiAgICBsYXRpdHVkZTogcC5sYXRpdHVkZSwKICAgIGFsdGl0dWRlOiBwLmFsdGl0dWRlCiAgfQoKZGVmaW5lIGZ1bmN0aW9uIExvY2F0aW9uSG91cnNPZk9wZXJhdGlvbihob3Vyc09mT3BlcmF0aW9uIExpc3Q8RkhJUi5Mb2NhdGlvbi5Ib3Vyc09mT3BlcmF0aW9uPik6CiAgaG91cnNPZk9wZXJhdGlvbiBoT08KICByZXR1cm4gRkhJUi5Mb2NhdGlvbi5Ib3Vyc09mT3BlcmF0aW9uewogICAgZGF5c09mV2VlazogaE9PLmRheXNPZldlZWssCiAgICBhbGxEYXk6IGhPTy5hbGxEYXksCiAgICBvcGVuaW5nVGltZTogaE9PLm9wZW5pbmdUaW1lLAogICAgY2xvc2luZ1RpbWU6IGhPTy5jbG9zaW5nVGltZQogIH0KCmRlZmluZSBmdW5jdGlvbiBMb2NhdGlvblJlc291cmNlKGxvY2F0aW9uIExvY2F0aW9uLCBwcm9maWxlVVJMcyBMaXN0PEZISVIuY2Fub25pY2FsPik6CiAgbG9jYXRpb24gbAogIHJldHVybiBMb2NhdGlvbnsKICAgIGlkOiBGSElSLmlkIHt2YWx1ZTogJ0xDUi0nICsgbC5pZH0sCiAgICBtZXRhOiBNZXRhRWxlbWVudChsLCBwcm9maWxlVVJMcyksCiAgICBleHRlbnNpb246IGwuZXh0ZW5zaW9uLAogICAgc3RhdHVzOiBsLnN0YXR1cywKICAgIG9wZXJhdGlvbmFsU3RhdHVzOiBsLm9wZXJhdGlvbmFsU3RhdHVzLAogICAgbmFtZTogbC5uYW1lLAogICAgYWxpYXM6IGwuYWxpYXMsCiAgICBkZXNjcmlwdGlvbjogbC5kZXNjcmlwdGlvbiwKICAgIG1vZGU6IGwubW9kZSwKICAgIHR5cGU6IGwudHlwZSwKICAgIHRlbGVjb206IGwudGVsZWNvbSwKICAgIGFkZHJlc3M6IExvY2F0aW9uQWRkcmVzcyhsLmFkZHJlc3MpLAogICAgcGh5c2ljYWxUeXBlOiBsLnBoeXNpY2FsVHlwZSwKICAgIHBvc2l0aW9uOiBMb2NhdGlvblBvc2l0aW9uKGwucG9zaXRpb24pLAogICAgbWFuYWdpbmdPcmdhbml6YXRpb246IGwubWFuYWdpbmdPcmdhbml6YXRpb24sCiAgICBwYXJ0T2Y6IGwucGFydE9mLAogICAgaG91cnNPZk9wZXJhdGlvbjogTG9jYXRpb25Ib3Vyc09mT3BlcmF0aW9uKGwuaG91cnNPZk9wZXJhdGlvbiksCiAgICBhdmFpbGFiaWxpdHlFeGNlcHRpb25zOiBsLmF2YWlsYWJpbGl0eUV4Y2VwdGlvbnMsCiAgICBlbmRwb2ludDogbC5lbmRwb2ludAogIH0KCmRlZmluZSBmdW5jdGlvbiBNZWRpY2F0aW9uSW5ncmVkaWVudChpbmdyZWRpZW50IExpc3Q8RkhJUi5NZWRpY2F0aW9uLkluZ3JlZGllbnQ+KToKICBpbmdyZWRpZW50IGkKICByZXR1cm4gRkhJUi5NZWRpY2F0aW9uLkluZ3JlZGllbnR7CiAgICBpdGVtOiBpLml0ZW0sCiAgICBzdHJlbmd0aDogaS5zdHJlbmd0aAogIH0KCmRlZmluZSBmdW5jdGlvbiBNZWRpY2F0aW9uQmF0Y2goYmF0Y2ggRkhJUi5NZWRpY2F0aW9uLkJhdGNoKToKICBiYXRjaCBiCiAgcmV0dXJuIEZISVIuTWVkaWNhdGlvbi5CYXRjaHsKICAgIGxvdE51bWJlcjogYi5sb3ROdW1iZXIsCiAgICBleHBpcmF0aW9uRGF0ZTogYi5leHBpcmF0aW9uRGF0ZQogIH0KCmRlZmluZSBmdW5jdGlvbiBNZWRpY2F0aW9uUmVzb3VyY2UobWVkaWNhdGlvbiBNZWRpY2F0aW9uLCBwcm9maWxlVVJMcyBMaXN0PEZISVIuY2Fub25pY2FsPik6CiAgbWVkaWNhdGlvbiBtCiAgcmV0dXJuIE1lZGljYXRpb257CiAgICBpZDogRkhJUi5pZCB7dmFsdWU6ICdMQ1ItJyArIG0uaWR9LAogICAgbWV0YTogTWV0YUVsZW1lbnQobSwgcHJvZmlsZVVSTHMpLAogICAgZXh0ZW5zaW9uOiBtLmV4dGVuc2lvbiwKICAgIGNvZGU6IG0uY29kZSwKICAgIHN0YXR1czogbS5zdGF0dXMsCiAgICBtYW51ZmFjdHVyZXI6IG0ubWFudWZhY3R1cmVyLAogICAgZm9ybTogbS5mb3JtLAogICAgYW1vdW50OiBtLmFtb3VudCwKICAgIGluZ3JlZGllbnQ6IE1lZGljYXRpb25JbmdyZWRpZW50KG0uaW5ncmVkaWVudCksCiAgICBiYXRjaDogTWVkaWNhdGlvbkJhdGNoKG0uYmF0Y2gpCiAgfQoKZGVmaW5lIGZ1bmN0aW9uIE1lZGljYXRpb25BZG1pbmlzdHJhdGlvblBlcmZvcm1lcihwZXJmb3JtZXIgTGlzdDxGSElSLk1lZGljYXRpb25BZG1pbmlzdHJhdGlvbi5QZXJmb3JtZXI+KToKICBwZXJmb3JtZXIgcAogIHJldHVybiBGSElSLk1lZGljYXRpb25BZG1pbmlzdHJhdGlvbi5QZXJmb3JtZXJ7CiAgICBmdW5jdGlvbjogcC5mdW5jdGlvbiwKICAgIGFjdG9yOiBwLmFjdG9yCiAgfQoKZGVmaW5lIGZ1bmN0aW9uIE1lZGljYXRpb25BZG1pbmlzdHJhdGlvbkRvc2FnZShkb3NhZ2UgRkhJUi5NZWRpY2F0aW9uQWRtaW5pc3RyYXRpb24uRG9zYWdlKToKICBkb3NhZ2UgZAogIHJldHVybiBGSElSLk1lZGljYXRpb25BZG1pbmlzdHJhdGlvbi5Eb3NhZ2V7CiAgICB0ZXh0OiBkLnRleHQsCiAgICBzaXRlOiBkLnNpdGUsCiAgICByb3V0ZTogZC5yb3V0ZSwKICAgIG1ldGhvZDogZC5tZXRob2QsCiAgICBkb3NlOiBkLmRvc2UsCiAgICByYXRlOiBkLnJhdGUKICB9CgpkZWZpbmUgZnVuY3Rpb24gTWVkaWNhdGlvbkFkbWluaXN0cmF0aW9uUmVzb3VyY2UobWVkaWNhdGlvbkFkbWluaXN0cmF0aW9uIE1lZGljYXRpb25BZG1pbmlzdHJhdGlvbiwgcHJvZmlsZVVSTHMgTGlzdDxGSElSLmNhbm9uaWNhbD4pOgogIG1lZGljYXRpb25BZG1pbmlzdHJhdGlvbiBtCiAgcmV0dXJuIE1lZGljYXRpb25BZG1pbmlzdHJhdGlvbnsKICAgIGlkOiBGSElSLmlkIHt2YWx1ZTogJ0xDUi0nICsgbS5pZH0sCiAgICBtZXRhOiBNZXRhRWxlbWVudChtLCBwcm9maWxlVVJMcyksCiAgICBleHRlbnNpb246IG0uZXh0ZW5zaW9uLAogICAgaW5zdGFudGlhdGVzOiBtLmluc3RhbnRpYXRlcywKICAgIHBhcnRPZjogbS5wYXJ0T2YsCiAgICBzdGF0dXM6IG0uc3RhdHVzLAogICAgc3RhdHVzUmVhc29uOiBtLnN0YXR1c1JlYXNvbiwKICAgIGNhdGVnb3J5OiBtLmNhdGVnb3J5LAogICAgbWVkaWNhdGlvbjogbS5tZWRpY2F0aW9uLAogICAgc3ViamVjdDogbS5zdWJqZWN0LAogICAgY29udGV4dDogbS5jb250ZXh0LAogICAgc3VwcG9ydGluZ0luZm9ybWF0aW9uOiBtLnN1cHBvcnRpbmdJbmZvcm1hdGlvbiwKICAgIGVmZmVjdGl2ZTogbS5lZmZlY3RpdmUsCiAgICBwZXJmb3JtZXI6IE1lZGljYXRpb25BZG1pbmlzdHJhdGlvblBlcmZvcm1lcihtLnBlcmZvcm1lciksCiAgICByZWFzb25Db2RlOiBtLnJlYXNvbkNvZGUsCiAgICByZWFzb25SZWZlcmVuY2U6IG0ucmVhc29uUmVmZXJlbmNlLAogICAgcmVxdWVzdDogbS5yZXF1ZXN0LAogICAgZGV2aWNlOiBtLmRldmljZSwKICAgIG5vdGU6IG0ubm90ZSwKICAgIGRvc2FnZTogTWVkaWNhdGlvbkFkbWluaXN0cmF0aW9uRG9zYWdlKG0uZG9zYWdlKSwKICAgIGV2ZW50SGlzdG9yeTogbS5ldmVudEhpc3RvcnkKICB9CgpkZWZpbmUgZnVuY3Rpb24gTWVkaWNhdGlvblJlcXVlc3REb3NlQW5kUmF0ZShkb3NlQW5kUmF0ZSBMaXN0PEZISVIuRG9zYWdlLkRvc2VBbmRSYXRlPik6CiAgZG9zZUFuZFJhdGUgZFIKICByZXR1cm4gRkhJUi5Eb3NhZ2UuRG9zZUFuZFJhdGV7CiAgICB0eXBlOiBkUi50eXBlLAogICAgZG9zZTogZFIuZG9zZSwKICAgIHJhdGU6IGRSLnJhdGUKICB9CgpkZWZpbmUgZnVuY3Rpb24gTWVkaWNhdGlvblJlcXVlc3REb3NhZ2VJbnN0cnVjdGlvbihkb3NhZ2VJbnN0cnVjdGlvbiBMaXN0PEZISVIuRG9zYWdlPik6CiAgZG9zYWdlSW5zdHJ1Y3Rpb24gZEkKICByZXR1cm4gRkhJUi5Eb3NhZ2V7CiAgICB0ZXh0OiBkSS50ZXh0LAogICAgcGF0aWVudEluc3RydWN0aW9uOiBkSS5wYXRpZW50SW5zdHJ1Y3Rpb24sCiAgICB0aW1pbmc6IGRJLnRpbWluZywKICAgIGFzTmVlZGVkOiBkSS5hc05lZWRlZCwKICAgIHNpdGU6IGRJLnNpdGUsCiAgICByb3V0ZTogZEkucm91dGUsCiAgICBtZXRob2Q6IGRJLm1ldGhvZCwKICAgIGRvc2VBbmRSYXRlOiBNZWRpY2F0aW9uUmVxdWVzdERvc2VBbmRSYXRlKGRJLmRvc2VBbmRSYXRlKQogIH0KCmRlZmluZSBmdW5jdGlvbiBNZWRpY2F0aW9uUmVxdWVzdFJlc291cmNlKG1lZGljYXRpb25SZXF1ZXN0IE1lZGljYXRpb25SZXF1ZXN0LCBwcm9maWxlVVJMcyBMaXN0PEZISVIuY2Fub25pY2FsPik6CiAgbWVkaWNhdGlvblJlcXVlc3QgbQogIHJldHVybiBNZWRpY2F0aW9uUmVxdWVzdHsKICAgIGlkOiBGSElSLmlkIHt2YWx1ZTogJ0xDUi0nICsgbS5pZH0sCiAgICBtZXRhOiBNZXRhRWxlbWVudChtZWRpY2F0aW9uUmVxdWVzdCwgcHJvZmlsZVVSTHMpLAogICAgZXh0ZW5zaW9uOiBtLmV4dGVuc2lvbiwKICAgIHN0YXR1czogbS5zdGF0dXMsCiAgICBzdGF0dXNSZWFzb246IG0uc3RhdHVzUmVhc29uLAogICAgaW50ZW50OiBtLmludGVudCwKICAgIGNhdGVnb3J5OiBtLmNhdGVnb3J5LAogICAgcHJpb3JpdHk6IG0ucHJpb3JpdHksCiAgICBkb05vdFBlcmZvcm06IG0uZG9Ob3RQZXJmb3JtLAogICAgcmVwb3J0ZWQ6IG0ucmVwb3J0ZWQsCiAgICBtZWRpY2F0aW9uOiBtLm1lZGljYXRpb24sCiAgICBzdWJqZWN0OiBtLnN1YmplY3QsCiAgICBlbmNvdW50ZXI6IG0uZW5jb3VudGVyLAogICAgYXV0aG9yZWRPbjogbS5hdXRob3JlZE9uLAogICAgcmVxdWVzdGVyOiBtLnJlcXVlc3RlciwKICAgIHJlY29yZGVyOiBtLnJlY29yZGVyLAogICAgcmVhc29uQ29kZTogbS5yZWFzb25Db2RlLAogICAgcmVhc29uUmVmZXJlbmNlOiBtLnJlYXNvblJlZmVyZW5jZSwKICAgIGluc3RhbnRpYXRlc0Nhbm9uaWNhbDogbS5pbnN0YW50aWF0ZXNDYW5vbmljYWwsCiAgICBpbnN0YW50aWF0ZXNVcmk6IG0uaW5zdGFudGlhdGVzVXJpLAogICAgY291cnNlT2ZUaGVyYXB5VHlwZTogbS5jb3Vyc2VPZlRoZXJhcHlUeXBlLAogICAgZG9zYWdlSW5zdHJ1Y3Rpb246IE1lZGljYXRpb25SZXF1ZXN0RG9zYWdlSW5zdHJ1Y3Rpb24obS5kb3NhZ2VJbnN0cnVjdGlvbikKICB9CgovKiBObyBsb25nZXIgbmVlZGVkIGJ1dCBzYXZpbmcgaW4gY2FzZSBpdCdzIHVzZWZ1bCBsYXRlcgpkZWZpbmUgZnVuY3Rpb24gUGF0aWVudElkZW50aWZpZXIoaWRlbnRpZmllciBMaXN0PEZISVIuSWRlbnRpZmllcj4pOgogIGlkZW50aWZpZXIgaQogIHJldHVybiBGSElSLklkZW50aWZpZXJ7CiAgICBpZDogaS5pZCwKICAgIGV4dGVuc2lvbjogaS5leHRlbnNpb24sCiAgICB1c2U6IGkudXNlLAogICAgdHlwZTogaS50eXBlLAogICAgc3lzdGVtOiBpLnN5c3RlbSwKICAgIHZhbHVlOiBpLnZhbHVlLAogICAgcGVyaW9kOiBpLnBlcmlvZCwKICAgIGFzc2lnbmVyOiBpLmFzc2lnbmVyCiAgfSovCgpkZWZpbmUgZnVuY3Rpb24gUGF0aWVudE5hbWUobmFtZSBMaXN0PEZISVIuSHVtYW5OYW1lPik6CiAgbmFtZSBuCiAgcmV0dXJuIEZISVIuSHVtYW5OYW1lewogICAgaWQ6IG4uaWQsCiAgICBleHRlbnNpb246IG4uZXh0ZW5zaW9uLAogICAgdXNlOiBuLnVzZSwKICAgIHRleHQ6IG4udGV4dCwKICAgIGZhbWlseTogbi5mYW1pbHksCiAgICBnaXZlbjogbi5naXZlbiwKICAgIHByZWZpeDogbi5wcmVmaXgsCiAgICBzdWZmaXg6IG4uc3VmZml4LAogICAgcGVyaW9kOiBuLnBlcmlvZAogIH0KCmRlZmluZSBmdW5jdGlvbiBQYXRpZW50VGVsZWNvbSh0ZWxlY29tIExpc3Q8RkhJUi5Db250YWN0UG9pbnQ+KToKICB0ZWxlY29tIHQKICByZXR1cm4gRkhJUi5Db250YWN0UG9pbnR7CiAgICBzeXN0ZW06IHQuc3lzdGVtLAogICAgdmFsdWU6IHQudmFsdWUsCiAgICB1c2U6IHQudXNlLAogICAgcmFuazogdC5yYW5rLAogICAgcGVyaW9kOiB0LnBlcmlvZAogIH0KCmRlZmluZSBmdW5jdGlvbiBQYXRpZW50QWRkcmVzcyhhZGRyZXNzIExpc3Q8RkhJUi5BZGRyZXNzPik6CiAgYWRkcmVzcyBhCiAgcmV0dXJuIEZISVIuQWRkcmVzc3sKICAgIHVzZTogYS51c2UsCiAgICB0eXBlOiBhLnR5cGUsCiAgICB0ZXh0OiBhLnRleHQsCiAgICBsaW5lOiBhLmxpbmUsCiAgICBjaXR5OiBhLmNpdHksCiAgICBkaXN0cmljdDogYS5kaXN0cmljdCwKICAgIHN0YXRlOiBhLnN0YXRlLAogICAgcG9zdGFsQ29kZTogYS5wb3N0YWxDb2RlLAogICAgY291bnRyeTogYS5jb3VudHJ5LAogICAgcGVyaW9kOiBhLnBlcmlvZAogIH0KCmRlZmluZSBmdW5jdGlvbiBQYXRpZW50Q29udGFjdChjb250YWN0IExpc3Q8RkhJUi5QYXRpZW50LkNvbnRhY3Q+KToKICBjb250YWN0IGMKICByZXR1cm4gRkhJUi5QYXRpZW50LkNvbnRhY3R7CiAgICByZWxhdGlvbnNoaXA6IGMucmVsYXRpb25zaGlwLAogICAgbmFtZTogYy5uYW1lLAogICAgdGVsZWNvbTogYy50ZWxlY29tLAogICAgYWRkcmVzczogYy5hZGRyZXNzLAogICAgZ2VuZGVyOiBjLmdlbmRlciwKICAgIG9yZ2FuaXphdGlvbjogYy5vcmdhbml6YXRpb24sCiAgICBwZXJpb2Q6IGMucGVyaW9kCiAgfQoKZGVmaW5lIGZ1bmN0aW9uIFBhdGllbnRDb21tdW5pY2F0aW9uKGNvbW11bmljYXRpb24gTGlzdDxGSElSLlBhdGllbnQuQ29tbXVuaWNhdGlvbj4pOgogIGNvbW11bmljYXRpb24gYwogIHJldHVybiBGSElSLlBhdGllbnQuQ29tbXVuaWNhdGlvbnsKICAgIGxhbmd1YWdlOiBjLmxhbmd1YWdlLAogICAgcHJlZmVycmVkOiBjLnByZWZlcnJlZAogIH0KCmRlZmluZSBmdW5jdGlvbiBQYXRpZW50TGluayhsaW5rIExpc3Q8RkhJUi5QYXRpZW50Lkxpbms+KToKICBsaW5rIGwKICByZXR1cm4gRkhJUi5QYXRpZW50Lkxpbmt7CiAgICBleHRlbnNpb246IGwuZXh0ZW5zaW9uLAogICAgbW9kaWZpZXJFeHRlbnNpb246IGwubW9kaWZpZXJFeHRlbnNpb24sCiAgICBvdGhlcjogbC5vdGhlciwKICAgIHR5cGU6IGwudHlwZQogIH0KCmRlZmluZSBmdW5jdGlvbiBQYXRpZW50UmVzb3VyY2UocGF0aWVudCBQYXRpZW50LCBwcm9maWxlVVJMcyBMaXN0PEZISVIuY2Fub25pY2FsPik6CiAgcGF0aWVudCBwCiAgcmV0dXJuIFBhdGllbnR7CiAgICBpZDogRkhJUi5pZHt2YWx1ZTogJ0xDUi0nICsgcC5pZH0sCiAgICBtZXRhOiBNZXRhRWxlbWVudChwLCBwcm9maWxlVVJMcyksCiAgICBleHRlbnNpb246IEdldFBhdGllbnRFeHRlbnNpb25zKHApLAogICAgaWRlbnRpZmllcjogcC5pZGVudGlmaWVyLAogICAgYWN0aXZlOiBwLmFjdGl2ZSwKICAgIG5hbWU6IFBhdGllbnROYW1lKHAubmFtZSksCiAgICB0ZWxlY29tOiBQYXRpZW50VGVsZWNvbShwLnRlbGVjb20pLAogICAgZ2VuZGVyOiBwLmdlbmRlciwKICAgIGJpcnRoRGF0ZTogcC5iaXJ0aERhdGUsCiAgICBkZWNlYXNlZDogcC5kZWNlYXNlZCwKICAgIGFkZHJlc3M6IFBhdGllbnRBZGRyZXNzKHAuYWRkcmVzcyksCiAgICBtYXJpdGFsU3RhdHVzOiBwLm1hcml0YWxTdGF0dXMsCiAgICBtdWx0aXBsZUJpcnRoOiBwLm11bHRpcGxlQmlydGgsCiAgICBjb250YWN0OiBQYXRpZW50Q29udGFjdChwLmNvbnRhY3QpLAogICAgY29tbXVuaWNhdGlvbjogUGF0aWVudENvbW11bmljYXRpb24ocC5jb21tdW5pY2F0aW9uKSwKICAgIGxpbms6IFBhdGllbnRMaW5rKHAubGluaykKICB9CgpkZWZpbmUgZnVuY3Rpb24gUHJvY2VkdXJlUGVyZm9ybWVyKHBlcmZvcm1lciBMaXN0PEZISVIuUHJvY2VkdXJlLlBlcmZvcm1lcj4pOgogIHBlcmZvcm1lciBwCiAgcmV0dXJuIEZISVIuUHJvY2VkdXJlLlBlcmZvcm1lcnsKICAgIGZ1bmN0aW9uOiBwLmZ1bmN0aW9uLAogICAgYWN0b3I6IHAuYWN0b3IsCiAgICBvbkJlaGFsZk9mOiBwLm9uQmVoYWxmT2YKICB9CgpkZWZpbmUgZnVuY3Rpb24gUHJvY2VkdXJlRm9jYWxEZXZpY2UoZGV2aWNlIExpc3Q8RkhJUi5Qcm9jZWR1cmUuRm9jYWxEZXZpY2U+KToKICBkZXZpY2UgZAogIHJldHVybiBGSElSLlByb2NlZHVyZS5Gb2NhbERldmljZXsKICAgIGFjdGlvbjogZC5hY3Rpb24sCiAgICBtYW5pcHVsYXRlZDogZC5tYW5pcHVsYXRlZAogIH0KCmRlZmluZSBmdW5jdGlvbiBQcm9jZWR1cmVSZXNvdXJjZShwcm9jZWR1cmUgUHJvY2VkdXJlLCBwcm9maWxlVVJMcyBMaXN0PEZISVIuY2Fub25pY2FsPik6CiAgcHJvY2VkdXJlIHAKICByZXR1cm4gUHJvY2VkdXJlewogICAgaWQ6IEZISVIuaWQge3ZhbHVlOiAnTENSLScgKyBwLmlkfSwKICAgIG1ldGE6IE1ldGFFbGVtZW50KHAsIHByb2ZpbGVVUkxzKSwKICAgIGV4dGVuc2lvbjogcC5leHRlbnNpb24sCiAgICBpbnN0YW50aWF0ZXNDYW5vbmljYWw6IHAuaW5zdGFudGlhdGVzQ2Fub25pY2FsLAogICAgaW5zdGFudGlhdGVzVXJpOiBwLmluc3RhbnRpYXRlc1VyaSwKICAgIGJhc2VkT246IHAuYmFzZWRPbiwKICAgIHBhcnRPZjogcC5wYXJ0T2YsCiAgICBzdGF0dXM6IHAuc3RhdHVzLAogICAgc3RhdHVzUmVhc29uOiBwLnN0YXR1c1JlYXNvbiwKICAgIGNhdGVnb3J5OiBwLmNhdGVnb3J5LAogICAgY29kZTogcC5jb2RlLAogICAgc3ViamVjdDogcC5zdWJqZWN0LAogICAgZW5jb3VudGVyOiBwLmVuY291bnRlciwKICAgIHBlcmZvcm1lZDogcC5wZXJmb3JtZWQsCiAgICByZWNvcmRlcjogcC5yZWNvcmRlciwKICAgIGFzc2VydGVyOiBwLmFzc2VydGVyLAogICAgcGVyZm9ybWVyOiBQcm9jZWR1cmVQZXJmb3JtZXIocC5wZXJmb3JtZXIpLAogICAgbG9jYXRpb246IHAubG9jYXRpb24sCiAgICByZWFzb25Db2RlOiBwLnJlYXNvbkNvZGUsCiAgICByZWFzb25SZWZlcmVuY2U6IHAucmVhc29uUmVmZXJlbmNlLAogICAgYm9keVNpdGU6IHAuYm9keVNpdGUsCiAgICBvdXRjb21lOiBwLm91dGNvbWUsCiAgICByZXBvcnQ6IHAucmVwb3J0LAogICAgY29tcGxpY2F0aW9uOiBwLmNvbXBsaWNhdGlvbiwKICAgIGNvbXBsaWNhdGlvbkRldGFpbDogcC5jb21wbGljYXRpb25EZXRhaWwsCiAgICBmb2xsb3dVcDogcC5mb2xsb3dVcCwKICAgIG5vdGU6IHAubm90ZSwKICAgIGZvY2FsRGV2aWNlOiBQcm9jZWR1cmVGb2NhbERldmljZShwLmZvY2FsRGV2aWNlKSwKICAgIHVzZWRSZWZlcmVuY2U6IHAudXNlZFJlZmVyZW5jZSwKICAgIHVzZWRDb2RlOiBwLnVzZWRDb2RlCiAgfQoKZGVmaW5lIGZ1bmN0aW9uIFNlcnZpY2VSZXF1ZXN0UmVzb3VyY2Uoc2VydmljZVJlcXVlc3QgU2VydmljZVJlcXVlc3QsIHByb2ZpbGVVUkxzIExpc3Q8RkhJUi5jYW5vbmljYWw+KToKICBzZXJ2aWNlUmVxdWVzdCBzUgogIHJldHVybiBTZXJ2aWNlUmVxdWVzdHsKICAgIGlkOiBGSElSLmlkIHt2YWx1ZTogJ0xDUi0nICsgc1IuaWR9LAogICAgbWV0YTogTWV0YUVsZW1lbnQoc1IsIHByb2ZpbGVVUkxzKSwKICAgIGV4dGVuc2lvbjogc1IuZXh0ZW5zaW9uLAogICAgaW5zdGFudGlhdGVzQ2Fub25pY2FsOiBzUi5pbnN0YW50aWF0ZXNDYW5vbmljYWwsCiAgICBpbnN0YW50aWF0ZXNVcmk6IHNSLmluc3RhbnRpYXRlc1VyaSwKICAgIGJhc2VkT246IHNSLmJhc2VkT24sCiAgICByZXBsYWNlczogc1IucmVwbGFjZXMsCiAgICByZXF1aXNpdGlvbjogc1IucmVxdWlzaXRpb24sCiAgICBzdGF0dXM6IHNSLnN0YXR1cywKICAgIGludGVudDogc1IuaW50ZW50LAogICAgY2F0ZWdvcnk6IHNSLmNhdGVnb3J5LAogICAgcHJpb3JpdHk6IHNSLnByaW9yaXR5LAogICAgZG9Ob3RQZXJmb3JtOiBzUi5kb05vdFBlcmZvcm0sCiAgICBjb2RlOiBzUi5jb2RlLAogICAgb3JkZXJEZXRhaWw6IHNSLm9yZGVyRGV0YWlsLAogICAgcXVhbnRpdHk6IHNSLnF1YW50aXR5LAogICAgc3ViamVjdDogc1Iuc3ViamVjdCwKICAgIGVuY291bnRlcjogc1IuZW5jb3VudGVyLAogICAgb2NjdXJyZW5jZTogc1Iub2NjdXJyZW5jZSwKICAgIGFzTmVlZGVkOiBzUi5hc05lZWRlZCwKICAgIGF1dGhvcmVkT246IHNSLmF1dGhvcmVkT24sCiAgICByZXF1ZXN0ZXI6IHNSLnJlcXVlc3RlciwKICAgIHBlcmZvcm1lclR5cGU6IHNSLnBlcmZvcm1lclR5cGUsCiAgICBwZXJmb3JtZXI6IHNSLnBlcmZvcm1lciwKICAgIGxvY2F0aW9uQ29kZTogc1IubG9jYXRpb25Db2RlLAogICAgbG9jYXRpb25SZWZlcmVuY2U6IHNSLmxvY2F0aW9uUmVmZXJlbmNlLAogICAgcmVhc29uQ29kZTogc1IucmVhc29uQ29kZSwKICAgIHJlYXNvblJlZmVyZW5jZTogc1IucmVhc29uUmVmZXJlbmNlLAogICAgaW5zdXJhbmNlOiBzUi5pbnN1cmFuY2UsCiAgICBzdXBwb3J0aW5nSW5mbzogc1Iuc3VwcG9ydGluZ0luZm8sCiAgICBzcGVjaW1lbjogc1Iuc3BlY2ltZW4sCiAgICBib2R5U2l0ZTogc1IuYm9keVNpdGUsCiAgICBub3RlOiBzUi5ub3RlLAogICAgcGF0aWVudEluc3RydWN0aW9uOiBzUi5wYXRpZW50SW5zdHJ1Y3Rpb24sCiAgICByZWxldmFudEhpc3Rvcnk6IHNSLnJlbGV2YW50SGlzdG9yeQogIH0KCmRlZmluZSBmdW5jdGlvbiBTcGVjaW1lbkNvbGxlY3Rpb24oY29sbGVjdGlvbiBGSElSLlNwZWNpbWVuLkNvbGxlY3Rpb24pOgogIGNvbGxlY3Rpb24gYwogIHJldHVybiBGSElSLlNwZWNpbWVuLkNvbGxlY3Rpb257CiAgICBjb2xsZWN0b3I6IGMuY29sbGVjdG9yLAogICAgY29sbGVjdGVkOiBjLmNvbGxlY3RlZCwKICAgICJkdXJhdGlvbiI6IGMuImR1cmF0aW9uIiwKICAgIHF1YW50aXR5OiBjLnF1YW50aXR5LAogICAgbWV0aG9kOiBjLm1ldGhvZCwKICAgIGJvZHlTaXRlOiBjLmJvZHlTaXRlLAogICAgZmFzdGluZ1N0YXR1czogYy5mYXN0aW5nU3RhdHVzCiAgfQoKZGVmaW5lIGZ1bmN0aW9uIFNwZWNpbWVuUHJvY2Vzc2luZyhwcm9jZXNzaW5nIExpc3Q8RkhJUi5TcGVjaW1lbi5Qcm9jZXNzaW5nPik6CiAgcHJvY2Vzc2luZyBwCiAgcmV0dXJuIEZISVIuU3BlY2ltZW4uUHJvY2Vzc2luZ3sKICAgIGRlc2NyaXB0aW9uOiBwLmRlc2NyaXB0aW9uLAogICAgcHJvY2VkdXJlOiBwLnByb2NlZHVyZSwKICAgIGFkZGl0aXZlOiBwLmFkZGl0aXZlLAogICAgdGltZTogcC50aW1lCiAgfQoKZGVmaW5lIGZ1bmN0aW9uIFNwZWNpbWVuQ29udGFpbmVyKGNvbnRhaW5lciBMaXN0PEZISVIuU3BlY2ltZW4uQ29udGFpbmVyPik6CiAgY29udGFpbmVyIGMKICByZXR1cm4gRkhJUi5TcGVjaW1lbi5Db250YWluZXJ7CiAgICBkZXNjcmlwdGlvbjogYy5kZXNjcmlwdGlvbiwKICAgIHR5cGU6IGMudHlwZSwKICAgIGNhcGFjaXR5OiBjLmNhcGFjaXR5LAogICAgc3BlY2ltZW5RdWFudGl0eTogYy5zcGVjaW1lblF1YW50aXR5LAogICAgYWRkaXRpdmU6IGMuYWRkaXRpdmUKICB9CgpkZWZpbmUgZnVuY3Rpb24gU3BlY2ltZW5SZXNvdXJjZShzcGVjaW1lbiBTcGVjaW1lbiwgcHJvZmlsZVVSTHMgTGlzdDxGSElSLmNhbm9uaWNhbD4pOgogIHNwZWNpbWVuIHMKICByZXR1cm4gU3BlY2ltZW57CiAgICBpZDogRkhJUi5pZCB7dmFsdWU6ICdMQ1ItJyArIHMuaWR9LAogICAgbWV0YTogTWV0YUVsZW1lbnQocywgcHJvZmlsZVVSTHMpLAogICAgZXh0ZW5zaW9uOiBzLmV4dGVuc2lvbiwKICAgIGlkZW50aWZpZXI6IHMuaWRlbnRpZmllciwKICAgIGFjY2Vzc2lvbklkZW50aWZpZXI6IHMuYWNjZXNzaW9uSWRlbnRpZmllciwKICAgIHN0YXR1czogcy5zdGF0dXMsCiAgICB0eXBlOiBzLnR5cGUsCiAgICBzdWJqZWN0OiBzLnN1YmplY3QsCiAgICByZWNlaXZlZFRpbWU6IHMucmVjZWl2ZWRUaW1lLAogICAgcGFyZW50OiBzLnBhcmVudCwKICAgIHJlcXVlc3Q6IHMucmVxdWVzdCwKICAgIGNvbGxlY3Rpb246IFNwZWNpbWVuQ29sbGVjdGlvbihzLmNvbGxlY3Rpb24pLAogICAgcHJvY2Vzc2luZzogU3BlY2ltZW5Qcm9jZXNzaW5nKHMucHJvY2Vzc2luZyksCiAgICBjb250YWluZXI6IFNwZWNpbWVuQ29udGFpbmVyKHMuY29udGFpbmVyKSwKICAgIGNvbmRpdGlvbjogcy5jb25kaXRpb24sCiAgICBub3RlOiBzLm5vdGUKICB9CgpkZWZpbmUgZnVuY3Rpb24gIk9wZXJhdGlvbk91dGNvbWVSZXNvdXJjZSIoZXJyb3JJZCBTdHJpbmcsIHJlc291cmNlSWQgRkhJUi5pZCwgbWVzc2FnZSBTdHJpbmcpOgogIE9wZXJhdGlvbk91dGNvbWV7CiAgICAgIGlkOiBGSElSLmlke3ZhbHVlOiBlcnJvcklkfSwKICAgICAgaXNzdWU6IHsKICAgICAgICAgIEZISVIuT3BlcmF0aW9uT3V0Y29tZS5Jc3N1ZXsKICAgICAgICAgIHNldmVyaXR5OiBGSElSLklzc3VlU2V2ZXJpdHl7dmFsdWU6ICdlcnJvcid9LAogICAgICAgICAgY29kZTogRkhJUi5Jc3N1ZVR5cGV7dmFsdWU6ICdleGNlcHRpb24nfSwKICAgICAgICAgIGRldGFpbHM6IAogICAgICAgICAgICAgIEZISVIuQ29kZWFibGVDb25jZXB0ewogICAgICAgICAgICAgICAgICBjb2Rpbmc6IHsKICAgICAgICAgICAgICAgICAgICAgIENvZGluZ3sKICAgICAgICAgICAgICAgICAgICAgIHN5c3RlbTogdXJpe3ZhbHVlOiAnaHR0cHM6Ly9sYW50YW5hZ3JvdXAuY29tL3ZhbGlkYXRpb24tZXJyb3InfSwKICAgICAgICAgICAgICAgICAgICAgIGNvZGU6IGNvZGV7dmFsdWU6ICdFcnJvcid9LAogICAgICAgICAgICAgICAgICAgICAgZGlzcGxheTogc3RyaW5ne3ZhbHVlOiAnUmVzb3VyY2UgJyArIHJlc291cmNlSWQgKyAnIGZhaWxlZCB2YWxpZGF0aW9uOiAnICsgbWVzc2FnZX0KICAgICAgICAgICAgICAgICAgICAgIH0KICAgICAgICAgICAgICAgICAgfQogICAgICAgICAgICAgIH0KICAgICAgICAgIH0KICAgICAgfQogIH0=",
+            "url": "http://www.cdc.gov/nhsn/fhirportal/dqm/ig/Library-SharedResourceCreation.cql"
           }
         ]
       },
@@ -8748,13 +8748,17 @@
             "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/computable-measure-cqfm"
           ]
         },
+        "text": {
+          "status": "extensions",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <table class=\"narrative-table\">\n    <tbody>\n<tr>\n\n<th colspan=\"2\" scope=\"row\" class=\"row-header\">Knowledge Artifact Metadata</th>\n\n</tr>\n\n<tr>\n\n<th scope=\"row\" class=\"row-header\">Name (machine-readable)</th>\n\n<td class=\"content-container\">NHSNAcuteCareHospitalDailyInitialPopulation</td>\n</tr>\n\n\n<tr>\n\n<th scope=\"row\" class=\"row-header\">Title (human-readable)</th>\n\n<td class=\"content-container\">NHSN Acute Care Hospital Daily Initial Population</td>\n</tr>\n\n\n\n<tr>\n\n<th scope=\"row\" class=\"row-header\">Status</th>\n\n<td class=\"content-container\">Draft</td>\n</tr>\n\n\n<tr>\n\n<th scope=\"row\" class=\"row-header\">Experimental</th>\n\n<td class=\"content-container\">false</td>\n</tr>\n\n\n<tr>\n\n<th scope=\"row\" class=\"row-header\">Description</th>\n\n<td class=\"content-container\"><div><p>All encounters with an inpatient, observation, or short stay status for patients of any age during the measurement period.</p>\n</div></td>\n</tr>\n\n\n\n\n\n\n\n\n\n\n\n\n<tr>\n\n<th scope=\"row\" class=\"row-header\">Measure Steward</th>\n\n<td class=\"content-container\">CDC National Healthcare Safety Network (NHSN)</td>\n</tr>\n\n\n<tr>\n\n<th scope=\"row\" class=\"row-header\">Steward Contact Details</th>\n\n<td class=\"content-container\">CDC National Healthcare Safety Network (NHSN): <a href=\"http://www.cdc.gov/nhsn\">http://www.cdc.gov/nhsn</a>,<a href=\"mailto:nhsn@cdc.gov\">nhsn@cdc.gov</a></td>\n</tr>\n\n\n<tr>\n\n<th scope=\"row\" class=\"row-header\">Copyright</th>\n\n<td class=\"content-container\"><div><p>Limited proprietary coding is contained in the Measure specifications for user convenience. Users of proprietary code sets should obtain all necessary licenses from the owners of the code sets.</p>\n</div></td>\n</tr>\n\n\n\n<tr>\n  \n  \n<th scope=\"row\" class=\"row-header\">Documentation</th>\n\n  \n  \n  \n  \n  <td class=\"content-container\">\n    \n    <em>Description</em>: https://www.cdc.gov/nhsn/index.html [placeholder for link to protocol on CDC website]\n    \n    <br/>\n    \n    \n    \n    \n    <em>Content URL</em>: <a href=\"https://www.cdc.gov/nhsn/index.html\">https://www.cdc.gov/nhsn/index.html</a>\n    \n    <br/>\n    \n    \n    \n    <em>Document</em>: null @ https://www.cdc.gov/nhsn/index.html\n    \n    \n    \n  </td>\n</tr>\n\n\n\n\n\n\n\n\n\n\n<tr>\n\n<th colspan=\"2\" scope=\"row\" class=\"row-header\">Measure Metadata</th>\n\n</tr>\n\n\n\n\n\n\n<tr>\n\n<th scope=\"row\" class=\"row-header\">Version Number</th>\n\n<td class=\"content-container\">2.0.0-cibuild</td>\n</tr>\n\n\n<tr>\n\n<th scope=\"row\" class=\"row-header\">Measure Scoring</th>\n\n<td class=\"content-container\"><span title=\"Codes:{http://terminology.hl7.org/CodeSystem/measure-scoring cohort}\">Cohort</span></td>\n</tr>\n\n\n\n<tr>\n\n<th scope=\"row\" class=\"row-header\">Measure Type</th>\n\n<td class=\"content-container\"><span title=\"Codes:{http://terminology.hl7.org/CodeSystem/measure-type outcome}\">Outcome</span></td>\n</tr>\n\n\n\n\n<tr>\n\n<th scope=\"row\" class=\"row-header\">Rationale</th>\n\n<td class=\"content-container\"><div><p>The NHSN Acute Care Hospital (ACH) Daily module enables the measurement of facility and unit-specific incidence and prevalence of Coronavirus 2019 (COVID-19), Influenza, and Respiratory Syncytial Virus (RSV) disease among patients admitted to the hospital (inpatient, observation, or short stay status), and specific associated patient outcomes.  The ACH Daily Daily module supports an electronic health record (EHR)-/vendor-neutral standard for reporting patient-level data on hospitalized patients with a respiratory illness due to one or more of the pathogens under surveillance. Data collected via the ACH Daily module may be used by facilities for quality improvement and patient care planning purposes, as well as by local, state, and federal public health agencies in coordination and response to public health outbreaks. The ACH Daily module offers a mechanism for ongoing monitoring of infectious respiratory viral illness among hospitalized patients with minimal human resource expenditure via 100% electronically automated data capture. This initial version of the module is based on electronic data capture and upload of demographic, administrative, and clinical data from the facility’s electronic source systems such as the electronic health record (EHR), patient registration system (admission, discharge, and transfer [ADT] data), laboratory information system, and pharmacy electronic medication administration system. Facilities will have access to their data via the analysis functions of NHSN.</p>\n</div></td>\n</tr>\n\n\n\n\n\n\n\n  \n<tr>\n\n<th scope=\"row\" class=\"row-header\">Population Basis</th>\n\n<td class=\"content-container\">Encounter</td>\n</tr>\n\n\n\n\n\n  \n    <tr>\n\n<th colspan=\"2\" scope=\"row\" class=\"row-header\">Measure Population Criteria</th>\n\n</tr>\n  \n  \n  \n  \n    <tr>\n      \n        \n<th scope=\"row\" class=\"row-header\">Initial Population</th>\n\n      \n      <td class=\"content-container\">\n        \n        <em>ID</em>: initial-population\n        <br/>\n        \n        \n          <em>Description</em>:\n          <p style=\"white-space: pre-line\" class=\"tab-one\">The Acute Care Hospital Daily Initial Population includes all encounters with an inpatient, observation, or short stay status for patients of any age during the measurement period.</p>\n        \n        \n          \n            \n            <em>Logic Definition</em>: <a href=\"#nhsnacutecarehospitaldailyinitialpopulation-initial-population\">Initial Population</a> \n          \n        \n      </td>\n    </tr>\n  \n\n  \n  \n\n\n\n\n\n\n\n\n\n\n\n  <tr>\n\n<th colspan=\"2\" scope=\"row\" class=\"row-header\">Supplemental Data Elements</th>\n\n</tr>\n\n\n<tr>\n  \n<th scope=\"row\" class=\"row-header\">Supplemental Data Element</th>\n\n  <td class=\"content-container\">\n    \n      <em>ID</em>: sde-minimal-patient\n      \n      <br/>\n      \n    \n    \n      \n        \n          <em>Usage Code</em>: <span title=\"Codes:{http://terminology.hl7.org/CodeSystem/measure-data-usage supplemental-data}\">Supplemental Data</span>\n        \n        <br/>\n      \n    \n    \n      <em>Description</em>: SDE Minimal Patient\n    \n    \n      \n        <br/>\n        \n        <em>Logic Definition</em>: <a href=\"#nhsnacutecarehospitaldailyinitialpopulation-sde-minimal-patient\">SDE Minimal Patient</a> \n      \n    \n  </td>\n</tr>\n\n<tr>\n  \n<th scope=\"row\" class=\"row-header\">Supplemental Data Element</th>\n\n  <td class=\"content-container\">\n    \n      <em>ID</em>: sde-location\n      \n      <br/>\n      \n    \n    \n      \n        \n          <em>Usage Code</em>: <span title=\"Codes:{http://terminology.hl7.org/CodeSystem/measure-data-usage supplemental-data}\">Supplemental Data</span>\n        \n        <br/>\n      \n    \n    \n      <em>Description</em>: SDE Location\n    \n    \n      \n        <br/>\n        \n        <em>Logic Definition</em>: <a href=\"#nhsnacutecarehospitaldailyinitialpopulation-sde-location\">SDE Location</a> \n      \n    \n  </td>\n</tr>\n\n<tr>\n  \n<th scope=\"row\" class=\"row-header\">Supplemental Data Element</th>\n\n  <td class=\"content-container\">\n    \n      <em>ID</em>: sde-encounter-discharge-disposition\n      \n      <br/>\n      \n    \n    \n      \n        \n          <em>Usage Code</em>: <span title=\"Codes:{http://terminology.hl7.org/CodeSystem/measure-data-usage supplemental-data}\">Supplemental Data</span>\n        \n        <br/>\n      \n    \n    \n      <em>Description</em>: SDE Encounter Discharge Dispositions\n    \n    \n      \n        <br/>\n        \n        <em>Logic Definition</em>: <a href=\"#nhsnacutecarehospitaldailyinitialpopulation-sde-encounter-discharge-dispositions\">SDE Encounter Discharge Dispositions</a> \n      \n    \n  </td>\n</tr>\n\n<tr>\n  \n<th scope=\"row\" class=\"row-header\">Supplemental Data Element</th>\n\n  <td class=\"content-container\">\n    \n      <em>ID</em>: sde-ach-daily-observation\n      \n      <br/>\n      \n    \n    \n      \n        \n          <em>Usage Code</em>: <span title=\"Codes:{http://terminology.hl7.org/CodeSystem/measure-data-usage supplemental-data}\">Supplemental Data</span>\n        \n        <br/>\n      \n    \n    \n      <em>Description</em>: SDE ACH Daily Observation\n    \n    \n      \n        <br/>\n        \n        <em>Logic Definition</em>: <a href=\"#nhsnacutecarehospitaldailyinitialpopulation-sde-ach-daily-observation\">SDE ACH Daily Observation</a> \n      \n    \n  </td>\n</tr>\n\n<tr>\n  \n<th scope=\"row\" class=\"row-header\">Supplemental Data Element</th>\n\n  <td class=\"content-container\">\n    \n      <em>ID</em>: sde-rsv-pre-admission-observation\n      \n      <br/>\n      \n    \n    \n      \n        \n          <em>Usage Code</em>: <span title=\"Codes:{http://terminology.hl7.org/CodeSystem/measure-data-usage supplemental-data}\">Supplemental Data</span>\n        \n        <br/>\n      \n    \n    \n      <em>Description</em>: SDE RSV PRE Admission Observation\n    \n    \n      \n        <br/>\n        \n        <em>Logic Definition</em>: <a href=\"#nhsnacutecarehospitaldailyinitialpopulation-sde-rsv-pre-admission-observation\">SDE RSV PRE Admission Observation</a> \n      \n    \n  </td>\n</tr>\n\n<tr>\n  \n<th scope=\"row\" class=\"row-header\">Supplemental Data Element</th>\n\n  <td class=\"content-container\">\n    \n      <em>ID</em>: sde-covid-and-influenza-pre-admission-observation\n      \n      <br/>\n      \n    \n    \n      \n        \n          <em>Usage Code</em>: <span title=\"Codes:{http://terminology.hl7.org/CodeSystem/measure-data-usage supplemental-data}\">Supplemental Data</span>\n        \n        <br/>\n      \n    \n    \n      <em>Description</em>: SDE COVID And Influenza PRE Admission Observation\n    \n    \n      \n        <br/>\n        \n        <em>Logic Definition</em>: <a href=\"#nhsnacutecarehospitaldailyinitialpopulation-sde-covid-and-influenza-pre-admission-observation\">SDE COVID And Influenza PRE Admission Observation</a> \n      \n    \n  </td>\n</tr>\n\n<tr>\n  \n<th scope=\"row\" class=\"row-header\">Supplemental Data Element</th>\n\n  <td class=\"content-container\">\n    \n      <em>ID</em>: sde-ach-daily-specimen\n      \n      <br/>\n      \n    \n    \n      \n        \n          <em>Usage Code</em>: <span title=\"Codes:{http://terminology.hl7.org/CodeSystem/measure-data-usage supplemental-data}\">Supplemental Data</span>\n        \n        <br/>\n      \n    \n    \n      <em>Description</em>: SDE ACH Daily Specimen\n    \n    \n      \n        <br/>\n        \n        <em>Logic Definition</em>: <a href=\"#nhsnacutecarehospitaldailyinitialpopulation-sde-ach-daily-specimen\">SDE ACH Daily Specimen</a> \n      \n    \n  </td>\n</tr>\n\n<tr>\n  \n<th scope=\"row\" class=\"row-header\">Supplemental Data Element</th>\n\n  <td class=\"content-container\">\n    \n      <em>ID</em>: sde-rsv-specimen\n      \n      <br/>\n      \n    \n    \n      \n        \n          <em>Usage Code</em>: <span title=\"Codes:{http://terminology.hl7.org/CodeSystem/measure-data-usage supplemental-data}\">Supplemental Data</span>\n        \n        <br/>\n      \n    \n    \n      <em>Description</em>: SDE RSV Specimen\n    \n    \n      \n        <br/>\n        \n        <em>Logic Definition</em>: <a href=\"#nhsnacutecarehospitaldailyinitialpopulation-sde-rsv-specimen\">SDE RSV Specimen</a> \n      \n    \n  </td>\n</tr>\n\n<tr>\n  \n<th scope=\"row\" class=\"row-header\">Supplemental Data Element</th>\n\n  <td class=\"content-container\">\n    \n      <em>ID</em>: sde-covid-and-influenza-specimen\n      \n      <br/>\n      \n    \n    \n      \n        \n          <em>Usage Code</em>: <span title=\"Codes:{http://terminology.hl7.org/CodeSystem/measure-data-usage supplemental-data}\">Supplemental Data</span>\n        \n        <br/>\n      \n    \n    \n      <em>Description</em>: SDE COVID And Influenza Specimen\n    \n    \n      \n        <br/>\n        \n        <em>Logic Definition</em>: <a href=\"#nhsnacutecarehospitaldailyinitialpopulation-sde-covid-and-influenza-specimen\">SDE COVID And Influenza Specimen</a> \n      \n    \n  </td>\n</tr>\n\n<tr>\n  \n<th scope=\"row\" class=\"row-header\">Supplemental Data Element</th>\n\n  <td class=\"content-container\">\n    \n      <em>ID</em>: sde-ach-daily-diagnosticreport\n      \n      <br/>\n      \n    \n    \n      \n        \n          <em>Usage Code</em>: <span title=\"Codes:{http://terminology.hl7.org/CodeSystem/measure-data-usage supplemental-data}\">Supplemental Data</span>\n        \n        <br/>\n      \n    \n    \n      <em>Description</em>: SDE ACH Daily DiagnosticReport\n    \n    \n      \n        <br/>\n        \n        <em>Logic Definition</em>: <a href=\"#nhsnacutecarehospitaldailyinitialpopulation-sde-ach-daily-diagnosticreport\">SDE ACH Daily DiagnosticReport</a> \n      \n    \n  </td>\n</tr>\n\n<tr>\n  \n<th scope=\"row\" class=\"row-header\">Supplemental Data Element</th>\n\n  <td class=\"content-container\">\n    \n      <em>ID</em>: sde-rsv-diagnosticreport\n      \n      <br/>\n      \n    \n    \n      \n        \n          <em>Usage Code</em>: <span title=\"Codes:{http://terminology.hl7.org/CodeSystem/measure-data-usage supplemental-data}\">Supplemental Data</span>\n        \n        <br/>\n      \n    \n    \n      <em>Description</em>: SDE RSV DiagnosticReport\n    \n    \n      \n        <br/>\n        \n        <em>Logic Definition</em>: <a href=\"#nhsnacutecarehospitaldailyinitialpopulation-sde-rsv-diagnosticreport\">SDE RSV DiagnosticReport</a> \n      \n    \n  </td>\n</tr>\n\n<tr>\n  \n<th scope=\"row\" class=\"row-header\">Supplemental Data Element</th>\n\n  <td class=\"content-container\">\n    \n      <em>ID</em>: sde-covid-and-influenza-diagnosticreport\n      \n      <br/>\n      \n    \n    \n      \n        \n          <em>Usage Code</em>: <span title=\"Codes:{http://terminology.hl7.org/CodeSystem/measure-data-usage supplemental-data}\">Supplemental Data</span>\n        \n        <br/>\n      \n    \n    \n      <em>Description</em>: SDE COVID And Influenza DiagnosticReport\n    \n    \n      \n        <br/>\n        \n        <em>Logic Definition</em>: <a href=\"#nhsnacutecarehospitaldailyinitialpopulation-sde-covid-and-influenza-diagnosticreport\">SDE COVID And Influenza DiagnosticReport</a> \n      \n    \n  </td>\n</tr>\n\n<tr>\n  \n<th scope=\"row\" class=\"row-header\">Supplemental Data Element</th>\n\n  <td class=\"content-container\">\n    \n      <em>ID</em>: sde-ach-daily-diagnosticreport-result-from-lab\n      \n      <br/>\n      \n    \n    \n      \n        \n          <em>Usage Code</em>: <span title=\"Codes:{http://terminology.hl7.org/CodeSystem/measure-data-usage supplemental-data}\">Supplemental Data</span>\n        \n        <br/>\n      \n    \n    \n      <em>Description</em>: SDE ACH Daily DiagnosticReport Result from Lab\n    \n    \n      \n        <br/>\n        \n        <em>Logic Definition</em>: <a href=\"#nhsnacutecarehospitaldailyinitialpopulation-sde-ach-daily-diagnosticreport-result-from-lab\">SDE ACH Daily DiagnosticReport Result from Lab</a> \n      \n    \n  </td>\n</tr>\n\n<tr>\n  \n<th scope=\"row\" class=\"row-header\">Supplemental Data Element</th>\n\n  <td class=\"content-container\">\n    \n      <em>ID</em>: sde-covid-and-influenza-diagnosticreport-result-from-lab\n      \n      <br/>\n      \n    \n    \n      \n        \n          <em>Usage Code</em>: <span title=\"Codes:{http://terminology.hl7.org/CodeSystem/measure-data-usage supplemental-data}\">Supplemental Data</span>\n        \n        <br/>\n      \n    \n    \n      <em>Description</em>: SDE COVID and Influenza DiagnosticReport Result from Lab\n    \n    \n      \n        <br/>\n        \n        <em>Logic Definition</em>: <a href=\"#nhsnacutecarehospitaldailyinitialpopulation-sde-covid-and-influenza-diagnosticreport-result-from-lab\">SDE COVID and Influenza DiagnosticReport Result from Lab</a> \n      \n    \n  </td>\n</tr>\n\n<tr>\n  \n<th scope=\"row\" class=\"row-header\">Supplemental Data Element</th>\n\n  <td class=\"content-container\">\n    \n      <em>ID</em>: sde-rsv-diagnosticreport-result-from-lab\n      \n      <br/>\n      \n    \n    \n      \n        \n          <em>Usage Code</em>: <span title=\"Codes:{http://terminology.hl7.org/CodeSystem/measure-data-usage supplemental-data}\">Supplemental Data</span>\n        \n        <br/>\n      \n    \n    \n      <em>Description</em>: SDE RSV DiagnosticReport Result from Lab\n    \n    \n      \n        <br/>\n        \n        <em>Logic Definition</em>: <a href=\"#nhsnacutecarehospitaldailyinitialpopulation-sde-rsv-diagnosticreport-result-from-lab\">SDE RSV DiagnosticReport Result from Lab</a> \n      \n    \n  </td>\n</tr>\n\n<tr>\n  \n<th scope=\"row\" class=\"row-header\">Supplemental Data Element</th>\n\n  <td class=\"content-container\">\n    \n      <em>ID</em>: sde-ach-daily-servicerequest\n      \n      <br/>\n      \n    \n    \n      \n        \n          <em>Usage Code</em>: <span title=\"Codes:{http://terminology.hl7.org/CodeSystem/measure-data-usage supplemental-data}\">Supplemental Data</span>\n        \n        <br/>\n      \n    \n    \n      <em>Description</em>: SDE ACH Daily ServiceRequest\n    \n    \n      \n        <br/>\n        \n        <em>Logic Definition</em>: <a href=\"#nhsnacutecarehospitaldailyinitialpopulation-sde-ach-daily-servicerequest\">SDE ACH Daily ServiceRequest</a> \n      \n    \n  </td>\n</tr>\n\n<tr>\n  \n<th scope=\"row\" class=\"row-header\">Supplemental Data Element</th>\n\n  <td class=\"content-container\">\n    \n      <em>ID</em>: sde-isolation-precautions-implemented\n      \n      <br/>\n      \n    \n    \n      \n        \n          <em>Usage Code</em>: <span title=\"Codes:{http://terminology.hl7.org/CodeSystem/measure-data-usage supplemental-data}\">Supplemental Data</span>\n        \n        <br/>\n      \n    \n    \n      <em>Description</em>: SDE Isolation Precautions Implemented\n    \n    \n      \n        <br/>\n        \n        <em>Logic Definition</em>: <a href=\"#nhsnacutecarehospitaldailyinitialpopulation-sde-isolation-precautions-implemented\">SDE Isolation Precautions Implemented</a> \n      \n    \n  </td>\n</tr>\n\n<tr>\n  \n<th scope=\"row\" class=\"row-header\">Supplemental Data Element</th>\n\n  <td class=\"content-container\">\n    \n      <em>ID</em>: sde-covid-or-influenza-medication-administered\n      \n      <br/>\n      \n    \n    \n      \n        \n          <em>Usage Code</em>: <span title=\"Codes:{http://terminology.hl7.org/CodeSystem/measure-data-usage supplemental-data}\">Supplemental Data</span>\n        \n        <br/>\n      \n    \n    \n      <em>Description</em>: SDE Covid or Influenza Medication Administered\n    \n    \n      \n        <br/>\n        \n        <em>Logic Definition</em>: <a href=\"#nhsnacutecarehospitaldailyinitialpopulation-sde-covid-or-influenza-medication-administered\">SDE Covid or Influenza Medication Administered</a> \n      \n    \n  </td>\n</tr>\n\n<tr>\n  \n<th scope=\"row\" class=\"row-header\">Supplemental Data Element</th>\n\n  <td class=\"content-container\">\n    \n      <em>ID</em>: sde-covid-or-influenza-medication-ordered\n      \n      <br/>\n      \n    \n    \n      \n        \n          <em>Usage Code</em>: <span title=\"Codes:{http://terminology.hl7.org/CodeSystem/measure-data-usage supplemental-data}\">Supplemental Data</span>\n        \n        <br/>\n      \n    \n    \n      <em>Description</em>: SDE Covid or Influenza Medication Ordered\n    \n    \n      \n        <br/>\n        \n        <em>Logic Definition</em>: <a href=\"#nhsnacutecarehospitaldailyinitialpopulation-sde-covid-or-influenza-medication-ordered\">SDE Covid or Influenza Medication Ordered</a> \n      \n    \n  </td>\n</tr>\n\n<tr>\n  \n<th scope=\"row\" class=\"row-header\">Supplemental Data Element</th>\n\n  <td class=\"content-container\">\n    \n      <em>ID</em>: sde-medication\n      \n      <br/>\n      \n    \n    \n      \n        \n          <em>Usage Code</em>: <span title=\"Codes:{http://terminology.hl7.org/CodeSystem/measure-data-usage supplemental-data}\">Supplemental Data</span>\n        \n        <br/>\n      \n    \n    \n      <em>Description</em>: SDE Medication\n    \n    \n      \n        <br/>\n        \n        <em>Logic Definition</em>: <a href=\"#nhsnacutecarehospitaldailyinitialpopulation-sde-medication\">SDE Medication</a> \n      \n    \n  </td>\n</tr>\n\n<tr>\n  \n<th scope=\"row\" class=\"row-header\">Supplemental Data Element</th>\n\n  <td class=\"content-container\">\n    \n      <em>ID</em>: sde-all-observations\n      \n      <br/>\n      \n    \n    \n      \n        \n          <em>Usage Code</em>: <span title=\"Codes:{http://terminology.hl7.org/CodeSystem/measure-data-usage supplemental-data}\">Supplemental Data</span>\n        \n        <br/>\n      \n    \n    \n      <em>Description</em>: SDE All Observations\n    \n    \n      \n        <br/>\n        \n        <em>Logic Definition</em>: <a href=\"#nhsnacutecarehospitaldailyinitialpopulation-sde-all-observations\">SDE All Observations</a> \n      \n    \n  </td>\n</tr>\n\n<tr>\n  \n<th scope=\"row\" class=\"row-header\">Supplemental Data Element</th>\n\n  <td class=\"content-container\">\n    \n      <em>ID</em>: sde-all-servicerequests\n      \n      <br/>\n      \n    \n    \n      \n        \n          <em>Usage Code</em>: <span title=\"Codes:{http://terminology.hl7.org/CodeSystem/measure-data-usage supplemental-data}\">Supplemental Data</span>\n        \n        <br/>\n      \n    \n    \n      <em>Description</em>: SDE All ServiceRequests\n    \n    \n      \n        <br/>\n        \n        <em>Logic Definition</em>: <a href=\"#nhsnacutecarehospitaldailyinitialpopulation-sde-all-servicerequests\">SDE All ServiceRequests</a> \n      \n    \n  </td>\n</tr>\n\n<tr>\n  \n<th scope=\"row\" class=\"row-header\">Supplemental Data Element</th>\n\n  <td class=\"content-container\">\n    \n      <em>ID</em>: sde-all-procedures\n      \n      <br/>\n      \n    \n    \n      \n        \n          <em>Usage Code</em>: <span title=\"Codes:{http://terminology.hl7.org/CodeSystem/measure-data-usage supplemental-data}\">Supplemental Data</span>\n        \n        <br/>\n      \n    \n    \n      <em>Description</em>: SDE All Procedures\n    \n    \n      \n        <br/>\n        \n        <em>Logic Definition</em>: <a href=\"#nhsnacutecarehospitaldailyinitialpopulation-sde-all-procedures\">SDE All Procedures</a> \n      \n    \n  </td>\n</tr>\n\n<tr>\n  \n<th scope=\"row\" class=\"row-header\">Supplemental Data Element</th>\n\n  <td class=\"content-container\">\n    \n      <em>ID</em>: sde-encounter\n      \n      <br/>\n      \n    \n    \n      \n        \n          <em>Usage Code</em>: <span title=\"Codes:{http://terminology.hl7.org/CodeSystem/measure-data-usage supplemental-data}\">Supplemental Data</span>\n        \n        <br/>\n      \n    \n    \n      <em>Description</em>: SDE Encounter\n    \n    \n      \n        <br/>\n        \n        <em>Logic Definition</em>: <a href=\"#nhsnacutecarehospitaldailyinitialpopulation-sde-encounter\">SDE Encounter</a> \n      \n    \n  </td>\n</tr>\n\n<tr>\n  \n<th scope=\"row\" class=\"row-header\">Supplemental Data Element</th>\n\n  <td class=\"content-container\">\n    \n      <em>ID</em>: sde-ip-encounters\n      \n      <br/>\n      \n    \n    \n      \n        \n          <em>Usage Code</em>: <span title=\"Codes:{http://terminology.hl7.org/CodeSystem/measure-data-usage supplemental-data}\">Supplemental Data</span>\n        \n        <br/>\n      \n    \n    \n      <em>Description</em>: SDE IP Encounters\n    \n    \n      \n        <br/>\n        \n        <em>Logic Definition</em>: <a href=\"#nhsnacutecarehospitaldailyinitialpopulation-sde-ip-encounters\">SDE IP Encounters</a> \n      \n    \n  </td>\n</tr>\n\n\n<tr>\n\n<th colspan=\"2\" scope=\"row\" class=\"row-header\">Measure Logic</th>\n\n</tr>\n\n<tr>\n\n<th scope=\"row\" class=\"row-header\">Primary Library</th>\n\n<td class=\"content-container\"><a href=\"Library-NHSNAcuteCareHospitalDailyInitialPopulation.html\">NHSNAcuteCareHospitalDailyInitialPopulation</a></td>\n</tr>\n\n\n\n\n  \n  \n\n<tr>\n  \n  \n  \n  \n  \n<th scope=\"row\" class=\"row-header\">Dependency</th>\n\n  \n  <td class=\"content-container\">\n    \n    <em>Description</em>: FHIR model information\n    \n    <br/>\n    \n    \n    \n    \n    \n    \n    <em>Resource</em>: <a href=\"http://fhir.org/guides/cqf/common/4.0.1/4.0.1/Library-FHIR-ModelInfo.html\">http://fhir.org/guides/cqf/common/Library/FHIR-ModelInfo|4.0.1</a>\n    <br/>\n    <em>Canonical URL</em>: <tt>http://fhir.org/guides/cqf/common/Library/FHIR-ModelInfo|4.0.1</tt>\n    \n  </td>\n</tr>\n\n<tr>\n  \n  \n  \n  \n  \n<th scope=\"row\" class=\"row-header\">Dependency</th>\n\n  \n  <td class=\"content-container\">\n    \n    <em>Description</em>: Library FHIRHelpers\n    \n    <br/>\n    \n    \n    \n    \n    \n    \n    <em>Resource</em>: <code>http://www.cdc.gov/nhsn/fhirportal/dqm/ig/Library/FHIRHelpers|4.0.2</code>\n    <br/>\n    <em>Canonical URL</em>: <tt>http://www.cdc.gov/nhsn/fhirportal/dqm/ig/Library/FHIRHelpers|4.0.2</tt>\n    \n  </td>\n</tr>\n\n<tr>\n  \n  \n  \n  \n  \n<th scope=\"row\" class=\"row-header\">Dependency</th>\n\n  \n  <td class=\"content-container\">\n    \n    <em>Description</em>: Library NHSNHelpers\n    \n    <br/>\n    \n    \n    \n    \n    \n    \n    <em>Resource</em>: <code>http://www.cdc.gov/nhsn/fhirportal/dqm/ig/Library/NHSNHelpers|0.0.002</code>\n    <br/>\n    <em>Canonical URL</em>: <tt>http://www.cdc.gov/nhsn/fhirportal/dqm/ig/Library/NHSNHelpers|0.0.002</tt>\n    \n  </td>\n</tr>\n\n<tr>\n  \n  \n  \n  \n  \n<th scope=\"row\" class=\"row-header\">Dependency</th>\n\n  \n  <td class=\"content-container\">\n    \n    <em>Description</em>: Library SharedResource\n    \n    <br/>\n    \n    \n    \n    \n    \n    \n    <em>Resource</em>: <code>http://www.cdc.gov/nhsn/fhirportal/dqm/ig/Library/SharedResourceCreation|0.1.010</code>\n    <br/>\n    <em>Canonical URL</em>: <tt>http://www.cdc.gov/nhsn/fhirportal/dqm/ig/Library/SharedResourceCreation|0.1.010</tt>\n    \n  </td>\n</tr>\n\n<tr>\n  \n  \n  \n  \n  \n<th scope=\"row\" class=\"row-header\">Dependency</th>\n\n  \n  <td class=\"content-container\">\n    \n    <em>Description</em>: Code system ActCode\n    \n    <br/>\n    \n    \n    \n    \n    \n    \n    <em>Resource</em>: <a href=\"http://terminology.hl7.org/7.0.1/CodeSystem-v3-ActCode.html\">ActCodeversion: null9.0.0)</a>\n    <br/>\n    <em>Canonical URL</em>: <tt>http://terminology.hl7.org/CodeSystem/v3-ActCode|9.0.0</tt>\n    \n  </td>\n</tr>\n\n<tr>\n  \n  \n  \n  \n  \n<th scope=\"row\" class=\"row-header\">Dependency</th>\n\n  \n  <td class=\"content-container\">\n    \n    <em>Description</em>: Code system Observation Category\n    \n    <br/>\n    \n    \n    \n    \n    \n    \n    <em>Resource</em>: <a href=\"http://terminology.hl7.org/7.0.1/CodeSystem-observation-category.html\">Observation Category Codesversion: null2.0.0)</a>\n    <br/>\n    <em>Canonical URL</em>: <tt>http://terminology.hl7.org/CodeSystem/observation-category|2.0.0</tt>\n    \n  </td>\n</tr>\n\n<tr>\n  \n  \n  \n  \n  \n<th scope=\"row\" class=\"row-header\">Dependency</th>\n\n  \n  <td class=\"content-container\">\n    \n    <em>Description</em>: Value set Encounter Inpatient\n    \n    <br/>\n    \n    \n    \n    \n    \n    \n    <em>Resource</em>: <a href=\"https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.3.666.5.307/expansion\">Encounter Inpatient</a>\n    <br/>\n    <em>Canonical URL</em>: <tt>http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307</tt>\n    \n  </td>\n</tr>\n\n<tr>\n  \n  \n  \n  \n  \n<th scope=\"row\" class=\"row-header\">Dependency</th>\n\n  \n  <td class=\"content-container\">\n    \n    <em>Description</em>: Value set NHSN Inpatient Encounter Class Codes\n    \n    <br/>\n    \n    \n    \n    \n    \n    \n    <em>Resource</em>: <a href=\"https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1046.274/expansion\">NHSN Inpatient Encounter Class Codes</a>\n    <br/>\n    <em>Canonical URL</em>: <tt>http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1046.274</tt>\n    \n  </td>\n</tr>\n\n<tr>\n  \n  \n  \n  \n  \n<th scope=\"row\" class=\"row-header\">Dependency</th>\n\n  \n  <td class=\"content-container\">\n    \n    <em>Description</em>: Value set Observation Services\n    \n    <br/>\n    \n    \n    \n    \n    \n    \n    <em>Resource</em>: <a href=\"https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1111.143/expansion\">Observation Services</a>\n    <br/>\n    <em>Canonical URL</em>: <tt>http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1111.143</tt>\n    \n  </td>\n</tr>\n\n<tr>\n  \n  \n  \n  \n  \n<th scope=\"row\" class=\"row-header\">Dependency</th>\n\n  \n  <td class=\"content-container\">\n    \n    <em>Description</em>: Value set Inpatient, Emergency, and Observation Locations\n    \n    <br/>\n    \n    \n    \n    \n    \n    \n    <em>Resource</em>: <a href=\"https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1046.265/expansion\">Inpatient, Emergency, and Observation Locations</a>\n    <br/>\n    <em>Canonical URL</em>: <tt>http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1046.265</tt>\n    \n  </td>\n</tr>\n\n<tr>\n  \n  \n  \n  \n  \n<th scope=\"row\" class=\"row-header\">Dependency</th>\n\n  \n  <td class=\"content-container\">\n    \n    <em>Description</em>: Value set COVID_19 (Tests for SARS_CoV_2 Nucleic Acid)\n    \n    <br/>\n    \n    \n    \n    \n    \n    \n    <em>Resource</em>: <a href=\"https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1146.1142/expansion\">COVID_19 (Tests for SARS_CoV_2 Nucleic Acid)version: null20250218)</a>\n    <br/>\n    <em>Canonical URL</em>: <tt>http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1142|20250218</tt>\n    \n  </td>\n</tr>\n\n<tr>\n  \n  \n  \n  \n  \n<th scope=\"row\" class=\"row-header\">Dependency</th>\n\n  \n  <td class=\"content-container\">\n    \n    <em>Description</em>: Value set COVID_19 (Tests for SARS_CoV_2 Antigen)\n    \n    <br/>\n    \n    \n    \n    \n    \n    \n    <em>Resource</em>: <a href=\"https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1146.1158/expansion\">COVID_19 (Tests for SARS_CoV_2 Antigen)version: null20240123)</a>\n    <br/>\n    <em>Canonical URL</em>: <tt>http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1158|20240123</tt>\n    \n  </td>\n</tr>\n\n<tr>\n  \n  \n  \n  \n  \n<th scope=\"row\" class=\"row-header\">Dependency</th>\n\n  \n  <td class=\"content-container\">\n    \n    <em>Description</em>: Value set Influenza (Tests for influenza A or B virus Nucleic Acid)\n    \n    <br/>\n    \n    \n    \n    \n    \n    \n    <em>Resource</em>: <a href=\"https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1146.336/expansion\">Influenza (Tests for influenza A or B virus Nucleic Acid)version: null20250218)</a>\n    <br/>\n    <em>Canonical URL</em>: <tt>http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.336|20250218</tt>\n    \n  </td>\n</tr>\n\n<tr>\n  \n  \n  \n  \n  \n<th scope=\"row\" class=\"row-header\">Dependency</th>\n\n  \n  <td class=\"content-container\">\n    \n    <em>Description</em>: Value set Influenza (Tests for influenza A or B virus Antigen)\n    \n    <br/>\n    \n    \n    \n    \n    \n    \n    <em>Resource</em>: <a href=\"https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1146.337/expansion\">Influenza (Tests for influenza A or B virus Antigen)</a>\n    <br/>\n    <em>Canonical URL</em>: <tt>http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.337</tt>\n    \n  </td>\n</tr>\n\n<tr>\n  \n  \n  \n  \n  \n<th scope=\"row\" class=\"row-header\">Dependency</th>\n\n  \n  <td class=\"content-container\">\n    \n    <em>Description</em>: Value set RSV (Tests for RSV Nucleic Acid)\n    \n    <br/>\n    \n    \n    \n    \n    \n    \n    <em>Resource</em>: <a href=\"https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1146.1312/expansion\">RSV (Tests for RSV Nucleic Acid)version: null20250218)</a>\n    <br/>\n    <em>Canonical URL</em>: <tt>http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1312|20250218</tt>\n    \n  </td>\n</tr>\n\n<tr>\n  \n  \n  \n  \n  \n<th scope=\"row\" class=\"row-header\">Dependency</th>\n\n  \n  <td class=\"content-container\">\n    \n    <em>Description</em>: Value set RSV (Tests for RSV Antigen)\n    \n    <br/>\n    \n    \n    \n    \n    \n    \n    <em>Resource</em>: <a href=\"https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1146.1311/expansion\">RSV (Tests for RSV Antigen)</a>\n    <br/>\n    <em>Canonical URL</em>: <tt>http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1311</tt>\n    \n  </td>\n</tr>\n\n<tr>\n  \n  \n  \n  \n  \n<th scope=\"row\" class=\"row-header\">Dependency</th>\n\n  \n  <td class=\"content-container\">\n    \n    <em>Description</em>: Value set Discharge Disposition\n    \n    <br/>\n    \n    \n    \n    \n    \n    \n    <em>Resource</em>: <a href=\"http://terminology.hl7.org/7.0.1/ValueSet-clinical-discharge-disposition.html\">Clinical Discharge Dispositionversion: null2.0.0)</a>\n    <br/>\n    <em>Canonical URL</em>: <tt>http://terminology.hl7.org/ValueSet/clinical-discharge-disposition|2.0.0</tt>\n    \n  </td>\n</tr>\n\n<tr>\n  \n  \n  \n  \n  \n<th scope=\"row\" class=\"row-header\">Dependency</th>\n\n  \n  <td class=\"content-container\">\n    \n    <em>Description</em>: Value set Anakinra\n    \n    <br/>\n    \n    \n    \n    \n    \n    \n    <em>Resource</em>: <a href=\"https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.3.3616.200.110.102.2054/expansion\">Anakinra</a>\n    <br/>\n    <em>Canonical URL</em>: <tt>http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3616.200.110.102.2054</tt>\n    \n  </td>\n</tr>\n\n<tr>\n  \n  \n  \n  \n  \n<th scope=\"row\" class=\"row-header\">Dependency</th>\n\n  \n  <td class=\"content-container\">\n    \n    <em>Description</em>: Value set Baloxavir\n    \n    <br/>\n    \n    \n    \n    \n    \n    \n    <em>Resource</em>: <a href=\"https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1190.85/expansion\">Baloxavir</a>\n    <br/>\n    <em>Canonical URL</em>: <tt>http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1190.85</tt>\n    \n  </td>\n</tr>\n\n<tr>\n  \n  \n  \n  \n  \n<th scope=\"row\" class=\"row-header\">Dependency</th>\n\n  \n  <td class=\"content-container\">\n    \n    <em>Description</em>: Value set Bamlanivimab\n    \n    <br/>\n    \n    \n    \n    \n    \n    \n    <em>Resource</em>: <a href=\"https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.3.3616.200.110.102.2099/expansion\">Bamlanivimab</a>\n    <br/>\n    <em>Canonical URL</em>: <tt>http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3616.200.110.102.2099</tt>\n    \n  </td>\n</tr>\n\n<tr>\n  \n  \n  \n  \n  \n<th scope=\"row\" class=\"row-header\">Dependency</th>\n\n  \n  <td class=\"content-container\">\n    \n    <em>Description</em>: Value set Baricitinib\n    \n    <br/>\n    \n    \n    \n    \n    \n    \n    <em>Resource</em>: <a href=\"https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.3.3616.200.110.102.2046/expansion\">Baricitinib</a>\n    <br/>\n    <em>Canonical URL</em>: <tt>http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3616.200.110.102.2046</tt>\n    \n  </td>\n</tr>\n\n<tr>\n  \n  \n  \n  \n  \n<th scope=\"row\" class=\"row-header\">Dependency</th>\n\n  \n  <td class=\"content-container\">\n    \n    <em>Description</em>: Value set Bebtelovimab\n    \n    <br/>\n    \n    \n    \n    \n    \n    \n    <em>Resource</em>: <a href=\"https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.3.3616.200.110.102.2105/expansion\">Bebtelovimab</a>\n    <br/>\n    <em>Canonical URL</em>: <tt>http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3616.200.110.102.2105</tt>\n    \n  </td>\n</tr>\n\n<tr>\n  \n  \n  \n  \n  \n<th scope=\"row\" class=\"row-header\">Dependency</th>\n\n  \n  <td class=\"content-container\">\n    \n    <em>Description</em>: Value set Casirivimab\n    \n    <br/>\n    \n    \n    \n    \n    \n    \n    <em>Resource</em>: <a href=\"https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.3.3616.200.110.102.2097/expansion\">Casirivimab</a>\n    <br/>\n    <em>Canonical URL</em>: <tt>http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3616.200.110.102.2097</tt>\n    \n  </td>\n</tr>\n\n<tr>\n  \n  \n  \n  \n  \n<th scope=\"row\" class=\"row-header\">Dependency</th>\n\n  \n  <td class=\"content-container\">\n    \n    <em>Description</em>: Value set Casirivimab / Imdevimab\n    \n    <br/>\n    \n    \n    \n    \n    \n    \n    <em>Resource</em>: <a href=\"https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.3.3616.200.110.102.2103/expansion\">Casirivimab / Imdevimab</a>\n    <br/>\n    <em>Canonical URL</em>: <tt>http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3616.200.110.102.2103</tt>\n    \n  </td>\n</tr>\n\n<tr>\n  \n  \n  \n  \n  \n<th scope=\"row\" class=\"row-header\">Dependency</th>\n\n  \n  <td class=\"content-container\">\n    \n    <em>Description</em>: Value set COVID19 RxNorm Value Set for Tocilizumab\n    \n    <br/>\n    \n    \n    \n    \n    \n    \n    <em>Resource</em>: <a href=\"https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.3.3616.200.110.102.2087/expansion\">COVID19 RxNorm Value Set for Tocilizumab</a>\n    <br/>\n    <em>Canonical URL</em>: <tt>http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3616.200.110.102.2087</tt>\n    \n  </td>\n</tr>\n\n<tr>\n  \n  \n  \n  \n  \n<th scope=\"row\" class=\"row-header\">Dependency</th>\n\n  \n  <td class=\"content-container\">\n    \n    <em>Description</em>: Value set Etesevimab\n    \n    <br/>\n    \n    \n    \n    \n    \n    \n    <em>Resource</em>: <a href=\"https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.3.3616.200.110.102.2100/expansion\">Etesevimab</a>\n    <br/>\n    <em>Canonical URL</em>: <tt>http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3616.200.110.102.2100</tt>\n    \n  </td>\n</tr>\n\n<tr>\n  \n  \n  \n  \n  \n<th scope=\"row\" class=\"row-header\">Dependency</th>\n\n  \n  <td class=\"content-container\">\n    \n    <em>Description</em>: Value set Imdevimab\n    \n    <br/>\n    \n    \n    \n    \n    \n    \n    <em>Resource</em>: <a href=\"https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.3.3616.200.110.102.2098/expansion\">Imdevimab</a>\n    <br/>\n    <em>Canonical URL</em>: <tt>http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3616.200.110.102.2098</tt>\n    \n  </td>\n</tr>\n\n<tr>\n  \n  \n  \n  \n  \n<th scope=\"row\" class=\"row-header\">Dependency</th>\n\n  \n  <td class=\"content-container\">\n    \n    <em>Description</em>: Value set Molnupiravir\n    \n    <br/>\n    \n    \n    \n    \n    \n    \n    <em>Resource</em>: <a href=\"https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.3.3616.200.110.102.2119/expansion\">Molnupiravir</a>\n    <br/>\n    <em>Canonical URL</em>: <tt>http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3616.200.110.102.2119</tt>\n    \n  </td>\n</tr>\n\n<tr>\n  \n  \n  \n  \n  \n<th scope=\"row\" class=\"row-header\">Dependency</th>\n\n  \n  <td class=\"content-container\">\n    \n    <em>Description</em>: Value set Nirmatrelvir / Ritonavir\n    \n    <br/>\n    \n    \n    \n    \n    \n    \n    <em>Resource</em>: <a href=\"https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.3.3616.200.110.102.2104/expansion\">Nirmatrelvir / Ritonavir</a>\n    <br/>\n    <em>Canonical URL</em>: <tt>http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3616.200.110.102.2104</tt>\n    \n  </td>\n</tr>\n\n<tr>\n  \n  \n  \n  \n  \n<th scope=\"row\" class=\"row-header\">Dependency</th>\n\n  \n  <td class=\"content-container\">\n    \n    <em>Description</em>: Value set Oseltamivir\n    \n    <br/>\n    \n    \n    \n    \n    \n    \n    <em>Resource</em>: <a href=\"https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.3.3616.200.110.102.2078/expansion\">Oseltamivir</a>\n    <br/>\n    <em>Canonical URL</em>: <tt>http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3616.200.110.102.2078</tt>\n    \n  </td>\n</tr>\n\n<tr>\n  \n  \n  \n  \n  \n<th scope=\"row\" class=\"row-header\">Dependency</th>\n\n  \n  <td class=\"content-container\">\n    \n    <em>Description</em>: Value set Peramivir\n    \n    <br/>\n    \n    \n    \n    \n    \n    \n    <em>Resource</em>: <a href=\"https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1190.86/expansion\">Peramivir</a>\n    <br/>\n    <em>Canonical URL</em>: <tt>http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1190.86</tt>\n    \n  </td>\n</tr>\n\n<tr>\n  \n  \n  \n  \n  \n<th scope=\"row\" class=\"row-header\">Dependency</th>\n\n  \n  <td class=\"content-container\">\n    \n    <em>Description</em>: Value set Remdesivir\n    \n    <br/>\n    \n    \n    \n    \n    \n    \n    <em>Resource</em>: <a href=\"https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.3.3616.200.110.102.2081/expansion\">Remdesivir</a>\n    <br/>\n    <em>Canonical URL</em>: <tt>http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3616.200.110.102.2081</tt>\n    \n  </td>\n</tr>\n\n<tr>\n  \n  \n  \n  \n  \n<th scope=\"row\" class=\"row-header\">Dependency</th>\n\n  \n  <td class=\"content-container\">\n    \n    <em>Description</em>: Value set Sarilumab\n    \n    <br/>\n    \n    \n    \n    \n    \n    \n    <em>Resource</em>: <a href=\"https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.3.3616.200.110.102.2084/expansion\">Sarilumab</a>\n    <br/>\n    <em>Canonical URL</em>: <tt>http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3616.200.110.102.2084</tt>\n    \n  </td>\n</tr>\n\n<tr>\n  \n  \n  \n  \n  \n<th scope=\"row\" class=\"row-header\">Dependency</th>\n\n  \n  <td class=\"content-container\">\n    \n    <em>Description</em>: Value set Sotrovimab\n    \n    <br/>\n    \n    \n    \n    \n    \n    \n    <em>Resource</em>: <a href=\"https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.3.3616.200.110.102.2101/expansion\">Sotrovimab</a>\n    <br/>\n    <em>Canonical URL</em>: <tt>http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3616.200.110.102.2101</tt>\n    \n  </td>\n</tr>\n\n<tr>\n  \n  \n  \n  \n  \n<th scope=\"row\" class=\"row-header\">Dependency</th>\n\n  \n  <td class=\"content-container\">\n    \n    <em>Description</em>: Value set Tofacitinib\n    \n    <br/>\n    \n    \n    \n    \n    \n    \n    <em>Resource</em>: <a href=\"https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.3.3616.200.110.102.2102/expansion\">Tofacitinib</a>\n    <br/>\n    <em>Canonical URL</em>: <tt>http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3616.200.110.102.2102</tt>\n    \n  </td>\n</tr>\n\n<tr>\n  \n  \n  \n  \n  \n<th scope=\"row\" class=\"row-header\">Dependency</th>\n\n  \n  <td class=\"content-container\">\n    \n    <em>Description</em>: Value set Zanamivir\n    \n    <br/>\n    \n    \n    \n    \n    \n    \n    <em>Resource</em>: <a href=\"https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1190.87/expansion\">Zanamivir</a>\n    <br/>\n    <em>Canonical URL</em>: <tt>http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1190.87</tt>\n    \n  </td>\n</tr>\n\n<tr>\n  \n  \n  \n  \n  \n<th scope=\"row\" class=\"row-header\">Dependency</th>\n\n  \n  <td class=\"content-container\">\n    \n    <em>Description</em>: Value set Transmission Based Precaution Types\n    \n    <br/>\n    \n    \n    \n    \n    \n    \n    <em>Resource</em>: <a href=\"https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.10.20.22.5.300/expansion\">Transmission Based Precaution Typesversion: null20240607)</a>\n    <br/>\n    <em>Canonical URL</em>: <tt>http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.10.20.22.5.300|20240607</tt>\n    \n  </td>\n</tr>\n\n\n  \n  <tr>\n    <th scope=\"row\" class=\"row-header\">Direct Reference Code</th>\n    <td class=\"content-container\">\n      \n        <em>Display</em>: observation encounter\n        <br/>\n      \n      <em>Code</em>: OBSENC\n      <br/>\n      <em>System</em>: <tt>http://terminology.hl7.org/CodeSystem/v3-ActCode</tt>\n    </td>\n  </tr>\n\n  <tr>\n    <th scope=\"row\" class=\"row-header\">Direct Reference Code</th>\n    <td class=\"content-container\">\n      \n        <em>Display</em>: Laboratory\n        <br/>\n      \n      <em>Code</em>: laboratory\n      <br/>\n      <em>System</em>: <tt>http://terminology.hl7.org/CodeSystem/observation-category</tt>\n    </td>\n  </tr>\n\n  \n  <tr>\n  \n<th scope=\"row\" class=\"row-header\">Parameter</th>\n\n  <td class=\"content-container\">\n    <em>Name</em>: Measurement Period\n    <br/>\n    <em>Use</em>: In\n    <br/>\n    <em>Min Cardinality</em>: 0\n    <br/>\n    <em>Max Cardinality</em>: 1\n    <br/>\n    <em>Type</em>: Period\n  </td>\n</tr>\n  \n  <tr>\n  \n<th scope=\"row\" class=\"row-header\">Parameter</th>\n\n  <td class=\"content-container\">\n    <em>Name</em>: SDE Encounter\n    <br/>\n    <em>Use</em>: Out\n    <br/>\n    <em>Min Cardinality</em>: 0\n    <br/>\n    <em>Max Cardinality</em>: *\n    <br/>\n    <em>Type</em>: Encounter\n  </td>\n</tr>\n  \n  <tr>\n  \n<th scope=\"row\" class=\"row-header\">Parameter</th>\n\n  <td class=\"content-container\">\n    <em>Name</em>: SDE ACH Daily ServiceRequest\n    <br/>\n    <em>Use</em>: Out\n    <br/>\n    <em>Min Cardinality</em>: 0\n    <br/>\n    <em>Max Cardinality</em>: *\n    <br/>\n    <em>Type</em>: ServiceRequest\n  </td>\n</tr>\n  \n  <tr>\n  \n<th scope=\"row\" class=\"row-header\">Parameter</th>\n\n  <td class=\"content-container\">\n    <em>Name</em>: SDE RSV Specimen\n    <br/>\n    <em>Use</em>: Out\n    <br/>\n    <em>Min Cardinality</em>: 0\n    <br/>\n    <em>Max Cardinality</em>: *\n    <br/>\n    <em>Type</em>: Specimen\n  </td>\n</tr>\n  \n  <tr>\n  \n<th scope=\"row\" class=\"row-header\">Parameter</th>\n\n  <td class=\"content-container\">\n    <em>Name</em>: SDE ACH Daily Specimen\n    <br/>\n    <em>Use</em>: Out\n    <br/>\n    <em>Min Cardinality</em>: 0\n    <br/>\n    <em>Max Cardinality</em>: *\n    <br/>\n    <em>Type</em>: Specimen\n  </td>\n</tr>\n  \n  <tr>\n  \n<th scope=\"row\" class=\"row-header\">Parameter</th>\n\n  <td class=\"content-container\">\n    <em>Name</em>: SDE ACH Daily DiagnosticReport\n    <br/>\n    <em>Use</em>: Out\n    <br/>\n    <em>Min Cardinality</em>: 0\n    <br/>\n    <em>Max Cardinality</em>: *\n    <br/>\n    <em>Type</em>: DiagnosticReport\n  </td>\n</tr>\n  \n  <tr>\n  \n<th scope=\"row\" class=\"row-header\">Parameter</th>\n\n  <td class=\"content-container\">\n    <em>Name</em>: SDE RSV DiagnosticReport\n    <br/>\n    <em>Use</em>: Out\n    <br/>\n    <em>Min Cardinality</em>: 0\n    <br/>\n    <em>Max Cardinality</em>: *\n    <br/>\n    <em>Type</em>: DiagnosticReport\n  </td>\n</tr>\n  \n  <tr>\n  \n<th scope=\"row\" class=\"row-header\">Parameter</th>\n\n  <td class=\"content-container\">\n    <em>Name</em>: SDE ACH Daily Observation\n    <br/>\n    <em>Use</em>: Out\n    <br/>\n    <em>Min Cardinality</em>: 0\n    <br/>\n    <em>Max Cardinality</em>: *\n    <br/>\n    <em>Type</em>: Observation\n  </td>\n</tr>\n  \n  <tr>\n  \n<th scope=\"row\" class=\"row-header\">Parameter</th>\n\n  <td class=\"content-container\">\n    <em>Name</em>: Initial Population\n    <br/>\n    <em>Use</em>: Out\n    <br/>\n    <em>Min Cardinality</em>: 0\n    <br/>\n    <em>Max Cardinality</em>: *\n    <br/>\n    <em>Type</em>: Encounter\n  </td>\n</tr>\n  \n  <tr>\n  \n<th scope=\"row\" class=\"row-header\">Parameter</th>\n\n  <td class=\"content-container\">\n    <em>Name</em>: SDE All Procedures\n    <br/>\n    <em>Use</em>: Out\n    <br/>\n    <em>Min Cardinality</em>: 0\n    <br/>\n    <em>Max Cardinality</em>: *\n    <br/>\n    <em>Type</em>: Procedure\n  </td>\n</tr>\n  \n  <tr>\n  \n<th scope=\"row\" class=\"row-header\">Parameter</th>\n\n  <td class=\"content-container\">\n    <em>Name</em>: SDE Encounter Discharge Dispositions\n    <br/>\n    <em>Use</em>: Out\n    <br/>\n    <em>Min Cardinality</em>: 0\n    <br/>\n    <em>Max Cardinality</em>: *\n    <br/>\n    <em>Type</em>: Encounter\n  </td>\n</tr>\n  \n  <tr>\n  \n<th scope=\"row\" class=\"row-header\">Parameter</th>\n\n  <td class=\"content-container\">\n    <em>Name</em>: SDE Covid or Influenza Medication Ordered\n    <br/>\n    <em>Use</em>: Out\n    <br/>\n    <em>Min Cardinality</em>: 0\n    <br/>\n    <em>Max Cardinality</em>: *\n    <br/>\n    <em>Type</em>: MedicationRequest\n  </td>\n</tr>\n  \n  <tr>\n  \n<th scope=\"row\" class=\"row-header\">Parameter</th>\n\n  <td class=\"content-container\">\n    <em>Name</em>: SDE Minimal Patient\n    <br/>\n    <em>Use</em>: Out\n    <br/>\n    <em>Min Cardinality</em>: 0\n    <br/>\n    <em>Max Cardinality</em>: 1\n    <br/>\n    <em>Type</em>: Patient\n  </td>\n</tr>\n  \n  <tr>\n  \n<th scope=\"row\" class=\"row-header\">Parameter</th>\n\n  <td class=\"content-container\">\n    <em>Name</em>: SDE All Observations\n    <br/>\n    <em>Use</em>: Out\n    <br/>\n    <em>Min Cardinality</em>: 0\n    <br/>\n    <em>Max Cardinality</em>: *\n    <br/>\n    <em>Type</em>: Observation\n  </td>\n</tr>\n  \n  <tr>\n  \n<th scope=\"row\" class=\"row-header\">Parameter</th>\n\n  <td class=\"content-container\">\n    <em>Name</em>: SDE Medication\n    <br/>\n    <em>Use</em>: Out\n    <br/>\n    <em>Min Cardinality</em>: 0\n    <br/>\n    <em>Max Cardinality</em>: *\n    <br/>\n    <em>Type</em>: Medication\n  </td>\n</tr>\n  \n  <tr>\n  \n<th scope=\"row\" class=\"row-header\">Parameter</th>\n\n  <td class=\"content-container\">\n    <em>Name</em>: SDE Covid or Influenza Medication Administered\n    <br/>\n    <em>Use</em>: Out\n    <br/>\n    <em>Min Cardinality</em>: 0\n    <br/>\n    <em>Max Cardinality</em>: *\n    <br/>\n    <em>Type</em>: MedicationAdministration\n  </td>\n</tr>\n  \n  <tr>\n  \n<th scope=\"row\" class=\"row-header\">Parameter</th>\n\n  <td class=\"content-container\">\n    <em>Name</em>: SDE RSV DiagnosticReport Result from Lab\n    <br/>\n    <em>Use</em>: Out\n    <br/>\n    <em>Min Cardinality</em>: 0\n    <br/>\n    <em>Max Cardinality</em>: *\n    <br/>\n    <em>Type</em>: DiagnosticReport\n  </td>\n</tr>\n  \n  <tr>\n  \n<th scope=\"row\" class=\"row-header\">Parameter</th>\n\n  <td class=\"content-container\">\n    <em>Name</em>: SDE IP Encounters\n    <br/>\n    <em>Use</em>: Out\n    <br/>\n    <em>Min Cardinality</em>: 0\n    <br/>\n    <em>Max Cardinality</em>: *\n    <br/>\n    <em>Type</em>: Encounter\n  </td>\n</tr>\n  \n  <tr>\n  \n<th scope=\"row\" class=\"row-header\">Parameter</th>\n\n  <td class=\"content-container\">\n    <em>Name</em>: SDE RSV PRE Admission Observation\n    <br/>\n    <em>Use</em>: Out\n    <br/>\n    <em>Min Cardinality</em>: 0\n    <br/>\n    <em>Max Cardinality</em>: *\n    <br/>\n    <em>Type</em>: Observation\n  </td>\n</tr>\n  \n  <tr>\n  \n<th scope=\"row\" class=\"row-header\">Parameter</th>\n\n  <td class=\"content-container\">\n    <em>Name</em>: SDE Isolation Precautions Implemented\n    <br/>\n    <em>Use</em>: Out\n    <br/>\n    <em>Min Cardinality</em>: 0\n    <br/>\n    <em>Max Cardinality</em>: *\n    <br/>\n    <em>Type</em>: Procedure\n  </td>\n</tr>\n  \n  <tr>\n  \n<th scope=\"row\" class=\"row-header\">Parameter</th>\n\n  <td class=\"content-container\">\n    <em>Name</em>: SDE COVID And Influenza Specimen\n    <br/>\n    <em>Use</em>: Out\n    <br/>\n    <em>Min Cardinality</em>: 0\n    <br/>\n    <em>Max Cardinality</em>: *\n    <br/>\n    <em>Type</em>: Specimen\n  </td>\n</tr>\n  \n  <tr>\n  \n<th scope=\"row\" class=\"row-header\">Parameter</th>\n\n  <td class=\"content-container\">\n    <em>Name</em>: SDE All ServiceRequests\n    <br/>\n    <em>Use</em>: Out\n    <br/>\n    <em>Min Cardinality</em>: 0\n    <br/>\n    <em>Max Cardinality</em>: *\n    <br/>\n    <em>Type</em>: ServiceRequest\n  </td>\n</tr>\n  \n  <tr>\n  \n<th scope=\"row\" class=\"row-header\">Parameter</th>\n\n  <td class=\"content-container\">\n    <em>Name</em>: SDE COVID And Influenza DiagnosticReport\n    <br/>\n    <em>Use</em>: Out\n    <br/>\n    <em>Min Cardinality</em>: 0\n    <br/>\n    <em>Max Cardinality</em>: *\n    <br/>\n    <em>Type</em>: DiagnosticReport\n  </td>\n</tr>\n  \n  <tr>\n  \n<th scope=\"row\" class=\"row-header\">Parameter</th>\n\n  <td class=\"content-container\">\n    <em>Name</em>: SDE COVID And Influenza PRE Admission Observation\n    <br/>\n    <em>Use</em>: Out\n    <br/>\n    <em>Min Cardinality</em>: 0\n    <br/>\n    <em>Max Cardinality</em>: *\n    <br/>\n    <em>Type</em>: Observation\n  </td>\n</tr>\n  \n  <tr>\n  \n<th scope=\"row\" class=\"row-header\">Parameter</th>\n\n  <td class=\"content-container\">\n    <em>Name</em>: SDE ACH Daily DiagnosticReport Result from Lab\n    <br/>\n    <em>Use</em>: Out\n    <br/>\n    <em>Min Cardinality</em>: 0\n    <br/>\n    <em>Max Cardinality</em>: *\n    <br/>\n    <em>Type</em>: DiagnosticReport\n  </td>\n</tr>\n  \n  <tr>\n  \n<th scope=\"row\" class=\"row-header\">Parameter</th>\n\n  <td class=\"content-container\">\n    <em>Name</em>: SDE COVID and Influenza DiagnosticReport Result from Lab\n    <br/>\n    <em>Use</em>: Out\n    <br/>\n    <em>Min Cardinality</em>: 0\n    <br/>\n    <em>Max Cardinality</em>: *\n    <br/>\n    <em>Type</em>: DiagnosticReport\n  </td>\n</tr>\n  \n  <tr>\n  \n<th scope=\"row\" class=\"row-header\">Parameter</th>\n\n  <td class=\"content-container\">\n    <em>Name</em>: SDE Location\n    <br/>\n    <em>Use</em>: Out\n    <br/>\n    <em>Min Cardinality</em>: 0\n    <br/>\n    <em>Max Cardinality</em>: *\n    <br/>\n    <em>Type</em>: Location\n  </td>\n</tr>\n  \n  \n  <tr>\n    <th colspan=\"2\" scope=\"row\" class=\"section-header\"><a name=\"effective-data-requirements\"> </a>Measure Logic Data Requirements</th>\n  </tr>\n  \n  \n<tr>\n  <th scope=\"row\" class=\"row-header\">Data Requirement</th>\n  <td class=\"content-container\">\n    <em>Type</em>: Encounter\n    <br/>\n  \n    <em>Profile(s)</em>: \n  \n    <a href=\"http://hl7.org/fhir/R4/encounter.html\">Encounter</a>\n    <br/>        \n  \n   \n   \n    <em>Must Support Elements</em>: type, status, period, id, extension, identifier, statusHistory, class, classHistory, serviceType, priority, subject, length, reasonCode, reasonReference, diagnosis, account, hospitalization, location, partOf, hospitalization.dischargeDisposition\n    <br/>\n   \n  \n    <em>Code Filter(s)</em>: \n    <br/>\n  \n  \n    <span class=\"tab-one\"><em>Path</em>: type</span>\n    <br/>\n  \n  \n  \n    <span class=\"tab-one\"><em>ValueSet</em>:</span> <a href=\"https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.3.666.5.307/expansion\">Encounter Inpatient</a>\n    <br/> \n  \n  \n  \n   \n  </td>\n</tr>\n\n<tr>\n  <th scope=\"row\" class=\"row-header\">Data Requirement</th>\n  <td class=\"content-container\">\n    <em>Type</em>: Encounter\n    <br/>\n  \n    <em>Profile(s)</em>: \n  \n    <a href=\"http://hl7.org/fhir/R4/encounter.html\">Encounter</a>\n    <br/>        \n  \n   \n   \n    <em>Must Support Elements</em>: class, status, period, id, extension, identifier, statusHistory, classHistory, type, serviceType, priority, subject, length, reasonCode, reasonReference, diagnosis, account, hospitalization, location, partOf, hospitalization.dischargeDisposition\n    <br/>\n   \n  \n    <em>Code Filter(s)</em>: \n    <br/>\n  \n  \n    <span class=\"tab-one\"><em>Path</em>: class</span>\n    <br/>\n  \n  \n  \n    <span class=\"tab-one\"><em>ValueSet</em>:</span> <a href=\"https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1046.274/expansion\">NHSN Inpatient Encounter Class Codes</a>\n    <br/> \n  \n  \n  \n   \n  </td>\n</tr>\n\n<tr>\n  <th scope=\"row\" class=\"row-header\">Data Requirement</th>\n  <td class=\"content-container\">\n    <em>Type</em>: Encounter\n    <br/>\n  \n    <em>Profile(s)</em>: \n  \n    <a href=\"http://hl7.org/fhir/R4/encounter.html\">Encounter</a>\n    <br/>        \n  \n   \n   \n    <em>Must Support Elements</em>: type, status, period, id, extension, identifier, statusHistory, class, classHistory, serviceType, priority, subject, length, reasonCode, reasonReference, diagnosis, account, hospitalization, location, partOf, hospitalization.dischargeDisposition\n    <br/>\n   \n  \n    <em>Code Filter(s)</em>: \n    <br/>\n  \n  \n    <span class=\"tab-one\"><em>Path</em>: type</span>\n    <br/>\n  \n  \n  \n    <span class=\"tab-one\"><em>ValueSet</em>:</span> <a href=\"https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1111.143/expansion\">Observation Services</a>\n    <br/> \n  \n  \n  \n   \n  </td>\n</tr>\n\n<tr>\n  <th scope=\"row\" class=\"row-header\">Data Requirement</th>\n  <td class=\"content-container\">\n    <em>Type</em>: Encounter\n    <br/>\n  \n    <em>Profile(s)</em>: \n  \n    <a href=\"http://hl7.org/fhir/R4/encounter.html\">Encounter</a>\n    <br/>        \n  \n   \n   \n    <em>Must Support Elements</em>: class, status, period, id, extension, identifier, statusHistory, classHistory, type, serviceType, priority, subject, length, reasonCode, reasonReference, diagnosis, account, hospitalization, location, partOf, hospitalization.dischargeDisposition\n    <br/>\n   \n  \n    <em>Code Filter(s)</em>: \n    <br/>\n  \n  \n    <span class=\"tab-one\"><em>Path</em>: class</span>\n    <br/>\n  \n  \n  \n  \n    <span class=\"tab-one\"><em>Code</em>: </span>\n    <br/>\n  \n  \n   \n  </td>\n</tr>\n\n<tr>\n  <th scope=\"row\" class=\"row-header\">Data Requirement</th>\n  <td class=\"content-container\">\n    <em>Type</em>: Encounter\n    <br/>\n  \n    <em>Profile(s)</em>: \n  \n    <a href=\"http://hl7.org/fhir/R4/encounter.html\">Encounter</a>\n    <br/>        \n  \n   \n   \n    <em>Must Support Elements</em>: status, period, id, extension, identifier, statusHistory, class, classHistory, type, serviceType, priority, subject, length, reasonCode, reasonReference, diagnosis, account, hospitalization, location, partOf, hospitalization.dischargeDisposition\n    <br/>\n   \n   \n  </td>\n</tr>\n\n<tr>\n  <th scope=\"row\" class=\"row-header\">Data Requirement</th>\n  <td class=\"content-container\">\n    <em>Type</em>: Location\n    <br/>\n  \n    <em>Profile(s)</em>: \n  \n    <a href=\"http://hl7.org/fhir/R4/location.html\">Location</a>\n    <br/>        \n  \n   \n   \n    <em>Must Support Elements</em>: id, extension, status, operationalStatus, name, alias, description, mode, type, telecom, address, physicalType, position, managingOrganization, partOf, hoursOfOperation, availabilityExceptions, endpoint\n    <br/>\n   \n   \n  </td>\n</tr>\n\n<tr>\n  <th scope=\"row\" class=\"row-header\">Data Requirement</th>\n  <td class=\"content-container\">\n    <em>Type</em>: ServiceRequest\n    <br/>\n  \n    <em>Profile(s)</em>: \n  \n    <a href=\"http://hl7.org/fhir/R4/servicerequest.html\">ServiceRequest</a>\n    <br/>        \n  \n   \n   \n    <em>Must Support Elements</em>: code, id, extension, instantiatesCanonical, instantiatesUri, basedOn, replaces, requisition, status, intent, category, priority, doNotPerform, orderDetail, quantity, subject, encounter, occurrence, asNeeded, authoredOn, performerType, performer, locationCode, locationReference, reasonCode, reasonReference, insurance, supportingInfo, specimen, bodySite, note, patientInstruction, relevantHistory\n    <br/>\n   \n  \n    <em>Code Filter(s)</em>: \n    <br/>\n  \n  \n    <span class=\"tab-one\"><em>Path</em>: code</span>\n    <br/>\n  \n  \n  \n    <span class=\"tab-one\"><em>ValueSet</em>:</span> <a href=\"https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1146.1142/expansion\">COVID_19 (Tests for SARS_CoV_2 Nucleic Acid)version: null20250218)</a>\n    <br/> \n  \n  \n  \n   \n  </td>\n</tr>\n\n<tr>\n  <th scope=\"row\" class=\"row-header\">Data Requirement</th>\n  <td class=\"content-container\">\n    <em>Type</em>: ServiceRequest\n    <br/>\n  \n    <em>Profile(s)</em>: \n  \n    <a href=\"http://hl7.org/fhir/R4/servicerequest.html\">ServiceRequest</a>\n    <br/>        \n  \n   \n   \n    <em>Must Support Elements</em>: code, id, extension, instantiatesCanonical, instantiatesUri, basedOn, replaces, requisition, status, intent, category, priority, doNotPerform, orderDetail, quantity, subject, encounter, occurrence, asNeeded, authoredOn, performerType, performer, locationCode, locationReference, reasonCode, reasonReference, insurance, supportingInfo, specimen, bodySite, note, patientInstruction, relevantHistory\n    <br/>\n   \n  \n    <em>Code Filter(s)</em>: \n    <br/>\n  \n  \n    <span class=\"tab-one\"><em>Path</em>: code</span>\n    <br/>\n  \n  \n  \n    <span class=\"tab-one\"><em>ValueSet</em>:</span> <a href=\"https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1146.1158/expansion\">COVID_19 (Tests for SARS_CoV_2 Antigen)version: null20240123)</a>\n    <br/> \n  \n  \n  \n   \n  </td>\n</tr>\n\n<tr>\n  <th scope=\"row\" class=\"row-header\">Data Requirement</th>\n  <td class=\"content-container\">\n    <em>Type</em>: ServiceRequest\n    <br/>\n  \n    <em>Profile(s)</em>: \n  \n    <a href=\"http://hl7.org/fhir/R4/servicerequest.html\">ServiceRequest</a>\n    <br/>        \n  \n   \n   \n    <em>Must Support Elements</em>: code, id, extension, instantiatesCanonical, instantiatesUri, basedOn, replaces, requisition, status, intent, category, priority, doNotPerform, orderDetail, quantity, subject, encounter, occurrence, asNeeded, authoredOn, performerType, performer, locationCode, locationReference, reasonCode, reasonReference, insurance, supportingInfo, specimen, bodySite, note, patientInstruction, relevantHistory\n    <br/>\n   \n  \n    <em>Code Filter(s)</em>: \n    <br/>\n  \n  \n    <span class=\"tab-one\"><em>Path</em>: code</span>\n    <br/>\n  \n  \n  \n    <span class=\"tab-one\"><em>ValueSet</em>:</span> <a href=\"https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1146.336/expansion\">Influenza (Tests for influenza A or B virus Nucleic Acid)version: null20250218)</a>\n    <br/> \n  \n  \n  \n   \n  </td>\n</tr>\n\n<tr>\n  <th scope=\"row\" class=\"row-header\">Data Requirement</th>\n  <td class=\"content-container\">\n    <em>Type</em>: ServiceRequest\n    <br/>\n  \n    <em>Profile(s)</em>: \n  \n    <a href=\"http://hl7.org/fhir/R4/servicerequest.html\">ServiceRequest</a>\n    <br/>        \n  \n   \n   \n    <em>Must Support Elements</em>: code, id, extension, instantiatesCanonical, instantiatesUri, basedOn, replaces, requisition, status, intent, category, priority, doNotPerform, orderDetail, quantity, subject, encounter, occurrence, asNeeded, authoredOn, performerType, performer, locationCode, locationReference, reasonCode, reasonReference, insurance, supportingInfo, specimen, bodySite, note, patientInstruction, relevantHistory\n    <br/>\n   \n  \n    <em>Code Filter(s)</em>: \n    <br/>\n  \n  \n    <span class=\"tab-one\"><em>Path</em>: code</span>\n    <br/>\n  \n  \n  \n    <span class=\"tab-one\"><em>ValueSet</em>:</span> <a href=\"https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1146.337/expansion\">Influenza (Tests for influenza A or B virus Antigen)</a>\n    <br/> \n  \n  \n  \n   \n  </td>\n</tr>\n\n<tr>\n  <th scope=\"row\" class=\"row-header\">Data Requirement</th>\n  <td class=\"content-container\">\n    <em>Type</em>: ServiceRequest\n    <br/>\n  \n    <em>Profile(s)</em>: \n  \n    <a href=\"http://hl7.org/fhir/R4/servicerequest.html\">ServiceRequest</a>\n    <br/>        \n  \n   \n   \n    <em>Must Support Elements</em>: code, id, extension, instantiatesCanonical, instantiatesUri, basedOn, replaces, requisition, status, intent, category, priority, doNotPerform, orderDetail, quantity, subject, encounter, occurrence, asNeeded, authoredOn, performerType, performer, locationCode, locationReference, reasonCode, reasonReference, insurance, supportingInfo, specimen, bodySite, note, patientInstruction, relevantHistory\n    <br/>\n   \n  \n    <em>Code Filter(s)</em>: \n    <br/>\n  \n  \n    <span class=\"tab-one\"><em>Path</em>: code</span>\n    <br/>\n  \n  \n  \n    <span class=\"tab-one\"><em>ValueSet</em>:</span> <a href=\"https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1146.1312/expansion\">RSV (Tests for RSV Nucleic Acid)version: null20250218)</a>\n    <br/> \n  \n  \n  \n   \n  </td>\n</tr>\n\n<tr>\n  <th scope=\"row\" class=\"row-header\">Data Requirement</th>\n  <td class=\"content-container\">\n    <em>Type</em>: ServiceRequest\n    <br/>\n  \n    <em>Profile(s)</em>: \n  \n    <a href=\"http://hl7.org/fhir/R4/servicerequest.html\">ServiceRequest</a>\n    <br/>        \n  \n   \n   \n    <em>Must Support Elements</em>: code, id, extension, instantiatesCanonical, instantiatesUri, basedOn, replaces, requisition, status, intent, category, priority, doNotPerform, orderDetail, quantity, subject, encounter, occurrence, asNeeded, authoredOn, performerType, performer, locationCode, locationReference, reasonCode, reasonReference, insurance, supportingInfo, specimen, bodySite, note, patientInstruction, relevantHistory\n    <br/>\n   \n  \n    <em>Code Filter(s)</em>: \n    <br/>\n  \n  \n    <span class=\"tab-one\"><em>Path</em>: code</span>\n    <br/>\n  \n  \n  \n    <span class=\"tab-one\"><em>ValueSet</em>:</span> <a href=\"https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1146.1311/expansion\">RSV (Tests for RSV Antigen)</a>\n    <br/> \n  \n  \n  \n   \n  </td>\n</tr>\n\n<tr>\n  <th scope=\"row\" class=\"row-header\">Data Requirement</th>\n  <td class=\"content-container\">\n    <em>Type</em>: ServiceRequest\n    <br/>\n  \n    <em>Profile(s)</em>: \n  \n    <a href=\"http://hl7.org/fhir/R4/servicerequest.html\">ServiceRequest</a>\n    <br/>        \n  \n   \n   \n    <em>Must Support Elements</em>: id, extension, instantiatesCanonical, instantiatesUri, basedOn, replaces, requisition, status, intent, category, priority, doNotPerform, code, orderDetail, quantity, subject, encounter, occurrence, asNeeded, authoredOn, performerType, performer, locationCode, locationReference, reasonCode, reasonReference, insurance, supportingInfo, specimen, bodySite, note, patientInstruction, relevantHistory\n    <br/>\n   \n   \n  </td>\n</tr>\n\n<tr>\n  <th scope=\"row\" class=\"row-header\">Data Requirement</th>\n  <td class=\"content-container\">\n    <em>Type</em>: Observation\n    <br/>\n  \n    <em>Profile(s)</em>: \n  \n    <a href=\"http://hl7.org/fhir/R4/observation.html\">Observation</a>\n    <br/>        \n  \n   \n   \n    <em>Must Support Elements</em>: code, category, status, effective, specimen, specimen.collection, specimen.collection.collected, id, extension, basedOn, partOf, subject, focus, encounter, issued, performer, value, dataAbsentReason, interpretation, note, bodySite, method, device, referenceRange, hasMember, derivedFrom, component\n    <br/>\n   \n  \n    <em>Code Filter(s)</em>: \n    <br/>\n  \n  \n    <span class=\"tab-one\"><em>Path</em>: code</span>\n    <br/>\n  \n  \n  \n    <span class=\"tab-one\"><em>ValueSet</em>:</span> <a href=\"https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1146.1312/expansion\">RSV (Tests for RSV Nucleic Acid)version: null20250218)</a>\n    <br/> \n  \n  \n  \n   \n  </td>\n</tr>\n\n<tr>\n  <th scope=\"row\" class=\"row-header\">Data Requirement</th>\n  <td class=\"content-container\">\n    <em>Type</em>: Observation\n    <br/>\n  \n    <em>Profile(s)</em>: \n  \n    <a href=\"http://hl7.org/fhir/R4/observation.html\">Observation</a>\n    <br/>        \n  \n   \n   \n    <em>Must Support Elements</em>: code, category, status, effective, specimen, specimen.collection, specimen.collection.collected, id, extension, basedOn, partOf, subject, focus, encounter, issued, performer, value, dataAbsentReason, interpretation, note, bodySite, method, device, referenceRange, hasMember, derivedFrom, component\n    <br/>\n   \n  \n    <em>Code Filter(s)</em>: \n    <br/>\n  \n  \n    <span class=\"tab-one\"><em>Path</em>: code</span>\n    <br/>\n  \n  \n  \n    <span class=\"tab-one\"><em>ValueSet</em>:</span> <a href=\"https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1146.1311/expansion\">RSV (Tests for RSV Antigen)</a>\n    <br/> \n  \n  \n  \n   \n  </td>\n</tr>\n\n<tr>\n  <th scope=\"row\" class=\"row-header\">Data Requirement</th>\n  <td class=\"content-container\">\n    <em>Type</em>: Observation\n    <br/>\n  \n    <em>Profile(s)</em>: \n  \n    <a href=\"http://hl7.org/fhir/R4/observation.html\">Observation</a>\n    <br/>        \n  \n   \n   \n    <em>Must Support Elements</em>: code, category, status, effective, specimen, specimen.collection, specimen.collection.collected, id, extension, basedOn, partOf, subject, focus, encounter, issued, performer, value, dataAbsentReason, interpretation, note, bodySite, method, device, referenceRange, hasMember, derivedFrom, component\n    <br/>\n   \n  \n    <em>Code Filter(s)</em>: \n    <br/>\n  \n  \n    <span class=\"tab-one\"><em>Path</em>: code</span>\n    <br/>\n  \n  \n  \n    <span class=\"tab-one\"><em>ValueSet</em>:</span> <a href=\"https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1146.336/expansion\">Influenza (Tests for influenza A or B virus Nucleic Acid)version: null20250218)</a>\n    <br/> \n  \n  \n  \n   \n  </td>\n</tr>\n\n<tr>\n  <th scope=\"row\" class=\"row-header\">Data Requirement</th>\n  <td class=\"content-container\">\n    <em>Type</em>: Observation\n    <br/>\n  \n    <em>Profile(s)</em>: \n  \n    <a href=\"http://hl7.org/fhir/R4/observation.html\">Observation</a>\n    <br/>        \n  \n   \n   \n    <em>Must Support Elements</em>: code, category, status, effective, specimen, specimen.collection, specimen.collection.collected, id, extension, basedOn, partOf, subject, focus, encounter, issued, performer, value, dataAbsentReason, interpretation, note, bodySite, method, device, referenceRange, hasMember, derivedFrom, component\n    <br/>\n   \n  \n    <em>Code Filter(s)</em>: \n    <br/>\n  \n  \n    <span class=\"tab-one\"><em>Path</em>: code</span>\n    <br/>\n  \n  \n  \n    <span class=\"tab-one\"><em>ValueSet</em>:</span> <a href=\"https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1146.337/expansion\">Influenza (Tests for influenza A or B virus Antigen)</a>\n    <br/> \n  \n  \n  \n   \n  </td>\n</tr>\n\n<tr>\n  <th scope=\"row\" class=\"row-header\">Data Requirement</th>\n  <td class=\"content-container\">\n    <em>Type</em>: Observation\n    <br/>\n  \n    <em>Profile(s)</em>: \n  \n    <a href=\"http://hl7.org/fhir/R4/observation.html\">Observation</a>\n    <br/>        \n  \n   \n   \n    <em>Must Support Elements</em>: code, category, status, effective, specimen, specimen.collection, specimen.collection.collected, id, extension, basedOn, partOf, subject, focus, encounter, issued, performer, value, dataAbsentReason, interpretation, note, bodySite, method, device, referenceRange, hasMember, derivedFrom, component\n    <br/>\n   \n  \n    <em>Code Filter(s)</em>: \n    <br/>\n  \n  \n    <span class=\"tab-one\"><em>Path</em>: code</span>\n    <br/>\n  \n  \n  \n    <span class=\"tab-one\"><em>ValueSet</em>:</span> <a href=\"https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1146.1142/expansion\">COVID_19 (Tests for SARS_CoV_2 Nucleic Acid)version: null20250218)</a>\n    <br/> \n  \n  \n  \n   \n  </td>\n</tr>\n\n<tr>\n  <th scope=\"row\" class=\"row-header\">Data Requirement</th>\n  <td class=\"content-container\">\n    <em>Type</em>: Observation\n    <br/>\n  \n    <em>Profile(s)</em>: \n  \n    <a href=\"http://hl7.org/fhir/R4/observation.html\">Observation</a>\n    <br/>        \n  \n   \n   \n    <em>Must Support Elements</em>: code, category, status, effective, specimen, specimen.collection, specimen.collection.collected, id, extension, basedOn, partOf, subject, focus, encounter, issued, performer, value, dataAbsentReason, interpretation, note, bodySite, method, device, referenceRange, hasMember, derivedFrom, component\n    <br/>\n   \n  \n    <em>Code Filter(s)</em>: \n    <br/>\n  \n  \n    <span class=\"tab-one\"><em>Path</em>: code</span>\n    <br/>\n  \n  \n  \n    <span class=\"tab-one\"><em>ValueSet</em>:</span> <a href=\"https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1146.1158/expansion\">COVID_19 (Tests for SARS_CoV_2 Antigen)version: null20240123)</a>\n    <br/> \n  \n  \n  \n   \n  </td>\n</tr>\n\n<tr>\n  <th scope=\"row\" class=\"row-header\">Data Requirement</th>\n  <td class=\"content-container\">\n    <em>Type</em>: Observation\n    <br/>\n  \n    <em>Profile(s)</em>: \n  \n    <a href=\"http://hl7.org/fhir/R4/observation.html\">Observation</a>\n    <br/>        \n  \n   \n   \n    <em>Must Support Elements</em>: category, status, effective, specimen, specimen.collection, specimen.collection.collected, id, extension, basedOn, partOf, code, subject, focus, encounter, issued, performer, value, dataAbsentReason, interpretation, note, bodySite, method, device, referenceRange, hasMember, derivedFrom, component\n    <br/>\n   \n   \n  </td>\n</tr>\n\n<tr>\n  <th scope=\"row\" class=\"row-header\">Data Requirement</th>\n  <td class=\"content-container\">\n    <em>Type</em>: Specimen\n    <br/>\n  \n    <em>Profile(s)</em>: \n  \n    <a href=\"http://hl7.org/fhir/R4/specimen.html\">Specimen</a>\n    <br/>        \n  \n   \n   \n    <em>Must Support Elements</em>: id, extension, identifier, accessionIdentifier, status, type, subject, receivedTime, parent, request, collection, processing, container, condition, note\n    <br/>\n   \n   \n  </td>\n</tr>\n\n<tr>\n  <th scope=\"row\" class=\"row-header\">Data Requirement</th>\n  <td class=\"content-container\">\n    <em>Type</em>: DiagnosticReport\n    <br/>\n  \n    <em>Profile(s)</em>: \n  \n    <a href=\"http://hl7.org/fhir/R4/diagnosticreport.html\">DiagnosticReport</a>\n    <br/>        \n  \n   \n   \n    <em>Must Support Elements</em>: code, status, id, extension, basedOn, category, subject, encounter, effective, issued, performer, resultsInterpreter, specimen, result, conclusion, conclusionCode\n    <br/>\n   \n  \n    <em>Code Filter(s)</em>: \n    <br/>\n  \n  \n    <span class=\"tab-one\"><em>Path</em>: code</span>\n    <br/>\n  \n  \n  \n    <span class=\"tab-one\"><em>ValueSet</em>:</span> <a href=\"https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1146.1142/expansion\">COVID_19 (Tests for SARS_CoV_2 Nucleic Acid)version: null20250218)</a>\n    <br/> \n  \n  \n  \n   \n  </td>\n</tr>\n\n<tr>\n  <th scope=\"row\" class=\"row-header\">Data Requirement</th>\n  <td class=\"content-container\">\n    <em>Type</em>: DiagnosticReport\n    <br/>\n  \n    <em>Profile(s)</em>: \n  \n    <a href=\"http://hl7.org/fhir/R4/diagnosticreport.html\">DiagnosticReport</a>\n    <br/>        \n  \n   \n   \n    <em>Must Support Elements</em>: code, status, id, extension, basedOn, category, subject, encounter, effective, issued, performer, resultsInterpreter, specimen, result, conclusion, conclusionCode\n    <br/>\n   \n  \n    <em>Code Filter(s)</em>: \n    <br/>\n  \n  \n    <span class=\"tab-one\"><em>Path</em>: code</span>\n    <br/>\n  \n  \n  \n    <span class=\"tab-one\"><em>ValueSet</em>:</span> <a href=\"https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1146.1158/expansion\">COVID_19 (Tests for SARS_CoV_2 Antigen)version: null20240123)</a>\n    <br/> \n  \n  \n  \n   \n  </td>\n</tr>\n\n<tr>\n  <th scope=\"row\" class=\"row-header\">Data Requirement</th>\n  <td class=\"content-container\">\n    <em>Type</em>: DiagnosticReport\n    <br/>\n  \n    <em>Profile(s)</em>: \n  \n    <a href=\"http://hl7.org/fhir/R4/diagnosticreport.html\">DiagnosticReport</a>\n    <br/>        \n  \n   \n   \n    <em>Must Support Elements</em>: code, status, id, extension, basedOn, category, subject, encounter, effective, issued, performer, resultsInterpreter, specimen, result, conclusion, conclusionCode\n    <br/>\n   \n  \n    <em>Code Filter(s)</em>: \n    <br/>\n  \n  \n    <span class=\"tab-one\"><em>Path</em>: code</span>\n    <br/>\n  \n  \n  \n    <span class=\"tab-one\"><em>ValueSet</em>:</span> <a href=\"https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1146.336/expansion\">Influenza (Tests for influenza A or B virus Nucleic Acid)version: null20250218)</a>\n    <br/> \n  \n  \n  \n   \n  </td>\n</tr>\n\n<tr>\n  <th scope=\"row\" class=\"row-header\">Data Requirement</th>\n  <td class=\"content-container\">\n    <em>Type</em>: DiagnosticReport\n    <br/>\n  \n    <em>Profile(s)</em>: \n  \n    <a href=\"http://hl7.org/fhir/R4/diagnosticreport.html\">DiagnosticReport</a>\n    <br/>        \n  \n   \n   \n    <em>Must Support Elements</em>: code, status, id, extension, basedOn, category, subject, encounter, effective, issued, performer, resultsInterpreter, specimen, result, conclusion, conclusionCode\n    <br/>\n   \n  \n    <em>Code Filter(s)</em>: \n    <br/>\n  \n  \n    <span class=\"tab-one\"><em>Path</em>: code</span>\n    <br/>\n  \n  \n  \n    <span class=\"tab-one\"><em>ValueSet</em>:</span> <a href=\"https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1146.337/expansion\">Influenza (Tests for influenza A or B virus Antigen)</a>\n    <br/> \n  \n  \n  \n   \n  </td>\n</tr>\n\n<tr>\n  <th scope=\"row\" class=\"row-header\">Data Requirement</th>\n  <td class=\"content-container\">\n    <em>Type</em>: DiagnosticReport\n    <br/>\n  \n    <em>Profile(s)</em>: \n  \n    <a href=\"http://hl7.org/fhir/R4/diagnosticreport.html\">DiagnosticReport</a>\n    <br/>        \n  \n   \n   \n    <em>Must Support Elements</em>: code, status, id, extension, basedOn, category, subject, encounter, effective, issued, performer, resultsInterpreter, specimen, result, conclusion, conclusionCode\n    <br/>\n   \n  \n    <em>Code Filter(s)</em>: \n    <br/>\n  \n  \n    <span class=\"tab-one\"><em>Path</em>: code</span>\n    <br/>\n  \n  \n  \n    <span class=\"tab-one\"><em>ValueSet</em>:</span> <a href=\"https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1146.1312/expansion\">RSV (Tests for RSV Nucleic Acid)version: null20250218)</a>\n    <br/> \n  \n  \n  \n   \n  </td>\n</tr>\n\n<tr>\n  <th scope=\"row\" class=\"row-header\">Data Requirement</th>\n  <td class=\"content-container\">\n    <em>Type</em>: DiagnosticReport\n    <br/>\n  \n    <em>Profile(s)</em>: \n  \n    <a href=\"http://hl7.org/fhir/R4/diagnosticreport.html\">DiagnosticReport</a>\n    <br/>        \n  \n   \n   \n    <em>Must Support Elements</em>: code, status, id, extension, basedOn, category, subject, encounter, effective, issued, performer, resultsInterpreter, specimen, result, conclusion, conclusionCode\n    <br/>\n   \n  \n    <em>Code Filter(s)</em>: \n    <br/>\n  \n  \n    <span class=\"tab-one\"><em>Path</em>: code</span>\n    <br/>\n  \n  \n  \n    <span class=\"tab-one\"><em>ValueSet</em>:</span> <a href=\"https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1146.1311/expansion\">RSV (Tests for RSV Antigen)</a>\n    <br/> \n  \n  \n  \n   \n  </td>\n</tr>\n\n<tr>\n  <th scope=\"row\" class=\"row-header\">Data Requirement</th>\n  <td class=\"content-container\">\n    <em>Type</em>: DiagnosticReport\n    <br/>\n  \n    <em>Profile(s)</em>: \n  \n    <a href=\"http://hl7.org/fhir/R4/diagnosticreport.html\">DiagnosticReport</a>\n    <br/>        \n  \n   \n   \n    <em>Must Support Elements</em>: status, id, extension, basedOn, category, code, subject, encounter, effective, issued, performer, resultsInterpreter, specimen, result, conclusion, conclusionCode\n    <br/>\n   \n   \n  </td>\n</tr>\n\n<tr>\n  <th scope=\"row\" class=\"row-header\">Data Requirement</th>\n  <td class=\"content-container\">\n    <em>Type</em>: Procedure\n    <br/>\n  \n    <em>Profile(s)</em>: \n  \n    <a href=\"http://hl7.org/fhir/R4/procedure.html\">Procedure</a>\n    <br/>        \n  \n   \n   \n    <em>Must Support Elements</em>: id, extension, instantiatesCanonical, instantiatesUri, basedOn, partOf, status, statusReason, category, code, subject, encounter, performed, recorder, asserter, performer, location, reasonCode, reasonReference, bodySite, outcome, report, complication, complicationDetail, followUp, note, focalDevice, usedReference, usedCode\n    <br/>\n   \n   \n  </td>\n</tr>\n\n<tr>\n  <th scope=\"row\" class=\"row-header\">Data Requirement</th>\n  <td class=\"content-container\">\n    <em>Type</em>: Procedure\n    <br/>\n  \n    <em>Profile(s)</em>: \n  \n    <a href=\"http://hl7.org/fhir/R4/procedure.html\">Procedure</a>\n    <br/>        \n  \n   \n   \n    <em>Must Support Elements</em>: code, performed, id, extension, instantiatesCanonical, instantiatesUri, basedOn, partOf, status, statusReason, category, subject, encounter, recorder, asserter, performer, location, reasonCode, reasonReference, bodySite, outcome, report, complication, complicationDetail, followUp, note, focalDevice, usedReference, usedCode\n    <br/>\n   \n  \n    <em>Code Filter(s)</em>: \n    <br/>\n  \n  \n    <span class=\"tab-one\"><em>Path</em>: code</span>\n    <br/>\n  \n  \n  \n    <span class=\"tab-one\"><em>ValueSet</em>:</span> <a href=\"https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.10.20.22.5.300/expansion\">Transmission Based Precaution Typesversion: null20240607)</a>\n    <br/> \n  \n  \n  \n   \n  </td>\n</tr>\n\n<tr>\n  <th scope=\"row\" class=\"row-header\">Data Requirement</th>\n  <td class=\"content-container\">\n    <em>Type</em>: Medication\n    <br/>\n  \n    <em>Profile(s)</em>: \n  \n    <a href=\"http://hl7.org/fhir/R4/medication.html\">Medication</a>\n    <br/>        \n  \n   \n   \n    <em>Must Support Elements</em>: id, extension, code, status, manufacturer, form, amount, ingredient, batch\n    <br/>\n   \n  \n    <em>Code Filter(s)</em>: \n    <br/>\n  \n  \n    <span class=\"tab-one\"><em>Path</em>: id</span>\n    <br/>\n  \n  \n  \n  \n  \n   \n  </td>\n</tr>\n\n<tr>\n  <th scope=\"row\" class=\"row-header\">Data Requirement</th>\n  <td class=\"content-container\">\n    <em>Type</em>: Patient\n    <br/>\n  \n    <em>Profile(s)</em>: \n  \n    <a href=\"http://hl7.org/fhir/R4/patient.html\">Patient</a>\n    <br/>        \n  \n   \n   \n    <em>Must Support Elements</em>: id, identifier, active, name, telecom, gender, birthDate, deceased, address, maritalStatus, multipleBirth, contact, communication, link\n    <br/>\n   \n   \n  </td>\n</tr>\n\n<tr>\n  <th scope=\"row\" class=\"row-header\">Data Requirement</th>\n  <td class=\"content-container\">\n    <em>Type</em>: MedicationRequest\n    <br/>\n  \n    <em>Profile(s)</em>: \n  \n    <a href=\"http://hl7.org/fhir/R4/medicationrequest.html\">MedicationRequest</a>\n    <br/>        \n  \n   \n   \n    <em>Must Support Elements</em>: medication, authoredOn, id, extension, status, intent, category, priority, doNotPerform, reported, subject, encounter, requester, recorder, reasonCode, reasonReference, instantiatesCanonical, instantiatesUri, courseOfTherapyType, dosageInstruction\n    <br/>\n   \n   \n  </td>\n</tr>\n\n<tr>\n  <th scope=\"row\" class=\"row-header\">Data Requirement</th>\n  <td class=\"content-container\">\n    <em>Type</em>: MedicationAdministration\n    <br/>\n  \n    <em>Profile(s)</em>: \n  \n    <a href=\"http://hl7.org/fhir/R4/medicationadministration.html\">MedicationAdministration</a>\n    <br/>        \n  \n   \n   \n    <em>Must Support Elements</em>: medication, status, effective, id, extension, instantiates, partOf, statusReason, category, subject, context, supportingInformation, performer, reasonCode, reasonReference, request, device, note, dosage, eventHistory\n    <br/>\n   \n   \n  </td>\n</tr>\n\n  \n  <tr>\n\n<th colspan=\"2\" scope=\"row\" class=\"row-header\">Measure Logic Definitions</th>\n\n</tr>\n  \n          \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"nhsnacutecarehospitaldailyinitialpopulation-encounters\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> NHSNAcuteCareHospitalDailyInitialPopulation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">//Common Retrievals define &quot;Encounters&quot;:   [Encounter]</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"nhsnacutecarehospitaldailyinitialpopulation-encounterinpatient\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> NHSNAcuteCareHospitalDailyInitialPopulation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">define &quot;EncounterInpatient&quot;:   ([Encounter: &quot;Encounter Inpatient&quot;]     union [Encounter: class in &quot;NHSN Inpatient Encounter Class Codes&quot;]) Encounters   where Encounters.status in {'in-progress', 'finished', 'triaged', 'onleave', 'entered-in-error'}     and Encounters.period overlaps &quot;Measurement Period&quot;</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"nhsnacutecarehospitaldailyinitialpopulation-encounterobservation\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> NHSNAcuteCareHospitalDailyInitialPopulation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">define &quot;EncounterObservation&quot;:   ([Encounter: &quot;Observation Services&quot;]     union [Encounter: class in {&quot;observation encounter&quot;}]) Encounters   where Encounters.status in {'in-progress', 'finished', 'triaged', 'onleave', 'entered-in-error'}     and Encounters.period overlaps &quot;Measurement Period&quot;</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"nhsnacutecarehospitaldailyinitialpopulation-encounters-with-patient-hospital-locations\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> NHSNAcuteCareHospitalDailyInitialPopulation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">define &quot;Encounters with Patient Hospital Locations&quot;:   [Encounter] Encounters   where exists(     Encounters.location EncounterLocation     let types: NHSNHelpers.GetLocation(EncounterLocation.location).type     where exists(       types type       where type in &quot;Inpatient, Emergency, and Observation Locations&quot;     )     and EncounterLocation.period overlaps Encounters.period     and Encounters.status in {'in-progress', 'finished', 'triaged', 'onleave', 'entered-in-error' }     and Encounters.period overlaps &quot;Measurement Period&quot;   )</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"nhsnacutecarehospitaldailyinitialpopulation-initial-population\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> NHSNAcuteCareHospitalDailyInitialPopulation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">//---------------------------------- // Initial Population //---------------------------------- define &quot;Initial Population&quot;:   EncounterInpatient   union EncounterObservation   union &quot;Encounters with Patient Hospital Locations&quot;</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"nhsnacutecarehospitaldailyinitialpopulation-sde-encounter\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> NHSNAcuteCareHospitalDailyInitialPopulation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">define &quot;SDE Encounter&quot;:    &quot;Encounters&quot; Encounters   where not CheckIP(Encounters)   and exists(     &quot;Initial Population&quot; IP     where Encounters.period overlaps IP.period)   return SharedResource.EncounterResource(Encounters,   {FHIR.canonical{value: 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-encounter'}})</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"nhsnacutecarehospitaldailyinitialpopulation-sde-ach-daily-servicerequest\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> NHSNAcuteCareHospitalDailyInitialPopulation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">define &quot;SDE ACH Daily ServiceRequest&quot;:   ([ServiceRequest: &quot;COVID_19 (Tests for SARS_CoV_2 Nucleic Acid)&quot;]    union  [ServiceRequest: &quot;COVID_19 (Tests for SARS_CoV_2 Antigen)&quot;]    union  [ServiceRequest: &quot;Influenza (Tests for influenza A or B virus Nucleic Acid)&quot;]   union  [ServiceRequest: &quot;Influenza (Tests for influenza A or B virus Antigen)&quot;]   union  [ServiceRequest: &quot;RSV (Tests for RSV Nucleic Acid)&quot;]   union  [ServiceRequest: &quot;RSV (Tests for RSV Antigen)&quot;]   ) ServiceRequests     where ServiceRequests.intent ~ 'order'       and ServiceRequests.status ~ 'completed'       and exists(&quot;Initial Population&quot;)   return ServiceRequestResource(ServiceRequests,   {FHIR.canonical{value: 'http://www.cdc.gov/nhsn/fhirportal/dqm/ig/StructureDefinition/ach-daily-servicerequest'}})</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"nhsnacutecarehospitaldailyinitialpopulation-rsv-observation\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> NHSNAcuteCareHospitalDailyInitialPopulation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">define &quot;RSV Observation&quot;:   ([Observation: &quot;RSV (Tests for RSV Nucleic Acid)&quot;]   union [Observation: &quot;RSV (Tests for RSV Antigen)&quot;]      ) Observations     where exists(Observations.category Category where Category ~ &quot;laboratory&quot;)       and Observations.status in {'final','registered','preliminary','partial'}       and exists(&quot;Initial Population&quot;)</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"nhsnacutecarehospitaldailyinitialpopulation-rsv-pre-admission-observation\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> NHSNAcuteCareHospitalDailyInitialPopulation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">//further constrain RSV observation for 8 day lookback define &quot;RSV PRE Admission Observation&quot;:   &quot;RSV Observation&quot; O    where exists(EncounterInpatient E      where (       NHSNHelpers.&quot;Normalize Interval&quot;(O.effective) 8 days or less on or before start of E.period       or NHSNHelpers.&quot;Normalize Interval&quot;(GetSpecimen(O.specimen).collection.collected) 8 days or less on or before start of E.period       )       and start of E.period during &quot;Measurement Period&quot;     )</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"nhsnacutecarehospitaldailyinitialpopulation-sde-rsv-specimen\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> NHSNAcuteCareHospitalDailyInitialPopulation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">//return the Specimen related to the RSV Observation Pre Admission define &quot;SDE RSV Specimen&quot;:   &quot;RSV PRE Admission Observation&quot; ObservationWithSpecimen     let Specimen: GetSpecimen(ObservationWithSpecimen.specimen)     return SharedResource.SpecimenResource(Specimen,     {FHIR.canonical{value: 'http://www.cdc.gov/nhsn/fhirportal/dqm/ig/StructureDefinition/ach-daily-specimen'}})</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"nhsnacutecarehospitaldailyinitialpopulation-covid-and-influenza-observation\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> NHSNAcuteCareHospitalDailyInitialPopulation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">//----------------------------------------------- // Logic related to Laboratory //----------------------------------------------- //Lab Observations define &quot;COVID And Influenza Observation&quot;:   ([Observation: &quot;Influenza (Tests for influenza A or B virus Nucleic Acid)&quot;]    union [Observation: &quot;Influenza (Tests for influenza A or B virus Antigen)&quot;]   union [Observation: &quot;COVID_19 (Tests for SARS_CoV_2 Nucleic Acid)&quot;]   union [Observation: &quot;COVID_19 (Tests for SARS_CoV_2 Antigen)&quot;]   ) Observations     where exists(Observations.category Category where Category ~ &quot;laboratory&quot;)       and Observations.status in {'final','registered','preliminary','partial'}       and exists(&quot;Initial Population&quot;)</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"nhsnacutecarehospitaldailyinitialpopulation-ach-daily-observation\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> NHSNAcuteCareHospitalDailyInitialPopulation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">define &quot;ACH Daily Observation&quot;:   &quot;RSV Observation&quot;   union &quot;COVID And Influenza Observation&quot;</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"nhsnacutecarehospitaldailyinitialpopulation-sde-ach-daily-specimen\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> NHSNAcuteCareHospitalDailyInitialPopulation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">//return the Specimen related to the Observation during the Measurement Period define &quot;SDE ACH Daily Specimen&quot;:   &quot;ACH Daily Observation&quot; ObservationWithSpecimen     let Specimen: GetSpecimen(ObservationWithSpecimen.specimen)     return SharedResource.SpecimenResource(Specimen,     {FHIR.canonical{value: 'http://www.cdc.gov/nhsn/fhirportal/dqm/ig/StructureDefinition/ach-daily-specimen'}})</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"nhsnacutecarehospitaldailyinitialpopulation-covid-and-influenza-diagnosticreport\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> NHSNAcuteCareHospitalDailyInitialPopulation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">//Lab DiagnosticReport define &quot;COVID And Influenza DiagnosticReport&quot;:   ([DiagnosticReport: &quot;COVID_19 (Tests for SARS_CoV_2 Nucleic Acid)&quot;]     union [DiagnosticReport: &quot;COVID_19 (Tests for SARS_CoV_2 Antigen)&quot;]     union [DiagnosticReport: &quot;Influenza (Tests for influenza A or B virus Nucleic Acid)&quot;]     union [DiagnosticReport: &quot;Influenza (Tests for influenza A or B virus Antigen)&quot;]   ) Reports     where exists(&quot;Initial Population&quot;)       and Reports.status in {'final','registered','preliminary','partial'}</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"nhsnacutecarehospitaldailyinitialpopulation-rsv-diagnosticreport\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> NHSNAcuteCareHospitalDailyInitialPopulation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">define &quot;RSV DiagnosticReport&quot;:   ([DiagnosticReport: &quot;RSV (Tests for RSV Nucleic Acid)&quot;]     union [DiagnosticReport: &quot;RSV (Tests for RSV Antigen)&quot;]   ) Reports     where exists(&quot;Initial Population&quot;)       and Reports.status in {'final','registered','preliminary','partial'}</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"nhsnacutecarehospitaldailyinitialpopulation-ach-daily-diagnosticreport\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> NHSNAcuteCareHospitalDailyInitialPopulation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">define &quot;ACH Daily DiagnosticReport&quot;:   &quot;COVID And Influenza DiagnosticReport&quot;     union &quot;RSV DiagnosticReport&quot;</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"nhsnacutecarehospitaldailyinitialpopulation-sde-ach-daily-diagnosticreport\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> NHSNAcuteCareHospitalDailyInitialPopulation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">//return the DiagnosticReport during the Measurement Period define &quot;SDE ACH Daily DiagnosticReport&quot;:   &quot;ACH Daily DiagnosticReport&quot; Reports     return SharedResource.DiagnosticReportLabResource(Reports,     {FHIR.canonical{value: 'http://www.cdc.gov/nhsn/fhirportal/dqm/ig/StructureDefinition/ach-daily-diagnosticreport-lab'}})</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"nhsnacutecarehospitaldailyinitialpopulation-sde-rsv-diagnosticreport\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> NHSNAcuteCareHospitalDailyInitialPopulation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">//return the RSV DiagnosticReport pre admission define &quot;SDE RSV DiagnosticReport&quot;:   &quot;RSV DiagnosticReport&quot; Reports     return SharedResource.DiagnosticReportLabResource(Reports,     {FHIR.canonical{value: 'http://www.cdc.gov/nhsn/fhirportal/dqm/ig/StructureDefinition/ach-daily-diagnosticreport-lab'}})</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"nhsnacutecarehospitaldailyinitialpopulation-sde-ach-daily-observation\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> NHSNAcuteCareHospitalDailyInitialPopulation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">//return the Observation during the Measurement Period define &quot;SDE ACH Daily Observation&quot;:   &quot;ACH Daily Observation&quot; Observations     return ObservationLabResource(Observations,     {FHIR.canonical{value: 'http://www.cdc.gov/nhsn/fhirportal/dqm/ig/StructureDefinition/ach-daily-observation-lab'}})</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"nhsnacutecarehospitaldailyinitialpopulation-sde-all-procedures\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> NHSNAcuteCareHospitalDailyInitialPopulation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">//To catch all isolation precautions define &quot;SDE All Procedures&quot;:   [Procedure] P   where exists(&quot;Initial Population&quot;)   return SharedResource.ProcedureResource(P,   {FHIR.canonical{value: 'http://www.cdc.gov/nhsn/fhirportal/dqm/ig/StructureDefinition/ach-daily-procedure'}})</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"nhsnacutecarehospitaldailyinitialpopulation-sde-encounter-discharge-dispositions\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> NHSNAcuteCareHospitalDailyInitialPopulation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">define &quot;SDE Encounter Discharge Dispositions&quot;:  &quot;Initial Population&quot; DischargeDispositions    where DischargeDispositions.hospitalization.dischargeDisposition in &quot;Discharge Disposition&quot;   return SharedResource.EncounterResource(DischargeDispositions,   {FHIR.canonical{value: 'http://www.cdc.gov/nhsn/fhirportal/dqm/ig/StructureDefinition/ach-daily-encounter'}})</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"nhsnacutecarehospitaldailyinitialpopulation-sde-covid-or-influenza-medication-ordered\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> NHSNAcuteCareHospitalDailyInitialPopulation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">define &quot;SDE Covid or Influenza Medication Ordered&quot;:   [MedicationRequest] RPSMedRequest     let Meds: GetMedicationCode(RPSMedRequest.medication)     where (Meds in &quot;Anakinra&quot;             or Meds in &quot;Baloxavir&quot;             or Meds in &quot;Bamlanivimab&quot;             or Meds in &quot;Baricitinib&quot;             or Meds in &quot;Bebtelovimab&quot;             or Meds in &quot;Casirivimab&quot;             or Meds in &quot;Casirivimab / Imdevimab&quot;             or Meds in &quot;COVID19 RxNorm Value Set for Tocilizumab&quot;             or Meds in &quot;Etesevimab&quot;             or Meds in &quot;Imdevimab&quot;             or Meds in &quot;Molnupiravir&quot;             or Meds in &quot;Nirmatrelvir / Ritonavir&quot;             or Meds in &quot;Oseltamivir&quot;             or Meds in &quot;Peramivir&quot;             or Meds in &quot;Remdesivir&quot;             or Meds in &quot;Sarilumab&quot;             or Meds in &quot;Sotrovimab&quot;                 or Meds in &quot;Tofacitinib&quot;             or Meds in &quot;Zanamivir&quot;)       and exists(&quot;Initial Population&quot;)       and NHSNHelpers.&quot;Normalize Interval&quot;(RPSMedRequest.authoredOn) during &quot;Measurement Period&quot;     return MedicationRequestResource(RPSMedRequest,     {FHIR.canonical{value: 'http://www.cdc.gov/nhsn/fhirportal/dqm/ig/StructureDefinition/ach-daily-medicationrequest'}})</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"nhsnacutecarehospitaldailyinitialpopulation-sde-minimal-patient\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> NHSNAcuteCareHospitalDailyInitialPopulation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">define &quot;SDE Minimal Patient&quot;:   Patient p   where exists(&quot;Initial Population&quot;)   return SharedResource.PatientResource(p,    {FHIR.canonical{value: 'http://www.cdc.gov/nhsn/fhirportal/dqm/ig/StructureDefinition/cross-measure-patient'}})</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"nhsnacutecarehospitaldailyinitialpopulation-observations\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> NHSNAcuteCareHospitalDailyInitialPopulation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">define &quot;Observations&quot;:   [Observation]</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"nhsnacutecarehospitaldailyinitialpopulation-sde-all-observations\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> NHSNAcuteCareHospitalDailyInitialPopulation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">//To catch all isolation precautions define &quot;SDE All Observations&quot;:   &quot;Observations&quot; O   where exists(&quot;Initial Population&quot;)   return ObservationLabResource(O,   {FHIR.canonical{value: 'http://www.cdc.gov/nhsn/fhirportal/dqm/ig/StructureDefinition/ach-daily-observation'}})</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"nhsnacutecarehospitaldailyinitialpopulation-sde-covid-or-influenza-medication-administered\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> NHSNAcuteCareHospitalDailyInitialPopulation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">define &quot;SDE Covid or Influenza Medication Administered&quot;:   [MedicationAdministration] RPSMedAdmin     let Meds: GetMedicationCode(RPSMedAdmin.medication)    where (Meds in &quot;Anakinra&quot;             or Meds in &quot;Bamlanivimab&quot;             or Meds in &quot;Baloxavir&quot;             or Meds in &quot;Baricitinib&quot;             or Meds in &quot;Bebtelovimab&quot;             or Meds in &quot;Casirivimab&quot;             or Meds in &quot;Casirivimab / Imdevimab&quot;             or Meds in &quot;COVID19 RxNorm Value Set for Tocilizumab&quot;             or Meds in &quot;Etesevimab&quot;             or Meds in &quot;Imdevimab&quot;             or Meds in &quot;Molnupiravir&quot;             or Meds in &quot;Nirmatrelvir / Ritonavir&quot;             or Meds in &quot;Oseltamivir&quot;             or Meds in &quot;Peramivir&quot;             or Meds in &quot;Remdesivir&quot;             or Meds in &quot;Sarilumab&quot;             or Meds in &quot;Sotrovimab&quot;                 or Meds in &quot;Tofacitinib&quot;             or Meds in &quot;Zanamivir&quot;)       and RPSMedAdmin.status ~ 'completed'       and exists(&quot;Initial Population&quot;)       and NHSNHelpers.&quot;Normalize Interval&quot;(RPSMedAdmin.effective) during &quot;Measurement Period&quot;     return SharedResource.MedicationAdministrationResource(RPSMedAdmin,     {FHIR.canonical{value: 'http://www.cdc.gov/nhsn/fhirportal/dqm/ig/StructureDefinition/ach-daily-medicationadministration'}})</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"nhsnacutecarehospitaldailyinitialpopulation-sde-medication\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> NHSNAcuteCareHospitalDailyInitialPopulation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">define &quot;SDE Medication&quot;:   (&quot;SDE Covid or Influenza Medication Ordered&quot;   union &quot;SDE Covid or Influenza Medication Administered&quot;) MedReqOrAdmin   where MedReqOrAdmin.medication is FHIR.Reference   return SharedResource.MedicationResource(GetMedicationFrom(MedReqOrAdmin.medication),   {FHIR.canonical{value: 'http://www.cdc.gov/nhsn/fhirportal/dqm/ig/StructureDefinition/ach-daily-medication'}})</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"nhsnacutecarehospitaldailyinitialpopulation-diagnosticreports\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> NHSNAcuteCareHospitalDailyInitialPopulation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">define &quot;DiagnosticReports&quot;:   [DiagnosticReport]</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"nhsnacutecarehospitaldailyinitialpopulation-rsv-observations\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> NHSNAcuteCareHospitalDailyInitialPopulation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">define &quot;RSV Observations&quot;:   &quot;Observations&quot; Observations   where Observations.code in &quot;RSV (Tests for RSV Nucleic Acid)&quot;     or Observations.code in &quot;RSV (Tests for RSV Antigen)&quot;</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"nhsnacutecarehospitaldailyinitialpopulation-rsv-diagnosticreport-observations\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> NHSNAcuteCareHospitalDailyInitialPopulation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">define &quot;RSV DiagnosticReport Observations&quot;:   &quot;DiagnosticReports&quot; Reports   where exists(     &quot;RSV Observations&quot; Observations     where Reports.result.references(Observations)   )</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"nhsnacutecarehospitaldailyinitialpopulation-rsv-diagnosticreport-result-from-lab\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> NHSNAcuteCareHospitalDailyInitialPopulation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">define &quot;RSV DiagnosticReport Result from Lab&quot;:   [DiagnosticReport] Reports     where exists(&quot;RSV DiagnosticReport Observations&quot;)       and Reports.status in {'final','registered','preliminary','partial'}       and exists(&quot;Initial Population&quot;)</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"nhsnacutecarehospitaldailyinitialpopulation-sde-rsv-diagnosticreport-result-from-lab\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> NHSNAcuteCareHospitalDailyInitialPopulation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">//return the RSV DiagnosticReport based on the result pre admission define &quot;SDE RSV DiagnosticReport Result from Lab&quot;:   &quot;RSV DiagnosticReport Result from Lab&quot; Reports     return SharedResource.DiagnosticReportLabResource(Reports,     {FHIR.canonical{value: 'http://www.cdc.gov/nhsn/fhirportal/dqm/ig/StructureDefinition/ach-daily-diagnosticreport-lab'}})</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"nhsnacutecarehospitaldailyinitialpopulation-sde-ip-encounters\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> NHSNAcuteCareHospitalDailyInitialPopulation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">//---------------------------------- // SDE //---------------------------------- define &quot;SDE IP Encounters&quot;:   &quot;Initial Population&quot; IP   return SharedResource.EncounterResource(IP,    {FHIR.canonical{value: 'http://www.cdc.gov/nhsn/fhirportal/dqm/ig/StructureDefinition/ach-daily-encounter'}})</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"nhsnacutecarehospitaldailyinitialpopulation-sde-rsv-pre-admission-observation\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> NHSNAcuteCareHospitalDailyInitialPopulation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">//return the RSV Observation Pre Admission     define &quot;SDE RSV PRE Admission Observation&quot;:   &quot;RSV PRE Admission Observation&quot; Observations     return ObservationLabResource(Observations,      {FHIR.canonical{value: 'http://www.cdc.gov/nhsn/fhirportal/dqm/ig/StructureDefinition/ach-daily-observation-lab'}})</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"nhsnacutecarehospitaldailyinitialpopulation-sde-isolation-precautions-implemented\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> NHSNAcuteCareHospitalDailyInitialPopulation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">define &quot;SDE Isolation Precautions Implemented&quot;:   [Procedure: &quot;Transmission Based Precaution Types&quot;] IsolationPrecautions     where NHSNHelpers.&quot;Normalize Interval&quot;(IsolationPrecautions.performed) during &quot;Measurement Period&quot;     and exists(&quot;Initial Population&quot;)   return SharedResource.ProcedureResource(IsolationPrecautions,   {FHIR.canonical{value: 'http://www.cdc.gov/nhsn/fhirportal/dqm/ig/StructureDefinition/ach-daily-procedure'}})</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"nhsnacutecarehospitaldailyinitialpopulation-covid-and-influenza-pre-admission-observation\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> NHSNAcuteCareHospitalDailyInitialPopulation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">//further constrain COVID-19 and Influenza Observations for 14 day lookback define &quot;COVID And Influenza PRE Admission Observation&quot;:   &quot;COVID And Influenza Observation&quot; O     where exists( EncounterInpatient E      where (       NHSNHelpers.&quot;Normalize Interval&quot;(O.effective) 14 days or less on or before start of E.period       or NHSNHelpers.&quot;Normalize Interval&quot;(GetSpecimen(O.specimen).collection.collected) 14 days or less on or before start of E.period       )       and start of E.period during &quot;Measurement Period&quot;     )</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"nhsnacutecarehospitaldailyinitialpopulation-sde-covid-and-influenza-specimen\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> NHSNAcuteCareHospitalDailyInitialPopulation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">//return the Specimen related to the COVID-19 And Influenza Observation Pre Admission define &quot;SDE COVID And Influenza Specimen&quot;:   &quot;COVID And Influenza PRE Admission Observation&quot; ObservationWithSpecimen     let Specimen: GetSpecimen(ObservationWithSpecimen.specimen)     return SharedResource.SpecimenResource(Specimen,     {FHIR.canonical{value: 'http://www.cdc.gov/nhsn/fhirportal/dqm/ig/StructureDefinition/ach-daily-specimen'}})</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"nhsnacutecarehospitaldailyinitialpopulation-sde-all-servicerequests\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> NHSNAcuteCareHospitalDailyInitialPopulation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">//To catch all isolation precautions define &quot;SDE All ServiceRequests&quot;:   [ServiceRequest] SR   where exists(&quot;Initial Population&quot;)   return ServiceRequestResource(SR,   {FHIR.canonical{value: 'http://www.cdc.gov/nhsn/fhirportal/dqm/ig/StructureDefinition/ach-daily-servicerequest'}})</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"nhsnacutecarehospitaldailyinitialpopulation-sde-covid-and-influenza-diagnosticreport\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> NHSNAcuteCareHospitalDailyInitialPopulation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">//return the COVID-19 And Influenza DiagnosticReport pre admission define &quot;SDE COVID And Influenza DiagnosticReport&quot;:   &quot;COVID And Influenza DiagnosticReport&quot; Reports     return SharedResource.DiagnosticReportLabResource(Reports,     {FHIR.canonical{value: 'http://www.cdc.gov/nhsn/fhirportal/dqm/ig/StructureDefinition/ach-daily-diagnosticreport-lab'}})</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"nhsnacutecarehospitaldailyinitialpopulation-sde-covid-and-influenza-pre-admission-observation\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> NHSNAcuteCareHospitalDailyInitialPopulation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">//return the COVID-19 and Influenza Observation Pre Admission define &quot;SDE COVID And Influenza PRE Admission Observation&quot;:   &quot;COVID And Influenza PRE Admission Observation&quot; Observations     return ObservationLabResource(Observations,     {FHIR.canonical{value: 'http://www.cdc.gov/nhsn/fhirportal/dqm/ig/StructureDefinition/ach-daily-observation-lab'}})</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"nhsnacutecarehospitaldailyinitialpopulation-covid-and-influenza-diagnosticreport-observations\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> NHSNAcuteCareHospitalDailyInitialPopulation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">define &quot;COVID and Influenza DiagnosticReport Observations&quot;:   &quot;Observations&quot; Observations   where Observations.code in &quot;COVID_19 (Tests for SARS_CoV_2 Nucleic Acid)&quot;     or Observations.code in &quot;COVID_19 (Tests for SARS_CoV_2 Antigen)&quot;     or Observations.code in &quot;Influenza (Tests for influenza A or B virus Nucleic Acid)&quot;     or Observations.code in &quot;Influenza (Tests for influenza A or B virus Antigen)&quot;</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"nhsnacutecarehospitaldailyinitialpopulation-covid-and-influenza-diagnosticreport-result-from-lab\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> NHSNAcuteCareHospitalDailyInitialPopulation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">define &quot;COVID and Influenza DiagnosticReport Result from Lab&quot;:   &quot;DiagnosticReports&quot; Reports     where exists(       &quot;COVID and Influenza DiagnosticReport Observations&quot; Observations       where Reports.result.references(Observations)     )     and Reports.status in {'final','registered','preliminary','partial'}     and exists(&quot;Initial Population&quot;)</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"nhsnacutecarehospitaldailyinitialpopulation-ach-daily-diagnosticreport-result-from-lab\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> NHSNAcuteCareHospitalDailyInitialPopulation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">define &quot;ACH Daily DiagnosticReport Result from Lab&quot;:   &quot;COVID and Influenza DiagnosticReport Result from Lab&quot;     union &quot;RSV DiagnosticReport Result from Lab&quot;</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"nhsnacutecarehospitaldailyinitialpopulation-sde-ach-daily-diagnosticreport-result-from-lab\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> NHSNAcuteCareHospitalDailyInitialPopulation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">//return the DiagnosticReport based on the result during the Measurement Period     define &quot;SDE ACH Daily DiagnosticReport Result from Lab&quot;:   &quot;ACH Daily DiagnosticReport Result from Lab&quot; Reports     return SharedResource.DiagnosticReportLabResource(Reports,     {FHIR.canonical{value: 'http://www.cdc.gov/nhsn/fhirportal/dqm/ig/StructureDefinition/ach-daily-diagnosticreport-lab'}})</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"nhsnacutecarehospitaldailyinitialpopulation-sde-covid-and-influenza-diagnosticreport-result-from-lab\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> NHSNAcuteCareHospitalDailyInitialPopulation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">//return the COVID-19 and Influenza DiagnosticReport based on the result pre admission define &quot;SDE COVID and Influenza DiagnosticReport Result from Lab&quot;:   &quot;COVID and Influenza DiagnosticReport Result from Lab&quot; Reports     return SharedResource.DiagnosticReportLabResource(Reports,     {FHIR.canonical{value: 'http://www.cdc.gov/nhsn/fhirportal/dqm/ig/StructureDefinition/ach-daily-diagnosticreport-lab'}})</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"nhsnacutecarehospitaldailyinitialpopulation-sde-location\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> NHSNAcuteCareHospitalDailyInitialPopulation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">define &quot;SDE Location&quot;:   [Location] Locations   where exists(&quot;Initial Population&quot;)   return SharedResource.LocationResource(Locations,   {FHIR.canonical{value: 'http://www.cdc.gov/nhsn/fhirportal/dqm/ig/StructureDefinition/ach-daily-location'}})</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"nhsnacutecarehospitaldailyinitialpopulation-checkip\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> NHSNAcuteCareHospitalDailyInitialPopulation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">//----------------------------------------------------- //functions //----------------------------------------------------- define function &quot;CheckIP&quot;(encounter Encounter):   exists(&quot;Initial Population&quot; IP   where encounter.id = IP.id)</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"fhirhelpers-tostring\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> FHIRHelpers</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">define function ToString(value EncounterStatus): value.value</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"fhirhelpers-tointerval\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> FHIRHelpers</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">define function ToInterval(period FHIR.Period):     if period is null then         null      else          if period.&quot;start&quot;.value is null then             Interval(period.&quot;start&quot;.value, period.&quot;end&quot;.value]         else              if time from period.&quot;start&quot;.value is null and time from period.&quot;end&quot;.value is not null then                 Interval[                     DateTime(year from period.&quot;start&quot;.value, month from period.&quot;start&quot;.value, day from period.&quot;start&quot;.value,                         0, 0, 0, 0, timezoneoffset from period.&quot;end&quot;.value),                      period.&quot;end&quot;.value                 ]         else              if time from period.&quot;end&quot;.value is null and time from period.&quot;start&quot;.value is not null then                 Interval[                     period.&quot;start&quot;.value,                      DateTime(year from period.&quot;end&quot;.value, month from period.&quot;end&quot;.value, day from period.&quot;end&quot;.value,                         23, 59, 59, 999, timezoneoffset from period.&quot;start&quot;.value)                 ]         else Interval[period.&quot;start&quot;.value, period.&quot;end&quot;.value]</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"nhsnhelpers-getlocation\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> NHSNHelpers</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">define function &quot;GetLocation&quot;(reference Reference ):   singleton from (  [Location] Locations   where Locations.id = GetId(reference.reference)   )</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"fhirhelpers-tostring\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> FHIRHelpers</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">define function ToString(value string): value.value</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"nhsnhelpers-getid\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> NHSNHelpers</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">define function &quot;GetId&quot;(uri String ):   Last(Split(uri, '/'))</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"fhirhelpers-toconcept\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> FHIRHelpers</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">define function ToConcept(concept FHIR.CodeableConcept):     if concept is null then         null     else         System.Concept {             codes: concept.coding C return ToCode(C),             display: concept.text.value         }</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"fhirhelpers-tocode\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> FHIRHelpers</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">define function ToCode(coding FHIR.Coding):     if coding is null then         null     else         System.Code {           code: coding.code.value,           system: coding.system.value,           version: coding.version.value,           display: coding.display.value         }</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"sharedresourcecreation-encounterresource\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> SharedResourceCreation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">define function EncounterResource(encounter Encounter, profileURLs List&lt;FHIR.canonical&gt;):   encounter e   return Encounter{     id: FHIR.id{value: 'LCR-' + e.id},     meta: MetaElement(e, profileURLs),     extension: e.extension,     identifier: EncounterIdentifier(e.identifier),     status: e.status,     statusHistory: EncounterStatusHistory(e.statusHistory),     class: e.class,     classHistory: EncounterClassHistory(e.classHistory),     type: e.type,     serviceType: e.serviceType,     priority: e.priority,     subject: e.subject,     period: e.period,     length: e.length,     reasonCode: e.reasonCode,     reasonReference: e.reasonReference,     diagnosis: EncounterDiagnosis(e.diagnosis),     account: e.account,     hospitalization: EncounterHospitalization(e.hospitalization),     location: EncounterLocation(e.location),     partOf: e.partOf   }</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"sharedresourcecreation-metaelement\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> SharedResourceCreation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">define function &quot;MetaElement&quot;(resource Resource, profileURLs List&lt;FHIR.canonical&gt;):   resource r   return FHIR.Meta{     extension: r.meta.extension,     versionId: r.meta.versionId,     lastUpdated: r.meta.lastUpdated,     profile: profileURLs,     security: r.meta.security,     tag: r.meta.tag   }</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"sharedresourcecreation-encounteridentifier\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> SharedResourceCreation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">define function EncounterIdentifier(identifier List&lt;FHIR.Identifier&gt;):   identifier i   return FHIR.Identifier{     use: i.use,     type: i.type,     system: i.system,     value: i.value,     period: i.period   }</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"sharedresourcecreation-encounterstatushistory\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> SharedResourceCreation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">define function EncounterStatusHistory(statusHistory List&lt;FHIR.Encounter.StatusHistory&gt;):   statusHistory sH   return FHIR.Encounter.StatusHistory{     status: sH.status,     period: sH.period   }</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"sharedresourcecreation-encounterclasshistory\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> SharedResourceCreation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">define function EncounterClassHistory(classHistory List&lt;FHIR.Encounter.ClassHistory&gt;):   classHistory cH   return FHIR.Encounter.ClassHistory{     class: cH.class,     period: cH.period   }</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"sharedresourcecreation-encounterdiagnosis\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> SharedResourceCreation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">/*No longer needed but saving for potential future use define function EncounterParticipant(participant List&lt;FHIR.Encounter.Participant&gt;):   participant p   return FHIR.Encounter.Participant{     type: p.type,     period: p.period,     individual: p.individual   }*/  define function EncounterDiagnosis(diagnosis List&lt;FHIR.Encounter.Diagnosis&gt;):   diagnosis d   return FHIR.Encounter.Diagnosis{     condition: d.condition,     use: d.use,     rank: d.rank   }</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"sharedresourcecreation-encounterhospitalization\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> SharedResourceCreation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">define function EncounterHospitalization(hospitalization FHIR.Encounter.Hospitalization):   hospitalization h   return FHIR.Encounter.Hospitalization{     preAdmissionIdentifier: h.preAdmissionIdentifier,     origin: h.origin,     admitSource: h.admitSource,     reAdmission: h.reAdmission,     dietPreference: h.dietPreference,     specialCourtesy: h.specialCourtesy,     specialArrangement: h.specialArrangement,     destination: h.destination,     dischargeDisposition: h.dischargeDisposition   }</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"sharedresourcecreation-encounterlocation\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> SharedResourceCreation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">define function EncounterLocation(location List&lt;FHIR.Encounter.Location&gt;):   location l   return FHIR.Encounter.Location{     location: l.location,     status: l.status,     physicalType: l.physicalType,     period: l.period   }</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"fhirhelpers-tostring\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> FHIRHelpers</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">define function ToString(value ServiceRequestIntent): value.value</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"fhirhelpers-tostring\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> FHIRHelpers</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">define function ToString(value ServiceRequestStatus): value.value</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"nhsnacutecarehospitaldailyinitialpopulation-servicerequestresource\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> NHSNAcuteCareHospitalDailyInitialPopulation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">define function ServiceRequestResource(serviceRequest ServiceRequest, profileURLs List&lt;FHIR.canonical&gt;):   serviceRequest sR   return ServiceRequest{     id: FHIR.id {value: 'LCR-' + sR.id},     meta: SharedResource.MetaElement(sR, profileURLs),     extension: sR.extension,     instantiatesCanonical: sR.instantiatesCanonical,     instantiatesUri: sR.instantiatesUri,     basedOn: sR.basedOn,     replaces: sR.replaces,     requisition: sR.requisition,     status: sR.status,     intent: sR.intent,     category: sR.category,     priority: sR.priority,     doNotPerform: sR.doNotPerform,     code: sR.code,     orderDetail: sR.orderDetail,     quantity: sR.quantity,     subject: sR.subject,     encounter: sR.encounter,     occurrence: sR.occurrence,     asNeeded: sR.asNeeded,     authoredOn: sR.authoredOn,     performerType: sR.performerType,     performer: sR.performer,     locationCode: sR.locationCode,     locationReference: sR.locationReference,     reasonCode: sR.reasonCode,     reasonReference: sR.reasonReference,     insurance: sR.insurance,     supportingInfo: sR.supportingInfo,     specimen: sR.specimen,     bodySite: sR.bodySite,     note: sR.note,     patientInstruction: sR.patientInstruction,     relevantHistory: sR.relevantHistory   }</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"fhirhelpers-tostring\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> FHIRHelpers</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">define function ToString(value ObservationStatus): value.value</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"nhsnacutecarehospitaldailyinitialpopulation-getspecimen\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> NHSNAcuteCareHospitalDailyInitialPopulation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">define function &quot;GetSpecimen&quot;(reference FHIR.Reference):   singleton from (     [Specimen] Specimens     where Specimens.id = NHSNHelpers.GetId(reference.reference)   )</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"sharedresourcecreation-specimenresource\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> SharedResourceCreation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">define function SpecimenResource(specimen Specimen, profileURLs List&lt;FHIR.canonical&gt;):   specimen s   return Specimen{     id: FHIR.id {value: 'LCR-' + s.id},     meta: MetaElement(s, profileURLs),     extension: s.extension,     identifier: s.identifier,     accessionIdentifier: s.accessionIdentifier,     status: s.status,     type: s.type,     subject: s.subject,     receivedTime: s.receivedTime,     parent: s.parent,     request: s.request,     collection: SpecimenCollection(s.collection),     processing: SpecimenProcessing(s.processing),     container: SpecimenContainer(s.container),     condition: s.condition,     note: s.note   }</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"sharedresourcecreation-specimencollection\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> SharedResourceCreation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">define function SpecimenCollection(collection FHIR.Specimen.Collection):   collection c   return FHIR.Specimen.Collection{     collector: c.collector,     collected: c.collected,     &quot;duration&quot;: c.&quot;duration&quot;,     quantity: c.quantity,     method: c.method,     bodySite: c.bodySite,     fastingStatus: c.fastingStatus   }</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"sharedresourcecreation-specimenprocessing\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> SharedResourceCreation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">define function SpecimenProcessing(processing List&lt;FHIR.Specimen.Processing&gt;):   processing p   return FHIR.Specimen.Processing{     description: p.description,     procedure: p.procedure,     additive: p.additive,     time: p.time   }</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"sharedresourcecreation-specimencontainer\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> SharedResourceCreation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">define function SpecimenContainer(container List&lt;FHIR.Specimen.Container&gt;):   container c   return FHIR.Specimen.Container{     description: c.description,     type: c.type,     capacity: c.capacity,     specimenQuantity: c.specimenQuantity,     additive: c.additive   }</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"fhirhelpers-tostring\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> FHIRHelpers</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">define function ToString(value DiagnosticReportStatus): value.value</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"sharedresourcecreation-diagnosticreportlabresource\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> SharedResourceCreation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">define function DiagnosticReportLabResource(diagnosticReport DiagnosticReport, profileURLs List&lt;FHIR.canonical&gt;):   diagnosticReport d   return DiagnosticReport{     id: FHIR.id{value: 'LCR-' + d.id},     meta: MetaElement(d, profileURLs),     extension: d.extension,     basedOn: d.basedOn,     status: d.status,     category: DiagnosticReportCategory(d.category),     code: d.code,     subject: d.subject,     encounter: d.encounter,     effective: d.effective,     issued: d.issued,     performer: d.performer,     resultsInterpreter: d.resultsInterpreter,     specimen: d.specimen,     result: d.result,     conclusion: d.conclusion,     conclusionCode: d.conclusionCode   }</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"sharedresourcecreation-diagnosticreportcategory\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> SharedResourceCreation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">define function DiagnosticReportCategory(category List&lt;CodeableConcept&gt;):   category c   return CodeableConcept{     coding: DiagnosticReportCoding(c.coding)   }</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"sharedresourcecreation-diagnosticreportcoding\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> SharedResourceCreation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">define function DiagnosticReportCoding(coding List&lt;Coding&gt;):   coding c   return Coding{     system: c.system,     version: c.version,     code: c.code,     display: c.display,     userSelected: c.userSelected   }</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"nhsnacutecarehospitaldailyinitialpopulation-observationlabresource\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> NHSNAcuteCareHospitalDailyInitialPopulation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">define function ObservationLabResource(observation Observation, profileURLs List&lt;FHIR.canonical&gt;):   observation o   return Observation{     id: FHIR.id {value: 'LCR-' + o.id},     meta: SharedResource.MetaElement(o, profileURLs),     extension: o.extension,     basedOn: o.basedOn,     partOf: o.partOf,     status: o.status,     category: ObservationLabCategory(o.category),     code: o.code,     subject: o.subject,     focus: o.focus,     encounter: o.encounter,     effective: o.effective,     issued: o.issued,     performer: o.performer,     value: o.value,     dataAbsentReason: o.dataAbsentReason,     interpretation: o.interpretation,     note: o.note,     bodySite: o.bodySite,     method: o.method,     specimen: o.specimen,     device: o.device,     referenceRange: SharedResource.ObservationReferenceRange(o.referenceRange),     hasMember: o.hasMember,     derivedFrom: o.derivedFrom,     component: SharedResource.ObservationComponent(o.component)   }</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"nhsnacutecarehospitaldailyinitialpopulation-observationlabcategory\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> NHSNAcuteCareHospitalDailyInitialPopulation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">define function ObservationLabCategory(category List&lt;CodeableConcept&gt;):   category c   return CodeableConcept{     coding: ObservationLabCoding(c.coding),     text: c.text   }</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"nhsnacutecarehospitaldailyinitialpopulation-observationlabcoding\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> NHSNAcuteCareHospitalDailyInitialPopulation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">define function ObservationLabCoding(coding List&lt;Coding&gt;):   coding c   return Coding{     system: c.system,     version: c.version,     code: c.code,     display: c.display,     userSelected: c.userSelected   }</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"sharedresourcecreation-observationreferencerange\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> SharedResourceCreation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">define function ObservationReferenceRange(referenceRange List&lt;FHIR.Observation.ReferenceRange&gt;):   referenceRange rR   return FHIR.Observation.ReferenceRange{     low: rR.low,     high: rR.high,     type: rR.type,     appliesTo: rR.appliesTo,     age: rR.age,     text: rR.text   }</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"sharedresourcecreation-observationcomponent\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> SharedResourceCreation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">define function ObservationComponent(component List&lt;FHIR.Observation.Component&gt;):   component c   return FHIR.Observation.Component{     code: c.code,     value: c.value,     dataAbsentReason: c.dataAbsentReason,     interpretation: c.interpretation,     referenceRange: c.referenceRange   }</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"sharedresourcecreation-procedureresource\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> SharedResourceCreation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">define function ProcedureResource(procedure Procedure, profileURLs List&lt;FHIR.canonical&gt;):   procedure p   return Procedure{     id: FHIR.id {value: 'LCR-' + p.id},     meta: MetaElement(p, profileURLs),     extension: p.extension,     instantiatesCanonical: p.instantiatesCanonical,     instantiatesUri: p.instantiatesUri,     basedOn: p.basedOn,     partOf: p.partOf,     status: p.status,     statusReason: p.statusReason,     category: p.category,     code: p.code,     subject: p.subject,     encounter: p.encounter,     performed: p.performed,     recorder: p.recorder,     asserter: p.asserter,     performer: ProcedurePerformer(p.performer),     location: p.location,     reasonCode: p.reasonCode,     reasonReference: p.reasonReference,     bodySite: p.bodySite,     outcome: p.outcome,     report: p.report,     complication: p.complication,     complicationDetail: p.complicationDetail,     followUp: p.followUp,     note: p.note,     focalDevice: ProcedureFocalDevice(p.focalDevice),     usedReference: p.usedReference,     usedCode: p.usedCode   }</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"sharedresourcecreation-procedureperformer\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> SharedResourceCreation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">define function ProcedurePerformer(performer List&lt;FHIR.Procedure.Performer&gt;):   performer p   return FHIR.Procedure.Performer{     function: p.function,     actor: p.actor,     onBehalfOf: p.onBehalfOf   }</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"sharedresourcecreation-procedurefocaldevice\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> SharedResourceCreation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">define function ProcedureFocalDevice(device List&lt;FHIR.Procedure.FocalDevice&gt;):   device d   return FHIR.Procedure.FocalDevice{     action: d.action,     manipulated: d.manipulated   }</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"nhsnacutecarehospitaldailyinitialpopulation-getmedicationcode\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> NHSNAcuteCareHospitalDailyInitialPopulation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">define function &quot;GetMedicationCode&quot;(choice Choice&lt;FHIR.CodeableConcept, FHIR.Reference&gt;):   case     when choice is FHIR.CodeableConcept then       choice as FHIR.CodeableConcept     when choice is FHIR.Reference then       GetMedication(choice as FHIR.Reference).code     else       null as FHIR.CodeableConcept   end</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"nhsnacutecarehospitaldailyinitialpopulation-getmedication\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> NHSNAcuteCareHospitalDailyInitialPopulation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">define function &quot;GetMedication&quot;(reference Reference ):   singleton from (     [Medication: id in {NHSNHelpers.GetId(reference.reference)}]   )</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"nhsnhelpers-normalize-interval\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> NHSNHelpers</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">define function &quot;Normalize Interval&quot;(choice Choice&lt;FHIR.dateTime, FHIR.Period, FHIR.Timing, FHIR.instant, FHIR.string, FHIR.Age, FHIR.Range&gt;):   case    when choice is FHIR.dateTime then      Interval[FHIRHelpers.ToDateTime(choice as FHIR.dateTime), FHIRHelpers.ToDateTime(choice as FHIR.dateTime)]   when choice is FHIR.Period then     FHIRHelpers.ToInterval(choice as FHIR.Period)   when choice is FHIR.instant then    Interval[FHIRHelpers.ToDateTime(choice as FHIR.instant), FHIRHelpers.ToDateTime(choice as FHIR.instant)]   when choice is FHIR.Age then     Interval[FHIRHelpers.ToDate(Patient.birthDate) + FHIRHelpers.ToQuantity(choice as FHIR.Age),      FHIRHelpers.ToDate(Patient.birthDate) + FHIRHelpers.ToQuantity(choice as FHIR.Age) + 1 year)   when choice is FHIR.Range then     Interval[FHIRHelpers.ToDate(Patient.birthDate) + FHIRHelpers.ToQuantity((choice as FHIR.Range).low),      FHIRHelpers.ToDate(Patient.birthDate) + FHIRHelpers.ToQuantity((choice as FHIR.Range).high) + 1 year)   when choice is FHIR.Timing then     Message(null as Interval&lt;DateTime&gt;, true, '1', 'Error', 'Cannot compute a single interval from a Timing type')     when choice is FHIR.string then       Message(null as Interval&lt;DateTime&gt;, true, '1', 'Error', 'Cannot compute an interval from a String value')   else    null as Interval&lt;DateTime&gt;  end</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"fhirhelpers-todatetime\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> FHIRHelpers</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">define function ToDateTime(value dateTime): value.value</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"fhirhelpers-todatetime\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> FHIRHelpers</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">define function ToDateTime(value instant): value.value</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"fhirhelpers-todate\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> FHIRHelpers</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">define function ToDate(value date): value.value</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"fhirhelpers-toquantity\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> FHIRHelpers</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">define function ToQuantity(quantity FHIR.Quantity):     case         when quantity is null then null         when quantity.value is null then null         when quantity.comparator is not null then             Message(null, true, 'FHIRHelpers.ToQuantity.ComparatorQuantityNotSupported', 'Error', 'FHIR Quantity value has a comparator and cannot be converted to a System.Quantity value.')         when quantity.system is null or quantity.system.value = 'http://unitsofmeasure.org'               or quantity.system.value = 'http://hl7.org/fhirpath/CodeSystem/calendar-units' then             System.Quantity { value: quantity.value.value, unit: ToCalendarUnit(Coalesce(quantity.code.value, quantity.unit.value, '1')) }         else             Message(null, true, 'FHIRHelpers.ToQuantity.InvalidFHIRQuantity', 'Error', 'Invalid FHIR Quantity code: ' &amp; quantity.unit.value &amp; ' (' &amp; quantity.system.value &amp; '|' &amp; quantity.code.value &amp; ')')     end</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"fhirhelpers-tocalendarunit\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> FHIRHelpers</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">define function ToCalendarUnit(unit System.String):     case unit         when 'ms' then 'millisecond'         when 's' then 'second'         when 'min' then 'minute'         when 'h' then 'hour'         when 'd' then 'day'         when 'wk' then 'week'         when 'mo' then 'month'         when 'a' then 'year'         else unit     end</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"nhsnacutecarehospitaldailyinitialpopulation-medicationrequestresource\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> NHSNAcuteCareHospitalDailyInitialPopulation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">define function MedicationRequestResource(medicationRequest MedicationRequest, profileURLs List&lt;FHIR.canonical&gt;):   medicationRequest m   return MedicationRequest{     id: FHIR.id {value: 'LCR-' + m.id},     meta: SharedResource.MetaElement(medicationRequest, profileURLs),     extension: m.extension,     status: m.status,     intent: m.intent,     category: m.category,     priority: m.priority,     doNotPerform: m.doNotPerform,     reported: m.reported,     medication: m.medication,     subject: m.subject,     encounter: m.encounter,     authoredOn: m.authoredOn,     requester: m.requester,     recorder: m.recorder,     reasonCode: m.reasonCode,     reasonReference: m.reasonReference,     instantiatesCanonical: m.instantiatesCanonical,     instantiatesUri: m.instantiatesUri,     courseOfTherapyType: m.courseOfTherapyType,     dosageInstruction: MedicationRequestDosageInstruction(m.dosageInstruction)   }</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"nhsnacutecarehospitaldailyinitialpopulation-medicationrequestdosageinstruction\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> NHSNAcuteCareHospitalDailyInitialPopulation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">define function MedicationRequestDosageInstruction(dosageInstruction List&lt;FHIR.Dosage&gt;):   dosageInstruction dI   return FHIR.Dosage{     text: dI.text,     patientInstruction: dI.patientInstruction,     timing: MedicationRequestTiming(dI.timing),     asNeeded: dI.asNeeded,     site: dI.site,     route: dI.route,     method: dI.method,     doseAndRate: SharedResource.MedicationRequestDoseAndRate(dI.doseAndRate)   }</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"nhsnacutecarehospitaldailyinitialpopulation-medicationrequesttiming\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> NHSNAcuteCareHospitalDailyInitialPopulation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">define function MedicationRequestTiming(timing FHIR.Timing):   timing t   return FHIR.Timing{     event: t.event,     repeat: MedicationRequestRepeat(t.repeat),     code: t.code   }</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"nhsnacutecarehospitaldailyinitialpopulation-medicationrequestrepeat\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> NHSNAcuteCareHospitalDailyInitialPopulation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">//  // Measure Specific Resource Creation Functions  // define function MedicationRequestRepeat(repeat FHIR.Timing.Repeat):   repeat r   return FHIR.Timing.Repeat{     bounds: r.bounds,     count: r.count,     countMax: r.countMax,     &quot;duration&quot;: r.&quot;duration&quot;,     durationMax: r.durationMax,     durationUnit: r.durationUnit,     frequency: r.frequency,     frequencyMax: r.frequencyMax,     period: r.period,     periodMax: r.periodMax,     periodUnit: r.periodUnit,     dayOfWeek: r.dayOfWeek,     timeOfDay: r.timeOfDay,     &quot;when&quot;: r.&quot;when&quot;,     offset: r.offset   }</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"sharedresourcecreation-medicationrequestdoseandrate\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> SharedResourceCreation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">define function MedicationRequestDoseAndRate(doseAndRate List&lt;FHIR.Dosage.DoseAndRate&gt;):   doseAndRate dR   return FHIR.Dosage.DoseAndRate{     type: dR.type,     dose: dR.dose,     rate: dR.rate   }</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"sharedresourcecreation-patientresource\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> SharedResourceCreation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">define function PatientResource(patient Patient, profileURLs List&lt;FHIR.canonical&gt;):   patient p   return Patient{     id: FHIR.id{value: 'LCR-' + p.id},     meta: MetaElement(p, profileURLs),     extension: GetPatientExtensions(p),     identifier: p.identifier,     active: p.active,     name: PatientName(p.name),     telecom: PatientTelecom(p.telecom),     gender: p.gender,     birthDate: p.birthDate,     deceased: p.deceased,     address: PatientAddress(p.address),     maritalStatus: p.maritalStatus,     multipleBirth: p.multipleBirth,     contact: PatientContact(p.contact),     communication: PatientCommunication(p.communication),     link: PatientLink(p.link)   }</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"sharedresourcecreation-getpatientextensions\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> SharedResourceCreation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">define function &quot;GetPatientExtensions&quot;(domainResource DomainResource):   domainResource.extension E   where E.url = 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-race'     or E.url = 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity'     or E.url = 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-tribal-affiliation'     or E.url = 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-birthsex'     or E.url = 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-sex'     or E.url = 'http://www.cdc.gov/nhsn/fhirportal/dqm/ig/StructureDefinition/link-original-resource-id-extension'   return E</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"fhirhelpers-tostring\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> FHIRHelpers</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">define function ToString(value uri): value.value</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"sharedresourcecreation-patientname\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> SharedResourceCreation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">/* No longer needed but saving in case it's useful later define function PatientIdentifier(identifier List&lt;FHIR.Identifier&gt;):   identifier i   return FHIR.Identifier{     id: i.id,     extension: i.extension,     use: i.use,     type: i.type,     system: i.system,     value: i.value,     period: i.period,     assigner: i.assigner   }*/  define function PatientName(name List&lt;FHIR.HumanName&gt;):   name n   return FHIR.HumanName{     id: n.id,     extension: n.extension,     use: n.use,     text: n.text,     family: n.family,     given: n.given,     prefix: n.prefix,     suffix: n.suffix,     period: n.period   }</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"sharedresourcecreation-patienttelecom\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> SharedResourceCreation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">define function PatientTelecom(telecom List&lt;FHIR.ContactPoint&gt;):   telecom t   return FHIR.ContactPoint{     system: t.system,     value: t.value,     use: t.use,     rank: t.rank,     period: t.period   }</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"sharedresourcecreation-patientaddress\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> SharedResourceCreation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">define function PatientAddress(address List&lt;FHIR.Address&gt;):   address a   return FHIR.Address{     use: a.use,     type: a.type,     text: a.text,     line: a.line,     city: a.city,     district: a.district,     state: a.state,     postalCode: a.postalCode,     country: a.country,     period: a.period   }</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"sharedresourcecreation-patientcontact\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> SharedResourceCreation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">define function PatientContact(contact List&lt;FHIR.Patient.Contact&gt;):   contact c   return FHIR.Patient.Contact{     relationship: c.relationship,     name: c.name,     telecom: c.telecom,     address: c.address,     gender: c.gender,     organization: c.organization,     period: c.period   }</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"sharedresourcecreation-patientcommunication\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> SharedResourceCreation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">define function PatientCommunication(communication List&lt;FHIR.Patient.Communication&gt;):   communication c   return FHIR.Patient.Communication{     language: c.language,     preferred: c.preferred   }</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"sharedresourcecreation-patientlink\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> SharedResourceCreation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">define function PatientLink(link List&lt;FHIR.Patient.Link&gt;):   link l   return FHIR.Patient.Link{     extension: l.extension,     modifierExtension: l.modifierExtension,     other: l.other,     type: l.type   }</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"fhirhelpers-tostring\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> FHIRHelpers</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">define function ToString(value MedicationAdministrationStatus): value.value</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"sharedresourcecreation-medicationadministrationresource\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> SharedResourceCreation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">define function MedicationAdministrationResource(medicationAdministration MedicationAdministration, profileURLs List&lt;FHIR.canonical&gt;):   medicationAdministration m   return MedicationAdministration{     id: FHIR.id {value: 'LCR-' + m.id},     meta: MetaElement(m, profileURLs),     extension: m.extension,     instantiates: m.instantiates,     partOf: m.partOf,     status: m.status,     statusReason: m.statusReason,     category: m.category,     medication: m.medication,     subject: m.subject,     context: m.context,     supportingInformation: m.supportingInformation,     effective: m.effective,     performer: MedicationAdministrationPerformer(m.performer),     reasonCode: m.reasonCode,     reasonReference: m.reasonReference,     request: m.request,     device: m.device,     note: m.note,     dosage: MedicationAdministrationDosage(m.dosage),     eventHistory: m.eventHistory   }</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"sharedresourcecreation-medicationadministrationperformer\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> SharedResourceCreation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">define function MedicationAdministrationPerformer(performer List&lt;FHIR.MedicationAdministration.Performer&gt;):   performer p   return FHIR.MedicationAdministration.Performer{     function: p.function,     actor: p.actor   }</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"sharedresourcecreation-medicationadministrationdosage\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> SharedResourceCreation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">define function MedicationAdministrationDosage(dosage FHIR.MedicationAdministration.Dosage):   dosage d   return FHIR.MedicationAdministration.Dosage{     text: d.text,     site: d.site,     route: d.route,     method: d.method,     dose: d.dose,     rate: d.rate   }</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"sharedresourcecreation-medicationresource\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> SharedResourceCreation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">define function MedicationResource(medication Medication, profileURLs List&lt;FHIR.canonical&gt;):   medication m   return Medication{     id: FHIR.id {value: 'LCR-' + m.id},     meta: MetaElement(m, profileURLs),     extension: m.extension,     code: m.code,     status: m.status,     manufacturer: m.manufacturer,     form: m.form,     amount: m.amount,     ingredient: MedicationIngredient(m.ingredient),     batch: MedicationBatch(m.batch)   }</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"sharedresourcecreation-medicationingredient\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> SharedResourceCreation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">define function MedicationIngredient(ingredient List&lt;FHIR.Medication.Ingredient&gt;):   ingredient i   return FHIR.Medication.Ingredient{     item: i.item,     strength: i.strength   }</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"sharedresourcecreation-medicationbatch\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> SharedResourceCreation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">define function MedicationBatch(batch FHIR.Medication.Batch):   batch b   return FHIR.Medication.Batch{     lotNumber: b.lotNumber,     expirationDate: b.expirationDate   }</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"nhsnacutecarehospitaldailyinitialpopulation-getmedicationfrom\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> NHSNAcuteCareHospitalDailyInitialPopulation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">define function &quot;GetMedicationFrom&quot;(choice Choice&lt;FHIR.CodeableConcept, FHIR.Reference&gt;):   case     when choice is FHIR.Reference then       GetMedication(choice as FHIR.Reference)     else       null   end</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"nhsnacutecarehospitaldailyinitialpopulation-references\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> NHSNAcuteCareHospitalDailyInitialPopulation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">define fluent function references(references List&lt;FHIR.Reference&gt;, resource FHIR.Resource):   exists(references R where R.references(resource))</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"nhsnacutecarehospitaldailyinitialpopulation-references\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> NHSNAcuteCareHospitalDailyInitialPopulation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">define fluent function references(reference FHIR.Reference, resource FHIR.Resource):   resource.id = Last(Split(reference.reference, '/'))</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"sharedresourcecreation-locationresource\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> SharedResourceCreation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">define function LocationResource(location Location, profileURLs List&lt;FHIR.canonical&gt;):   location l   return Location{     id: FHIR.id {value: 'LCR-' + l.id},     meta: MetaElement(l, profileURLs),     extension: l.extension,     status: l.status,     operationalStatus: l.operationalStatus,     name: l.name,     alias: l.alias,     description: l.description,     mode: l.mode,     type: l.type,     telecom: l.telecom,     address: LocationAddress(l.address),     physicalType: l.physicalType,     position: LocationPosition(l.position),     managingOrganization: l.managingOrganization,     partOf: l.partOf,     hoursOfOperation: LocationHoursOfOperation(l.hoursOfOperation),     availabilityExceptions: l.availabilityExceptions,     endpoint: l.endpoint   }</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"sharedresourcecreation-locationaddress\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> SharedResourceCreation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">define function LocationAddress(address FHIR.Address):   address a   return FHIR.Address{     use: a.use,     type: a.type,     text: a.text,     line: a.line,     city: a.city,     district: a.district,     state: a.state,     postalCode: a.postalCode,     country: a.country,     period: a.period   }</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"sharedresourcecreation-locationposition\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> SharedResourceCreation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">define function LocationPosition(position FHIR.Location.Position):   position p   return FHIR.Location.Position{     longitude: p.longitude,     latitude: p.latitude,     altitude: p.altitude   }</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"sharedresourcecreation-locationhoursofoperation\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> SharedResourceCreation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">define function LocationHoursOfOperation(hoursOfOperation List&lt;FHIR.Location.HoursOfOperation&gt;):   hoursOfOperation hOO   return FHIR.Location.HoursOfOperation{     daysOfWeek: hOO.daysOfWeek,     allDay: hOO.allDay,     openingTime: hOO.openingTime,     closingTime: hOO.closingTime   }</code></pre>\n  </td>\n\n</tr>\n\n  \n\n<tr>\n  <th colspan=\"2\" scope=\"row\" class=\"row-header\">Generated using version 0.4.6 of the sample-content-ig Liquid templates</th>\n</tr>\n    </tbody>\n  </table>\n</div>"
+        },
         "contained": [
           {
             "resourceType": "Library",
             "id": "effective-data-requirements",
             "extension": [
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-directReferenceCode",
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-directReferenceCode",
                 "valueCoding": {
                   "system": "http://terminology.hl7.org/CodeSystem/v3-ActCode",
                   "code": "OBSENC",
@@ -8762,7 +8766,7 @@
                 }
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-directReferenceCode",
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-directReferenceCode",
                 "valueCoding": {
                   "system": "http://terminology.hl7.org/CodeSystem/observation-category",
                   "code": "laboratory",
@@ -8770,7 +8774,6 @@
                 }
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
                 "extension": [
                   {
                     "url": "libraryName",
@@ -8788,10 +8791,10 @@
                     "url": "displaySequence",
                     "valueInteger": 0
                   }
-                ]
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
                 "extension": [
                   {
                     "url": "libraryName",
@@ -8809,10 +8812,10 @@
                     "url": "displaySequence",
                     "valueInteger": 1
                   }
-                ]
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
                 "extension": [
                   {
                     "url": "libraryName",
@@ -8830,10 +8833,10 @@
                     "url": "displaySequence",
                     "valueInteger": 2
                   }
-                ]
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
                 "extension": [
                   {
                     "url": "libraryName",
@@ -8851,10 +8854,10 @@
                     "url": "displaySequence",
                     "valueInteger": 3
                   }
-                ]
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
                 "extension": [
                   {
                     "url": "libraryName",
@@ -8872,10 +8875,10 @@
                     "url": "displaySequence",
                     "valueInteger": 4
                   }
-                ]
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
                 "extension": [
                   {
                     "url": "libraryName",
@@ -8893,10 +8896,31 @@
                     "url": "displaySequence",
                     "valueInteger": 5
                   }
-                ]
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
+                "extension": [
+                  {
+                    "url": "libraryName",
+                    "valueString": "NHSNAcuteCareHospitalDailyInitialPopulation"
+                  },
+                  {
+                    "url": "name",
+                    "valueString": "SDE ACH Daily ServiceRequest"
+                  },
+                  {
+                    "url": "statement",
+                    "valueString": "define \"SDE ACH Daily ServiceRequest\":   ([ServiceRequest: \"COVID_19 (Tests for SARS_CoV_2 Nucleic Acid)\"]    union  [ServiceRequest: \"COVID_19 (Tests for SARS_CoV_2 Antigen)\"]    union  [ServiceRequest: \"Influenza (Tests for influenza A or B virus Nucleic Acid)\"]   union  [ServiceRequest: \"Influenza (Tests for influenza A or B virus Antigen)\"]   union  [ServiceRequest: \"RSV (Tests for RSV Nucleic Acid)\"]   union  [ServiceRequest: \"RSV (Tests for RSV Antigen)\"]   ) ServiceRequests     where ServiceRequests.intent ~ 'order'       and ServiceRequests.status ~ 'completed'       and exists(\"Initial Population\")   return ServiceRequestResource(ServiceRequests,   {FHIR.canonical{value: 'http://www.cdc.gov/nhsn/fhirportal/dqm/ig/StructureDefinition/ach-daily-servicerequest'}})"
+                  },
+                  {
+                    "url": "displaySequence",
+                    "valueInteger": 6
+                  }
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
+              },
+              {
                 "extension": [
                   {
                     "url": "libraryName",
@@ -8912,12 +8936,12 @@
                   },
                   {
                     "url": "displaySequence",
-                    "valueInteger": 6
+                    "valueInteger": 7
                   }
-                ]
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
                 "extension": [
                   {
                     "url": "libraryName",
@@ -8933,12 +8957,12 @@
                   },
                   {
                     "url": "displaySequence",
-                    "valueInteger": 7
+                    "valueInteger": 8
                   }
-                ]
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
                 "extension": [
                   {
                     "url": "libraryName",
@@ -8954,390 +8978,12 @@
                   },
                   {
                     "url": "displaySequence",
-                    "valueInteger": 8
-                  }
-                ]
-              },
-              {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
-                "extension": [
-                  {
-                    "url": "libraryName",
-                    "valueString": "NHSNAcuteCareHospitalDailyInitialPopulation"
-                  },
-                  {
-                    "url": "name",
-                    "valueString": "RSV DiagnosticReport"
-                  },
-                  {
-                    "url": "statement",
-                    "valueString": "define \"RSV DiagnosticReport\":   ([DiagnosticReport: \"RSV (Tests for RSV Nucleic Acid)\"]     union [DiagnosticReport: \"RSV (Tests for RSV Antigen)\"]   ) Reports     where exists(\"Initial Population\")       and Reports.status in {'final','registered','preliminary','partial'}"
-                  },
-                  {
-                    "url": "displaySequence",
                     "valueInteger": 9
                   }
-                ]
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
-                "extension": [
-                  {
-                    "url": "libraryName",
-                    "valueString": "NHSNAcuteCareHospitalDailyInitialPopulation"
-                  },
-                  {
-                    "url": "name",
-                    "valueString": "SDE RSV DiagnosticReport"
-                  },
-                  {
-                    "url": "statement",
-                    "valueString": "//return the RSV DiagnosticReport pre admission define \"SDE RSV DiagnosticReport\":   \"RSV DiagnosticReport\" Reports     return SharedResource.DiagnosticReportLabResource(Reports,     {FHIR.canonical{value: 'http://www.cdc.gov/nhsn/fhirportal/dqm/ig/StructureDefinition/ach-daily-diagnosticreport-lab'}})"
-                  },
-                  {
-                    "url": "displaySequence",
-                    "valueInteger": 10
-                  }
-                ]
-              },
-              {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
-                "extension": [
-                  {
-                    "url": "libraryName",
-                    "valueString": "NHSNAcuteCareHospitalDailyInitialPopulation"
-                  },
-                  {
-                    "url": "name",
-                    "valueString": "SDE All Procedures"
-                  },
-                  {
-                    "url": "statement",
-                    "valueString": "//To catch all isolation precautions define \"SDE All Procedures\":   [Procedure] P   where exists(\"Initial Population\")   return SharedResource.ProcedureResource(P,   {FHIR.canonical{value: 'http://www.cdc.gov/nhsn/fhirportal/dqm/ig/StructureDefinition/ach-daily-procedure'}})"
-                  },
-                  {
-                    "url": "displaySequence",
-                    "valueInteger": 11
-                  }
-                ]
-              },
-              {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
-                "extension": [
-                  {
-                    "url": "libraryName",
-                    "valueString": "NHSNAcuteCareHospitalDailyInitialPopulation"
-                  },
-                  {
-                    "url": "name",
-                    "valueString": "SDE Encounter Discharge Dispositions"
-                  },
-                  {
-                    "url": "statement",
-                    "valueString": "define \"SDE Encounter Discharge Dispositions\":  \"Initial Population\" DischargeDispositions    where DischargeDispositions.hospitalization.dischargeDisposition in \"Discharge Disposition\"   return SharedResource.EncounterResource(DischargeDispositions,   {FHIR.canonical{value: 'http://www.cdc.gov/nhsn/fhirportal/dqm/ig/StructureDefinition/ach-daily-encounter'}})"
-                  },
-                  {
-                    "url": "displaySequence",
-                    "valueInteger": 12
-                  }
-                ]
-              },
-              {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
-                "extension": [
-                  {
-                    "url": "libraryName",
-                    "valueString": "NHSNAcuteCareHospitalDailyInitialPopulation"
-                  },
-                  {
-                    "url": "name",
-                    "valueString": "SDE Covid or Influenza Medication Ordered"
-                  },
-                  {
-                    "url": "statement",
-                    "valueString": "define \"SDE Covid or Influenza Medication Ordered\":   [MedicationRequest] RPSMedRequest     let Meds: GetMedicationCode(RPSMedRequest.medication)     where (Meds in \"Anakinra\"             or Meds in \"Baloxavir\"             or Meds in \"Bamlanivimab\"             or Meds in \"Baricitinib\"             or Meds in \"Bebtelovimab\"             or Meds in \"Casirivimab\"             or Meds in \"Casirivimab / Imdevimab\"             or Meds in \"COVID19 RxNorm Value Set for Tocilizumab\"             or Meds in \"Etesevimab\"             or Meds in \"Imdevimab\"             or Meds in \"Molnupiravir\"             or Meds in \"Nirmatrelvir / Ritonavir\"             or Meds in \"Oseltamivir\"             or Meds in \"Peramivir\"             or Meds in \"Remdesivir\"             or Meds in \"Sarilumab\"             or Meds in \"Sotrovimab\"                 or Meds in \"Tofacitinib\"             or Meds in \"Zanamivir\")       and exists(\"Initial Population\")       and NHSNHelpers.\"Normalize Interval\"(RPSMedRequest.authoredOn) during \"Measurement Period\"     return SharedResource.MedicationRequestResource(RPSMedRequest,     {FHIR.canonical{value: 'http://www.cdc.gov/nhsn/fhirportal/dqm/ig/StructureDefinition/ach-daily-medicationrequest'}})"
-                  },
-                  {
-                    "url": "displaySequence",
-                    "valueInteger": 13
-                  }
-                ]
-              },
-              {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
-                "extension": [
-                  {
-                    "url": "libraryName",
-                    "valueString": "NHSNAcuteCareHospitalDailyInitialPopulation"
-                  },
-                  {
-                    "url": "name",
-                    "valueString": "SDE Minimal Patient"
-                  },
-                  {
-                    "url": "statement",
-                    "valueString": "define \"SDE Minimal Patient\":   Patient p   where exists(\"Initial Population\")   return SharedResource.PatientResource(p,    {FHIR.canonical{value: 'http://www.cdc.gov/nhsn/fhirportal/dqm/ig/StructureDefinition/cross-measure-patient'}})"
-                  },
-                  {
-                    "url": "displaySequence",
-                    "valueInteger": 14
-                  }
-                ]
-              },
-              {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
-                "extension": [
-                  {
-                    "url": "libraryName",
-                    "valueString": "NHSNAcuteCareHospitalDailyInitialPopulation"
-                  },
-                  {
-                    "url": "name",
-                    "valueString": "Observations"
-                  },
-                  {
-                    "url": "statement",
-                    "valueString": "define \"Observations\":   [Observation]"
-                  },
-                  {
-                    "url": "displaySequence",
-                    "valueInteger": 15
-                  }
-                ]
-              },
-              {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
-                "extension": [
-                  {
-                    "url": "libraryName",
-                    "valueString": "NHSNAcuteCareHospitalDailyInitialPopulation"
-                  },
-                  {
-                    "url": "name",
-                    "valueString": "SDE All Observations"
-                  },
-                  {
-                    "url": "statement",
-                    "valueString": "//To catch all isolation precautions define \"SDE All Observations\":   \"Observations\" O   where exists(\"Initial Population\")   return SharedResource.ObservationLabResource(O,   {FHIR.canonical{value: 'http://www.cdc.gov/nhsn/fhirportal/dqm/ig/StructureDefinition/ach-daily-observation'}})"
-                  },
-                  {
-                    "url": "displaySequence",
-                    "valueInteger": 16
-                  }
-                ]
-              },
-              {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
-                "extension": [
-                  {
-                    "url": "libraryName",
-                    "valueString": "NHSNAcuteCareHospitalDailyInitialPopulation"
-                  },
-                  {
-                    "url": "name",
-                    "valueString": "SDE Covid or Influenza Medication Administered"
-                  },
-                  {
-                    "url": "statement",
-                    "valueString": "define \"SDE Covid or Influenza Medication Administered\":   [MedicationAdministration] RPSMedAdmin     let Meds: GetMedicationCode(RPSMedAdmin.medication)    where (Meds in \"Anakinra\"             or Meds in \"Bamlanivimab\"             or Meds in \"Baloxavir\"             or Meds in \"Baricitinib\"             or Meds in \"Bebtelovimab\"             or Meds in \"Casirivimab\"             or Meds in \"Casirivimab / Imdevimab\"             or Meds in \"COVID19 RxNorm Value Set for Tocilizumab\"             or Meds in \"Etesevimab\"             or Meds in \"Imdevimab\"             or Meds in \"Molnupiravir\"             or Meds in \"Nirmatrelvir / Ritonavir\"             or Meds in \"Oseltamivir\"             or Meds in \"Peramivir\"             or Meds in \"Remdesivir\"             or Meds in \"Sarilumab\"             or Meds in \"Sotrovimab\"                 or Meds in \"Tofacitinib\"             or Meds in \"Zanamivir\")       and RPSMedAdmin.status ~ 'completed'       and exists(\"Initial Population\")       and NHSNHelpers.\"Normalize Interval\"(RPSMedAdmin.effective) during \"Measurement Period\"     return SharedResource.MedicationAdministrationResource(RPSMedAdmin,     {FHIR.canonical{value: 'http://www.cdc.gov/nhsn/fhirportal/dqm/ig/StructureDefinition/ach-daily-medicationadministration'}})"
-                  },
-                  {
-                    "url": "displaySequence",
-                    "valueInteger": 17
-                  }
-                ]
-              },
-              {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
-                "extension": [
-                  {
-                    "url": "libraryName",
-                    "valueString": "NHSNAcuteCareHospitalDailyInitialPopulation"
-                  },
-                  {
-                    "url": "name",
-                    "valueString": "SDE Medication"
-                  },
-                  {
-                    "url": "statement",
-                    "valueString": "define \"SDE Medication\":   (\"SDE Covid or Influenza Medication Ordered\"   union \"SDE Covid or Influenza Medication Administered\") MedReqOrAdmin   where MedReqOrAdmin.medication is FHIR.Reference   return SharedResource.MedicationResource(GetMedicationFrom(MedReqOrAdmin.medication),   {FHIR.canonical{value: 'http://www.cdc.gov/nhsn/fhirportal/dqm/ig/StructureDefinition/ach-daily-medication'}})"
-                  },
-                  {
-                    "url": "displaySequence",
-                    "valueInteger": 18
-                  }
-                ]
-              },
-              {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
-                "extension": [
-                  {
-                    "url": "libraryName",
-                    "valueString": "NHSNAcuteCareHospitalDailyInitialPopulation"
-                  },
-                  {
-                    "url": "name",
-                    "valueString": "DiagnosticReports"
-                  },
-                  {
-                    "url": "statement",
-                    "valueString": "define \"DiagnosticReports\":   [DiagnosticReport]"
-                  },
-                  {
-                    "url": "displaySequence",
-                    "valueInteger": 19
-                  }
-                ]
-              },
-              {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
-                "extension": [
-                  {
-                    "url": "libraryName",
-                    "valueString": "NHSNAcuteCareHospitalDailyInitialPopulation"
-                  },
-                  {
-                    "url": "name",
-                    "valueString": "RSV Observations"
-                  },
-                  {
-                    "url": "statement",
-                    "valueString": "define \"RSV Observations\":   \"Observations\" Observations   where Observations.code in \"RSV (Tests for RSV Nucleic Acid)\"     or Observations.code in \"RSV (Tests for RSV Antigen)\""
-                  },
-                  {
-                    "url": "displaySequence",
-                    "valueInteger": 20
-                  }
-                ]
-              },
-              {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
-                "extension": [
-                  {
-                    "url": "libraryName",
-                    "valueString": "NHSNAcuteCareHospitalDailyInitialPopulation"
-                  },
-                  {
-                    "url": "name",
-                    "valueString": "RSV DiagnosticReport Observations"
-                  },
-                  {
-                    "url": "statement",
-                    "valueString": "define \"RSV DiagnosticReport Observations\":   \"DiagnosticReports\" Reports   where exists(     \"RSV Observations\" Observations     where Reports.result.references(Observations)   )"
-                  },
-                  {
-                    "url": "displaySequence",
-                    "valueInteger": 21
-                  }
-                ]
-              },
-              {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
-                "extension": [
-                  {
-                    "url": "libraryName",
-                    "valueString": "NHSNAcuteCareHospitalDailyInitialPopulation"
-                  },
-                  {
-                    "url": "name",
-                    "valueString": "RSV DiagnosticReport Result from Lab"
-                  },
-                  {
-                    "url": "statement",
-                    "valueString": "define \"RSV DiagnosticReport Result from Lab\":   [DiagnosticReport] Reports     where exists(\"RSV DiagnosticReport Observations\")       and Reports.status in {'final','registered','preliminary','partial'}       and exists(\"Initial Population\")"
-                  },
-                  {
-                    "url": "displaySequence",
-                    "valueInteger": 22
-                  }
-                ]
-              },
-              {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
-                "extension": [
-                  {
-                    "url": "libraryName",
-                    "valueString": "NHSNAcuteCareHospitalDailyInitialPopulation"
-                  },
-                  {
-                    "url": "name",
-                    "valueString": "SDE RSV DiagnosticReport Result from Lab"
-                  },
-                  {
-                    "url": "statement",
-                    "valueString": "//return the RSV DiagnosticReport based on the result pre admission define \"SDE RSV DiagnosticReport Result from Lab\":   \"RSV DiagnosticReport Result from Lab\" Reports     return SharedResource.DiagnosticReportLabResource(Reports,     {FHIR.canonical{value: 'http://www.cdc.gov/nhsn/fhirportal/dqm/ig/StructureDefinition/ach-daily-diagnosticreport-lab'}})"
-                  },
-                  {
-                    "url": "displaySequence",
-                    "valueInteger": 23
-                  }
-                ]
-              },
-              {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
-                "extension": [
-                  {
-                    "url": "libraryName",
-                    "valueString": "NHSNAcuteCareHospitalDailyInitialPopulation"
-                  },
-                  {
-                    "url": "name",
-                    "valueString": "SDE IP Encounters"
-                  },
-                  {
-                    "url": "statement",
-                    "valueString": "//---------------------------------- // SDE //---------------------------------- define \"SDE IP Encounters\":   \"Initial Population\" IP   return SharedResource.EncounterResource(IP,    {FHIR.canonical{value: 'http://www.cdc.gov/nhsn/fhirportal/dqm/ig/StructureDefinition/ach-daily-encounter'}})"
-                  },
-                  {
-                    "url": "displaySequence",
-                    "valueInteger": 24
-                  }
-                ]
-              },
-              {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
-                "extension": [
-                  {
-                    "url": "libraryName",
-                    "valueString": "NHSNAcuteCareHospitalDailyInitialPopulation"
-                  },
-                  {
-                    "url": "name",
-                    "valueString": "SDE RSV PRE Admission Observation"
-                  },
-                  {
-                    "url": "statement",
-                    "valueString": "//return the RSV Observation Pre Admission     define \"SDE RSV PRE Admission Observation\":   \"RSV PRE Admission Observation\" Observations     return SharedResource.ObservationLabResource(Observations,      {FHIR.canonical{value: 'http://www.cdc.gov/nhsn/fhirportal/dqm/ig/StructureDefinition/ach-daily-observation-lab'}})"
-                  },
-                  {
-                    "url": "displaySequence",
-                    "valueInteger": 25
-                  }
-                ]
-              },
-              {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
-                "extension": [
-                  {
-                    "url": "libraryName",
-                    "valueString": "NHSNAcuteCareHospitalDailyInitialPopulation"
-                  },
-                  {
-                    "url": "name",
-                    "valueString": "SDE Isolation Precautions Implemented"
-                  },
-                  {
-                    "url": "statement",
-                    "valueString": "define \"SDE Isolation Precautions Implemented\":   [Procedure: \"Transmission Based Precaution Types\"] IsolationPrecautions     where NHSNHelpers.\"Normalize Interval\"(IsolationPrecautions.performed) during \"Measurement Period\"     and exists(\"Initial Population\")   return SharedResource.ProcedureResource(IsolationPrecautions,   {FHIR.canonical{value: 'http://www.cdc.gov/nhsn/fhirportal/dqm/ig/StructureDefinition/ach-daily-procedure'}})"
-                  },
-                  {
-                    "url": "displaySequence",
-                    "valueInteger": 26
-                  }
-                ]
-              },
-              {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
                 "extension": [
                   {
                     "url": "libraryName",
@@ -9353,12 +8999,12 @@
                   },
                   {
                     "url": "displaySequence",
-                    "valueInteger": 27
+                    "valueInteger": 10
                   }
-                ]
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
                 "extension": [
                   {
                     "url": "libraryName",
@@ -9366,20 +9012,20 @@
                   },
                   {
                     "url": "name",
-                    "valueString": "COVID And Influenza PRE Admission Observation"
+                    "valueString": "ACH Daily Observation"
                   },
                   {
                     "url": "statement",
-                    "valueString": "//further constrain COVID-19 and Influenza Observations for 14 day lookback define \"COVID And Influenza PRE Admission Observation\":   \"COVID And Influenza Observation\" O     where exists( EncounterInpatient E      where (       NHSNHelpers.\"Normalize Interval\"(O.effective) 14 days or less on or before start of E.period       or NHSNHelpers.\"Normalize Interval\"(GetSpecimen(O.specimen).collection.collected) 14 days or less on or before start of E.period       )       and start of E.period during \"Measurement Period\"     )"
+                    "valueString": "define \"ACH Daily Observation\":   \"RSV Observation\"   union \"COVID And Influenza Observation\""
                   },
                   {
                     "url": "displaySequence",
-                    "valueInteger": 28
+                    "valueInteger": 11
                   }
-                ]
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
                 "extension": [
                   {
                     "url": "libraryName",
@@ -9387,41 +9033,20 @@
                   },
                   {
                     "url": "name",
-                    "valueString": "SDE COVID And Influenza Specimen"
+                    "valueString": "SDE ACH Daily Specimen"
                   },
                   {
                     "url": "statement",
-                    "valueString": "//return the Specimen related to the COVID-19 And Influenza Observation Pre Admission define \"SDE COVID And Influenza Specimen\":   \"COVID And Influenza PRE Admission Observation\" ObservationWithSpecimen     let Specimen: GetSpecimen(ObservationWithSpecimen.specimen)     return SharedResource.SpecimenResource(Specimen,     {FHIR.canonical{value: 'http://www.cdc.gov/nhsn/fhirportal/dqm/ig/StructureDefinition/ach-daily-specimen'}})"
+                    "valueString": "//return the Specimen related to the Observation during the Measurement Period define \"SDE ACH Daily Specimen\":   \"ACH Daily Observation\" ObservationWithSpecimen     let Specimen: GetSpecimen(ObservationWithSpecimen.specimen)     return SharedResource.SpecimenResource(Specimen,     {FHIR.canonical{value: 'http://www.cdc.gov/nhsn/fhirportal/dqm/ig/StructureDefinition/ach-daily-specimen'}})"
                   },
                   {
                     "url": "displaySequence",
-                    "valueInteger": 29
+                    "valueInteger": 12
                   }
-                ]
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
-                "extension": [
-                  {
-                    "url": "libraryName",
-                    "valueString": "NHSNAcuteCareHospitalDailyInitialPopulation"
-                  },
-                  {
-                    "url": "name",
-                    "valueString": "SDE All ServiceRequests"
-                  },
-                  {
-                    "url": "statement",
-                    "valueString": "//To catch all isolation precautions define \"SDE All ServiceRequests\":   [ServiceRequest] SR   where exists(\"Initial Population\")   return SharedResource.ServiceRequestResource(SR,   {FHIR.canonical{value: 'http://www.cdc.gov/nhsn/fhirportal/dqm/ig/StructureDefinition/ach-daily-servicerequest'}})"
-                  },
-                  {
-                    "url": "displaySequence",
-                    "valueInteger": 30
-                  }
-                ]
-              },
-              {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
                 "extension": [
                   {
                     "url": "libraryName",
@@ -9437,12 +9062,516 @@
                   },
                   {
                     "url": "displaySequence",
-                    "valueInteger": 31
+                    "valueInteger": 13
                   }
-                ]
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
+                "extension": [
+                  {
+                    "url": "libraryName",
+                    "valueString": "NHSNAcuteCareHospitalDailyInitialPopulation"
+                  },
+                  {
+                    "url": "name",
+                    "valueString": "RSV DiagnosticReport"
+                  },
+                  {
+                    "url": "statement",
+                    "valueString": "define \"RSV DiagnosticReport\":   ([DiagnosticReport: \"RSV (Tests for RSV Nucleic Acid)\"]     union [DiagnosticReport: \"RSV (Tests for RSV Antigen)\"]   ) Reports     where exists(\"Initial Population\")       and Reports.status in {'final','registered','preliminary','partial'}"
+                  },
+                  {
+                    "url": "displaySequence",
+                    "valueInteger": 14
+                  }
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
+              },
+              {
+                "extension": [
+                  {
+                    "url": "libraryName",
+                    "valueString": "NHSNAcuteCareHospitalDailyInitialPopulation"
+                  },
+                  {
+                    "url": "name",
+                    "valueString": "ACH Daily DiagnosticReport"
+                  },
+                  {
+                    "url": "statement",
+                    "valueString": "define \"ACH Daily DiagnosticReport\":   \"COVID And Influenza DiagnosticReport\"     union \"RSV DiagnosticReport\""
+                  },
+                  {
+                    "url": "displaySequence",
+                    "valueInteger": 15
+                  }
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
+              },
+              {
+                "extension": [
+                  {
+                    "url": "libraryName",
+                    "valueString": "NHSNAcuteCareHospitalDailyInitialPopulation"
+                  },
+                  {
+                    "url": "name",
+                    "valueString": "SDE ACH Daily DiagnosticReport"
+                  },
+                  {
+                    "url": "statement",
+                    "valueString": "//return the DiagnosticReport during the Measurement Period define \"SDE ACH Daily DiagnosticReport\":   \"ACH Daily DiagnosticReport\" Reports     return SharedResource.DiagnosticReportLabResource(Reports,     {FHIR.canonical{value: 'http://www.cdc.gov/nhsn/fhirportal/dqm/ig/StructureDefinition/ach-daily-diagnosticreport-lab'}})"
+                  },
+                  {
+                    "url": "displaySequence",
+                    "valueInteger": 16
+                  }
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
+              },
+              {
+                "extension": [
+                  {
+                    "url": "libraryName",
+                    "valueString": "NHSNAcuteCareHospitalDailyInitialPopulation"
+                  },
+                  {
+                    "url": "name",
+                    "valueString": "SDE RSV DiagnosticReport"
+                  },
+                  {
+                    "url": "statement",
+                    "valueString": "//return the RSV DiagnosticReport pre admission define \"SDE RSV DiagnosticReport\":   \"RSV DiagnosticReport\" Reports     return SharedResource.DiagnosticReportLabResource(Reports,     {FHIR.canonical{value: 'http://www.cdc.gov/nhsn/fhirportal/dqm/ig/StructureDefinition/ach-daily-diagnosticreport-lab'}})"
+                  },
+                  {
+                    "url": "displaySequence",
+                    "valueInteger": 17
+                  }
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
+              },
+              {
+                "extension": [
+                  {
+                    "url": "libraryName",
+                    "valueString": "NHSNAcuteCareHospitalDailyInitialPopulation"
+                  },
+                  {
+                    "url": "name",
+                    "valueString": "SDE ACH Daily Observation"
+                  },
+                  {
+                    "url": "statement",
+                    "valueString": "//return the Observation during the Measurement Period define \"SDE ACH Daily Observation\":   \"ACH Daily Observation\" Observations     return ObservationLabResource(Observations,     {FHIR.canonical{value: 'http://www.cdc.gov/nhsn/fhirportal/dqm/ig/StructureDefinition/ach-daily-observation-lab'}})"
+                  },
+                  {
+                    "url": "displaySequence",
+                    "valueInteger": 18
+                  }
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
+              },
+              {
+                "extension": [
+                  {
+                    "url": "libraryName",
+                    "valueString": "NHSNAcuteCareHospitalDailyInitialPopulation"
+                  },
+                  {
+                    "url": "name",
+                    "valueString": "SDE All Procedures"
+                  },
+                  {
+                    "url": "statement",
+                    "valueString": "//To catch all isolation precautions define \"SDE All Procedures\":   [Procedure] P   where exists(\"Initial Population\")   return SharedResource.ProcedureResource(P,   {FHIR.canonical{value: 'http://www.cdc.gov/nhsn/fhirportal/dqm/ig/StructureDefinition/ach-daily-procedure'}})"
+                  },
+                  {
+                    "url": "displaySequence",
+                    "valueInteger": 19
+                  }
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
+              },
+              {
+                "extension": [
+                  {
+                    "url": "libraryName",
+                    "valueString": "NHSNAcuteCareHospitalDailyInitialPopulation"
+                  },
+                  {
+                    "url": "name",
+                    "valueString": "SDE Encounter Discharge Dispositions"
+                  },
+                  {
+                    "url": "statement",
+                    "valueString": "define \"SDE Encounter Discharge Dispositions\":  \"Initial Population\" DischargeDispositions    where DischargeDispositions.hospitalization.dischargeDisposition in \"Discharge Disposition\"   return SharedResource.EncounterResource(DischargeDispositions,   {FHIR.canonical{value: 'http://www.cdc.gov/nhsn/fhirportal/dqm/ig/StructureDefinition/ach-daily-encounter'}})"
+                  },
+                  {
+                    "url": "displaySequence",
+                    "valueInteger": 20
+                  }
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
+              },
+              {
+                "extension": [
+                  {
+                    "url": "libraryName",
+                    "valueString": "NHSNAcuteCareHospitalDailyInitialPopulation"
+                  },
+                  {
+                    "url": "name",
+                    "valueString": "SDE Covid or Influenza Medication Ordered"
+                  },
+                  {
+                    "url": "statement",
+                    "valueString": "define \"SDE Covid or Influenza Medication Ordered\":   [MedicationRequest] RPSMedRequest     let Meds: GetMedicationCode(RPSMedRequest.medication)     where (Meds in \"Anakinra\"             or Meds in \"Baloxavir\"             or Meds in \"Bamlanivimab\"             or Meds in \"Baricitinib\"             or Meds in \"Bebtelovimab\"             or Meds in \"Casirivimab\"             or Meds in \"Casirivimab / Imdevimab\"             or Meds in \"COVID19 RxNorm Value Set for Tocilizumab\"             or Meds in \"Etesevimab\"             or Meds in \"Imdevimab\"             or Meds in \"Molnupiravir\"             or Meds in \"Nirmatrelvir / Ritonavir\"             or Meds in \"Oseltamivir\"             or Meds in \"Peramivir\"             or Meds in \"Remdesivir\"             or Meds in \"Sarilumab\"             or Meds in \"Sotrovimab\"                 or Meds in \"Tofacitinib\"             or Meds in \"Zanamivir\")       and exists(\"Initial Population\")       and NHSNHelpers.\"Normalize Interval\"(RPSMedRequest.authoredOn) during \"Measurement Period\"     return MedicationRequestResource(RPSMedRequest,     {FHIR.canonical{value: 'http://www.cdc.gov/nhsn/fhirportal/dqm/ig/StructureDefinition/ach-daily-medicationrequest'}})"
+                  },
+                  {
+                    "url": "displaySequence",
+                    "valueInteger": 21
+                  }
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
+              },
+              {
+                "extension": [
+                  {
+                    "url": "libraryName",
+                    "valueString": "NHSNAcuteCareHospitalDailyInitialPopulation"
+                  },
+                  {
+                    "url": "name",
+                    "valueString": "SDE Minimal Patient"
+                  },
+                  {
+                    "url": "statement",
+                    "valueString": "define \"SDE Minimal Patient\":   Patient p   where exists(\"Initial Population\")   return SharedResource.PatientResource(p,    {FHIR.canonical{value: 'http://www.cdc.gov/nhsn/fhirportal/dqm/ig/StructureDefinition/cross-measure-patient'}})"
+                  },
+                  {
+                    "url": "displaySequence",
+                    "valueInteger": 22
+                  }
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
+              },
+              {
+                "extension": [
+                  {
+                    "url": "libraryName",
+                    "valueString": "NHSNAcuteCareHospitalDailyInitialPopulation"
+                  },
+                  {
+                    "url": "name",
+                    "valueString": "Observations"
+                  },
+                  {
+                    "url": "statement",
+                    "valueString": "define \"Observations\":   [Observation]"
+                  },
+                  {
+                    "url": "displaySequence",
+                    "valueInteger": 23
+                  }
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
+              },
+              {
+                "extension": [
+                  {
+                    "url": "libraryName",
+                    "valueString": "NHSNAcuteCareHospitalDailyInitialPopulation"
+                  },
+                  {
+                    "url": "name",
+                    "valueString": "SDE All Observations"
+                  },
+                  {
+                    "url": "statement",
+                    "valueString": "//To catch all isolation precautions define \"SDE All Observations\":   \"Observations\" O   where exists(\"Initial Population\")   return ObservationLabResource(O,   {FHIR.canonical{value: 'http://www.cdc.gov/nhsn/fhirportal/dqm/ig/StructureDefinition/ach-daily-observation'}})"
+                  },
+                  {
+                    "url": "displaySequence",
+                    "valueInteger": 24
+                  }
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
+              },
+              {
+                "extension": [
+                  {
+                    "url": "libraryName",
+                    "valueString": "NHSNAcuteCareHospitalDailyInitialPopulation"
+                  },
+                  {
+                    "url": "name",
+                    "valueString": "SDE Covid or Influenza Medication Administered"
+                  },
+                  {
+                    "url": "statement",
+                    "valueString": "define \"SDE Covid or Influenza Medication Administered\":   [MedicationAdministration] RPSMedAdmin     let Meds: GetMedicationCode(RPSMedAdmin.medication)    where (Meds in \"Anakinra\"             or Meds in \"Bamlanivimab\"             or Meds in \"Baloxavir\"             or Meds in \"Baricitinib\"             or Meds in \"Bebtelovimab\"             or Meds in \"Casirivimab\"             or Meds in \"Casirivimab / Imdevimab\"             or Meds in \"COVID19 RxNorm Value Set for Tocilizumab\"             or Meds in \"Etesevimab\"             or Meds in \"Imdevimab\"             or Meds in \"Molnupiravir\"             or Meds in \"Nirmatrelvir / Ritonavir\"             or Meds in \"Oseltamivir\"             or Meds in \"Peramivir\"             or Meds in \"Remdesivir\"             or Meds in \"Sarilumab\"             or Meds in \"Sotrovimab\"                 or Meds in \"Tofacitinib\"             or Meds in \"Zanamivir\")       and RPSMedAdmin.status ~ 'completed'       and exists(\"Initial Population\")       and NHSNHelpers.\"Normalize Interval\"(RPSMedAdmin.effective) during \"Measurement Period\"     return SharedResource.MedicationAdministrationResource(RPSMedAdmin,     {FHIR.canonical{value: 'http://www.cdc.gov/nhsn/fhirportal/dqm/ig/StructureDefinition/ach-daily-medicationadministration'}})"
+                  },
+                  {
+                    "url": "displaySequence",
+                    "valueInteger": 25
+                  }
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
+              },
+              {
+                "extension": [
+                  {
+                    "url": "libraryName",
+                    "valueString": "NHSNAcuteCareHospitalDailyInitialPopulation"
+                  },
+                  {
+                    "url": "name",
+                    "valueString": "SDE Medication"
+                  },
+                  {
+                    "url": "statement",
+                    "valueString": "define \"SDE Medication\":   (\"SDE Covid or Influenza Medication Ordered\"   union \"SDE Covid or Influenza Medication Administered\") MedReqOrAdmin   where MedReqOrAdmin.medication is FHIR.Reference   return SharedResource.MedicationResource(GetMedicationFrom(MedReqOrAdmin.medication),   {FHIR.canonical{value: 'http://www.cdc.gov/nhsn/fhirportal/dqm/ig/StructureDefinition/ach-daily-medication'}})"
+                  },
+                  {
+                    "url": "displaySequence",
+                    "valueInteger": 26
+                  }
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
+              },
+              {
+                "extension": [
+                  {
+                    "url": "libraryName",
+                    "valueString": "NHSNAcuteCareHospitalDailyInitialPopulation"
+                  },
+                  {
+                    "url": "name",
+                    "valueString": "DiagnosticReports"
+                  },
+                  {
+                    "url": "statement",
+                    "valueString": "define \"DiagnosticReports\":   [DiagnosticReport]"
+                  },
+                  {
+                    "url": "displaySequence",
+                    "valueInteger": 27
+                  }
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
+              },
+              {
+                "extension": [
+                  {
+                    "url": "libraryName",
+                    "valueString": "NHSNAcuteCareHospitalDailyInitialPopulation"
+                  },
+                  {
+                    "url": "name",
+                    "valueString": "RSV Observations"
+                  },
+                  {
+                    "url": "statement",
+                    "valueString": "define \"RSV Observations\":   \"Observations\" Observations   where Observations.code in \"RSV (Tests for RSV Nucleic Acid)\"     or Observations.code in \"RSV (Tests for RSV Antigen)\""
+                  },
+                  {
+                    "url": "displaySequence",
+                    "valueInteger": 28
+                  }
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
+              },
+              {
+                "extension": [
+                  {
+                    "url": "libraryName",
+                    "valueString": "NHSNAcuteCareHospitalDailyInitialPopulation"
+                  },
+                  {
+                    "url": "name",
+                    "valueString": "RSV DiagnosticReport Observations"
+                  },
+                  {
+                    "url": "statement",
+                    "valueString": "define \"RSV DiagnosticReport Observations\":   \"DiagnosticReports\" Reports   where exists(     \"RSV Observations\" Observations     where Reports.result.references(Observations)   )"
+                  },
+                  {
+                    "url": "displaySequence",
+                    "valueInteger": 29
+                  }
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
+              },
+              {
+                "extension": [
+                  {
+                    "url": "libraryName",
+                    "valueString": "NHSNAcuteCareHospitalDailyInitialPopulation"
+                  },
+                  {
+                    "url": "name",
+                    "valueString": "RSV DiagnosticReport Result from Lab"
+                  },
+                  {
+                    "url": "statement",
+                    "valueString": "define \"RSV DiagnosticReport Result from Lab\":   [DiagnosticReport] Reports     where exists(\"RSV DiagnosticReport Observations\")       and Reports.status in {'final','registered','preliminary','partial'}       and exists(\"Initial Population\")"
+                  },
+                  {
+                    "url": "displaySequence",
+                    "valueInteger": 30
+                  }
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
+              },
+              {
+                "extension": [
+                  {
+                    "url": "libraryName",
+                    "valueString": "NHSNAcuteCareHospitalDailyInitialPopulation"
+                  },
+                  {
+                    "url": "name",
+                    "valueString": "SDE RSV DiagnosticReport Result from Lab"
+                  },
+                  {
+                    "url": "statement",
+                    "valueString": "//return the RSV DiagnosticReport based on the result pre admission define \"SDE RSV DiagnosticReport Result from Lab\":   \"RSV DiagnosticReport Result from Lab\" Reports     return SharedResource.DiagnosticReportLabResource(Reports,     {FHIR.canonical{value: 'http://www.cdc.gov/nhsn/fhirportal/dqm/ig/StructureDefinition/ach-daily-diagnosticreport-lab'}})"
+                  },
+                  {
+                    "url": "displaySequence",
+                    "valueInteger": 31
+                  }
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
+              },
+              {
+                "extension": [
+                  {
+                    "url": "libraryName",
+                    "valueString": "NHSNAcuteCareHospitalDailyInitialPopulation"
+                  },
+                  {
+                    "url": "name",
+                    "valueString": "SDE IP Encounters"
+                  },
+                  {
+                    "url": "statement",
+                    "valueString": "//---------------------------------- // SDE //---------------------------------- define \"SDE IP Encounters\":   \"Initial Population\" IP   return SharedResource.EncounterResource(IP,    {FHIR.canonical{value: 'http://www.cdc.gov/nhsn/fhirportal/dqm/ig/StructureDefinition/ach-daily-encounter'}})"
+                  },
+                  {
+                    "url": "displaySequence",
+                    "valueInteger": 32
+                  }
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
+              },
+              {
+                "extension": [
+                  {
+                    "url": "libraryName",
+                    "valueString": "NHSNAcuteCareHospitalDailyInitialPopulation"
+                  },
+                  {
+                    "url": "name",
+                    "valueString": "SDE RSV PRE Admission Observation"
+                  },
+                  {
+                    "url": "statement",
+                    "valueString": "//return the RSV Observation Pre Admission     define \"SDE RSV PRE Admission Observation\":   \"RSV PRE Admission Observation\" Observations     return ObservationLabResource(Observations,      {FHIR.canonical{value: 'http://www.cdc.gov/nhsn/fhirportal/dqm/ig/StructureDefinition/ach-daily-observation-lab'}})"
+                  },
+                  {
+                    "url": "displaySequence",
+                    "valueInteger": 33
+                  }
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
+              },
+              {
+                "extension": [
+                  {
+                    "url": "libraryName",
+                    "valueString": "NHSNAcuteCareHospitalDailyInitialPopulation"
+                  },
+                  {
+                    "url": "name",
+                    "valueString": "SDE Isolation Precautions Implemented"
+                  },
+                  {
+                    "url": "statement",
+                    "valueString": "define \"SDE Isolation Precautions Implemented\":   [Procedure: \"Transmission Based Precaution Types\"] IsolationPrecautions     where NHSNHelpers.\"Normalize Interval\"(IsolationPrecautions.performed) during \"Measurement Period\"     and exists(\"Initial Population\")   return SharedResource.ProcedureResource(IsolationPrecautions,   {FHIR.canonical{value: 'http://www.cdc.gov/nhsn/fhirportal/dqm/ig/StructureDefinition/ach-daily-procedure'}})"
+                  },
+                  {
+                    "url": "displaySequence",
+                    "valueInteger": 34
+                  }
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
+              },
+              {
+                "extension": [
+                  {
+                    "url": "libraryName",
+                    "valueString": "NHSNAcuteCareHospitalDailyInitialPopulation"
+                  },
+                  {
+                    "url": "name",
+                    "valueString": "COVID And Influenza PRE Admission Observation"
+                  },
+                  {
+                    "url": "statement",
+                    "valueString": "//further constrain COVID-19 and Influenza Observations for 14 day lookback define \"COVID And Influenza PRE Admission Observation\":   \"COVID And Influenza Observation\" O     where exists( EncounterInpatient E      where (       NHSNHelpers.\"Normalize Interval\"(O.effective) 14 days or less on or before start of E.period       or NHSNHelpers.\"Normalize Interval\"(GetSpecimen(O.specimen).collection.collected) 14 days or less on or before start of E.period       )       and start of E.period during \"Measurement Period\"     )"
+                  },
+                  {
+                    "url": "displaySequence",
+                    "valueInteger": 35
+                  }
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
+              },
+              {
+                "extension": [
+                  {
+                    "url": "libraryName",
+                    "valueString": "NHSNAcuteCareHospitalDailyInitialPopulation"
+                  },
+                  {
+                    "url": "name",
+                    "valueString": "SDE COVID And Influenza Specimen"
+                  },
+                  {
+                    "url": "statement",
+                    "valueString": "//return the Specimen related to the COVID-19 And Influenza Observation Pre Admission define \"SDE COVID And Influenza Specimen\":   \"COVID And Influenza PRE Admission Observation\" ObservationWithSpecimen     let Specimen: GetSpecimen(ObservationWithSpecimen.specimen)     return SharedResource.SpecimenResource(Specimen,     {FHIR.canonical{value: 'http://www.cdc.gov/nhsn/fhirportal/dqm/ig/StructureDefinition/ach-daily-specimen'}})"
+                  },
+                  {
+                    "url": "displaySequence",
+                    "valueInteger": 36
+                  }
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
+              },
+              {
+                "extension": [
+                  {
+                    "url": "libraryName",
+                    "valueString": "NHSNAcuteCareHospitalDailyInitialPopulation"
+                  },
+                  {
+                    "url": "name",
+                    "valueString": "SDE All ServiceRequests"
+                  },
+                  {
+                    "url": "statement",
+                    "valueString": "//To catch all isolation precautions define \"SDE All ServiceRequests\":   [ServiceRequest] SR   where exists(\"Initial Population\")   return ServiceRequestResource(SR,   {FHIR.canonical{value: 'http://www.cdc.gov/nhsn/fhirportal/dqm/ig/StructureDefinition/ach-daily-servicerequest'}})"
+                  },
+                  {
+                    "url": "displaySequence",
+                    "valueInteger": 37
+                  }
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
+              },
+              {
                 "extension": [
                   {
                     "url": "libraryName",
@@ -9458,12 +9587,12 @@
                   },
                   {
                     "url": "displaySequence",
-                    "valueInteger": 32
+                    "valueInteger": 38
                   }
-                ]
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
                 "extension": [
                   {
                     "url": "libraryName",
@@ -9475,16 +9604,16 @@
                   },
                   {
                     "url": "statement",
-                    "valueString": "//return the COVID-19 and Influenza Observation Pre Admission define \"SDE COVID And Influenza PRE Admission Observation\":   \"COVID And Influenza PRE Admission Observation\" Observations     return SharedResource.ObservationLabResource(Observations,     {FHIR.canonical{value: 'http://www.cdc.gov/nhsn/fhirportal/dqm/ig/StructureDefinition/ach-daily-observation-lab'}})"
+                    "valueString": "//return the COVID-19 and Influenza Observation Pre Admission define \"SDE COVID And Influenza PRE Admission Observation\":   \"COVID And Influenza PRE Admission Observation\" Observations     return ObservationLabResource(Observations,     {FHIR.canonical{value: 'http://www.cdc.gov/nhsn/fhirportal/dqm/ig/StructureDefinition/ach-daily-observation-lab'}})"
                   },
                   {
                     "url": "displaySequence",
-                    "valueInteger": 33
+                    "valueInteger": 39
                   }
-                ]
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
                 "extension": [
                   {
                     "url": "libraryName",
@@ -9500,12 +9629,12 @@
                   },
                   {
                     "url": "displaySequence",
-                    "valueInteger": 34
+                    "valueInteger": 40
                   }
-                ]
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
                 "extension": [
                   {
                     "url": "libraryName",
@@ -9521,12 +9650,54 @@
                   },
                   {
                     "url": "displaySequence",
-                    "valueInteger": 35
+                    "valueInteger": 41
                   }
-                ]
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
+                "extension": [
+                  {
+                    "url": "libraryName",
+                    "valueString": "NHSNAcuteCareHospitalDailyInitialPopulation"
+                  },
+                  {
+                    "url": "name",
+                    "valueString": "ACH Daily DiagnosticReport Result from Lab"
+                  },
+                  {
+                    "url": "statement",
+                    "valueString": "define \"ACH Daily DiagnosticReport Result from Lab\":   \"COVID and Influenza DiagnosticReport Result from Lab\"     union \"RSV DiagnosticReport Result from Lab\""
+                  },
+                  {
+                    "url": "displaySequence",
+                    "valueInteger": 42
+                  }
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
+              },
+              {
+                "extension": [
+                  {
+                    "url": "libraryName",
+                    "valueString": "NHSNAcuteCareHospitalDailyInitialPopulation"
+                  },
+                  {
+                    "url": "name",
+                    "valueString": "SDE ACH Daily DiagnosticReport Result from Lab"
+                  },
+                  {
+                    "url": "statement",
+                    "valueString": "//return the DiagnosticReport based on the result during the Measurement Period     define \"SDE ACH Daily DiagnosticReport Result from Lab\":   \"ACH Daily DiagnosticReport Result from Lab\" Reports     return SharedResource.DiagnosticReportLabResource(Reports,     {FHIR.canonical{value: 'http://www.cdc.gov/nhsn/fhirportal/dqm/ig/StructureDefinition/ach-daily-diagnosticreport-lab'}})"
+                  },
+                  {
+                    "url": "displaySequence",
+                    "valueInteger": 43
+                  }
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
+              },
+              {
                 "extension": [
                   {
                     "url": "libraryName",
@@ -9542,12 +9713,12 @@
                   },
                   {
                     "url": "displaySequence",
-                    "valueInteger": 36
+                    "valueInteger": 44
                   }
-                ]
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
                 "extension": [
                   {
                     "url": "libraryName",
@@ -9563,12 +9734,12 @@
                   },
                   {
                     "url": "displaySequence",
-                    "valueInteger": 37
+                    "valueInteger": 45
                   }
-                ]
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
                 "extension": [
                   {
                     "url": "libraryName",
@@ -9584,12 +9755,12 @@
                   },
                   {
                     "url": "displaySequence",
-                    "valueInteger": 38
+                    "valueInteger": 46
                   }
-                ]
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
                 "extension": [
                   {
                     "url": "libraryName",
@@ -9605,12 +9776,12 @@
                   },
                   {
                     "url": "displaySequence",
-                    "valueInteger": 39
+                    "valueInteger": 47
                   }
-                ]
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
                 "extension": [
                   {
                     "url": "libraryName",
@@ -9626,12 +9797,12 @@
                   },
                   {
                     "url": "displaySequence",
-                    "valueInteger": 40
+                    "valueInteger": 48
                   }
-                ]
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
                 "extension": [
                   {
                     "url": "libraryName",
@@ -9647,12 +9818,33 @@
                   },
                   {
                     "url": "displaySequence",
-                    "valueInteger": 41
+                    "valueInteger": 49
                   }
-                ]
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
+                "extension": [
+                  {
+                    "url": "libraryName",
+                    "valueString": "FHIRHelpers"
+                  },
+                  {
+                    "url": "name",
+                    "valueString": "ToString"
+                  },
+                  {
+                    "url": "statement",
+                    "valueString": "define function ToString(value string): value.value"
+                  },
+                  {
+                    "url": "displaySequence",
+                    "valueInteger": 50
+                  }
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
+              },
+              {
                 "extension": [
                   {
                     "url": "libraryName",
@@ -9668,12 +9860,12 @@
                   },
                   {
                     "url": "displaySequence",
-                    "valueInteger": 42
+                    "valueInteger": 51
                   }
-                ]
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
                 "extension": [
                   {
                     "url": "libraryName",
@@ -9689,12 +9881,33 @@
                   },
                   {
                     "url": "displaySequence",
-                    "valueInteger": 43
+                    "valueInteger": 52
                   }
-                ]
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
+                "extension": [
+                  {
+                    "url": "libraryName",
+                    "valueString": "FHIRHelpers"
+                  },
+                  {
+                    "url": "name",
+                    "valueString": "ToCode"
+                  },
+                  {
+                    "url": "statement",
+                    "valueString": "define function ToCode(coding FHIR.Coding):     if coding is null then         null     else         System.Code {           code: coding.code.value,           system: coding.system.value,           version: coding.version.value,           display: coding.display.value         }"
+                  },
+                  {
+                    "url": "displaySequence",
+                    "valueInteger": 53
+                  }
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
+              },
+              {
                 "extension": [
                   {
                     "url": "libraryName",
@@ -9710,12 +9923,12 @@
                   },
                   {
                     "url": "displaySequence",
-                    "valueInteger": 44
+                    "valueInteger": 54
                   }
-                ]
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
                 "extension": [
                   {
                     "url": "libraryName",
@@ -9731,12 +9944,12 @@
                   },
                   {
                     "url": "displaySequence",
-                    "valueInteger": 45
+                    "valueInteger": 55
                   }
-                ]
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
                 "extension": [
                   {
                     "url": "libraryName",
@@ -9752,12 +9965,12 @@
                   },
                   {
                     "url": "displaySequence",
-                    "valueInteger": 46
+                    "valueInteger": 56
                   }
-                ]
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
                 "extension": [
                   {
                     "url": "libraryName",
@@ -9773,12 +9986,12 @@
                   },
                   {
                     "url": "displaySequence",
-                    "valueInteger": 47
+                    "valueInteger": 57
                   }
-                ]
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
                 "extension": [
                   {
                     "url": "libraryName",
@@ -9794,12 +10007,12 @@
                   },
                   {
                     "url": "displaySequence",
-                    "valueInteger": 48
+                    "valueInteger": 58
                   }
-                ]
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
                 "extension": [
                   {
                     "url": "libraryName",
@@ -9815,12 +10028,12 @@
                   },
                   {
                     "url": "displaySequence",
-                    "valueInteger": 49
+                    "valueInteger": 59
                   }
-                ]
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
                 "extension": [
                   {
                     "url": "libraryName",
@@ -9836,12 +10049,12 @@
                   },
                   {
                     "url": "displaySequence",
-                    "valueInteger": 50
+                    "valueInteger": 60
                   }
-                ]
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
                 "extension": [
                   {
                     "url": "libraryName",
@@ -9857,12 +10070,96 @@
                   },
                   {
                     "url": "displaySequence",
-                    "valueInteger": 51
+                    "valueInteger": 61
                   }
-                ]
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
+                "extension": [
+                  {
+                    "url": "libraryName",
+                    "valueString": "FHIRHelpers"
+                  },
+                  {
+                    "url": "name",
+                    "valueString": "ToString"
+                  },
+                  {
+                    "url": "statement",
+                    "valueString": "define function ToString(value ServiceRequestIntent): value.value"
+                  },
+                  {
+                    "url": "displaySequence",
+                    "valueInteger": 62
+                  }
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
+              },
+              {
+                "extension": [
+                  {
+                    "url": "libraryName",
+                    "valueString": "FHIRHelpers"
+                  },
+                  {
+                    "url": "name",
+                    "valueString": "ToString"
+                  },
+                  {
+                    "url": "statement",
+                    "valueString": "define function ToString(value ServiceRequestStatus): value.value"
+                  },
+                  {
+                    "url": "displaySequence",
+                    "valueInteger": 63
+                  }
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
+              },
+              {
+                "extension": [
+                  {
+                    "url": "libraryName",
+                    "valueString": "NHSNAcuteCareHospitalDailyInitialPopulation"
+                  },
+                  {
+                    "url": "name",
+                    "valueString": "ServiceRequestResource"
+                  },
+                  {
+                    "url": "statement",
+                    "valueString": "define function ServiceRequestResource(serviceRequest ServiceRequest, profileURLs List<FHIR.canonical>):   serviceRequest sR   return ServiceRequest{     id: FHIR.id {value: 'LCR-' + sR.id},     meta: SharedResource.MetaElement(sR, profileURLs),     extension: sR.extension,     instantiatesCanonical: sR.instantiatesCanonical,     instantiatesUri: sR.instantiatesUri,     basedOn: sR.basedOn,     replaces: sR.replaces,     requisition: sR.requisition,     status: sR.status,     intent: sR.intent,     category: sR.category,     priority: sR.priority,     doNotPerform: sR.doNotPerform,     code: sR.code,     orderDetail: sR.orderDetail,     quantity: sR.quantity,     subject: sR.subject,     encounter: sR.encounter,     occurrence: sR.occurrence,     asNeeded: sR.asNeeded,     authoredOn: sR.authoredOn,     performerType: sR.performerType,     performer: sR.performer,     locationCode: sR.locationCode,     locationReference: sR.locationReference,     reasonCode: sR.reasonCode,     reasonReference: sR.reasonReference,     insurance: sR.insurance,     supportingInfo: sR.supportingInfo,     specimen: sR.specimen,     bodySite: sR.bodySite,     note: sR.note,     patientInstruction: sR.patientInstruction,     relevantHistory: sR.relevantHistory   }"
+                  },
+                  {
+                    "url": "displaySequence",
+                    "valueInteger": 64
+                  }
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
+              },
+              {
+                "extension": [
+                  {
+                    "url": "libraryName",
+                    "valueString": "FHIRHelpers"
+                  },
+                  {
+                    "url": "name",
+                    "valueString": "ToString"
+                  },
+                  {
+                    "url": "statement",
+                    "valueString": "define function ToString(value ObservationStatus): value.value"
+                  },
+                  {
+                    "url": "displaySequence",
+                    "valueInteger": 65
+                  }
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
+              },
+              {
                 "extension": [
                   {
                     "url": "libraryName",
@@ -9878,12 +10175,12 @@
                   },
                   {
                     "url": "displaySequence",
-                    "valueInteger": 52
+                    "valueInteger": 66
                   }
-                ]
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
                 "extension": [
                   {
                     "url": "libraryName",
@@ -9899,12 +10196,12 @@
                   },
                   {
                     "url": "displaySequence",
-                    "valueInteger": 53
+                    "valueInteger": 67
                   }
-                ]
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
                 "extension": [
                   {
                     "url": "libraryName",
@@ -9920,12 +10217,12 @@
                   },
                   {
                     "url": "displaySequence",
-                    "valueInteger": 54
+                    "valueInteger": 68
                   }
-                ]
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
                 "extension": [
                   {
                     "url": "libraryName",
@@ -9941,12 +10238,12 @@
                   },
                   {
                     "url": "displaySequence",
-                    "valueInteger": 55
+                    "valueInteger": 69
                   }
-                ]
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
                 "extension": [
                   {
                     "url": "libraryName",
@@ -9962,12 +10259,33 @@
                   },
                   {
                     "url": "displaySequence",
-                    "valueInteger": 56
+                    "valueInteger": 70
                   }
-                ]
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
+                "extension": [
+                  {
+                    "url": "libraryName",
+                    "valueString": "FHIRHelpers"
+                  },
+                  {
+                    "url": "name",
+                    "valueString": "ToString"
+                  },
+                  {
+                    "url": "statement",
+                    "valueString": "define function ToString(value DiagnosticReportStatus): value.value"
+                  },
+                  {
+                    "url": "displaySequence",
+                    "valueInteger": 71
+                  }
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
+              },
+              {
                 "extension": [
                   {
                     "url": "libraryName",
@@ -9983,12 +10301,12 @@
                   },
                   {
                     "url": "displaySequence",
-                    "valueInteger": 57
+                    "valueInteger": 72
                   }
-                ]
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
                 "extension": [
                   {
                     "url": "libraryName",
@@ -10004,12 +10322,12 @@
                   },
                   {
                     "url": "displaySequence",
-                    "valueInteger": 58
+                    "valueInteger": 73
                   }
-                ]
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
                 "extension": [
                   {
                     "url": "libraryName",
@@ -10025,478 +10343,16 @@
                   },
                   {
                     "url": "displaySequence",
-                    "valueInteger": 59
-                  }
-                ]
-              },
-              {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
-                "extension": [
-                  {
-                    "url": "libraryName",
-                    "valueString": "SharedResourceCreation"
-                  },
-                  {
-                    "url": "name",
-                    "valueString": "ProcedureResource"
-                  },
-                  {
-                    "url": "statement",
-                    "valueString": "define function ProcedureResource(procedure Procedure, profileURLs List<FHIR.canonical>):   procedure p   return Procedure{     id: FHIR.id {value: 'LCR-' + p.id},     meta: MetaElement(p, profileURLs),     extension: p.extension,     instantiatesCanonical: p.instantiatesCanonical,     instantiatesUri: p.instantiatesUri,     basedOn: p.basedOn,     partOf: p.partOf,     status: p.status,     statusReason: p.statusReason,     category: p.category,     code: p.code,     subject: p.subject,     encounter: p.encounter,     performed: p.performed,     recorder: p.recorder,     asserter: p.asserter,     performer: ProcedurePerformer(p.performer),     location: p.location,     reasonCode: p.reasonCode,     reasonReference: p.reasonReference,     bodySite: p.bodySite,     outcome: p.outcome,     report: p.report,     complication: p.complication,     complicationDetail: p.complicationDetail,     followUp: p.followUp,     note: p.note,     focalDevice: ProcedureFocalDevice(p.focalDevice),     usedReference: p.usedReference,     usedCode: p.usedCode   }"
-                  },
-                  {
-                    "url": "displaySequence",
-                    "valueInteger": 60
-                  }
-                ]
-              },
-              {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
-                "extension": [
-                  {
-                    "url": "libraryName",
-                    "valueString": "SharedResourceCreation"
-                  },
-                  {
-                    "url": "name",
-                    "valueString": "ProcedurePerformer"
-                  },
-                  {
-                    "url": "statement",
-                    "valueString": "define function ProcedurePerformer(performer List<FHIR.Procedure.Performer>):   performer p   return FHIR.Procedure.Performer{     function: p.function,     actor: p.actor,     onBehalfOf: p.onBehalfOf   }"
-                  },
-                  {
-                    "url": "displaySequence",
-                    "valueInteger": 61
-                  }
-                ]
-              },
-              {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
-                "extension": [
-                  {
-                    "url": "libraryName",
-                    "valueString": "SharedResourceCreation"
-                  },
-                  {
-                    "url": "name",
-                    "valueString": "ProcedureFocalDevice"
-                  },
-                  {
-                    "url": "statement",
-                    "valueString": "define function ProcedureFocalDevice(device List<FHIR.Procedure.FocalDevice>):   device d   return FHIR.Procedure.FocalDevice{     action: d.action,     manipulated: d.manipulated   }"
-                  },
-                  {
-                    "url": "displaySequence",
-                    "valueInteger": 62
-                  }
-                ]
-              },
-              {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
-                "extension": [
-                  {
-                    "url": "libraryName",
-                    "valueString": "NHSNAcuteCareHospitalDailyInitialPopulation"
-                  },
-                  {
-                    "url": "name",
-                    "valueString": "GetMedicationCode"
-                  },
-                  {
-                    "url": "statement",
-                    "valueString": "define function \"GetMedicationCode\"(choice Choice<FHIR.CodeableConcept, FHIR.Reference>):   case     when choice is FHIR.CodeableConcept then       choice as FHIR.CodeableConcept     when choice is FHIR.Reference then       GetMedication(choice as FHIR.Reference).code     else       null as FHIR.CodeableConcept   end"
-                  },
-                  {
-                    "url": "displaySequence",
-                    "valueInteger": 63
-                  }
-                ]
-              },
-              {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
-                "extension": [
-                  {
-                    "url": "libraryName",
-                    "valueString": "NHSNAcuteCareHospitalDailyInitialPopulation"
-                  },
-                  {
-                    "url": "name",
-                    "valueString": "GetMedication"
-                  },
-                  {
-                    "url": "statement",
-                    "valueString": "define function \"GetMedication\"(reference Reference ):   singleton from (     [Medication: id in {NHSNHelpers.GetId(reference.reference)}]   )"
-                  },
-                  {
-                    "url": "displaySequence",
-                    "valueInteger": 64
-                  }
-                ]
-              },
-              {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
-                "extension": [
-                  {
-                    "url": "libraryName",
-                    "valueString": "NHSNHelpers"
-                  },
-                  {
-                    "url": "name",
-                    "valueString": "Normalize Interval"
-                  },
-                  {
-                    "url": "statement",
-                    "valueString": "define function \"Normalize Interval\"(choice Choice<FHIR.dateTime, FHIR.Period, FHIR.Timing, FHIR.instant, FHIR.string, FHIR.Age, FHIR.Range>):   case    when choice is FHIR.dateTime then      Interval[FHIRHelpers.ToDateTime(choice as FHIR.dateTime), FHIRHelpers.ToDateTime(choice as FHIR.dateTime)]   when choice is FHIR.Period then     FHIRHelpers.ToInterval(choice as FHIR.Period)   when choice is FHIR.instant then    Interval[FHIRHelpers.ToDateTime(choice as FHIR.instant), FHIRHelpers.ToDateTime(choice as FHIR.instant)]   when choice is FHIR.Age then     Interval[FHIRHelpers.ToDate(Patient.birthDate) + FHIRHelpers.ToQuantity(choice as FHIR.Age),      FHIRHelpers.ToDate(Patient.birthDate) + FHIRHelpers.ToQuantity(choice as FHIR.Age) + 1 year)   when choice is FHIR.Range then     Interval[FHIRHelpers.ToDate(Patient.birthDate) + FHIRHelpers.ToQuantity((choice as FHIR.Range).low),      FHIRHelpers.ToDate(Patient.birthDate) + FHIRHelpers.ToQuantity((choice as FHIR.Range).high) + 1 year)   when choice is FHIR.Timing then     Message(null as Interval<DateTime>, true, '1', 'Error', 'Cannot compute a single interval from a Timing type')     when choice is FHIR.string then       Message(null as Interval<DateTime>, true, '1', 'Error', 'Cannot compute an interval from a String value')   else    null as Interval<DateTime>  end"
-                  },
-                  {
-                    "url": "displaySequence",
-                    "valueInteger": 65
-                  }
-                ]
-              },
-              {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
-                "extension": [
-                  {
-                    "url": "libraryName",
-                    "valueString": "FHIRHelpers"
-                  },
-                  {
-                    "url": "name",
-                    "valueString": "ToDateTime"
-                  },
-                  {
-                    "url": "statement",
-                    "valueString": "define function ToDateTime(value dateTime): value.value"
-                  },
-                  {
-                    "url": "displaySequence",
-                    "valueInteger": 66
-                  }
-                ]
-              },
-              {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
-                "extension": [
-                  {
-                    "url": "libraryName",
-                    "valueString": "FHIRHelpers"
-                  },
-                  {
-                    "url": "name",
-                    "valueString": "ToDate"
-                  },
-                  {
-                    "url": "statement",
-                    "valueString": "define function ToDate(value date): value.value"
-                  },
-                  {
-                    "url": "displaySequence",
-                    "valueInteger": 67
-                  }
-                ]
-              },
-              {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
-                "extension": [
-                  {
-                    "url": "libraryName",
-                    "valueString": "FHIRHelpers"
-                  },
-                  {
-                    "url": "name",
-                    "valueString": "ToQuantity"
-                  },
-                  {
-                    "url": "statement",
-                    "valueString": "define function ToQuantity(quantity FHIR.Quantity):     case         when quantity is null then null         when quantity.value is null then null         when quantity.comparator is not null then             Message(null, true, 'FHIRHelpers.ToQuantity.ComparatorQuantityNotSupported', 'Error', 'FHIR Quantity value has a comparator and cannot be converted to a System.Quantity value.')         when quantity.system is null or quantity.system.value = 'http://unitsofmeasure.org'               or quantity.system.value = 'http://hl7.org/fhirpath/CodeSystem/calendar-units' then             System.Quantity { value: quantity.value.value, unit: ToCalendarUnit(Coalesce(quantity.code.value, quantity.unit.value, '1')) }         else             Message(null, true, 'FHIRHelpers.ToQuantity.InvalidFHIRQuantity', 'Error', 'Invalid FHIR Quantity code: ' & quantity.unit.value & ' (' & quantity.system.value & '|' & quantity.code.value & ')')     end"
-                  },
-                  {
-                    "url": "displaySequence",
-                    "valueInteger": 68
-                  }
-                ]
-              },
-              {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
-                "extension": [
-                  {
-                    "url": "libraryName",
-                    "valueString": "FHIRHelpers"
-                  },
-                  {
-                    "url": "name",
-                    "valueString": "ToCalendarUnit"
-                  },
-                  {
-                    "url": "statement",
-                    "valueString": "define function ToCalendarUnit(unit System.String):     case unit         when 'ms' then 'millisecond'         when 's' then 'second'         when 'min' then 'minute'         when 'h' then 'hour'         when 'd' then 'day'         when 'wk' then 'week'         when 'mo' then 'month'         when 'a' then 'year'         else unit     end"
-                  },
-                  {
-                    "url": "displaySequence",
-                    "valueInteger": 69
-                  }
-                ]
-              },
-              {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
-                "extension": [
-                  {
-                    "url": "libraryName",
-                    "valueString": "SharedResourceCreation"
-                  },
-                  {
-                    "url": "name",
-                    "valueString": "MedicationRequestResource"
-                  },
-                  {
-                    "url": "statement",
-                    "valueString": "define function MedicationRequestResource(medicationRequest MedicationRequest, profileURLs List<FHIR.canonical>):   medicationRequest m   return MedicationRequest{     id: FHIR.id {value: 'LCR-' + m.id},     meta: MetaElement(medicationRequest, profileURLs),     extension: m.extension,     status: m.status,     statusReason: m.statusReason,     intent: m.intent,     category: m.category,     priority: m.priority,     doNotPerform: m.doNotPerform,     reported: m.reported,     medication: m.medication,     subject: m.subject,     encounter: m.encounter,     authoredOn: m.authoredOn,     requester: m.requester,     recorder: m.recorder,     reasonCode: m.reasonCode,     reasonReference: m.reasonReference,     instantiatesCanonical: m.instantiatesCanonical,     instantiatesUri: m.instantiatesUri,     courseOfTherapyType: m.courseOfTherapyType,     dosageInstruction: MedicationRequestDosageInstruction(m.dosageInstruction)   }"
-                  },
-                  {
-                    "url": "displaySequence",
-                    "valueInteger": 70
-                  }
-                ]
-              },
-              {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
-                "extension": [
-                  {
-                    "url": "libraryName",
-                    "valueString": "SharedResourceCreation"
-                  },
-                  {
-                    "url": "name",
-                    "valueString": "MedicationRequestDosageInstruction"
-                  },
-                  {
-                    "url": "statement",
-                    "valueString": "define function MedicationRequestDosageInstruction(dosageInstruction List<FHIR.Dosage>):   dosageInstruction dI   return FHIR.Dosage{     text: dI.text,     patientInstruction: dI.patientInstruction,     timing: dI.timing,     asNeeded: dI.asNeeded,     site: dI.site,     route: dI.route,     method: dI.method,     doseAndRate: MedicationRequestDoseAndRate(dI.doseAndRate)   }"
-                  },
-                  {
-                    "url": "displaySequence",
-                    "valueInteger": 71
-                  }
-                ]
-              },
-              {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
-                "extension": [
-                  {
-                    "url": "libraryName",
-                    "valueString": "SharedResourceCreation"
-                  },
-                  {
-                    "url": "name",
-                    "valueString": "MedicationRequestDoseAndRate"
-                  },
-                  {
-                    "url": "statement",
-                    "valueString": "define function MedicationRequestDoseAndRate(doseAndRate List<FHIR.Dosage.DoseAndRate>):   doseAndRate dR   return FHIR.Dosage.DoseAndRate{     type: dR.type,     dose: dR.dose,     rate: dR.rate   }"
-                  },
-                  {
-                    "url": "displaySequence",
-                    "valueInteger": 72
-                  }
-                ]
-              },
-              {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
-                "extension": [
-                  {
-                    "url": "libraryName",
-                    "valueString": "SharedResourceCreation"
-                  },
-                  {
-                    "url": "name",
-                    "valueString": "PatientResource"
-                  },
-                  {
-                    "url": "statement",
-                    "valueString": "define function PatientResource(patient Patient, profileURLs List<FHIR.canonical>):   patient p   return Patient{     id: FHIR.id{value: 'LCR-' + p.id},     meta: MetaElement(p, profileURLs),     extension: GetPatientExtensions(p) union GetIdExtensions(p),     identifier: p.identifier,     active: p.active,     name: PatientName(p.name),     telecom: PatientTelecom(p.telecom),     gender: p.gender,     birthDate: p.birthDate,     deceased: p.deceased,     address: PatientAddress(p.address),     maritalStatus: p.maritalStatus,     multipleBirth: p.multipleBirth,     photo: p.photo,     contact: PatientContact(p.contact),     communication: PatientCommunication(p.communication),     generalPractitioner: p.generalPractitioner,     managingOrganization: p.managingOrganization,     link: PatientLink(p.link)   }"
-                  },
-                  {
-                    "url": "displaySequence",
-                    "valueInteger": 73
-                  }
-                ]
-              },
-              {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
-                "extension": [
-                  {
-                    "url": "libraryName",
-                    "valueString": "SharedResourceCreation"
-                  },
-                  {
-                    "url": "name",
-                    "valueString": "GetPatientExtensions"
-                  },
-                  {
-                    "url": "statement",
-                    "valueString": "define function \"GetPatientExtensions\"(domainResource DomainResource):   domainResource.extension E   where E.url.value = 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-race'     or E.url.value = 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity'     or E.url.value = 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-birthsex'     or E.url.value = 'http://www.cdc.gov/nhsn/fhirportal/dqm/ig/StructureDefinition/link-original-resource-id-extension'   return E"
-                  },
-                  {
-                    "url": "displaySequence",
                     "valueInteger": 74
                   }
-                ]
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
                 "extension": [
                   {
                     "url": "libraryName",
-                    "valueString": "SharedResourceCreation"
-                  },
-                  {
-                    "url": "name",
-                    "valueString": "GetIdExtensions"
-                  },
-                  {
-                    "url": "statement",
-                    "valueString": "define function \"GetIdExtensions\"(domainResource DomainResource):   domainResource.extension E   where E.url.value = 'http://www.cdc.gov/nhsn/fhirportal/dqm/ig/StructureDefinition/link-original-resource-id-extension'   return E"
-                  },
-                  {
-                    "url": "displaySequence",
-                    "valueInteger": 75
-                  }
-                ]
-              },
-              {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
-                "extension": [
-                  {
-                    "url": "libraryName",
-                    "valueString": "SharedResourceCreation"
-                  },
-                  {
-                    "url": "name",
-                    "valueString": "PatientName"
-                  },
-                  {
-                    "url": "statement",
-                    "valueString": "/* No longer needed but saving in case it's useful later define function PatientIdentifier(identifier List<FHIR.Identifier>):   identifier i   return FHIR.Identifier{     id: i.id,     extension: i.extension,     use: i.use,     type: i.type,     system: i.system,     value: i.value,     period: i.period,     assigner: i.assigner   }*/  define function PatientName(name List<FHIR.HumanName>):   name n   return FHIR.HumanName{     id: n.id,     extension: n.extension,     use: n.use,     text: n.text,     family: n.family,     given: n.given,     prefix: n.prefix,     suffix: n.suffix,     period: n.period   }"
-                  },
-                  {
-                    "url": "displaySequence",
-                    "valueInteger": 76
-                  }
-                ]
-              },
-              {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
-                "extension": [
-                  {
-                    "url": "libraryName",
-                    "valueString": "SharedResourceCreation"
-                  },
-                  {
-                    "url": "name",
-                    "valueString": "PatientTelecom"
-                  },
-                  {
-                    "url": "statement",
-                    "valueString": "define function PatientTelecom(telecom List<FHIR.ContactPoint>):   telecom t   return FHIR.ContactPoint{     system: t.system,     value: t.value,     use: t.use,     rank: t.rank,     period: t.period   }"
-                  },
-                  {
-                    "url": "displaySequence",
-                    "valueInteger": 77
-                  }
-                ]
-              },
-              {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
-                "extension": [
-                  {
-                    "url": "libraryName",
-                    "valueString": "SharedResourceCreation"
-                  },
-                  {
-                    "url": "name",
-                    "valueString": "PatientAddress"
-                  },
-                  {
-                    "url": "statement",
-                    "valueString": "define function PatientAddress(address List<FHIR.Address>):   address a   return FHIR.Address{     id: a.id,     extension: a.extension,     use: a.use,     type: a.type,     text: a.text,     line: a.line,     city: a.city,     district: a.district,     state: a.state,     postalCode: a.postalCode,     country: a.country,     period: a.period   }"
-                  },
-                  {
-                    "url": "displaySequence",
-                    "valueInteger": 78
-                  }
-                ]
-              },
-              {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
-                "extension": [
-                  {
-                    "url": "libraryName",
-                    "valueString": "SharedResourceCreation"
-                  },
-                  {
-                    "url": "name",
-                    "valueString": "PatientContact"
-                  },
-                  {
-                    "url": "statement",
-                    "valueString": "define function PatientContact(contact List<FHIR.Patient.Contact>):   contact c   return FHIR.Patient.Contact{     id: c.id,     extension: c.extension,     relationship: c.relationship,     name: c.name,     telecom: c.telecom,     address: c.address,     gender: c.gender,     organization: c.organization,     period: c.period   }"
-                  },
-                  {
-                    "url": "displaySequence",
-                    "valueInteger": 79
-                  }
-                ]
-              },
-              {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
-                "extension": [
-                  {
-                    "url": "libraryName",
-                    "valueString": "SharedResourceCreation"
-                  },
-                  {
-                    "url": "name",
-                    "valueString": "PatientCommunication"
-                  },
-                  {
-                    "url": "statement",
-                    "valueString": "define function PatientCommunication(communication List<FHIR.Patient.Communication>):   communication c   return FHIR.Patient.Communication{     id: c.id,     extension: c.extension,     language: c.language,     preferred: c.preferred   }"
-                  },
-                  {
-                    "url": "displaySequence",
-                    "valueInteger": 80
-                  }
-                ]
-              },
-              {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
-                "extension": [
-                  {
-                    "url": "libraryName",
-                    "valueString": "SharedResourceCreation"
-                  },
-                  {
-                    "url": "name",
-                    "valueString": "PatientLink"
-                  },
-                  {
-                    "url": "statement",
-                    "valueString": "define function PatientLink(link List<FHIR.Patient.Link>):   link l   return FHIR.Patient.Link{     id: l.id,     extension: l.extension,     modifierExtension: l.modifierExtension,     other: l.other,     type: l.type   }"
-                  },
-                  {
-                    "url": "displaySequence",
-                    "valueInteger": 81
-                  }
-                ]
-              },
-              {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
-                "extension": [
-                  {
-                    "url": "libraryName",
-                    "valueString": "SharedResourceCreation"
+                    "valueString": "NHSNAcuteCareHospitalDailyInitialPopulation"
                   },
                   {
                     "url": "name",
@@ -10504,20 +10360,20 @@
                   },
                   {
                     "url": "statement",
-                    "valueString": "define function ObservationLabResource(observation Observation, profileURLs List<FHIR.canonical>):   observation o   return Observation{     id: FHIR.id {value: 'LCR-' + o.id},     meta: MetaElement(o, profileURLs),     extension: o.extension,     basedOn: o.basedOn,     partOf: o.partOf,     status: o.status,     category: ObservationLabCategory(o.category),     code: o.code,     subject: o.subject,     focus: o.focus,     encounter: o.encounter,     effective: o.effective,     issued: o.issued,     performer: o.performer,     value: o.value,     dataAbsentReason: o.dataAbsentReason,     interpretation: o.interpretation,     note: o.note,     bodySite: o.bodySite,     method: o.method,     specimen: o.specimen,     device: o.device,     referenceRange: ObservationReferenceRange(o.referenceRange),     hasMember: o.hasMember,     derivedFrom: o.derivedFrom,     component: ObservationComponent(o.component)   }"
+                    "valueString": "define function ObservationLabResource(observation Observation, profileURLs List<FHIR.canonical>):   observation o   return Observation{     id: FHIR.id {value: 'LCR-' + o.id},     meta: SharedResource.MetaElement(o, profileURLs),     extension: o.extension,     basedOn: o.basedOn,     partOf: o.partOf,     status: o.status,     category: ObservationLabCategory(o.category),     code: o.code,     subject: o.subject,     focus: o.focus,     encounter: o.encounter,     effective: o.effective,     issued: o.issued,     performer: o.performer,     value: o.value,     dataAbsentReason: o.dataAbsentReason,     interpretation: o.interpretation,     note: o.note,     bodySite: o.bodySite,     method: o.method,     specimen: o.specimen,     device: o.device,     referenceRange: SharedResource.ObservationReferenceRange(o.referenceRange),     hasMember: o.hasMember,     derivedFrom: o.derivedFrom,     component: SharedResource.ObservationComponent(o.component)   }"
                   },
                   {
                     "url": "displaySequence",
-                    "valueInteger": 82
+                    "valueInteger": 75
                   }
-                ]
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
                 "extension": [
                   {
                     "url": "libraryName",
-                    "valueString": "SharedResourceCreation"
+                    "valueString": "NHSNAcuteCareHospitalDailyInitialPopulation"
                   },
                   {
                     "url": "name",
@@ -10529,16 +10385,16 @@
                   },
                   {
                     "url": "displaySequence",
-                    "valueInteger": 83
+                    "valueInteger": 76
                   }
-                ]
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
                 "extension": [
                   {
                     "url": "libraryName",
-                    "valueString": "SharedResourceCreation"
+                    "valueString": "NHSNAcuteCareHospitalDailyInitialPopulation"
                   },
                   {
                     "url": "name",
@@ -10546,16 +10402,16 @@
                   },
                   {
                     "url": "statement",
-                    "valueString": "define function ObservationLabCoding(coding List<Coding>):   coding c   return Coding{     id: c.id,     extension: c.extension,     system: c.system,     version: c.version,     code: c.code,     display: c.display,     userSelected: c.userSelected   }"
+                    "valueString": "define function ObservationLabCoding(coding List<Coding>):   coding c   return Coding{     system: c.system,     version: c.version,     code: c.code,     display: c.display,     userSelected: c.userSelected   }"
                   },
                   {
                     "url": "displaySequence",
-                    "valueInteger": 84
+                    "valueInteger": 77
                   }
-                ]
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
                 "extension": [
                   {
                     "url": "libraryName",
@@ -10571,12 +10427,12 @@
                   },
                   {
                     "url": "displaySequence",
-                    "valueInteger": 85
+                    "valueInteger": 78
                   }
-                ]
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
                 "extension": [
                   {
                     "url": "libraryName",
@@ -10592,12 +10448,558 @@
                   },
                   {
                     "url": "displaySequence",
-                    "valueInteger": 86
+                    "valueInteger": 79
                   }
-                ]
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
+                "extension": [
+                  {
+                    "url": "libraryName",
+                    "valueString": "SharedResourceCreation"
+                  },
+                  {
+                    "url": "name",
+                    "valueString": "ProcedureResource"
+                  },
+                  {
+                    "url": "statement",
+                    "valueString": "define function ProcedureResource(procedure Procedure, profileURLs List<FHIR.canonical>):   procedure p   return Procedure{     id: FHIR.id {value: 'LCR-' + p.id},     meta: MetaElement(p, profileURLs),     extension: p.extension,     instantiatesCanonical: p.instantiatesCanonical,     instantiatesUri: p.instantiatesUri,     basedOn: p.basedOn,     partOf: p.partOf,     status: p.status,     statusReason: p.statusReason,     category: p.category,     code: p.code,     subject: p.subject,     encounter: p.encounter,     performed: p.performed,     recorder: p.recorder,     asserter: p.asserter,     performer: ProcedurePerformer(p.performer),     location: p.location,     reasonCode: p.reasonCode,     reasonReference: p.reasonReference,     bodySite: p.bodySite,     outcome: p.outcome,     report: p.report,     complication: p.complication,     complicationDetail: p.complicationDetail,     followUp: p.followUp,     note: p.note,     focalDevice: ProcedureFocalDevice(p.focalDevice),     usedReference: p.usedReference,     usedCode: p.usedCode   }"
+                  },
+                  {
+                    "url": "displaySequence",
+                    "valueInteger": 80
+                  }
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
+              },
+              {
+                "extension": [
+                  {
+                    "url": "libraryName",
+                    "valueString": "SharedResourceCreation"
+                  },
+                  {
+                    "url": "name",
+                    "valueString": "ProcedurePerformer"
+                  },
+                  {
+                    "url": "statement",
+                    "valueString": "define function ProcedurePerformer(performer List<FHIR.Procedure.Performer>):   performer p   return FHIR.Procedure.Performer{     function: p.function,     actor: p.actor,     onBehalfOf: p.onBehalfOf   }"
+                  },
+                  {
+                    "url": "displaySequence",
+                    "valueInteger": 81
+                  }
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
+              },
+              {
+                "extension": [
+                  {
+                    "url": "libraryName",
+                    "valueString": "SharedResourceCreation"
+                  },
+                  {
+                    "url": "name",
+                    "valueString": "ProcedureFocalDevice"
+                  },
+                  {
+                    "url": "statement",
+                    "valueString": "define function ProcedureFocalDevice(device List<FHIR.Procedure.FocalDevice>):   device d   return FHIR.Procedure.FocalDevice{     action: d.action,     manipulated: d.manipulated   }"
+                  },
+                  {
+                    "url": "displaySequence",
+                    "valueInteger": 82
+                  }
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
+              },
+              {
+                "extension": [
+                  {
+                    "url": "libraryName",
+                    "valueString": "NHSNAcuteCareHospitalDailyInitialPopulation"
+                  },
+                  {
+                    "url": "name",
+                    "valueString": "GetMedicationCode"
+                  },
+                  {
+                    "url": "statement",
+                    "valueString": "define function \"GetMedicationCode\"(choice Choice<FHIR.CodeableConcept, FHIR.Reference>):   case     when choice is FHIR.CodeableConcept then       choice as FHIR.CodeableConcept     when choice is FHIR.Reference then       GetMedication(choice as FHIR.Reference).code     else       null as FHIR.CodeableConcept   end"
+                  },
+                  {
+                    "url": "displaySequence",
+                    "valueInteger": 83
+                  }
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
+              },
+              {
+                "extension": [
+                  {
+                    "url": "libraryName",
+                    "valueString": "NHSNAcuteCareHospitalDailyInitialPopulation"
+                  },
+                  {
+                    "url": "name",
+                    "valueString": "GetMedication"
+                  },
+                  {
+                    "url": "statement",
+                    "valueString": "define function \"GetMedication\"(reference Reference ):   singleton from (     [Medication: id in {NHSNHelpers.GetId(reference.reference)}]   )"
+                  },
+                  {
+                    "url": "displaySequence",
+                    "valueInteger": 84
+                  }
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
+              },
+              {
+                "extension": [
+                  {
+                    "url": "libraryName",
+                    "valueString": "NHSNHelpers"
+                  },
+                  {
+                    "url": "name",
+                    "valueString": "Normalize Interval"
+                  },
+                  {
+                    "url": "statement",
+                    "valueString": "define function \"Normalize Interval\"(choice Choice<FHIR.dateTime, FHIR.Period, FHIR.Timing, FHIR.instant, FHIR.string, FHIR.Age, FHIR.Range>):   case    when choice is FHIR.dateTime then      Interval[FHIRHelpers.ToDateTime(choice as FHIR.dateTime), FHIRHelpers.ToDateTime(choice as FHIR.dateTime)]   when choice is FHIR.Period then     FHIRHelpers.ToInterval(choice as FHIR.Period)   when choice is FHIR.instant then    Interval[FHIRHelpers.ToDateTime(choice as FHIR.instant), FHIRHelpers.ToDateTime(choice as FHIR.instant)]   when choice is FHIR.Age then     Interval[FHIRHelpers.ToDate(Patient.birthDate) + FHIRHelpers.ToQuantity(choice as FHIR.Age),      FHIRHelpers.ToDate(Patient.birthDate) + FHIRHelpers.ToQuantity(choice as FHIR.Age) + 1 year)   when choice is FHIR.Range then     Interval[FHIRHelpers.ToDate(Patient.birthDate) + FHIRHelpers.ToQuantity((choice as FHIR.Range).low),      FHIRHelpers.ToDate(Patient.birthDate) + FHIRHelpers.ToQuantity((choice as FHIR.Range).high) + 1 year)   when choice is FHIR.Timing then     Message(null as Interval<DateTime>, true, '1', 'Error', 'Cannot compute a single interval from a Timing type')     when choice is FHIR.string then       Message(null as Interval<DateTime>, true, '1', 'Error', 'Cannot compute an interval from a String value')   else    null as Interval<DateTime>  end"
+                  },
+                  {
+                    "url": "displaySequence",
+                    "valueInteger": 85
+                  }
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
+              },
+              {
+                "extension": [
+                  {
+                    "url": "libraryName",
+                    "valueString": "FHIRHelpers"
+                  },
+                  {
+                    "url": "name",
+                    "valueString": "ToDateTime"
+                  },
+                  {
+                    "url": "statement",
+                    "valueString": "define function ToDateTime(value dateTime): value.value"
+                  },
+                  {
+                    "url": "displaySequence",
+                    "valueInteger": 86
+                  }
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
+              },
+              {
+                "extension": [
+                  {
+                    "url": "libraryName",
+                    "valueString": "FHIRHelpers"
+                  },
+                  {
+                    "url": "name",
+                    "valueString": "ToDateTime"
+                  },
+                  {
+                    "url": "statement",
+                    "valueString": "define function ToDateTime(value instant): value.value"
+                  },
+                  {
+                    "url": "displaySequence",
+                    "valueInteger": 87
+                  }
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
+              },
+              {
+                "extension": [
+                  {
+                    "url": "libraryName",
+                    "valueString": "FHIRHelpers"
+                  },
+                  {
+                    "url": "name",
+                    "valueString": "ToDate"
+                  },
+                  {
+                    "url": "statement",
+                    "valueString": "define function ToDate(value date): value.value"
+                  },
+                  {
+                    "url": "displaySequence",
+                    "valueInteger": 88
+                  }
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
+              },
+              {
+                "extension": [
+                  {
+                    "url": "libraryName",
+                    "valueString": "FHIRHelpers"
+                  },
+                  {
+                    "url": "name",
+                    "valueString": "ToQuantity"
+                  },
+                  {
+                    "url": "statement",
+                    "valueString": "define function ToQuantity(quantity FHIR.Quantity):     case         when quantity is null then null         when quantity.value is null then null         when quantity.comparator is not null then             Message(null, true, 'FHIRHelpers.ToQuantity.ComparatorQuantityNotSupported', 'Error', 'FHIR Quantity value has a comparator and cannot be converted to a System.Quantity value.')         when quantity.system is null or quantity.system.value = 'http://unitsofmeasure.org'               or quantity.system.value = 'http://hl7.org/fhirpath/CodeSystem/calendar-units' then             System.Quantity { value: quantity.value.value, unit: ToCalendarUnit(Coalesce(quantity.code.value, quantity.unit.value, '1')) }         else             Message(null, true, 'FHIRHelpers.ToQuantity.InvalidFHIRQuantity', 'Error', 'Invalid FHIR Quantity code: ' & quantity.unit.value & ' (' & quantity.system.value & '|' & quantity.code.value & ')')     end"
+                  },
+                  {
+                    "url": "displaySequence",
+                    "valueInteger": 89
+                  }
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
+              },
+              {
+                "extension": [
+                  {
+                    "url": "libraryName",
+                    "valueString": "FHIRHelpers"
+                  },
+                  {
+                    "url": "name",
+                    "valueString": "ToCalendarUnit"
+                  },
+                  {
+                    "url": "statement",
+                    "valueString": "define function ToCalendarUnit(unit System.String):     case unit         when 'ms' then 'millisecond'         when 's' then 'second'         when 'min' then 'minute'         when 'h' then 'hour'         when 'd' then 'day'         when 'wk' then 'week'         when 'mo' then 'month'         when 'a' then 'year'         else unit     end"
+                  },
+                  {
+                    "url": "displaySequence",
+                    "valueInteger": 90
+                  }
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
+              },
+              {
+                "extension": [
+                  {
+                    "url": "libraryName",
+                    "valueString": "NHSNAcuteCareHospitalDailyInitialPopulation"
+                  },
+                  {
+                    "url": "name",
+                    "valueString": "MedicationRequestResource"
+                  },
+                  {
+                    "url": "statement",
+                    "valueString": "define function MedicationRequestResource(medicationRequest MedicationRequest, profileURLs List<FHIR.canonical>):   medicationRequest m   return MedicationRequest{     id: FHIR.id {value: 'LCR-' + m.id},     meta: SharedResource.MetaElement(medicationRequest, profileURLs),     extension: m.extension,     status: m.status,     intent: m.intent,     category: m.category,     priority: m.priority,     doNotPerform: m.doNotPerform,     reported: m.reported,     medication: m.medication,     subject: m.subject,     encounter: m.encounter,     authoredOn: m.authoredOn,     requester: m.requester,     recorder: m.recorder,     reasonCode: m.reasonCode,     reasonReference: m.reasonReference,     instantiatesCanonical: m.instantiatesCanonical,     instantiatesUri: m.instantiatesUri,     courseOfTherapyType: m.courseOfTherapyType,     dosageInstruction: MedicationRequestDosageInstruction(m.dosageInstruction)   }"
+                  },
+                  {
+                    "url": "displaySequence",
+                    "valueInteger": 91
+                  }
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
+              },
+              {
+                "extension": [
+                  {
+                    "url": "libraryName",
+                    "valueString": "NHSNAcuteCareHospitalDailyInitialPopulation"
+                  },
+                  {
+                    "url": "name",
+                    "valueString": "MedicationRequestDosageInstruction"
+                  },
+                  {
+                    "url": "statement",
+                    "valueString": "define function MedicationRequestDosageInstruction(dosageInstruction List<FHIR.Dosage>):   dosageInstruction dI   return FHIR.Dosage{     text: dI.text,     patientInstruction: dI.patientInstruction,     timing: MedicationRequestTiming(dI.timing),     asNeeded: dI.asNeeded,     site: dI.site,     route: dI.route,     method: dI.method,     doseAndRate: SharedResource.MedicationRequestDoseAndRate(dI.doseAndRate)   }"
+                  },
+                  {
+                    "url": "displaySequence",
+                    "valueInteger": 92
+                  }
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
+              },
+              {
+                "extension": [
+                  {
+                    "url": "libraryName",
+                    "valueString": "NHSNAcuteCareHospitalDailyInitialPopulation"
+                  },
+                  {
+                    "url": "name",
+                    "valueString": "MedicationRequestTiming"
+                  },
+                  {
+                    "url": "statement",
+                    "valueString": "define function MedicationRequestTiming(timing FHIR.Timing):   timing t   return FHIR.Timing{     event: t.event,     repeat: MedicationRequestRepeat(t.repeat),     code: t.code   }"
+                  },
+                  {
+                    "url": "displaySequence",
+                    "valueInteger": 93
+                  }
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
+              },
+              {
+                "extension": [
+                  {
+                    "url": "libraryName",
+                    "valueString": "NHSNAcuteCareHospitalDailyInitialPopulation"
+                  },
+                  {
+                    "url": "name",
+                    "valueString": "MedicationRequestRepeat"
+                  },
+                  {
+                    "url": "statement",
+                    "valueString": "//  // Measure Specific Resource Creation Functions  // define function MedicationRequestRepeat(repeat FHIR.Timing.Repeat):   repeat r   return FHIR.Timing.Repeat{     bounds: r.bounds,     count: r.count,     countMax: r.countMax,     \"duration\": r.\"duration\",     durationMax: r.durationMax,     durationUnit: r.durationUnit,     frequency: r.frequency,     frequencyMax: r.frequencyMax,     period: r.period,     periodMax: r.periodMax,     periodUnit: r.periodUnit,     dayOfWeek: r.dayOfWeek,     timeOfDay: r.timeOfDay,     \"when\": r.\"when\",     offset: r.offset   }"
+                  },
+                  {
+                    "url": "displaySequence",
+                    "valueInteger": 94
+                  }
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
+              },
+              {
+                "extension": [
+                  {
+                    "url": "libraryName",
+                    "valueString": "SharedResourceCreation"
+                  },
+                  {
+                    "url": "name",
+                    "valueString": "MedicationRequestDoseAndRate"
+                  },
+                  {
+                    "url": "statement",
+                    "valueString": "define function MedicationRequestDoseAndRate(doseAndRate List<FHIR.Dosage.DoseAndRate>):   doseAndRate dR   return FHIR.Dosage.DoseAndRate{     type: dR.type,     dose: dR.dose,     rate: dR.rate   }"
+                  },
+                  {
+                    "url": "displaySequence",
+                    "valueInteger": 95
+                  }
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
+              },
+              {
+                "extension": [
+                  {
+                    "url": "libraryName",
+                    "valueString": "SharedResourceCreation"
+                  },
+                  {
+                    "url": "name",
+                    "valueString": "PatientResource"
+                  },
+                  {
+                    "url": "statement",
+                    "valueString": "define function PatientResource(patient Patient, profileURLs List<FHIR.canonical>):   patient p   return Patient{     id: FHIR.id{value: 'LCR-' + p.id},     meta: MetaElement(p, profileURLs),     extension: GetPatientExtensions(p),     identifier: p.identifier,     active: p.active,     name: PatientName(p.name),     telecom: PatientTelecom(p.telecom),     gender: p.gender,     birthDate: p.birthDate,     deceased: p.deceased,     address: PatientAddress(p.address),     maritalStatus: p.maritalStatus,     multipleBirth: p.multipleBirth,     contact: PatientContact(p.contact),     communication: PatientCommunication(p.communication),     link: PatientLink(p.link)   }"
+                  },
+                  {
+                    "url": "displaySequence",
+                    "valueInteger": 96
+                  }
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
+              },
+              {
+                "extension": [
+                  {
+                    "url": "libraryName",
+                    "valueString": "SharedResourceCreation"
+                  },
+                  {
+                    "url": "name",
+                    "valueString": "GetPatientExtensions"
+                  },
+                  {
+                    "url": "statement",
+                    "valueString": "define function \"GetPatientExtensions\"(domainResource DomainResource):   domainResource.extension E   where E.url = 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-race'     or E.url = 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity'     or E.url = 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-tribal-affiliation'     or E.url = 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-birthsex'     or E.url = 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-sex'     or E.url = 'http://www.cdc.gov/nhsn/fhirportal/dqm/ig/StructureDefinition/link-original-resource-id-extension'   return E"
+                  },
+                  {
+                    "url": "displaySequence",
+                    "valueInteger": 97
+                  }
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
+              },
+              {
+                "extension": [
+                  {
+                    "url": "libraryName",
+                    "valueString": "FHIRHelpers"
+                  },
+                  {
+                    "url": "name",
+                    "valueString": "ToString"
+                  },
+                  {
+                    "url": "statement",
+                    "valueString": "define function ToString(value uri): value.value"
+                  },
+                  {
+                    "url": "displaySequence",
+                    "valueInteger": 98
+                  }
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
+              },
+              {
+                "extension": [
+                  {
+                    "url": "libraryName",
+                    "valueString": "SharedResourceCreation"
+                  },
+                  {
+                    "url": "name",
+                    "valueString": "PatientName"
+                  },
+                  {
+                    "url": "statement",
+                    "valueString": "/* No longer needed but saving in case it's useful later define function PatientIdentifier(identifier List<FHIR.Identifier>):   identifier i   return FHIR.Identifier{     id: i.id,     extension: i.extension,     use: i.use,     type: i.type,     system: i.system,     value: i.value,     period: i.period,     assigner: i.assigner   }*/  define function PatientName(name List<FHIR.HumanName>):   name n   return FHIR.HumanName{     id: n.id,     extension: n.extension,     use: n.use,     text: n.text,     family: n.family,     given: n.given,     prefix: n.prefix,     suffix: n.suffix,     period: n.period   }"
+                  },
+                  {
+                    "url": "displaySequence",
+                    "valueInteger": 99
+                  }
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
+              },
+              {
+                "extension": [
+                  {
+                    "url": "libraryName",
+                    "valueString": "SharedResourceCreation"
+                  },
+                  {
+                    "url": "name",
+                    "valueString": "PatientTelecom"
+                  },
+                  {
+                    "url": "statement",
+                    "valueString": "define function PatientTelecom(telecom List<FHIR.ContactPoint>):   telecom t   return FHIR.ContactPoint{     system: t.system,     value: t.value,     use: t.use,     rank: t.rank,     period: t.period   }"
+                  },
+                  {
+                    "url": "displaySequence",
+                    "valueInteger": 100
+                  }
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
+              },
+              {
+                "extension": [
+                  {
+                    "url": "libraryName",
+                    "valueString": "SharedResourceCreation"
+                  },
+                  {
+                    "url": "name",
+                    "valueString": "PatientAddress"
+                  },
+                  {
+                    "url": "statement",
+                    "valueString": "define function PatientAddress(address List<FHIR.Address>):   address a   return FHIR.Address{     use: a.use,     type: a.type,     text: a.text,     line: a.line,     city: a.city,     district: a.district,     state: a.state,     postalCode: a.postalCode,     country: a.country,     period: a.period   }"
+                  },
+                  {
+                    "url": "displaySequence",
+                    "valueInteger": 101
+                  }
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
+              },
+              {
+                "extension": [
+                  {
+                    "url": "libraryName",
+                    "valueString": "SharedResourceCreation"
+                  },
+                  {
+                    "url": "name",
+                    "valueString": "PatientContact"
+                  },
+                  {
+                    "url": "statement",
+                    "valueString": "define function PatientContact(contact List<FHIR.Patient.Contact>):   contact c   return FHIR.Patient.Contact{     relationship: c.relationship,     name: c.name,     telecom: c.telecom,     address: c.address,     gender: c.gender,     organization: c.organization,     period: c.period   }"
+                  },
+                  {
+                    "url": "displaySequence",
+                    "valueInteger": 102
+                  }
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
+              },
+              {
+                "extension": [
+                  {
+                    "url": "libraryName",
+                    "valueString": "SharedResourceCreation"
+                  },
+                  {
+                    "url": "name",
+                    "valueString": "PatientCommunication"
+                  },
+                  {
+                    "url": "statement",
+                    "valueString": "define function PatientCommunication(communication List<FHIR.Patient.Communication>):   communication c   return FHIR.Patient.Communication{     language: c.language,     preferred: c.preferred   }"
+                  },
+                  {
+                    "url": "displaySequence",
+                    "valueInteger": 103
+                  }
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
+              },
+              {
+                "extension": [
+                  {
+                    "url": "libraryName",
+                    "valueString": "SharedResourceCreation"
+                  },
+                  {
+                    "url": "name",
+                    "valueString": "PatientLink"
+                  },
+                  {
+                    "url": "statement",
+                    "valueString": "define function PatientLink(link List<FHIR.Patient.Link>):   link l   return FHIR.Patient.Link{     extension: l.extension,     modifierExtension: l.modifierExtension,     other: l.other,     type: l.type   }"
+                  },
+                  {
+                    "url": "displaySequence",
+                    "valueInteger": 104
+                  }
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
+              },
+              {
+                "extension": [
+                  {
+                    "url": "libraryName",
+                    "valueString": "FHIRHelpers"
+                  },
+                  {
+                    "url": "name",
+                    "valueString": "ToString"
+                  },
+                  {
+                    "url": "statement",
+                    "valueString": "define function ToString(value MedicationAdministrationStatus): value.value"
+                  },
+                  {
+                    "url": "displaySequence",
+                    "valueInteger": 105
+                  }
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
+              },
+              {
                 "extension": [
                   {
                     "url": "libraryName",
@@ -10613,12 +11015,12 @@
                   },
                   {
                     "url": "displaySequence",
-                    "valueInteger": 87
+                    "valueInteger": 106
                   }
-                ]
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
                 "extension": [
                   {
                     "url": "libraryName",
@@ -10634,12 +11036,12 @@
                   },
                   {
                     "url": "displaySequence",
-                    "valueInteger": 88
+                    "valueInteger": 107
                   }
-                ]
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
                 "extension": [
                   {
                     "url": "libraryName",
@@ -10655,12 +11057,12 @@
                   },
                   {
                     "url": "displaySequence",
-                    "valueInteger": 89
+                    "valueInteger": 108
                   }
-                ]
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
                 "extension": [
                   {
                     "url": "libraryName",
@@ -10676,12 +11078,12 @@
                   },
                   {
                     "url": "displaySequence",
-                    "valueInteger": 90
+                    "valueInteger": 109
                   }
-                ]
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
                 "extension": [
                   {
                     "url": "libraryName",
@@ -10697,12 +11099,12 @@
                   },
                   {
                     "url": "displaySequence",
-                    "valueInteger": 91
+                    "valueInteger": 110
                   }
-                ]
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
                 "extension": [
                   {
                     "url": "libraryName",
@@ -10718,12 +11120,12 @@
                   },
                   {
                     "url": "displaySequence",
-                    "valueInteger": 92
+                    "valueInteger": 111
                   }
-                ]
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
                 "extension": [
                   {
                     "url": "libraryName",
@@ -10739,12 +11141,12 @@
                   },
                   {
                     "url": "displaySequence",
-                    "valueInteger": 93
+                    "valueInteger": 112
                   }
-                ]
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
                 "extension": [
                   {
                     "url": "libraryName",
@@ -10760,33 +11162,33 @@
                   },
                   {
                     "url": "displaySequence",
-                    "valueInteger": 94
+                    "valueInteger": 113
                   }
-                ]
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
                 "extension": [
                   {
                     "url": "libraryName",
-                    "valueString": "SharedResourceCreation"
+                    "valueString": "NHSNAcuteCareHospitalDailyInitialPopulation"
                   },
                   {
                     "url": "name",
-                    "valueString": "ServiceRequestResource"
+                    "valueString": "references"
                   },
                   {
                     "url": "statement",
-                    "valueString": "define function ServiceRequestResource(serviceRequest ServiceRequest, profileURLs List<FHIR.canonical>):   serviceRequest sR   return ServiceRequest{     id: FHIR.id {value: 'LCR-' + sR.id},     meta: MetaElement(sR, profileURLs),     extension: sR.extension,     instantiatesCanonical: sR.instantiatesCanonical,     instantiatesUri: sR.instantiatesUri,     basedOn: sR.basedOn,     replaces: sR.replaces,     requisition: sR.requisition,     status: sR.status,     intent: sR.intent,     category: sR.category,     priority: sR.priority,     doNotPerform: sR.doNotPerform,     code: sR.code,     orderDetail: sR.orderDetail,     quantity: sR.quantity,     subject: sR.subject,     encounter: sR.encounter,     occurrence: sR.occurrence,     asNeeded: sR.asNeeded,     authoredOn: sR.authoredOn,     requester: sR.requester,     performerType: sR.performerType,     performer: sR.performer,     locationCode: sR.locationCode,     locationReference: sR.locationReference,     reasonCode: sR.reasonCode,     reasonReference: sR.reasonReference,     insurance: sR.insurance,     supportingInfo: sR.supportingInfo,     specimen: sR.specimen,     bodySite: sR.bodySite,     note: sR.note,     patientInstruction: sR.patientInstruction,     relevantHistory: sR.relevantHistory   }"
+                    "valueString": "define fluent function references(reference FHIR.Reference, resource FHIR.Resource):   resource.id = Last(Split(reference.reference, '/'))"
                   },
                   {
                     "url": "displaySequence",
-                    "valueInteger": 95
+                    "valueInteger": 114
                   }
-                ]
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
                 "extension": [
                   {
                     "url": "libraryName",
@@ -10802,12 +11204,12 @@
                   },
                   {
                     "url": "displaySequence",
-                    "valueInteger": 96
+                    "valueInteger": 115
                   }
-                ]
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
                 "extension": [
                   {
                     "url": "libraryName",
@@ -10823,12 +11225,12 @@
                   },
                   {
                     "url": "displaySequence",
-                    "valueInteger": 97
+                    "valueInteger": 116
                   }
-                ]
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
                 "extension": [
                   {
                     "url": "libraryName",
@@ -10844,12 +11246,12 @@
                   },
                   {
                     "url": "displaySequence",
-                    "valueInteger": 98
+                    "valueInteger": 117
                   }
-                ]
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
                 "extension": [
                   {
                     "url": "libraryName",
@@ -10865,9 +11267,10 @@
                   },
                   {
                     "url": "displaySequence",
-                    "valueInteger": 99
+                    "valueInteger": 118
                   }
-                ]
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
               }
             ],
             "name": "EffectiveDataRequirements",
@@ -10883,6 +11286,11 @@
             "relatedArtifact": [
               {
                 "type": "depends-on",
+                "display": "FHIR model information",
+                "resource": "http://fhir.org/guides/cqf/common/Library/FHIR-ModelInfo|4.0.1"
+              },
+              {
+                "type": "depends-on",
                 "display": "Library FHIRHelpers",
                 "resource": "http://www.cdc.gov/nhsn/fhirportal/dqm/ig/Library/FHIRHelpers|4.0.2"
               },
@@ -10894,17 +11302,17 @@
               {
                 "type": "depends-on",
                 "display": "Library SharedResource",
-                "resource": "http://www.cdc.gov/nhsn/fhirportal/dqm/ig/Library/SharedResourceCreation|0.1.009"
+                "resource": "http://www.cdc.gov/nhsn/fhirportal/dqm/ig/Library/SharedResourceCreation|0.1.010"
               },
               {
                 "type": "depends-on",
                 "display": "Code system ActCode",
-                "resource": "http://terminology.hl7.org/CodeSystem/v3-ActCode"
+                "resource": "http://terminology.hl7.org/CodeSystem/v3-ActCode|9.0.0"
               },
               {
                 "type": "depends-on",
                 "display": "Code system Observation Category",
-                "resource": "http://terminology.hl7.org/CodeSystem/observation-category"
+                "resource": "http://terminology.hl7.org/CodeSystem/observation-category|2.0.0"
               },
               {
                 "type": "depends-on",
@@ -10928,8 +11336,28 @@
               },
               {
                 "type": "depends-on",
+                "display": "Value set COVID_19 (Tests for SARS_CoV_2 Nucleic Acid)",
+                "resource": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1142|20250218"
+              },
+              {
+                "type": "depends-on",
+                "display": "Value set COVID_19 (Tests for SARS_CoV_2 Antigen)",
+                "resource": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1158|20240123"
+              },
+              {
+                "type": "depends-on",
+                "display": "Value set Influenza (Tests for influenza A or B virus Nucleic Acid)",
+                "resource": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.336|20250218"
+              },
+              {
+                "type": "depends-on",
+                "display": "Value set Influenza (Tests for influenza A or B virus Antigen)",
+                "resource": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.337"
+              },
+              {
+                "type": "depends-on",
                 "display": "Value set RSV (Tests for RSV Nucleic Acid)",
-                "resource": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1312"
+                "resource": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1312|20250218"
               },
               {
                 "type": "depends-on",
@@ -10939,7 +11367,7 @@
               {
                 "type": "depends-on",
                 "display": "Value set Discharge Disposition",
-                "resource": "http://terminology.hl7.org/ValueSet/encounter-discharge-disposition"
+                "resource": "http://terminology.hl7.org/ValueSet/clinical-discharge-disposition|2.0.0"
               },
               {
                 "type": "depends-on",
@@ -11039,27 +11467,7 @@
               {
                 "type": "depends-on",
                 "display": "Value set Transmission Based Precaution Types",
-                "resource": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.10.20.22.5.300"
-              },
-              {
-                "type": "depends-on",
-                "display": "Value set Influenza (Tests for influenza A or B virus Nucleic Acid)",
-                "resource": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.336"
-              },
-              {
-                "type": "depends-on",
-                "display": "Value set Influenza (Tests for influenza A or B virus Antigen)",
-                "resource": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.337"
-              },
-              {
-                "type": "depends-on",
-                "display": "Value set COVID_19 (Tests for SARS_CoV_2 Nucleic Acid)",
-                "resource": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1142"
-              },
-              {
-                "type": "depends-on",
-                "display": "Value set COVID_19 (Tests for SARS_CoV_2 Antigen)",
-                "resource": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1158"
+                "resource": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.10.20.22.5.300|20240607"
               }
             ],
             "parameter": [
@@ -11078,6 +11486,13 @@
                 "type": "Encounter"
               },
               {
+                "name": "SDE ACH Daily ServiceRequest",
+                "use": "out",
+                "min": 0,
+                "max": "*",
+                "type": "ServiceRequest"
+              },
+              {
                 "name": "SDE RSV Specimen",
                 "use": "out",
                 "min": 0,
@@ -11085,11 +11500,32 @@
                 "type": "Specimen"
               },
               {
+                "name": "SDE ACH Daily Specimen",
+                "use": "out",
+                "min": 0,
+                "max": "*",
+                "type": "Specimen"
+              },
+              {
+                "name": "SDE ACH Daily DiagnosticReport",
+                "use": "out",
+                "min": 0,
+                "max": "*",
+                "type": "DiagnosticReport"
+              },
+              {
                 "name": "SDE RSV DiagnosticReport",
                 "use": "out",
                 "min": 0,
                 "max": "*",
                 "type": "DiagnosticReport"
+              },
+              {
+                "name": "SDE ACH Daily Observation",
+                "use": "out",
+                "min": 0,
+                "max": "*",
+                "type": "Observation"
               },
               {
                 "name": "Initial Population",
@@ -11202,6 +11638,13 @@
                 "min": 0,
                 "max": "*",
                 "type": "Observation"
+              },
+              {
+                "name": "SDE ACH Daily DiagnosticReport Result from Lab",
+                "use": "out",
+                "min": 0,
+                "max": "*",
+                "type": "DiagnosticReport"
               },
               {
                 "name": "SDE COVID and Influenza DiagnosticReport Result from Lab",
@@ -11421,6 +11864,329 @@
                 ]
               },
               {
+                "type": "ServiceRequest",
+                "profile": [
+                  "http://hl7.org/fhir/StructureDefinition/ServiceRequest"
+                ],
+                "mustSupport": [
+                  "code",
+                  "id",
+                  "extension",
+                  "instantiatesCanonical",
+                  "instantiatesUri",
+                  "basedOn",
+                  "replaces",
+                  "requisition",
+                  "status",
+                  "intent",
+                  "category",
+                  "priority",
+                  "doNotPerform",
+                  "orderDetail",
+                  "quantity",
+                  "subject",
+                  "encounter",
+                  "occurrence",
+                  "asNeeded",
+                  "authoredOn",
+                  "performerType",
+                  "performer",
+                  "locationCode",
+                  "locationReference",
+                  "reasonCode",
+                  "reasonReference",
+                  "insurance",
+                  "supportingInfo",
+                  "specimen",
+                  "bodySite",
+                  "note",
+                  "patientInstruction",
+                  "relevantHistory"
+                ],
+                "codeFilter": [
+                  {
+                    "path": "code",
+                    "valueSet": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1142|20250218"
+                  }
+                ]
+              },
+              {
+                "type": "ServiceRequest",
+                "profile": [
+                  "http://hl7.org/fhir/StructureDefinition/ServiceRequest"
+                ],
+                "mustSupport": [
+                  "code",
+                  "id",
+                  "extension",
+                  "instantiatesCanonical",
+                  "instantiatesUri",
+                  "basedOn",
+                  "replaces",
+                  "requisition",
+                  "status",
+                  "intent",
+                  "category",
+                  "priority",
+                  "doNotPerform",
+                  "orderDetail",
+                  "quantity",
+                  "subject",
+                  "encounter",
+                  "occurrence",
+                  "asNeeded",
+                  "authoredOn",
+                  "performerType",
+                  "performer",
+                  "locationCode",
+                  "locationReference",
+                  "reasonCode",
+                  "reasonReference",
+                  "insurance",
+                  "supportingInfo",
+                  "specimen",
+                  "bodySite",
+                  "note",
+                  "patientInstruction",
+                  "relevantHistory"
+                ],
+                "codeFilter": [
+                  {
+                    "path": "code",
+                    "valueSet": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1158|20240123"
+                  }
+                ]
+              },
+              {
+                "type": "ServiceRequest",
+                "profile": [
+                  "http://hl7.org/fhir/StructureDefinition/ServiceRequest"
+                ],
+                "mustSupport": [
+                  "code",
+                  "id",
+                  "extension",
+                  "instantiatesCanonical",
+                  "instantiatesUri",
+                  "basedOn",
+                  "replaces",
+                  "requisition",
+                  "status",
+                  "intent",
+                  "category",
+                  "priority",
+                  "doNotPerform",
+                  "orderDetail",
+                  "quantity",
+                  "subject",
+                  "encounter",
+                  "occurrence",
+                  "asNeeded",
+                  "authoredOn",
+                  "performerType",
+                  "performer",
+                  "locationCode",
+                  "locationReference",
+                  "reasonCode",
+                  "reasonReference",
+                  "insurance",
+                  "supportingInfo",
+                  "specimen",
+                  "bodySite",
+                  "note",
+                  "patientInstruction",
+                  "relevantHistory"
+                ],
+                "codeFilter": [
+                  {
+                    "path": "code",
+                    "valueSet": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.336|20250218"
+                  }
+                ]
+              },
+              {
+                "type": "ServiceRequest",
+                "profile": [
+                  "http://hl7.org/fhir/StructureDefinition/ServiceRequest"
+                ],
+                "mustSupport": [
+                  "code",
+                  "id",
+                  "extension",
+                  "instantiatesCanonical",
+                  "instantiatesUri",
+                  "basedOn",
+                  "replaces",
+                  "requisition",
+                  "status",
+                  "intent",
+                  "category",
+                  "priority",
+                  "doNotPerform",
+                  "orderDetail",
+                  "quantity",
+                  "subject",
+                  "encounter",
+                  "occurrence",
+                  "asNeeded",
+                  "authoredOn",
+                  "performerType",
+                  "performer",
+                  "locationCode",
+                  "locationReference",
+                  "reasonCode",
+                  "reasonReference",
+                  "insurance",
+                  "supportingInfo",
+                  "specimen",
+                  "bodySite",
+                  "note",
+                  "patientInstruction",
+                  "relevantHistory"
+                ],
+                "codeFilter": [
+                  {
+                    "path": "code",
+                    "valueSet": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.337"
+                  }
+                ]
+              },
+              {
+                "type": "ServiceRequest",
+                "profile": [
+                  "http://hl7.org/fhir/StructureDefinition/ServiceRequest"
+                ],
+                "mustSupport": [
+                  "code",
+                  "id",
+                  "extension",
+                  "instantiatesCanonical",
+                  "instantiatesUri",
+                  "basedOn",
+                  "replaces",
+                  "requisition",
+                  "status",
+                  "intent",
+                  "category",
+                  "priority",
+                  "doNotPerform",
+                  "orderDetail",
+                  "quantity",
+                  "subject",
+                  "encounter",
+                  "occurrence",
+                  "asNeeded",
+                  "authoredOn",
+                  "performerType",
+                  "performer",
+                  "locationCode",
+                  "locationReference",
+                  "reasonCode",
+                  "reasonReference",
+                  "insurance",
+                  "supportingInfo",
+                  "specimen",
+                  "bodySite",
+                  "note",
+                  "patientInstruction",
+                  "relevantHistory"
+                ],
+                "codeFilter": [
+                  {
+                    "path": "code",
+                    "valueSet": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1312|20250218"
+                  }
+                ]
+              },
+              {
+                "type": "ServiceRequest",
+                "profile": [
+                  "http://hl7.org/fhir/StructureDefinition/ServiceRequest"
+                ],
+                "mustSupport": [
+                  "code",
+                  "id",
+                  "extension",
+                  "instantiatesCanonical",
+                  "instantiatesUri",
+                  "basedOn",
+                  "replaces",
+                  "requisition",
+                  "status",
+                  "intent",
+                  "category",
+                  "priority",
+                  "doNotPerform",
+                  "orderDetail",
+                  "quantity",
+                  "subject",
+                  "encounter",
+                  "occurrence",
+                  "asNeeded",
+                  "authoredOn",
+                  "performerType",
+                  "performer",
+                  "locationCode",
+                  "locationReference",
+                  "reasonCode",
+                  "reasonReference",
+                  "insurance",
+                  "supportingInfo",
+                  "specimen",
+                  "bodySite",
+                  "note",
+                  "patientInstruction",
+                  "relevantHistory"
+                ],
+                "codeFilter": [
+                  {
+                    "path": "code",
+                    "valueSet": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1311"
+                  }
+                ]
+              },
+              {
+                "type": "ServiceRequest",
+                "profile": [
+                  "http://hl7.org/fhir/StructureDefinition/ServiceRequest"
+                ],
+                "mustSupport": [
+                  "id",
+                  "extension",
+                  "instantiatesCanonical",
+                  "instantiatesUri",
+                  "basedOn",
+                  "replaces",
+                  "requisition",
+                  "status",
+                  "intent",
+                  "category",
+                  "priority",
+                  "doNotPerform",
+                  "code",
+                  "orderDetail",
+                  "quantity",
+                  "subject",
+                  "encounter",
+                  "occurrence",
+                  "asNeeded",
+                  "authoredOn",
+                  "performerType",
+                  "performer",
+                  "locationCode",
+                  "locationReference",
+                  "reasonCode",
+                  "reasonReference",
+                  "insurance",
+                  "supportingInfo",
+                  "specimen",
+                  "bodySite",
+                  "note",
+                  "patientInstruction",
+                  "relevantHistory"
+                ]
+              },
+              {
                 "type": "Observation",
                 "profile": [
                   "http://hl7.org/fhir/StructureDefinition/Observation"
@@ -11457,7 +12223,7 @@
                 "codeFilter": [
                   {
                     "path": "code",
-                    "valueSet": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1312"
+                    "valueSet": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1312|20250218"
                   }
                 ]
               },
@@ -11539,7 +12305,7 @@
                 "codeFilter": [
                   {
                     "path": "code",
-                    "valueSet": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.336"
+                    "valueSet": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.336|20250218"
                   }
                 ]
               },
@@ -11621,7 +12387,7 @@
                 "codeFilter": [
                   {
                     "path": "code",
-                    "valueSet": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1142"
+                    "valueSet": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1142|20250218"
                   }
                 ]
               },
@@ -11662,7 +12428,7 @@
                 "codeFilter": [
                   {
                     "path": "code",
-                    "valueSet": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1158"
+                    "valueSet": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1158|20240123"
                   }
                 ]
               },
@@ -11750,7 +12516,7 @@
                 "codeFilter": [
                   {
                     "path": "code",
-                    "valueSet": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1312"
+                    "valueSet": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1142|20250218"
                   }
                 ]
               },
@@ -11780,7 +12546,7 @@
                 "codeFilter": [
                   {
                     "path": "code",
-                    "valueSet": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1311"
+                    "valueSet": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1158|20240123"
                   }
                 ]
               },
@@ -11810,67 +12576,7 @@
                 "codeFilter": [
                   {
                     "path": "code",
-                    "valueSet": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1142"
-                  }
-                ]
-              },
-              {
-                "type": "DiagnosticReport",
-                "profile": [
-                  "http://hl7.org/fhir/StructureDefinition/DiagnosticReport"
-                ],
-                "mustSupport": [
-                  "code",
-                  "status",
-                  "id",
-                  "extension",
-                  "basedOn",
-                  "category",
-                  "subject",
-                  "encounter",
-                  "effective",
-                  "issued",
-                  "performer",
-                  "resultsInterpreter",
-                  "specimen",
-                  "result",
-                  "conclusion",
-                  "conclusionCode"
-                ],
-                "codeFilter": [
-                  {
-                    "path": "code",
-                    "valueSet": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1158"
-                  }
-                ]
-              },
-              {
-                "type": "DiagnosticReport",
-                "profile": [
-                  "http://hl7.org/fhir/StructureDefinition/DiagnosticReport"
-                ],
-                "mustSupport": [
-                  "code",
-                  "status",
-                  "id",
-                  "extension",
-                  "basedOn",
-                  "category",
-                  "subject",
-                  "encounter",
-                  "effective",
-                  "issued",
-                  "performer",
-                  "resultsInterpreter",
-                  "specimen",
-                  "result",
-                  "conclusion",
-                  "conclusionCode"
-                ],
-                "codeFilter": [
-                  {
-                    "path": "code",
-                    "valueSet": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.336"
+                    "valueSet": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.336|20250218"
                   }
                 ]
               },
@@ -11910,6 +12616,66 @@
                   "http://hl7.org/fhir/StructureDefinition/DiagnosticReport"
                 ],
                 "mustSupport": [
+                  "code",
+                  "status",
+                  "id",
+                  "extension",
+                  "basedOn",
+                  "category",
+                  "subject",
+                  "encounter",
+                  "effective",
+                  "issued",
+                  "performer",
+                  "resultsInterpreter",
+                  "specimen",
+                  "result",
+                  "conclusion",
+                  "conclusionCode"
+                ],
+                "codeFilter": [
+                  {
+                    "path": "code",
+                    "valueSet": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1312|20250218"
+                  }
+                ]
+              },
+              {
+                "type": "DiagnosticReport",
+                "profile": [
+                  "http://hl7.org/fhir/StructureDefinition/DiagnosticReport"
+                ],
+                "mustSupport": [
+                  "code",
+                  "status",
+                  "id",
+                  "extension",
+                  "basedOn",
+                  "category",
+                  "subject",
+                  "encounter",
+                  "effective",
+                  "issued",
+                  "performer",
+                  "resultsInterpreter",
+                  "specimen",
+                  "result",
+                  "conclusion",
+                  "conclusionCode"
+                ],
+                "codeFilter": [
+                  {
+                    "path": "code",
+                    "valueSet": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1146.1311"
+                  }
+                ]
+              },
+              {
+                "type": "DiagnosticReport",
+                "profile": [
+                  "http://hl7.org/fhir/StructureDefinition/DiagnosticReport"
+                ],
+                "mustSupport": [
                   "status",
                   "id",
                   "extension",
@@ -12004,7 +12770,7 @@
                 "codeFilter": [
                   {
                     "path": "code",
-                    "valueSet": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.10.20.22.5.300"
+                    "valueSet": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.10.20.22.5.300|20240607"
                   }
                 ]
               },
@@ -12047,11 +12813,8 @@
                   "address",
                   "maritalStatus",
                   "multipleBirth",
-                  "photo",
                   "contact",
                   "communication",
-                  "generalPractitioner",
-                  "managingOrganization",
                   "link"
                 ]
               },
@@ -12066,7 +12829,6 @@
                   "id",
                   "extension",
                   "status",
-                  "statusReason",
                   "intent",
                   "category",
                   "priority",
@@ -12111,48 +12873,6 @@
                   "dosage",
                   "eventHistory"
                 ]
-              },
-              {
-                "type": "ServiceRequest",
-                "profile": [
-                  "http://hl7.org/fhir/StructureDefinition/ServiceRequest"
-                ],
-                "mustSupport": [
-                  "id",
-                  "extension",
-                  "instantiatesCanonical",
-                  "instantiatesUri",
-                  "basedOn",
-                  "replaces",
-                  "requisition",
-                  "status",
-                  "intent",
-                  "category",
-                  "priority",
-                  "doNotPerform",
-                  "code",
-                  "orderDetail",
-                  "quantity",
-                  "subject",
-                  "encounter",
-                  "occurrence",
-                  "asNeeded",
-                  "authoredOn",
-                  "requester",
-                  "performerType",
-                  "performer",
-                  "locationCode",
-                  "locationReference",
-                  "reasonCode",
-                  "reasonReference",
-                  "insurance",
-                  "supportingInfo",
-                  "specimen",
-                  "bodySite",
-                  "note",
-                  "patientInstruction",
-                  "relevantHistory"
-                ]
               }
             ]
           }
@@ -12163,16 +12883,13 @@
             "valueCode": "Encounter"
           },
           {
-            "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-softwaresystem",
-            "valueReference": {
-              "reference": "Device/cqf-tooling"
-            }
+            "url": "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-effectiveDataRequirements",
+            "valueCanonical": "#effective-data-requirements"
           },
           {
-            "id": "effective-data-requirements",
-            "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-effectiveDataRequirements",
+            "url": "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-softwaresystem",
             "valueReference": {
-              "reference": "#effective-data-requirements"
+              "reference": "Device/cqf-tooling"
             }
           }
         ],
@@ -12183,14 +12900,39 @@
             "value": "NHSNAcuteCareHospitalDailyInitialPopulation"
           }
         ],
-        "version": "1.0.0-dev",
+        "version": "2.0.0-cibuild",
         "name": "NHSNAcuteCareHospitalDailyInitialPopulation",
         "title": "NHSN Acute Care Hospital Daily Initial Population",
         "status": "draft",
         "experimental": false,
-        "date": "2025-05-12T12:59:43-05:00",
-        "publisher": "Lantana Consulting Group",
+        "date": "2026-01-08T09:28:49-05:00",
+        "publisher": "CDC National Healthcare Safety Network (NHSN)",
+        "contact": [
+          {
+            "name": "CDC National Healthcare Safety Network (NHSN)",
+            "telecom": [
+              {
+                "system": "url",
+                "value": "http://www.cdc.gov/nhsn"
+              },
+              {
+                "system": "email",
+                "value": "nhsn@cdc.gov"
+              }
+            ]
+          }
+        ],
         "description": "All encounters with an inpatient, observation, or short stay status for patients of any age during the measurement period. ",
+        "jurisdiction": [
+          {
+            "coding": [
+              {
+                "system": "urn:iso:std:iso:3166",
+                "code": "US"
+              }
+            ]
+          }
+        ],
         "copyright": "Limited proprietary coding is contained in the Measure specifications for user convenience. Users of proprietary code sets should obtain all necessary licenses from the owners of the code sets.",
         "relatedArtifact": [
           {
@@ -12205,7 +12947,7 @@
         "library": [
           "http://www.cdc.gov/nhsn/fhirportal/dqm/ig/Library/NHSNAcuteCareHospitalDailyInitialPopulation"
         ],
-        "disclaimer": "This performance measure is not a clinical guideline, does not establish a standard of medical care and has not been tested for all potential applications.        THE MEASURES AND SPECIFICATIONS ARE PROVIDED “AS IS�? WITHOUT WARRANTY OF ANY KIND.        This measure and specifications are subject to further revisions.",
+        "disclaimer": "This performance measure is not a clinical guideline, does not establish a standard of medical care and has not been tested for all potential applications.        THE MEASURES AND SPECIFICATIONS ARE PROVIDED “AS IS” WITHOUT WARRANTY OF ANY KIND.        This measure and specifications are subject to further revisions.",
         "scoring": {
           "coding": [
             {

--- a/DotNet/Automation/measures/NHSNAcuteCareHospitalDailyInitialPopulation.json
+++ b/DotNet/Automation/measures/NHSNAcuteCareHospitalDailyInitialPopulation.json
@@ -2621,6 +2621,45 @@
     {
       "resource": {
         "resourceType": "ValueSet",
+        "id": "clinical-discharge-disposition",
+        "meta": {
+          "profile": [
+            "http://hl7.org/fhir/StructureDefinition/shareablevalueset"
+          ]
+        },
+        "url": "http://terminology.hl7.org/ValueSet/clinical-discharge-disposition",
+        "name": "DischargeDisposition",
+        "title": "Discharge disposition",
+        "status": "active",
+        "compose": {
+          "include": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/discharge-disposition",
+              "concept": [
+                { "code": "home", "display": "Home" },
+                { "code": "alt-home", "display": "Alternative home" },
+                { "code": "other-hcf", "display": "Other healthcare facility" },
+                { "code": "hosp", "display": "Hospice" },
+                { "code": "long", "display": "Long-term care" },
+                { "code": "aadvice", "display": "Left against advice" },
+                { "code": "exp", "display": "Expired" },
+                { "code": "psy", "display": "Psychiatric hospital" },
+                { "code": "rehab", "display": "Rehabilitation" },
+                { "code": "snf", "display": "Skilled nursing facility" },
+                { "code": "oth", "display": "Other" }
+              ]
+            }
+          ]
+        }
+      },
+      "request": {
+        "method": "PUT",
+        "url": "ValueSet/clinical-discharge-disposition"
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "ValueSet",
         "id": "2.16.840.1.113762.1.4.1146.1143-20210528",
         "meta": {
           "versionId": "25",

--- a/DotNet/Automation/measures/NHSNAcuteCareHospitalMonthlyInitialPopulation.json
+++ b/DotNet/Automation/measures/NHSNAcuteCareHospitalMonthlyInitialPopulation.json
@@ -151,13 +151,17 @@
             "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/computable-measure-cqfm"
           ]
         },
+        "text": {
+          "status": "extensions",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n  <table class=\"narrative-table\">\n    <tbody>\n<tr>\n\n<th colspan=\"2\" scope=\"row\" class=\"row-header\">Knowledge Artifact Metadata</th>\n\n</tr>\n\n<tr>\n\n<th scope=\"row\" class=\"row-header\">Name (machine-readable)</th>\n\n<td class=\"content-container\">NHSNAcuteCareHospitalMonthlyInitialPopulation</td>\n</tr>\n\n\n<tr>\n\n<th scope=\"row\" class=\"row-header\">Title (human-readable)</th>\n\n<td class=\"content-container\">NHSN dQM Acute Care Hospital Monthly Initial Population</td>\n</tr>\n\n\n\n<tr>\n\n<th scope=\"row\" class=\"row-header\">Status</th>\n\n<td class=\"content-container\">Draft</td>\n</tr>\n\n\n<tr>\n\n<th scope=\"row\" class=\"row-header\">Experimental</th>\n\n<td class=\"content-container\">false</td>\n</tr>\n\n\n<tr>\n\n<th scope=\"row\" class=\"row-header\">Description</th>\n\n<td class=\"content-container\"><div><p>The Acute Care Hospital Monthly Initial Population includes all encounters for patients of any age in an ED, observation, or inpatient location or all encounters for patients of any age with an ED, observation, inpatient, or short stay status during the measurement period.</p>\n</div></td>\n</tr>\n\n\n\n\n\n\n\n\n\n\n\n\n<tr>\n\n<th scope=\"row\" class=\"row-header\">Measure Steward</th>\n\n<td class=\"content-container\">CDC National Healthcare Safety Network (NHSN)</td>\n</tr>\n\n\n<tr>\n\n<th scope=\"row\" class=\"row-header\">Steward Contact Details</th>\n\n<td class=\"content-container\">CDC National Healthcare Safety Network (NHSN): <a href=\"http://www.cdc.gov/nhsn\">http://www.cdc.gov/nhsn</a>,<a href=\"mailto:nhsn@cdc.gov\">nhsn@cdc.gov</a></td>\n</tr>\n\n\n<tr>\n\n<th scope=\"row\" class=\"row-header\">Copyright</th>\n\n<td class=\"content-container\"><div><p>Limited proprietary coding is contained in the Measure specifications for user convenience. Users of proprietary code sets should obtain all necessary licenses from the owners of the code sets.</p>\n</div></td>\n</tr>\n\n\n\n<tr>\n  \n  \n<th scope=\"row\" class=\"row-header\">Documentation</th>\n\n  \n  \n  \n  \n  <td class=\"content-container\">\n    \n    <em>Description</em>: https://www.cdc.gov/nhsn/index.html [placeholder for link to protocol on CDC website]\n    \n    <br/>\n    \n    \n    \n    \n    <em>Content URL</em>: <a href=\"https://www.cdc.gov/nhsn/index.html\">https://www.cdc.gov/nhsn/index.html</a>\n    \n    <br/>\n    \n    \n    \n    <em>Document</em>: null @ https://www.cdc.gov/nhsn/index.html\n    \n    \n    \n  </td>\n</tr>\n\n\n\n\n\n\n\n\n\n\n<tr>\n\n<th colspan=\"2\" scope=\"row\" class=\"row-header\">Measure Metadata</th>\n\n</tr>\n\n\n\n\n\n\n<tr>\n\n<th scope=\"row\" class=\"row-header\">Version Number</th>\n\n<td class=\"content-container\">2.0.0-cibuild</td>\n</tr>\n\n\n<tr>\n\n<th scope=\"row\" class=\"row-header\">Measure Scoring</th>\n\n<td class=\"content-container\"><span title=\"Codes:{http://terminology.hl7.org/CodeSystem/measure-scoring cohort}\">Cohort</span></td>\n</tr>\n\n\n\n<tr>\n\n<th scope=\"row\" class=\"row-header\">Measure Type</th>\n\n<td class=\"content-container\"><span title=\"Codes:{http://terminology.hl7.org/CodeSystem/measure-type outcome}\">Outcome</span></td>\n</tr>\n\n\n\n\n<tr>\n\n<th scope=\"row\" class=\"row-header\">Rationale</th>\n\n<td class=\"content-container\"><div><p>The NHSN Acute Care Hospital Monthly dQM allows for facilities to report line level patient data electronically to NHSN for the following modules that are reported monthly: Glycemic Control, Hypoglycemia; Healthcare facility-onset, antibiotic-Treated Clostridioides difficile (C. difficile) Infection (HT-CDI); Hospital-Onset Bacteremia &amp; Fungemia (HOB); Venous Thromboembolism (VTE); Late Onset Sepsis / Meningitis. *Please see <a href=\"https://www.cdc.gov/nhsn/acute-care-hospital/index.html\">Acute Care / Critical Access Hospitals (ACH) | NHSN | CDC</a> for the individual measure protocols.</p>\n</div></td>\n</tr>\n\n\n\n\n\n\n\n  \n<tr>\n\n<th scope=\"row\" class=\"row-header\">Population Basis</th>\n\n<td class=\"content-container\">Encounter</td>\n</tr>\n\n\n\n\n\n  \n    <tr>\n\n<th colspan=\"2\" scope=\"row\" class=\"row-header\">Measure Population Criteria</th>\n\n</tr>\n  \n  \n  \n  \n    <tr>\n      \n        \n<th scope=\"row\" class=\"row-header\">Initial Population</th>\n\n      \n      <td class=\"content-container\">\n        \n        <em>ID</em>: initial-population\n        <br/>\n        \n        \n          <em>Description</em>:\n          <p style=\"white-space: pre-line\" class=\"tab-one\">All encounters for patients of any age in an ED, observation, or inpatient location or all encounters for patients of any age with an ED, observation, inpatient, or short stay status during the measurement period.</p>\n        \n        \n          \n            \n            <em>Logic Definition</em>: <a href=\"#nhsnacutecarehospitalmonthlyinitialpopulation-initial-population\">Initial Population</a> \n          \n        \n      </td>\n    </tr>\n  \n\n  \n  \n\n\n\n\n\n\n\n\n\n\n\n  <tr>\n\n<th colspan=\"2\" scope=\"row\" class=\"row-header\">Supplemental Data Elements</th>\n\n</tr>\n\n\n<tr>\n  \n<th scope=\"row\" class=\"row-header\">Supplemental Data Element</th>\n\n  <td class=\"content-container\">\n    \n      <em>ID</em>: sde-condition\n      \n      <br/>\n      \n    \n    \n      \n        \n          <em>Usage Code</em>: <span title=\"Codes:{http://terminology.hl7.org/CodeSystem/measure-data-usage supplemental-data}\">Supplemental Data</span>\n        \n        <br/>\n      \n    \n    \n      <em>Description</em>: SDE Condition\n    \n    \n      \n        <br/>\n        \n        <em>Logic Definition</em>: <a href=\"#nhsnacutecarehospitalmonthlyinitialpopulation-sde-condition\">SDE Condition</a> \n      \n    \n  </td>\n</tr>\n\n<tr>\n  \n<th scope=\"row\" class=\"row-header\">Supplemental Data Element</th>\n\n  <td class=\"content-container\">\n    \n      <em>ID</em>: sde-device\n      \n      <br/>\n      \n    \n    \n      \n        \n          <em>Usage Code</em>: <span title=\"Codes:{http://terminology.hl7.org/CodeSystem/measure-data-usage supplemental-data}\">Supplemental Data</span>\n        \n        <br/>\n      \n    \n    \n      <em>Description</em>: SDE Device\n    \n    \n      \n        <br/>\n        \n        <em>Logic Definition</em>: <a href=\"#nhsnacutecarehospitalmonthlyinitialpopulation-sde-device\">SDE Device</a> \n      \n    \n  </td>\n</tr>\n\n<tr>\n  \n<th scope=\"row\" class=\"row-header\">Supplemental Data Element</th>\n\n  <td class=\"content-container\">\n    \n      <em>ID</em>: sde-diagnosticreport-lab\n      \n      <br/>\n      \n    \n    \n      \n        \n          <em>Usage Code</em>: <span title=\"Codes:{http://terminology.hl7.org/CodeSystem/measure-data-usage supplemental-data}\">Supplemental Data</span>\n        \n        <br/>\n      \n    \n    \n      <em>Description</em>: SDE DiagnosticReport Lab\n    \n    \n      \n        <br/>\n        \n        <em>Logic Definition</em>: <a href=\"#nhsnacutecarehospitalmonthlyinitialpopulation-sde-diagnosticreport-lab\">SDE DiagnosticReport Lab</a> \n      \n    \n  </td>\n</tr>\n\n<tr>\n  \n<th scope=\"row\" class=\"row-header\">Supplemental Data Element</th>\n\n  <td class=\"content-container\">\n    \n      <em>ID</em>: sde-diagnosticreport-note\n      \n      <br/>\n      \n    \n    \n      \n        \n          <em>Usage Code</em>: <span title=\"Codes:{http://terminology.hl7.org/CodeSystem/measure-data-usage supplemental-data}\">Supplemental Data</span>\n        \n        <br/>\n      \n    \n    \n      <em>Description</em>: SDE DiagnosticReport Note\n    \n    \n      \n        <br/>\n        \n        <em>Logic Definition</em>: <a href=\"#nhsnacutecarehospitalmonthlyinitialpopulation-sde-diagnosticreport-note\">SDE DiagnosticReport Note</a> \n      \n    \n  </td>\n</tr>\n\n<tr>\n  \n<th scope=\"row\" class=\"row-header\">Supplemental Data Element</th>\n\n  <td class=\"content-container\">\n    \n      <em>ID</em>: sde-diagnosticreport-others\n      \n      <br/>\n      \n    \n    \n      \n        \n          <em>Usage Code</em>: <span title=\"Codes:{http://terminology.hl7.org/CodeSystem/measure-data-usage supplemental-data}\">Supplemental Data</span>\n        \n        <br/>\n      \n    \n    \n      <em>Description</em>: SDE DiagnosticReport Others\n    \n    \n      \n        <br/>\n        \n        <em>Logic Definition</em>: <a href=\"#nhsnacutecarehospitalmonthlyinitialpopulation-sde-diagnosticreport-others\">SDE DiagnosticReport Others</a> \n      \n    \n  </td>\n</tr>\n\n<tr>\n  \n<th scope=\"row\" class=\"row-header\">Supplemental Data Element</th>\n\n  <td class=\"content-container\">\n    \n      <em>ID</em>: sde-encounter\n      \n      <br/>\n      \n    \n    \n      \n        \n          <em>Usage Code</em>: <span title=\"Codes:{http://terminology.hl7.org/CodeSystem/measure-data-usage supplemental-data}\">Supplemental Data</span>\n        \n        <br/>\n      \n    \n    \n      <em>Description</em>: SDE Encounter\n    \n    \n      \n        <br/>\n        \n        <em>Logic Definition</em>: <a href=\"#nhsnacutecarehospitalmonthlyinitialpopulation-sde-encounter\">SDE Encounter</a> \n      \n    \n  </td>\n</tr>\n\n<tr>\n  \n<th scope=\"row\" class=\"row-header\">Supplemental Data Element</th>\n\n  <td class=\"content-container\">\n    \n      <em>ID</em>: sde-location\n      \n      <br/>\n      \n    \n    \n      \n        \n          <em>Usage Code</em>: <span title=\"Codes:{http://terminology.hl7.org/CodeSystem/measure-data-usage supplemental-data}\">Supplemental Data</span>\n        \n        <br/>\n      \n    \n    \n      <em>Description</em>: SDE Location\n    \n    \n      \n        <br/>\n        \n        <em>Logic Definition</em>: <a href=\"#nhsnacutecarehospitalmonthlyinitialpopulation-sde-location\">SDE Location</a> \n      \n    \n  </td>\n</tr>\n\n<tr>\n  \n<th scope=\"row\" class=\"row-header\">Supplemental Data Element</th>\n\n  <td class=\"content-container\">\n    \n      <em>ID</em>: sde-medication-administration\n      \n      <br/>\n      \n    \n    \n      \n        \n          <em>Usage Code</em>: <span title=\"Codes:{http://terminology.hl7.org/CodeSystem/measure-data-usage supplemental-data}\">Supplemental Data</span>\n        \n        <br/>\n      \n    \n    \n      <em>Description</em>: SDE Medication Administration\n    \n    \n      \n        <br/>\n        \n        <em>Logic Definition</em>: <a href=\"#nhsnacutecarehospitalmonthlyinitialpopulation-sde-medication-administration\">SDE Medication Administration</a> \n      \n    \n  </td>\n</tr>\n\n<tr>\n  \n<th scope=\"row\" class=\"row-header\">Supplemental Data Element</th>\n\n  <td class=\"content-container\">\n    \n      <em>ID</em>: sde-medication-request\n      \n      <br/>\n      \n    \n    \n      \n        \n          <em>Usage Code</em>: <span title=\"Codes:{http://terminology.hl7.org/CodeSystem/measure-data-usage supplemental-data}\">Supplemental Data</span>\n        \n        <br/>\n      \n    \n    \n      <em>Description</em>: SDE Medication Request\n    \n    \n      \n        <br/>\n        \n        <em>Logic Definition</em>: <a href=\"#nhsnacutecarehospitalmonthlyinitialpopulation-sde-medication-request\">SDE Medication Request</a> \n      \n    \n  </td>\n</tr>\n\n<tr>\n  \n<th scope=\"row\" class=\"row-header\">Supplemental Data Element</th>\n\n  <td class=\"content-container\">\n    \n      <em>ID</em>: sde-medication\n      \n      <br/>\n      \n    \n    \n      \n        \n          <em>Usage Code</em>: <span title=\"Codes:{http://terminology.hl7.org/CodeSystem/measure-data-usage supplemental-data}\">Supplemental Data</span>\n        \n        <br/>\n      \n    \n    \n      <em>Description</em>: SDE Medication\n    \n    \n      \n        <br/>\n        \n        <em>Logic Definition</em>: <a href=\"#nhsnacutecarehospitalmonthlyinitialpopulation-sde-medication\">SDE Medication</a> \n      \n    \n  </td>\n</tr>\n\n<tr>\n  \n<th scope=\"row\" class=\"row-header\">Supplemental Data Element</th>\n\n  <td class=\"content-container\">\n    \n      <em>ID</em>: sde-observation-lab-category\n      \n      <br/>\n      \n    \n    \n      \n        \n          <em>Usage Code</em>: <span title=\"Codes:{http://terminology.hl7.org/CodeSystem/measure-data-usage supplemental-data}\">Supplemental Data</span>\n        \n        <br/>\n      \n    \n    \n      <em>Description</em>: SDE Observation Lab Category\n    \n    \n      \n        <br/>\n        \n        <em>Logic Definition</em>: <a href=\"#nhsnacutecarehospitalmonthlyinitialpopulation-sde-observation-lab-category\">SDE Observation Lab Category</a> \n      \n    \n  </td>\n</tr>\n\n<tr>\n  \n<th scope=\"row\" class=\"row-header\">Supplemental Data Element</th>\n\n  <td class=\"content-container\">\n    \n      <em>ID</em>: sde-observation-vital-signs-category\n      \n      <br/>\n      \n    \n    \n      \n        \n          <em>Usage Code</em>: <span title=\"Codes:{http://terminology.hl7.org/CodeSystem/measure-data-usage supplemental-data}\">Supplemental Data</span>\n        \n        <br/>\n      \n    \n    \n      <em>Description</em>: SDE Observation Vital Signs Category\n    \n    \n      \n        <br/>\n        \n        <em>Logic Definition</em>: <a href=\"#nhsnacutecarehospitalmonthlyinitialpopulation-sde-observation-vital-signs-category\">SDE Observation Vital Signs Category</a> \n      \n    \n  </td>\n</tr>\n\n<tr>\n  \n<th scope=\"row\" class=\"row-header\">Supplemental Data Element</th>\n\n  <td class=\"content-container\">\n    \n      <em>ID</em>: sde-observation-category\n      \n      <br/>\n      \n    \n    \n      \n        \n          <em>Usage Code</em>: <span title=\"Codes:{http://terminology.hl7.org/CodeSystem/measure-data-usage supplemental-data}\">Supplemental Data</span>\n        \n        <br/>\n      \n    \n    \n      <em>Description</em>: SDE Observation Category\n    \n    \n      \n        <br/>\n        \n        <em>Logic Definition</em>: <a href=\"#nhsnacutecarehospitalmonthlyinitialpopulation-sde-observation-category\">SDE Observation Category</a> \n      \n    \n  </td>\n</tr>\n\n<tr>\n  \n<th scope=\"row\" class=\"row-header\">Supplemental Data Element</th>\n\n  <td class=\"content-container\">\n    \n      <em>ID</em>: sde-coverage\n      \n      <br/>\n      \n    \n    \n      \n        \n          <em>Usage Code</em>: <span title=\"Codes:{http://terminology.hl7.org/CodeSystem/measure-data-usage supplemental-data}\">Supplemental Data</span>\n        \n        <br/>\n      \n    \n    \n      <em>Description</em>: SDE Coverage\n    \n    \n      \n        <br/>\n        \n        <em>Logic Definition</em>: <a href=\"#nhsnacutecarehospitalmonthlyinitialpopulation-sde-coverage\">SDE Coverage</a> \n      \n    \n  </td>\n</tr>\n\n<tr>\n  \n<th scope=\"row\" class=\"row-header\">Supplemental Data Element</th>\n\n  <td class=\"content-container\">\n    \n      <em>ID</em>: sde-procedure\n      \n      <br/>\n      \n    \n    \n      \n        \n          <em>Usage Code</em>: <span title=\"Codes:{http://terminology.hl7.org/CodeSystem/measure-data-usage supplemental-data}\">Supplemental Data</span>\n        \n        <br/>\n      \n    \n    \n      <em>Description</em>: SDE Procedure\n    \n    \n      \n        <br/>\n        \n        <em>Logic Definition</em>: <a href=\"#nhsnacutecarehospitalmonthlyinitialpopulation-sde-procedure\">SDE Procedure</a> \n      \n    \n  </td>\n</tr>\n\n<tr>\n  \n<th scope=\"row\" class=\"row-header\">Supplemental Data Element</th>\n\n  <td class=\"content-container\">\n    \n      <em>ID</em>: sde-specimen\n      \n      <br/>\n      \n    \n    \n      \n        \n          <em>Usage Code</em>: <span title=\"Codes:{http://terminology.hl7.org/CodeSystem/measure-data-usage supplemental-data}\">Supplemental Data</span>\n        \n        <br/>\n      \n    \n    \n      <em>Description</em>: SDE Specimen\n    \n    \n      \n        <br/>\n        \n        <em>Logic Definition</em>: <a href=\"#nhsnacutecarehospitalmonthlyinitialpopulation-sde-specimen\">SDE Specimen</a> \n      \n    \n  </td>\n</tr>\n\n<tr>\n  \n<th scope=\"row\" class=\"row-header\">Supplemental Data Element</th>\n\n  <td class=\"content-container\">\n    \n      <em>ID</em>: sde-service-request\n      \n      <br/>\n      \n    \n    \n      \n        \n          <em>Usage Code</em>: <span title=\"Codes:{http://terminology.hl7.org/CodeSystem/measure-data-usage supplemental-data}\">Supplemental Data</span>\n        \n        <br/>\n      \n    \n    \n      <em>Description</em>: SDE Service Request\n    \n    \n      \n        <br/>\n        \n        <em>Logic Definition</em>: <a href=\"#nhsnacutecarehospitalmonthlyinitialpopulation-sde-service-request\">SDE Service Request</a> \n      \n    \n  </td>\n</tr>\n\n<tr>\n  \n<th scope=\"row\" class=\"row-header\">Supplemental Data Element</th>\n\n  <td class=\"content-container\">\n    \n      <em>ID</em>: sde-minimal-patient\n      \n      <br/>\n      \n    \n    \n      \n        \n          <em>Usage Code</em>: <span title=\"Codes:{http://terminology.hl7.org/CodeSystem/measure-data-usage supplemental-data}\">Supplemental Data</span>\n        \n        <br/>\n      \n    \n    \n      <em>Description</em>: SDE Minimal Patient\n    \n    \n      \n        <br/>\n        \n        <em>Logic Definition</em>: <a href=\"#nhsnacutecarehospitalmonthlyinitialpopulation-sde-minimal-patient\">SDE Minimal Patient</a> \n      \n    \n  </td>\n</tr>\n\n<tr>\n  \n<th scope=\"row\" class=\"row-header\">Supplemental Data Element</th>\n\n  <td class=\"content-container\">\n    \n      <em>ID</em>: sde-ip-encounters\n      \n      <br/>\n      \n    \n    \n      \n        \n          <em>Usage Code</em>: <span title=\"Codes:{http://terminology.hl7.org/CodeSystem/measure-data-usage supplemental-data}\">Supplemental Data</span>\n        \n        <br/>\n      \n    \n    \n      <em>Description</em>: SDE IP Encounters\n    \n    \n      \n        <br/>\n        \n        <em>Logic Definition</em>: <a href=\"#nhsnacutecarehospitalmonthlyinitialpopulation-sde-ip-encounters\">SDE IP Encounters</a> \n      \n    \n  </td>\n</tr>\n\n\n<tr>\n\n<th colspan=\"2\" scope=\"row\" class=\"row-header\">Measure Logic</th>\n\n</tr>\n\n<tr>\n\n<th scope=\"row\" class=\"row-header\">Primary Library</th>\n\n<td class=\"content-container\"><a href=\"Library-NHSNAcuteCareHospitalMonthlyInitialPopulation.html\">NHSNAcuteCareHospitalMonthlyInitialPopulation</a></td>\n</tr>\n\n\n\n\n  \n  \n\n<tr>\n  \n  \n  \n  \n  \n<th scope=\"row\" class=\"row-header\">Dependency</th>\n\n  \n  <td class=\"content-container\">\n    \n    <em>Description</em>: FHIR model information\n    \n    <br/>\n    \n    \n    \n    \n    \n    \n    <em>Resource</em>: <a href=\"http://fhir.org/guides/cqf/common/4.0.1/4.0.1/Library-FHIR-ModelInfo.html\">http://fhir.org/guides/cqf/common/Library/FHIR-ModelInfo|4.0.1</a>\n    <br/>\n    <em>Canonical URL</em>: <tt>http://fhir.org/guides/cqf/common/Library/FHIR-ModelInfo|4.0.1</tt>\n    \n  </td>\n</tr>\n\n<tr>\n  \n  \n  \n  \n  \n<th scope=\"row\" class=\"row-header\">Dependency</th>\n\n  \n  <td class=\"content-container\">\n    \n    <em>Description</em>: Library FHIRHelpers\n    \n    <br/>\n    \n    \n    \n    \n    \n    \n    <em>Resource</em>: <code>http://www.cdc.gov/nhsn/fhirportal/dqm/ig/Library/FHIRHelpers|4.0.2</code>\n    <br/>\n    <em>Canonical URL</em>: <tt>http://www.cdc.gov/nhsn/fhirportal/dqm/ig/Library/FHIRHelpers|4.0.2</tt>\n    \n  </td>\n</tr>\n\n<tr>\n  \n  \n  \n  \n  \n<th scope=\"row\" class=\"row-header\">Dependency</th>\n\n  \n  <td class=\"content-container\">\n    \n    <em>Description</em>: Library NHSNHelpers\n    \n    <br/>\n    \n    \n    \n    \n    \n    \n    <em>Resource</em>: <code>http://www.cdc.gov/nhsn/fhirportal/dqm/ig/Library/NHSNHelpers|0.0.002</code>\n    <br/>\n    <em>Canonical URL</em>: <tt>http://www.cdc.gov/nhsn/fhirportal/dqm/ig/Library/NHSNHelpers|0.0.002</tt>\n    \n  </td>\n</tr>\n\n<tr>\n  \n  \n  \n  \n  \n<th scope=\"row\" class=\"row-header\">Dependency</th>\n\n  \n  <td class=\"content-container\">\n    \n    <em>Description</em>: Library SharedResource\n    \n    <br/>\n    \n    \n    \n    \n    \n    \n    <em>Resource</em>: <code>http://www.cdc.gov/nhsn/fhirportal/dqm/ig/Library/SharedResourceCreation|0.1.010</code>\n    <br/>\n    <em>Canonical URL</em>: <tt>http://www.cdc.gov/nhsn/fhirportal/dqm/ig/Library/SharedResourceCreation|0.1.010</tt>\n    \n  </td>\n</tr>\n\n<tr>\n  \n  \n  \n  \n  \n<th scope=\"row\" class=\"row-header\">Dependency</th>\n\n  \n  <td class=\"content-container\">\n    \n    <em>Description</em>: Code system ActCode\n    \n    <br/>\n    \n    \n    \n    \n    \n    \n    <em>Resource</em>: <a href=\"http://terminology.hl7.org/7.0.1/CodeSystem-v3-ActCode.html\">ActCodeversion: null9.0.0)</a>\n    <br/>\n    <em>Canonical URL</em>: <tt>http://terminology.hl7.org/CodeSystem/v3-ActCode|9.0.0</tt>\n    \n  </td>\n</tr>\n\n<tr>\n  \n  \n  \n  \n  \n<th scope=\"row\" class=\"row-header\">Dependency</th>\n\n  \n  <td class=\"content-container\">\n    \n    <em>Description</em>: Code system MedicationRequest Category\n    \n    <br/>\n    \n    \n    \n    \n    \n    \n    <em>Resource</em>: <a href=\"http://terminology.hl7.org/7.0.1/CodeSystem-medicationrequest-category.html\">MedicationRequest Category Codesversion: null1.0.0)</a>\n    <br/>\n    <em>Canonical URL</em>: <tt>http://terminology.hl7.org/CodeSystem/medicationrequest-category|1.0.0</tt>\n    \n  </td>\n</tr>\n\n<tr>\n  \n  \n  \n  \n  \n<th scope=\"row\" class=\"row-header\">Dependency</th>\n\n  \n  <td class=\"content-container\">\n    \n    <em>Description</em>: Code system SNOMEDCT\n    \n    <br/>\n    \n    \n    \n    \n    \n    \n    <em>Resource</em>: <a href=\"http://hl7.org/fhir/R4/codesystem-snomedct.html\">SNOMED CT (all versions)</a>\n    <br/>\n    <em>Canonical URL</em>: <tt>http://snomed.info/sct</tt>\n    \n  </td>\n</tr>\n\n<tr>\n  \n  \n  \n  \n  \n<th scope=\"row\" class=\"row-header\">Dependency</th>\n\n  \n  <td class=\"content-container\">\n    \n    <em>Description</em>: Code system Observation Category\n    \n    <br/>\n    \n    \n    \n    \n    \n    \n    <em>Resource</em>: <a href=\"http://terminology.hl7.org/7.0.1/CodeSystem-observation-category.html\">Observation Category Codesversion: null2.0.0)</a>\n    <br/>\n    <em>Canonical URL</em>: <tt>http://terminology.hl7.org/CodeSystem/observation-category|2.0.0</tt>\n    \n  </td>\n</tr>\n\n<tr>\n  \n  \n  \n  \n  \n<th scope=\"row\" class=\"row-header\">Dependency</th>\n\n  \n  <td class=\"content-container\">\n    \n    <em>Description</em>: Code system LOINC\n    \n    <br/>\n    \n    \n    \n    \n    \n    \n    <em>Resource</em>: <a href=\"http://terminology.hl7.org/6.5.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a>\n    <br/>\n    <em>Canonical URL</em>: <tt>http://loinc.org</tt>\n    \n  </td>\n</tr>\n\n<tr>\n  \n  \n  \n  \n  \n<th scope=\"row\" class=\"row-header\">Dependency</th>\n\n  \n  <td class=\"content-container\">\n    \n    <em>Description</em>: Code system V2-0074\n    \n    <br/>\n    \n    \n    \n    \n    \n    \n    <em>Resource</em>: <a href=\"http://terminology.hl7.org/7.0.1/CodeSystem-v2-0074.html\">diagnosticServiceSectionIdversion: null3.0.0)</a>\n    <br/>\n    <em>Canonical URL</em>: <tt>http://terminology.hl7.org/CodeSystem/v2-0074|3.0.0</tt>\n    \n  </td>\n</tr>\n\n<tr>\n  \n  \n  \n  \n  \n<th scope=\"row\" class=\"row-header\">Dependency</th>\n\n  \n  <td class=\"content-container\">\n    \n    <em>Description</em>: Code system Condition Category\n    \n    <br/>\n    \n    \n    \n    \n    \n    \n    <em>Resource</em>: <a href=\"http://terminology.hl7.org/7.0.1/CodeSystem-condition-category.html\">Condition Category Codesversion: null2.0.0)</a>\n    <br/>\n    <em>Canonical URL</em>: <tt>http://terminology.hl7.org/CodeSystem/condition-category|2.0.0</tt>\n    \n  </td>\n</tr>\n\n<tr>\n  \n  \n  \n  \n  \n<th scope=\"row\" class=\"row-header\">Dependency</th>\n\n  \n  <td class=\"content-container\">\n    \n    <em>Description</em>: Value set Encounter Inpatient\n    \n    <br/>\n    \n    \n    \n    \n    \n    \n    <em>Resource</em>: <a href=\"https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.3.666.5.307/expansion\">Encounter Inpatient</a>\n    <br/>\n    <em>Canonical URL</em>: <tt>http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307</tt>\n    \n  </td>\n</tr>\n\n<tr>\n  \n  \n  \n  \n  \n<th scope=\"row\" class=\"row-header\">Dependency</th>\n\n  \n  <td class=\"content-container\">\n    \n    <em>Description</em>: Value set Emergency Department Visit\n    \n    <br/>\n    \n    \n    \n    \n    \n    \n    <em>Resource</em>: <a href=\"https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.3.117.1.7.1.292/expansion\">Emergency Department Visit</a>\n    <br/>\n    <em>Canonical URL</em>: <tt>http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.292</tt>\n    \n  </td>\n</tr>\n\n<tr>\n  \n  \n  \n  \n  \n<th scope=\"row\" class=\"row-header\">Dependency</th>\n\n  \n  <td class=\"content-container\">\n    \n    <em>Description</em>: Value set Observation Services\n    \n    <br/>\n    \n    \n    \n    \n    \n    \n    <em>Resource</em>: <a href=\"https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1111.143/expansion\">Observation Services</a>\n    <br/>\n    <em>Canonical URL</em>: <tt>http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1111.143</tt>\n    \n  </td>\n</tr>\n\n<tr>\n  \n  \n  \n  \n  \n<th scope=\"row\" class=\"row-header\">Dependency</th>\n\n  \n  <td class=\"content-container\">\n    \n    <em>Description</em>: Value set NHSN Inpatient Encounter Class Codes\n    \n    <br/>\n    \n    \n    \n    \n    \n    \n    <em>Resource</em>: <a href=\"https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1046.274/expansion\">NHSN Inpatient Encounter Class Codes</a>\n    <br/>\n    <em>Canonical URL</em>: <tt>http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1046.274</tt>\n    \n  </td>\n</tr>\n\n<tr>\n  \n  \n  \n  \n  \n<th scope=\"row\" class=\"row-header\">Dependency</th>\n\n  \n  <td class=\"content-container\">\n    \n    <em>Description</em>: Value set Inpatient, Emergency, and Observation Locations\n    \n    <br/>\n    \n    \n    \n    \n    \n    \n    <em>Resource</em>: <a href=\"https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1046.265/expansion\">Inpatient, Emergency, and Observation Locations</a>\n    <br/>\n    <em>Canonical URL</em>: <tt>http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1046.265</tt>\n    \n  </td>\n</tr>\n\n\n  \n  <tr>\n    <th scope=\"row\" class=\"row-header\">Direct Reference Code</th>\n    <td class=\"content-container\">\n      \n        <em>Display</em>: emergency\n        <br/>\n      \n      <em>Code</em>: EMER\n      <br/>\n      <em>System</em>: <tt>http://terminology.hl7.org/CodeSystem/v3-ActCode</tt>\n    </td>\n  </tr>\n\n  <tr>\n    <th scope=\"row\" class=\"row-header\">Direct Reference Code</th>\n    <td class=\"content-container\">\n      \n        <em>Display</em>: observation encounter\n        <br/>\n      \n      <em>Code</em>: OBSENC\n      <br/>\n      <em>System</em>: <tt>http://terminology.hl7.org/CodeSystem/v3-ActCode</tt>\n    </td>\n  </tr>\n\n  <tr>\n    <th scope=\"row\" class=\"row-header\">Direct Reference Code</th>\n    <td class=\"content-container\">\n      \n        <em>Display</em>: Inpatient\n        <br/>\n      \n      <em>Code</em>: inpatient\n      <br/>\n      <em>System</em>: <tt>http://terminology.hl7.org/CodeSystem/medicationrequest-category</tt>\n    </td>\n  </tr>\n\n  <tr>\n    <th scope=\"row\" class=\"row-header\">Direct Reference Code</th>\n    <td class=\"content-container\">\n      \n        <em>Display</em>: Outpatient\n        <br/>\n      \n      <em>Code</em>: outpatient\n      <br/>\n      <em>System</em>: <tt>http://terminology.hl7.org/CodeSystem/medicationrequest-category</tt>\n    </td>\n  </tr>\n\n  <tr>\n    <th scope=\"row\" class=\"row-header\">Direct Reference Code</th>\n    <td class=\"content-container\">\n      \n        <em>Display</em>: Surgical procedure\n        <br/>\n      \n      <em>Code</em>: 387713003\n      <br/>\n      <em>System</em>: <tt>http://snomed.info/sct</tt>\n    </td>\n  </tr>\n\n  <tr>\n    <th scope=\"row\" class=\"row-header\">Direct Reference Code</th>\n    <td class=\"content-container\">\n      \n        <em>Display</em>: Diagnostic procedure\n        <br/>\n      \n      <em>Code</em>: 103693007\n      <br/>\n      <em>System</em>: <tt>http://snomed.info/sct</tt>\n    </td>\n  </tr>\n\n  <tr>\n    <th scope=\"row\" class=\"row-header\">Direct Reference Code</th>\n    <td class=\"content-container\">\n      \n        <em>Display</em>: Laboratory\n        <br/>\n      \n      <em>Code</em>: laboratory\n      <br/>\n      <em>System</em>: <tt>http://terminology.hl7.org/CodeSystem/observation-category</tt>\n    </td>\n  </tr>\n\n  <tr>\n    <th scope=\"row\" class=\"row-header\">Direct Reference Code</th>\n    <td class=\"content-container\">\n      \n        <em>Display</em>: Imaging\n        <br/>\n      \n      <em>Code</em>: imaging\n      <br/>\n      <em>System</em>: <tt>http://terminology.hl7.org/CodeSystem/observation-category</tt>\n    </td>\n  </tr>\n\n  <tr>\n    <th scope=\"row\" class=\"row-header\">Direct Reference Code</th>\n    <td class=\"content-container\">\n      \n        <em>Display</em>: Procedure\n        <br/>\n      \n      <em>Code</em>: procedure\n      <br/>\n      <em>System</em>: <tt>http://terminology.hl7.org/CodeSystem/observation-category</tt>\n    </td>\n  </tr>\n\n  <tr>\n    <th scope=\"row\" class=\"row-header\">Direct Reference Code</th>\n    <td class=\"content-container\">\n      \n        <em>Display</em>: Vital Signs\n        <br/>\n      \n      <em>Code</em>: vital-signs\n      <br/>\n      <em>System</em>: <tt>http://terminology.hl7.org/CodeSystem/observation-category</tt>\n    </td>\n  </tr>\n\n  <tr>\n    <th scope=\"row\" class=\"row-header\">Direct Reference Code</th>\n    <td class=\"content-container\">\n      \n        <em>Display</em>: Radiology\n        <br/>\n      \n      <em>Code</em>: LP29684-5\n      <br/>\n      <em>System</em>: <tt>http://loinc.org</tt>\n    </td>\n  </tr>\n\n  <tr>\n    <th scope=\"row\" class=\"row-header\">Direct Reference Code</th>\n    <td class=\"content-container\">\n      \n        <em>Display</em>: Pathology\n        <br/>\n      \n      <em>Code</em>: LP7839-6\n      <br/>\n      <em>System</em>: <tt>http://loinc.org</tt>\n    </td>\n  </tr>\n\n  <tr>\n    <th scope=\"row\" class=\"row-header\">Direct Reference Code</th>\n    <td class=\"content-container\">\n      \n        <em>Display</em>: Cardiology\n        <br/>\n      \n      <em>Code</em>: LP29708-2\n      <br/>\n      <em>System</em>: <tt>http://loinc.org</tt>\n    </td>\n  </tr>\n\n  <tr>\n    <th scope=\"row\" class=\"row-header\">Direct Reference Code</th>\n    <td class=\"content-container\">\n      \n        <em>Display</em>: Laboratory\n        <br/>\n      \n      <em>Code</em>: LAB\n      <br/>\n      <em>System</em>: <tt>http://terminology.hl7.org/CodeSystem/v2-0074</tt>\n    </td>\n  </tr>\n\n  <tr>\n    <th scope=\"row\" class=\"row-header\">Direct Reference Code</th>\n    <td class=\"content-container\">\n      \n        <em>Display</em>: Encounter Diagnosis\n        <br/>\n      \n      <em>Code</em>: encounter-diagnosis\n      <br/>\n      <em>System</em>: <tt>http://terminology.hl7.org/CodeSystem/condition-category</tt>\n    </td>\n  </tr>\n\n  <tr>\n    <th scope=\"row\" class=\"row-header\">Direct Reference Code</th>\n    <td class=\"content-container\">\n      \n        <em>Display</em>: Laboratory procedure\n        <br/>\n      \n      <em>Code</em>: 108252007\n      <br/>\n      <em>System</em>: <tt>http://snomed.info/sct</tt>\n    </td>\n  </tr>\n\n  <tr>\n    <th scope=\"row\" class=\"row-header\">Direct Reference Code</th>\n    <td class=\"content-container\">\n      \n        <em>Display</em>: Imaging\n        <br/>\n      \n      <em>Code</em>: 363679005\n      <br/>\n      <em>System</em>: <tt>http://snomed.info/sct</tt>\n    </td>\n  </tr>\n\n  \n  <tr>\n  \n<th scope=\"row\" class=\"row-header\">Parameter</th>\n\n  <td class=\"content-container\">\n    <em>Name</em>: Measurement Period\n    <br/>\n    <em>Use</em>: In\n    <br/>\n    <em>Min Cardinality</em>: 0\n    <br/>\n    <em>Max Cardinality</em>: 1\n    <br/>\n    <em>Type</em>: Period\n  </td>\n</tr>\n  \n  <tr>\n  \n<th scope=\"row\" class=\"row-header\">Parameter</th>\n\n  <td class=\"content-container\">\n    <em>Name</em>: SDE Encounter\n    <br/>\n    <em>Use</em>: Out\n    <br/>\n    <em>Min Cardinality</em>: 0\n    <br/>\n    <em>Max Cardinality</em>: *\n    <br/>\n    <em>Type</em>: Encounter\n  </td>\n</tr>\n  \n  <tr>\n  \n<th scope=\"row\" class=\"row-header\">Parameter</th>\n\n  <td class=\"content-container\">\n    <em>Name</em>: SDE Medication Request\n    <br/>\n    <em>Use</em>: Out\n    <br/>\n    <em>Min Cardinality</em>: 0\n    <br/>\n    <em>Max Cardinality</em>: *\n    <br/>\n    <em>Type</em>: MedicationRequest\n  </td>\n</tr>\n  \n  <tr>\n  \n<th scope=\"row\" class=\"row-header\">Parameter</th>\n\n  <td class=\"content-container\">\n    <em>Name</em>: SDE Coverage\n    <br/>\n    <em>Use</em>: Out\n    <br/>\n    <em>Min Cardinality</em>: 0\n    <br/>\n    <em>Max Cardinality</em>: *\n    <br/>\n    <em>Type</em>: Coverage\n  </td>\n</tr>\n  \n  <tr>\n  \n<th scope=\"row\" class=\"row-header\">Parameter</th>\n\n  <td class=\"content-container\">\n    <em>Name</em>: SDE Procedure\n    <br/>\n    <em>Use</em>: Out\n    <br/>\n    <em>Min Cardinality</em>: 0\n    <br/>\n    <em>Max Cardinality</em>: *\n    <br/>\n    <em>Type</em>: Procedure\n  </td>\n</tr>\n  \n  <tr>\n  \n<th scope=\"row\" class=\"row-header\">Parameter</th>\n\n  <td class=\"content-container\">\n    <em>Name</em>: SDE IP Encounters\n    <br/>\n    <em>Use</em>: Out\n    <br/>\n    <em>Min Cardinality</em>: 0\n    <br/>\n    <em>Max Cardinality</em>: *\n    <br/>\n    <em>Type</em>: Encounter\n  </td>\n</tr>\n  \n  <tr>\n  \n<th scope=\"row\" class=\"row-header\">Parameter</th>\n\n  <td class=\"content-container\">\n    <em>Name</em>: SDE Device\n    <br/>\n    <em>Use</em>: Out\n    <br/>\n    <em>Min Cardinality</em>: 0\n    <br/>\n    <em>Max Cardinality</em>: *\n    <br/>\n    <em>Type</em>: Device\n  </td>\n</tr>\n  \n  <tr>\n  \n<th scope=\"row\" class=\"row-header\">Parameter</th>\n\n  <td class=\"content-container\">\n    <em>Name</em>: SDE Observation Lab Category\n    <br/>\n    <em>Use</em>: Out\n    <br/>\n    <em>Min Cardinality</em>: 0\n    <br/>\n    <em>Max Cardinality</em>: *\n    <br/>\n    <em>Type</em>: Observation\n  </td>\n</tr>\n  \n  <tr>\n  \n<th scope=\"row\" class=\"row-header\">Parameter</th>\n\n  <td class=\"content-container\">\n    <em>Name</em>: SDE Observation Vital Signs Category\n    <br/>\n    <em>Use</em>: Out\n    <br/>\n    <em>Min Cardinality</em>: 0\n    <br/>\n    <em>Max Cardinality</em>: *\n    <br/>\n    <em>Type</em>: Observation\n  </td>\n</tr>\n  \n  <tr>\n  \n<th scope=\"row\" class=\"row-header\">Parameter</th>\n\n  <td class=\"content-container\">\n    <em>Name</em>: SDE DiagnosticReport Others\n    <br/>\n    <em>Use</em>: Out\n    <br/>\n    <em>Min Cardinality</em>: 0\n    <br/>\n    <em>Max Cardinality</em>: *\n    <br/>\n    <em>Type</em>: DiagnosticReport\n  </td>\n</tr>\n  \n  <tr>\n  \n<th scope=\"row\" class=\"row-header\">Parameter</th>\n\n  <td class=\"content-container\">\n    <em>Name</em>: SDE Medication Administration\n    <br/>\n    <em>Use</em>: Out\n    <br/>\n    <em>Min Cardinality</em>: 0\n    <br/>\n    <em>Max Cardinality</em>: *\n    <br/>\n    <em>Type</em>: MedicationAdministration\n  </td>\n</tr>\n  \n  <tr>\n  \n<th scope=\"row\" class=\"row-header\">Parameter</th>\n\n  <td class=\"content-container\">\n    <em>Name</em>: SDE Observation Category\n    <br/>\n    <em>Use</em>: Out\n    <br/>\n    <em>Min Cardinality</em>: 0\n    <br/>\n    <em>Max Cardinality</em>: *\n    <br/>\n    <em>Type</em>: Observation\n  </td>\n</tr>\n  \n  <tr>\n  \n<th scope=\"row\" class=\"row-header\">Parameter</th>\n\n  <td class=\"content-container\">\n    <em>Name</em>: SDE Condition\n    <br/>\n    <em>Use</em>: Out\n    <br/>\n    <em>Min Cardinality</em>: 0\n    <br/>\n    <em>Max Cardinality</em>: *\n    <br/>\n    <em>Type</em>: Condition\n  </td>\n</tr>\n  \n  <tr>\n  \n<th scope=\"row\" class=\"row-header\">Parameter</th>\n\n  <td class=\"content-container\">\n    <em>Name</em>: Initial Population\n    <br/>\n    <em>Use</em>: Out\n    <br/>\n    <em>Min Cardinality</em>: 0\n    <br/>\n    <em>Max Cardinality</em>: *\n    <br/>\n    <em>Type</em>: Encounter\n  </td>\n</tr>\n  \n  <tr>\n  \n<th scope=\"row\" class=\"row-header\">Parameter</th>\n\n  <td class=\"content-container\">\n    <em>Name</em>: SDE DiagnosticReport Lab\n    <br/>\n    <em>Use</em>: Out\n    <br/>\n    <em>Min Cardinality</em>: 0\n    <br/>\n    <em>Max Cardinality</em>: *\n    <br/>\n    <em>Type</em>: DiagnosticReport\n  </td>\n</tr>\n  \n  <tr>\n  \n<th scope=\"row\" class=\"row-header\">Parameter</th>\n\n  <td class=\"content-container\">\n    <em>Name</em>: SDE Location\n    <br/>\n    <em>Use</em>: Out\n    <br/>\n    <em>Min Cardinality</em>: 0\n    <br/>\n    <em>Max Cardinality</em>: *\n    <br/>\n    <em>Type</em>: Location\n  </td>\n</tr>\n  \n  <tr>\n  \n<th scope=\"row\" class=\"row-header\">Parameter</th>\n\n  <td class=\"content-container\">\n    <em>Name</em>: SDE Service Request\n    <br/>\n    <em>Use</em>: Out\n    <br/>\n    <em>Min Cardinality</em>: 0\n    <br/>\n    <em>Max Cardinality</em>: *\n    <br/>\n    <em>Type</em>: ServiceRequest\n  </td>\n</tr>\n  \n  <tr>\n  \n<th scope=\"row\" class=\"row-header\">Parameter</th>\n\n  <td class=\"content-container\">\n    <em>Name</em>: SDE DiagnosticReport Note\n    <br/>\n    <em>Use</em>: Out\n    <br/>\n    <em>Min Cardinality</em>: 0\n    <br/>\n    <em>Max Cardinality</em>: *\n    <br/>\n    <em>Type</em>: DiagnosticReport\n  </td>\n</tr>\n  \n  <tr>\n  \n<th scope=\"row\" class=\"row-header\">Parameter</th>\n\n  <td class=\"content-container\">\n    <em>Name</em>: SDE Minimal Patient\n    <br/>\n    <em>Use</em>: Out\n    <br/>\n    <em>Min Cardinality</em>: 0\n    <br/>\n    <em>Max Cardinality</em>: 1\n    <br/>\n    <em>Type</em>: Patient\n  </td>\n</tr>\n  \n  <tr>\n  \n<th scope=\"row\" class=\"row-header\">Parameter</th>\n\n  <td class=\"content-container\">\n    <em>Name</em>: SDE Medication\n    <br/>\n    <em>Use</em>: Out\n    <br/>\n    <em>Min Cardinality</em>: 0\n    <br/>\n    <em>Max Cardinality</em>: *\n    <br/>\n    <em>Type</em>: Medication\n  </td>\n</tr>\n  \n  <tr>\n  \n<th scope=\"row\" class=\"row-header\">Parameter</th>\n\n  <td class=\"content-container\">\n    <em>Name</em>: SDE Specimen\n    <br/>\n    <em>Use</em>: Out\n    <br/>\n    <em>Min Cardinality</em>: 0\n    <br/>\n    <em>Max Cardinality</em>: *\n    <br/>\n    <em>Type</em>: Specimen\n  </td>\n</tr>\n  \n  \n  <tr>\n    <th colspan=\"2\" scope=\"row\" class=\"section-header\"><a name=\"effective-data-requirements\"> </a>Measure Logic Data Requirements</th>\n  </tr>\n  \n  \n<tr>\n  <th scope=\"row\" class=\"row-header\">Data Requirement</th>\n  <td class=\"content-container\">\n    <em>Type</em>: Encounter\n    <br/>\n  \n    <em>Profile(s)</em>: \n  \n    <a href=\"http://hl7.org/fhir/R4/encounter.html\">Encounter</a>\n    <br/>        \n  \n   \n   \n    <em>Must Support Elements</em>: type, status, period, id, extension, identifier, statusHistory, class, classHistory, subject, reasonCode, diagnosis, hospitalization, location, partOf\n    <br/>\n   \n  \n    <em>Code Filter(s)</em>: \n    <br/>\n  \n  \n    <span class=\"tab-one\"><em>Path</em>: type</span>\n    <br/>\n  \n  \n  \n    <span class=\"tab-one\"><em>ValueSet</em>:</span> <a href=\"https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.3.666.5.307/expansion\">Encounter Inpatient</a>\n    <br/> \n  \n  \n  \n   \n  </td>\n</tr>\n\n<tr>\n  <th scope=\"row\" class=\"row-header\">Data Requirement</th>\n  <td class=\"content-container\">\n    <em>Type</em>: Encounter\n    <br/>\n  \n    <em>Profile(s)</em>: \n  \n    <a href=\"http://hl7.org/fhir/R4/encounter.html\">Encounter</a>\n    <br/>        \n  \n   \n   \n    <em>Must Support Elements</em>: type, status, period, id, extension, identifier, statusHistory, class, classHistory, subject, reasonCode, diagnosis, hospitalization, location, partOf\n    <br/>\n   \n  \n    <em>Code Filter(s)</em>: \n    <br/>\n  \n  \n    <span class=\"tab-one\"><em>Path</em>: type</span>\n    <br/>\n  \n  \n  \n    <span class=\"tab-one\"><em>ValueSet</em>:</span> <a href=\"https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.3.117.1.7.1.292/expansion\">Emergency Department Visit</a>\n    <br/> \n  \n  \n  \n   \n  </td>\n</tr>\n\n<tr>\n  <th scope=\"row\" class=\"row-header\">Data Requirement</th>\n  <td class=\"content-container\">\n    <em>Type</em>: Encounter\n    <br/>\n  \n    <em>Profile(s)</em>: \n  \n    <a href=\"http://hl7.org/fhir/R4/encounter.html\">Encounter</a>\n    <br/>        \n  \n   \n   \n    <em>Must Support Elements</em>: type, status, period, id, extension, identifier, statusHistory, class, classHistory, subject, reasonCode, diagnosis, hospitalization, location, partOf\n    <br/>\n   \n  \n    <em>Code Filter(s)</em>: \n    <br/>\n  \n  \n    <span class=\"tab-one\"><em>Path</em>: type</span>\n    <br/>\n  \n  \n  \n    <span class=\"tab-one\"><em>ValueSet</em>:</span> <a href=\"https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1111.143/expansion\">Observation Services</a>\n    <br/> \n  \n  \n  \n   \n  </td>\n</tr>\n\n<tr>\n  <th scope=\"row\" class=\"row-header\">Data Requirement</th>\n  <td class=\"content-container\">\n    <em>Type</em>: Encounter\n    <br/>\n  \n    <em>Profile(s)</em>: \n  \n    <a href=\"http://hl7.org/fhir/R4/encounter.html\">Encounter</a>\n    <br/>        \n  \n   \n   \n    <em>Must Support Elements</em>: class, status, period, id, extension, identifier, statusHistory, classHistory, type, subject, reasonCode, diagnosis, hospitalization, location, partOf\n    <br/>\n   \n  \n    <em>Code Filter(s)</em>: \n    <br/>\n  \n  \n    <span class=\"tab-one\"><em>Path</em>: class</span>\n    <br/>\n  \n  \n  \n    <span class=\"tab-one\"><em>ValueSet</em>:</span> <a href=\"https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1046.274/expansion\">NHSN Inpatient Encounter Class Codes</a>\n    <br/> \n  \n  \n  \n   \n  </td>\n</tr>\n\n<tr>\n  <th scope=\"row\" class=\"row-header\">Data Requirement</th>\n  <td class=\"content-container\">\n    <em>Type</em>: Encounter\n    <br/>\n  \n    <em>Profile(s)</em>: \n  \n    <a href=\"http://hl7.org/fhir/R4/encounter.html\">Encounter</a>\n    <br/>        \n  \n   \n   \n    <em>Must Support Elements</em>: class, status, period, id, extension, identifier, statusHistory, classHistory, type, subject, reasonCode, diagnosis, hospitalization, location, partOf\n    <br/>\n   \n  \n    <em>Code Filter(s)</em>: \n    <br/>\n  \n  \n    <span class=\"tab-one\"><em>Path</em>: class</span>\n    <br/>\n  \n  \n  \n  \n    <span class=\"tab-one\"><em>Code</em>: </span>\n    <br/>\n  \n  \n   \n  </td>\n</tr>\n\n<tr>\n  <th scope=\"row\" class=\"row-header\">Data Requirement</th>\n  <td class=\"content-container\">\n    <em>Type</em>: Encounter\n    <br/>\n  \n    <em>Profile(s)</em>: \n  \n    <a href=\"http://hl7.org/fhir/R4/encounter.html\">Encounter</a>\n    <br/>        \n  \n   \n   \n    <em>Must Support Elements</em>: class, status, period, id, extension, identifier, statusHistory, classHistory, type, subject, reasonCode, diagnosis, hospitalization, location, partOf\n    <br/>\n   \n  \n    <em>Code Filter(s)</em>: \n    <br/>\n  \n  \n    <span class=\"tab-one\"><em>Path</em>: class</span>\n    <br/>\n  \n  \n  \n  \n    <span class=\"tab-one\"><em>Code</em>: </span>\n    <br/>\n  \n  \n   \n  </td>\n</tr>\n\n<tr>\n  <th scope=\"row\" class=\"row-header\">Data Requirement</th>\n  <td class=\"content-container\">\n    <em>Type</em>: Encounter\n    <br/>\n  \n    <em>Profile(s)</em>: \n  \n    <a href=\"http://hl7.org/fhir/R4/encounter.html\">Encounter</a>\n    <br/>        \n  \n   \n   \n    <em>Must Support Elements</em>: status, period, id, extension, identifier, statusHistory, class, classHistory, type, subject, reasonCode, diagnosis, hospitalization, location, partOf\n    <br/>\n   \n   \n  </td>\n</tr>\n\n<tr>\n  <th scope=\"row\" class=\"row-header\">Data Requirement</th>\n  <td class=\"content-container\">\n    <em>Type</em>: Location\n    <br/>\n  \n    <em>Profile(s)</em>: \n  \n    <a href=\"http://hl7.org/fhir/R4/location.html\">Location</a>\n    <br/>        \n  \n   \n   \n    <em>Must Support Elements</em>: id, extension, status, name, alias, type, physicalType, managingOrganization, partOf\n    <br/>\n   \n   \n  </td>\n</tr>\n\n<tr>\n  <th scope=\"row\" class=\"row-header\">Data Requirement</th>\n  <td class=\"content-container\">\n    <em>Type</em>: MedicationRequest\n    <br/>\n  \n    <em>Profile(s)</em>: \n  \n    <a href=\"http://hl7.org/fhir/R4/medicationrequest.html\">MedicationRequest</a>\n    <br/>        \n  \n   \n   \n    <em>Must Support Elements</em>: authoredOn, id, extension, status, statusReason, intent, category, priority, doNotPerform, reported, medication, subject, encounter, requester, recorder, reasonCode, reasonReference, instantiatesCanonical, instantiatesUri, courseOfTherapyType, dosageInstruction\n    <br/>\n   \n   \n  </td>\n</tr>\n\n<tr>\n  <th scope=\"row\" class=\"row-header\">Data Requirement</th>\n  <td class=\"content-container\">\n    <em>Type</em>: Coverage\n    <br/>\n  \n    <em>Profile(s)</em>: \n  \n    <a href=\"http://hl7.org/fhir/R4/coverage.html\">Coverage</a>\n    <br/>        \n  \n   \n   \n    <em>Must Support Elements</em>: period, id, extension, status, type, beneficiary, payor\n    <br/>\n   \n   \n  </td>\n</tr>\n\n<tr>\n  <th scope=\"row\" class=\"row-header\">Data Requirement</th>\n  <td class=\"content-container\">\n    <em>Type</em>: Procedure\n    <br/>\n  \n    <em>Profile(s)</em>: \n  \n    <a href=\"http://hl7.org/fhir/R4/procedure.html\">Procedure</a>\n    <br/>        \n  \n   \n   \n    <em>Must Support Elements</em>: performed, id, basedOn, partOf, status, category, code, subject, encounter, location, reasonCode, reasonReference, bodySite\n    <br/>\n   \n   \n  </td>\n</tr>\n\n<tr>\n  <th scope=\"row\" class=\"row-header\">Data Requirement</th>\n  <td class=\"content-container\">\n    <em>Type</em>: Device\n    <br/>\n  \n    <em>Profile(s)</em>: \n  \n    <a href=\"http://hl7.org/fhir/R4/device.html\">Device</a>\n    <br/>        \n  \n   \n   \n    <em>Must Support Elements</em>: id, extension, status, expirationDate, lotNumber, serialNumber, modelNumber, partNumber, type, patient, parent\n    <br/>\n   \n   \n  </td>\n</tr>\n\n<tr>\n  <th scope=\"row\" class=\"row-header\">Data Requirement</th>\n  <td class=\"content-container\">\n    <em>Type</em>: Observation\n    <br/>\n  \n    <em>Profile(s)</em>: \n  \n    <a href=\"http://hl7.org/fhir/R4/observation.html\">Observation</a>\n    <br/>        \n  \n   \n   \n    <em>Must Support Elements</em>: id, extension, partOf, status, category, code, subject, encounter, effective, issued, value, dataAbsentReason, interpretation, bodySite, method, specimen, referenceRange, hasMember, derivedFrom, component\n    <br/>\n   \n   \n  </td>\n</tr>\n\n<tr>\n  <th scope=\"row\" class=\"row-header\">Data Requirement</th>\n  <td class=\"content-container\">\n    <em>Type</em>: DiagnosticReport\n    <br/>\n  \n    <em>Profile(s)</em>: \n  \n    <a href=\"http://hl7.org/fhir/R4/diagnosticreport.html\">DiagnosticReport</a>\n    <br/>        \n  \n   \n   \n    <em>Must Support Elements</em>: category, effective, id, extension, basedOn, status, code, subject, encounter, issued, specimen, result, conclusion, conclusionCode\n    <br/>\n   \n   \n  </td>\n</tr>\n\n<tr>\n  <th scope=\"row\" class=\"row-header\">Data Requirement</th>\n  <td class=\"content-container\">\n    <em>Type</em>: MedicationAdministration\n    <br/>\n  \n    <em>Profile(s)</em>: \n  \n    <a href=\"http://hl7.org/fhir/R4/medicationadministration.html\">MedicationAdministration</a>\n    <br/>        \n  \n   \n   \n    <em>Must Support Elements</em>: effective, id, extension, instantiates, partOf, status, statusReason, category, medication, subject, context, supportingInformation, performer, reasonCode, reasonReference, request, device, note, dosage, eventHistory\n    <br/>\n   \n   \n  </td>\n</tr>\n\n<tr>\n  <th scope=\"row\" class=\"row-header\">Data Requirement</th>\n  <td class=\"content-container\">\n    <em>Type</em>: Condition\n    <br/>\n  \n    <em>Profile(s)</em>: \n  \n    <a href=\"http://hl7.org/fhir/R4/condition.html\">Condition</a>\n    <br/>        \n  \n   \n   \n    <em>Must Support Elements</em>: id, extension, clinicalStatus, verificationStatus, category, code, subject, encounter, onset, abatement, recordedDate, encounter.reference\n    <br/>\n   \n   \n  </td>\n</tr>\n\n<tr>\n  <th scope=\"row\" class=\"row-header\">Data Requirement</th>\n  <td class=\"content-container\">\n    <em>Type</em>: ServiceRequest\n    <br/>\n  \n    <em>Profile(s)</em>: \n  \n    <a href=\"http://hl7.org/fhir/R4/servicerequest.html\">ServiceRequest</a>\n    <br/>        \n  \n   \n   \n    <em>Must Support Elements</em>: authoredOn, id, extension, basedOn, status, intent, category, priority, doNotPerform, code, quantity, subject, encounter, occurrence, asNeeded, specimen\n    <br/>\n   \n   \n  </td>\n</tr>\n\n<tr>\n  <th scope=\"row\" class=\"row-header\">Data Requirement</th>\n  <td class=\"content-container\">\n    <em>Type</em>: Patient\n    <br/>\n  \n    <em>Profile(s)</em>: \n  \n    <a href=\"http://hl7.org/fhir/R4/patient.html\">Patient</a>\n    <br/>        \n  \n   \n   \n    <em>Must Support Elements</em>: id, identifier, active, name, telecom, gender, birthDate, deceased, address, maritalStatus, multipleBirth, contact, communication, link\n    <br/>\n   \n   \n  </td>\n</tr>\n\n<tr>\n  <th scope=\"row\" class=\"row-header\">Data Requirement</th>\n  <td class=\"content-container\">\n    <em>Type</em>: Medication\n    <br/>\n  \n    <em>Profile(s)</em>: \n  \n    <a href=\"http://hl7.org/fhir/R4/medication.html\">Medication</a>\n    <br/>        \n  \n   \n   \n    <em>Must Support Elements</em>: id, extension, code, status, manufacturer, form, amount, ingredient, batch\n    <br/>\n   \n   \n  </td>\n</tr>\n\n<tr>\n  <th scope=\"row\" class=\"row-header\">Data Requirement</th>\n  <td class=\"content-container\">\n    <em>Type</em>: Specimen\n    <br/>\n  \n    <em>Profile(s)</em>: \n  \n    <a href=\"http://hl7.org/fhir/R4/specimen.html\">Specimen</a>\n    <br/>        \n  \n   \n   \n    <em>Must Support Elements</em>: collection, collection.collected, id, extension, identifier, accessionIdentifier, status, type, subject, parent, request, note\n    <br/>\n   \n   \n  </td>\n</tr>\n\n  \n  <tr>\n\n<th colspan=\"2\" scope=\"row\" class=\"row-header\">Measure Logic Definitions</th>\n\n</tr>\n  \n          \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"nhsnacutecarehospitalmonthlyinitialpopulation-encounters\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> NHSNAcuteCareHospitalMonthlyInitialPopulation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">define &quot;Encounters&quot;:   [Encounter]</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"nhsnacutecarehospitalmonthlyinitialpopulation-qualifying-encounters-during-measurement-period\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> NHSNAcuteCareHospitalMonthlyInitialPopulation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">define &quot;Qualifying Encounters During Measurement Period&quot;:  ( [Encounter: &quot;Encounter Inpatient&quot;]   union [Encounter: &quot;Emergency Department Visit&quot;]   union [Encounter: &quot;Observation Services&quot;]   union [Encounter: class in &quot;NHSN Inpatient Encounter Class Codes&quot;]   union [Encounter: class ~ &quot;emergency&quot;]   union [Encounter: class ~ &quot;observation encounter&quot;]) QualifyingEncounters   where QualifyingEncounters.status in {'in-progress', 'finished', 'triaged', 'onleave', 'entered-in-error'}     and QualifyingEncounters.period overlaps &quot;Measurement Period&quot;</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"nhsnacutecarehospitalmonthlyinitialpopulation-encounters-with-patient-hospital-locations\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> NHSNAcuteCareHospitalMonthlyInitialPopulation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">define &quot;Encounters with Patient Hospital Locations&quot;:   &quot;Encounters&quot; Encounters   where exists(     Encounters.location EncounterLocation     where NHSNHelpers.GetLocation(EncounterLocation.location).type in &quot;Inpatient, Emergency, and Observation Locations&quot;       and EncounterLocation.period overlaps Encounters.period   )   and Encounters.status in {'in-progress', 'finished', 'triaged', 'onleave', 'entered-in-error'}   and Encounters.period overlaps &quot;Measurement Period&quot;</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"nhsnacutecarehospitalmonthlyinitialpopulation-initial-population\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> NHSNAcuteCareHospitalMonthlyInitialPopulation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">define &quot;Initial Population&quot;:   &quot;Qualifying Encounters During Measurement Period&quot;   union &quot;Encounters with Patient Hospital Locations&quot;</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"nhsnacutecarehospitalmonthlyinitialpopulation-sde-encounter\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> NHSNAcuteCareHospitalMonthlyInitialPopulation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">//#End DiagnosticReport block  define &quot;SDE Encounter&quot;:    &quot;Encounters&quot; Encounters   where not CheckIP(Encounters)   and exists(     &quot;Initial Population&quot; IP     where Encounters.period overlaps IP.period)   return EncounterResource(Encounters,   {FHIR.canonical{value: 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-encounter'}})</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"nhsnacutecarehospitalmonthlyinitialpopulation-sde-medication-request\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> NHSNAcuteCareHospitalMonthlyInitialPopulation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">define &quot;SDE Medication Request&quot;:   [MedicationRequest] MedicationRequests    where exists(     &quot;Initial Population&quot; IP     where MedicationRequests.authoredOn during IP.period)   return MedicationRequestResource(MedicationRequests,   {FHIR.canonical{value: 'http://www.cdc.gov/nhsn/fhirportal/dqm/ig/StructureDefinition/ach-monthly-medicationrequest'}},   {&quot;inpatient&quot;, &quot;outpatient&quot;})</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"nhsnacutecarehospitalmonthlyinitialpopulation-sde-coverage\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> NHSNAcuteCareHospitalMonthlyInitialPopulation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">define &quot;SDE Coverage&quot;:   [Coverage] Coverages   where exists(     &quot;Initial Population&quot; IP     where Coverages.period overlaps IP.period)   return CoverageResource(Coverages,   {FHIR.canonical{value: 'http://www.cdc.gov/nhsn/fhirportal/dqm/ig/StructureDefinition/ach-monthly-coverage'}})</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"nhsnacutecarehospitalmonthlyinitialpopulation-sde-procedure\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> NHSNAcuteCareHospitalMonthlyInitialPopulation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">define &quot;SDE Procedure&quot;:   [Procedure] Procedures    where exists(     &quot;Initial Population&quot; IP     where NHSNHelpers.&quot;Normalize Interval&quot;(Procedures.performed) overlaps IP.period)      return ProcedureResource(Procedures,   {FHIR.canonical{value: 'http://www.cdc.gov/nhsn/fhirportal/dqm/ig/StructureDefinition/ach-monthly-procedure'}},   {&quot;Surgical procedure&quot;, &quot;Diagnostic procedure&quot;})</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"nhsnacutecarehospitalmonthlyinitialpopulation-sde-ip-encounters\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> NHSNAcuteCareHospitalMonthlyInitialPopulation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">define &quot;SDE IP Encounters&quot;:   &quot;Initial Population&quot; IP   return EncounterResource(IP,    {FHIR.canonical{value: 'http://www.cdc.gov/nhsn/fhirportal/dqm/ig/StructureDefinition/ach-monthly-encounter'}})</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"nhsnacutecarehospitalmonthlyinitialpopulation-sde-device\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> NHSNAcuteCareHospitalMonthlyInitialPopulation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">define &quot;SDE Device&quot;:   [Device] Devices    where exists(&quot;Initial Population&quot;)   return DeviceResource(Devices,   {FHIR.canonical{value: 'http://www.cdc.gov/nhsn/fhirportal/dqm/ig/StructureDefinition/ach-monthly-device'}})</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"nhsnacutecarehospitalmonthlyinitialpopulation-observations\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> NHSNAcuteCareHospitalMonthlyInitialPopulation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">define &quot;Observations&quot;:   [Observation]</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"nhsnacutecarehospitalmonthlyinitialpopulation-sde-observation-lab-category\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> NHSNAcuteCareHospitalMonthlyInitialPopulation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">define &quot;SDE Observation Lab Category&quot;:   &quot;Observations&quot; Observations    where (exists(Observations.category Category where Category ~ &quot;laboratory&quot;))     and exists(       &quot;Initial Population&quot; IP       where NHSNHelpers.&quot;Normalize Interval&quot;(Observations.effective) overlaps IP.period)   return ObservationLabResource(Observations,   {FHIR.canonical{value: 'http://www.cdc.gov/nhsn/fhirportal/dqm/ig/StructureDefinition/ach-monthly-observation-lab'}},   {&quot;imaging&quot;, &quot;procedure&quot;, &quot;vital-signs&quot;, &quot;laboratory&quot;})</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"nhsnacutecarehospitalmonthlyinitialpopulation-sde-observation-vital-signs-category\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> NHSNAcuteCareHospitalMonthlyInitialPopulation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">//Vital Signs Observation has its own profile in FHIR Base define &quot;SDE Observation Vital Signs Category&quot;:   &quot;Observations&quot; Observations    where (exists(Observations.category Category where Category ~ &quot;vital-signs&quot;))     and exists(       &quot;Initial Population&quot; IP       where NHSNHelpers.&quot;Normalize Interval&quot;(Observations.effective) overlaps IP.period)   return ObservationVitalSignsResource(Observations,   {FHIR.canonical{value: 'http://www.cdc.gov/nhsn/fhirportal/dqm/ig/StructureDefinition/ach-monthly-observation-vitals'}},   {&quot;imaging&quot;, &quot;procedure&quot;, &quot;vital-signs&quot;, &quot;laboratory&quot;})</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"nhsnacutecarehospitalmonthlyinitialpopulation-sde-diagnosticreport-others\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> NHSNAcuteCareHospitalMonthlyInitialPopulation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">define &quot;SDE DiagnosticReport Others&quot;:   [DiagnosticReport] DiagnosticReports   where not ((exists(DiagnosticReports.category Category where Category ~ &quot;Radiology&quot;))     or exists((DiagnosticReports.category Category where Category ~ &quot;Pathology&quot;))     or exists((DiagnosticReports.category Category where Category ~ &quot;Cardiology&quot;))     or exists(DiagnosticReports.category Category where Category ~ &quot;LAB&quot;))     and exists(&quot;Initial Population&quot; IP       where NHSNHelpers.&quot;Normalize Interval&quot;(DiagnosticReports.effective) overlaps IP.period)   return DiagnosticReportResource(DiagnosticReports,   {FHIR.canonical{value: 'http://www.cdc.gov/nhsn/fhirportal/dqm/ig/StructureDefinition/ach-monthly-diagnosticreport'}},   {&quot;Radiology&quot;, &quot;Pathology&quot;, &quot;Cardiology&quot;, &quot;LAB&quot;})</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"nhsnacutecarehospitalmonthlyinitialpopulation-sde-medication-administration\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> NHSNAcuteCareHospitalMonthlyInitialPopulation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">define &quot;SDE Medication Administration&quot;:   [MedicationAdministration] MedicationAdministrations    where exists(     &quot;Initial Population&quot; IP     where NHSNHelpers.&quot;Normalize Interval&quot;(MedicationAdministrations.effective) overlaps IP.period)   return MedicationAdministrationResource(MedicationAdministrations,   {FHIR.canonical{value: 'http://www.cdc.gov/nhsn/fhirportal/dqm/ig/StructureDefinition/ach-monthly-medicationadministration'}},   {&quot;inpatient&quot;, &quot;outpatient&quot;})</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"nhsnacutecarehospitalmonthlyinitialpopulation-sde-observation-category\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> NHSNAcuteCareHospitalMonthlyInitialPopulation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">//Defaulting to base FHIR profile as there are no individual profiles in US Core 3.1.1 that cover these Observation categories define &quot;SDE Observation Category&quot;:   &quot;Observations&quot; Observations    where (/*(exists(Observations.category Category where Category ~ &quot;social-history&quot;))     or (exists(Observations.category Category where Category ~ &quot;survey&quot;))     or */(exists(Observations.category Category where Category ~ &quot;imaging&quot;))     or (exists(Observations.category Category where Category ~ &quot;procedure&quot;)))     and exists(       &quot;Initial Population&quot; IP       where NHSNHelpers.&quot;Normalize Interval&quot;(Observations.effective) overlaps IP.period)   return ObservationResource(Observations,   {FHIR.canonical{value: 'http://www.cdc.gov/nhsn/fhirportal/dqm/ig/StructureDefinition/ach-monthly-observation'}},   {&quot;imaging&quot;, &quot;procedure&quot;, &quot;vital-signs&quot;, &quot;laboratory&quot;})</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"nhsnacutecarehospitalmonthlyinitialpopulation-conditions\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> NHSNAcuteCareHospitalMonthlyInitialPopulation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">define &quot;Conditions&quot;:   [Condition]</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"nhsnacutecarehospitalmonthlyinitialpopulation-sde-condition\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> NHSNAcuteCareHospitalMonthlyInitialPopulation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">//============================================================================ //Supplemental Data Element //When FHIR.canonical value is present, US Core 3.1.1 profiles are used //When FHIR.canonical value is not present, FHIR Base profiles are used //============================================================================ define &quot;SDE Condition&quot;:   &quot;Conditions&quot; Conditions      where exists(     &quot;Initial Population&quot; IP //Check for Problem List Conditions that were recorded before or during IP       where        (exists(IP.diagnosis Diagnoses           where NHSNHelpers.GetId(Diagnoses.condition.reference) = Conditions.id         )         or NHSNHelpers.GetId(Conditions.encounter.reference) = IP.id       )       and exists (Conditions.category categories         where categories ~ &quot;encounter-diagnosis&quot;     )   )   return ConditionResource(Conditions,   {FHIR.canonical{value: 'http://www.cdc.gov/nhsn/fhirportal/dqm/ig/StructureDefinition/ach-monthly-condition'}},    {&quot;encounter-diagnosis&quot;})</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"nhsnacutecarehospitalmonthlyinitialpopulation-diagnosticreports\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> NHSNAcuteCareHospitalMonthlyInitialPopulation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">define &quot;DiagnosticReports&quot;:   [DiagnosticReport]</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"nhsnacutecarehospitalmonthlyinitialpopulation-sde-diagnosticreport-lab\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> NHSNAcuteCareHospitalMonthlyInitialPopulation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">//This block collects all DiagnosticReport resources while also marking Lab and Note DiagnosticReports with the appropriate profiles //#Start DiagnosticReport block define &quot;SDE DiagnosticReport Lab&quot;:   &quot;DiagnosticReports&quot; DiagnosticReports   where (exists(DiagnosticReports.category Category where Category ~ &quot;LAB&quot;)     and exists(       &quot;Initial Population&quot; IP       where NHSNHelpers.&quot;Normalize Interval&quot;(DiagnosticReports.effective) overlaps IP.period))   return DiagnosticReportLabResource(DiagnosticReports,   {FHIR.canonical{value: 'http://www.cdc.gov/nhsn/fhirportal/dqm/ig/StructureDefinition/ach-monthly-diagnosticreport-lab'}},   {&quot;LAB&quot;, &quot;Radiology&quot;, &quot;Pathology&quot;, &quot;Cardiology&quot;})</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"nhsnacutecarehospitalmonthlyinitialpopulation-get-locations-from-ip-encounters-in-measurement-period\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> NHSNAcuteCareHospitalMonthlyInitialPopulation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">define &quot;Get Locations from IP Encounters in Measurement Period&quot;:   flatten(&quot;Initial Population&quot; IP   let locationElements: IP.location   return     locationElements LE     let locationReference: LE.location     return NHSNHelpers.GetLocation(locationReference))</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"nhsnacutecarehospitalmonthlyinitialpopulation-sde-location\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> NHSNAcuteCareHospitalMonthlyInitialPopulation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">define &quot;SDE Location&quot;:   &quot;Get Locations from IP Encounters in Measurement Period&quot; Locations   where exists(&quot;Initial Population&quot;)   and Locations is not null   return LocationResource(Locations,   {FHIR.canonical{value: 'http://www.cdc.gov/nhsn/fhirportal/dqm/ig/StructureDefinition/ach-monthly-location'}})</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"nhsnacutecarehospitalmonthlyinitialpopulation-sde-service-request\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> NHSNAcuteCareHospitalMonthlyInitialPopulation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">define &quot;SDE Service Request&quot;:   [ServiceRequest] ServiceRequests   where exists(&quot;Initial Population&quot; IP     where ServiceRequests.authoredOn during IP.period)   return ServiceRequestResource(ServiceRequests,   {FHIR.canonical{value: 'http://www.cdc.gov/nhsn/fhirportal/dqm/ig/StructureDefinition/ach-monthly-servicerequest'}},   {&quot;Laboratory procedure&quot;, &quot;Surgical procedure&quot;, &quot;Imaging&quot;})</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"nhsnacutecarehospitalmonthlyinitialpopulation-sde-diagnosticreport-note\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> NHSNAcuteCareHospitalMonthlyInitialPopulation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">define &quot;SDE DiagnosticReport Note&quot;:   &quot;DiagnosticReports&quot; DiagnosticReports   where ((exists(DiagnosticReports.category Category where Category ~ &quot;Radiology&quot;))     or exists((DiagnosticReports.category Category where Category ~ &quot;Pathology&quot;))     or exists((DiagnosticReports.category Category where Category ~ &quot;Cardiology&quot;)))     and exists(       &quot;Initial Population&quot; IP       where NHSNHelpers.&quot;Normalize Interval&quot;(DiagnosticReports.effective) overlaps IP.period)   return DiagnosticReportResource(DiagnosticReports,   {FHIR.canonical{value: 'http://www.cdc.gov/nhsn/fhirportal/dqm/ig/StructureDefinition/ach-monthly-diagnosticreport-note'}},   {&quot;Radiology&quot;, &quot;Pathology&quot;, &quot;Cardiology&quot;, &quot;LAB&quot;})</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"nhsnacutecarehospitalmonthlyinitialpopulation-sde-minimal-patient\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> NHSNAcuteCareHospitalMonthlyInitialPopulation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">define &quot;SDE Minimal Patient&quot;:   Patient p   return SharedResource.PatientResource(p,   {FHIR.canonical{value: 'http://www.cdc.gov/nhsn/fhirportal/dqm/ig/StructureDefinition/cross-measure-patient'}})</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"nhsnacutecarehospitalmonthlyinitialpopulation-medication-ids\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> NHSNAcuteCareHospitalMonthlyInitialPopulation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">define &quot;Medication IDs&quot;:   (&quot;SDE Medication Request&quot;   union &quot;SDE Medication Administration&quot;) MedReqOrAdmin   where MedReqOrAdmin.medication is FHIR.Reference     and exists(&quot;Initial Population&quot;) //No longer need to check for timing here because it's checked in SDE Medication Request/Administriation   return NHSNHelpers.GetId(MedReqOrAdmin.medication.reference)</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"nhsnacutecarehospitalmonthlyinitialpopulation-sde-medication\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> NHSNAcuteCareHospitalMonthlyInitialPopulation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">define &quot;SDE Medication&quot;:   [Medication] Medications   where Medications.id in &quot;Medication IDs&quot;   return SharedResource.MedicationResource(Medications,   {FHIR.canonical{value: 'http://www.cdc.gov/nhsn/fhirportal/dqm/ig/StructureDefinition/ach-monthly-medication'}})</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"nhsnacutecarehospitalmonthlyinitialpopulation-sde-specimen\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> NHSNAcuteCareHospitalMonthlyInitialPopulation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">define &quot;SDE Specimen&quot;:   [Specimen] Specimens   where exists(     &quot;Initial Population&quot; IP     where NHSNHelpers.&quot;Normalize Interval&quot;(Specimens.collection.collected) overlaps IP.period   )   return SpecimenResource(Specimens,   {FHIR.canonical{value: 'http://www.cdc.gov/nhsn/fhirportal/dqm/ig/StructureDefinition/ach-monthly-specimen'}})</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"nhsnacutecarehospitalmonthlyinitialpopulation-checkip\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> NHSNAcuteCareHospitalMonthlyInitialPopulation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">// //Functions // define function &quot;CheckIP&quot;(encounter Encounter):   exists(&quot;Initial Population&quot; IP   where encounter.id = IP.id)</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"fhirhelpers-tostring\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> FHIRHelpers</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">define function ToString(value EncounterStatus): value.value</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"fhirhelpers-tointerval\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> FHIRHelpers</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">define function ToInterval(period FHIR.Period):     if period is null then         null      else          if period.&quot;start&quot;.value is null then             Interval(period.&quot;start&quot;.value, period.&quot;end&quot;.value]         else              if time from period.&quot;start&quot;.value is null and time from period.&quot;end&quot;.value is not null then                 Interval[                     DateTime(year from period.&quot;start&quot;.value, month from period.&quot;start&quot;.value, day from period.&quot;start&quot;.value,                         0, 0, 0, 0, timezoneoffset from period.&quot;end&quot;.value),                      period.&quot;end&quot;.value                 ]         else              if time from period.&quot;end&quot;.value is null and time from period.&quot;start&quot;.value is not null then                 Interval[                     period.&quot;start&quot;.value,                      DateTime(year from period.&quot;end&quot;.value, month from period.&quot;end&quot;.value, day from period.&quot;end&quot;.value,                         23, 59, 59, 999, timezoneoffset from period.&quot;start&quot;.value)                 ]         else Interval[period.&quot;start&quot;.value, period.&quot;end&quot;.value]</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"nhsnhelpers-getlocation\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> NHSNHelpers</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">define function &quot;GetLocation&quot;(reference Reference ):   singleton from (  [Location] Locations   where Locations.id = GetId(reference.reference)   )</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"fhirhelpers-tostring\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> FHIRHelpers</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">define function ToString(value string): value.value</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"nhsnhelpers-getid\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> NHSNHelpers</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">define function &quot;GetId&quot;(uri String ):   Last(Split(uri, '/'))</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"fhirhelpers-toconcept\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> FHIRHelpers</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">define function ToConcept(concept FHIR.CodeableConcept):     if concept is null then         null     else         System.Concept {             codes: concept.coding C return ToCode(C),             display: concept.text.value         }</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"fhirhelpers-tocode\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> FHIRHelpers</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">define function ToCode(coding FHIR.Coding):     if coding is null then         null     else         System.Code {           code: coding.code.value,           system: coding.system.value,           version: coding.version.value,           display: coding.display.value         }</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"nhsnacutecarehospitalmonthlyinitialpopulation-encounterresource\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> NHSNAcuteCareHospitalMonthlyInitialPopulation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">define function EncounterResource(encounter Encounter, profileURLs List&lt;FHIR.canonical&gt;):   encounter e   return Encounter{     id: FHIR.id{value: 'LCR-' + e.id},     meta: SharedResource.MetaElement(e, profileURLs),     extension: e.extension,     identifier: SharedResource.EncounterIdentifier(e.identifier),     status: e.status,     statusHistory: SharedResource.EncounterStatusHistory(e.statusHistory),     class: e.class,     classHistory: SharedResource.EncounterClassHistory(e.classHistory),     type: e.type,     subject: e.subject,     period: e.period,     reasonCode: e.reasonCode,     diagnosis: SharedResource.EncounterDiagnosis(e.diagnosis),     hospitalization: EncounterHospitalization(e.hospitalization),     location: SharedResource.EncounterLocation(e.location),     partOf: e.partOf   }</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"sharedresourcecreation-metaelement\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> SharedResourceCreation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">define function &quot;MetaElement&quot;(resource Resource, profileURLs List&lt;FHIR.canonical&gt;):   resource r   return FHIR.Meta{     extension: r.meta.extension,     versionId: r.meta.versionId,     lastUpdated: r.meta.lastUpdated,     profile: profileURLs,     security: r.meta.security,     tag: r.meta.tag   }</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"sharedresourcecreation-encounteridentifier\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> SharedResourceCreation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">define function EncounterIdentifier(identifier List&lt;FHIR.Identifier&gt;):   identifier i   return FHIR.Identifier{     use: i.use,     type: i.type,     system: i.system,     value: i.value,     period: i.period   }</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"sharedresourcecreation-encounterstatushistory\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> SharedResourceCreation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">define function EncounterStatusHistory(statusHistory List&lt;FHIR.Encounter.StatusHistory&gt;):   statusHistory sH   return FHIR.Encounter.StatusHistory{     status: sH.status,     period: sH.period   }</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"sharedresourcecreation-encounterclasshistory\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> SharedResourceCreation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">define function EncounterClassHistory(classHistory List&lt;FHIR.Encounter.ClassHistory&gt;):   classHistory cH   return FHIR.Encounter.ClassHistory{     class: cH.class,     period: cH.period   }</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"sharedresourcecreation-encounterdiagnosis\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> SharedResourceCreation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">/*No longer needed but saving for potential future use define function EncounterParticipant(participant List&lt;FHIR.Encounter.Participant&gt;):   participant p   return FHIR.Encounter.Participant{     type: p.type,     period: p.period,     individual: p.individual   }*/  define function EncounterDiagnosis(diagnosis List&lt;FHIR.Encounter.Diagnosis&gt;):   diagnosis d   return FHIR.Encounter.Diagnosis{     condition: d.condition,     use: d.use,     rank: d.rank   }</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"nhsnacutecarehospitalmonthlyinitialpopulation-encounterhospitalization\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> NHSNAcuteCareHospitalMonthlyInitialPopulation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">define function EncounterHospitalization(hospitalization FHIR.Encounter.Hospitalization):   hospitalization h   return FHIR.Encounter.Hospitalization{     origin: h.origin,     admitSource: h.admitSource,     reAdmission: h.reAdmission,     dietPreference: h.dietPreference,     dischargeDisposition: h.dischargeDisposition   }</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"sharedresourcecreation-encounterlocation\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> SharedResourceCreation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">define function EncounterLocation(location List&lt;FHIR.Encounter.Location&gt;):   location l   return FHIR.Encounter.Location{     location: l.location,     status: l.status,     physicalType: l.physicalType,     period: l.period   }</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"fhirhelpers-todatetime\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> FHIRHelpers</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">define function ToDateTime(value dateTime): value.value</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"nhsnacutecarehospitalmonthlyinitialpopulation-medicationrequestresource\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> NHSNAcuteCareHospitalMonthlyInitialPopulation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">define function MedicationRequestResource(medicationRequest MedicationRequest, profileURLs List&lt;FHIR.canonical&gt;, acceptedCategories List&lt;System.Code&gt;):   medicationRequest m   return MedicationRequest{     id: FHIR.id {value: 'LCR-' + m.id},     meta: SharedResource.MetaElement(medicationRequest, profileURLs),     extension: m.extension,     status: m.status,     statusReason: m.statusReason,     intent: m.intent,     category: FilterCodeableConcepts(m.category, acceptedCategories),     priority: m.priority,     doNotPerform: m.doNotPerform,     reported: m.reported,     medication: m.medication,     subject: m.subject,     encounter: m.encounter,     authoredOn: m.authoredOn,     requester: m.requester,     recorder: m.recorder,     reasonCode: m.reasonCode,     reasonReference: m.reasonReference,     instantiatesCanonical: m.instantiatesCanonical,     instantiatesUri: m.instantiatesUri,     courseOfTherapyType: m.courseOfTherapyType,     dosageInstruction: SharedResource.MedicationRequestDosageInstruction(m.dosageInstruction)   }</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"nhsnacutecarehospitalmonthlyinitialpopulation-filtercodeableconcepts\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> NHSNAcuteCareHospitalMonthlyInitialPopulation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">define function FilterCodeableConcepts(codes List&lt;FHIR.CodeableConcept&gt;, accepted List&lt;System.Code&gt;):   if Count(accepted) &gt; 0     then RemoveUnaccepted(codes, accepted)   else codes</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"nhsnacutecarehospitalmonthlyinitialpopulation-removeunaccepted\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> NHSNAcuteCareHospitalMonthlyInitialPopulation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">define function RemoveUnaccepted(codes List&lt;FHIR.CodeableConcept&gt;, accepted List&lt;System.Code&gt;):   codes c   where exists(     accepted a     where c ~ a   )</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"sharedresourcecreation-medicationrequestdosageinstruction\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> SharedResourceCreation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">define function MedicationRequestDosageInstruction(dosageInstruction List&lt;FHIR.Dosage&gt;):   dosageInstruction dI   return FHIR.Dosage{     text: dI.text,     patientInstruction: dI.patientInstruction,     timing: dI.timing,     asNeeded: dI.asNeeded,     site: dI.site,     route: dI.route,     method: dI.method,     doseAndRate: MedicationRequestDoseAndRate(dI.doseAndRate)   }</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"sharedresourcecreation-medicationrequestdoseandrate\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> SharedResourceCreation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">define function MedicationRequestDoseAndRate(doseAndRate List&lt;FHIR.Dosage.DoseAndRate&gt;):   doseAndRate dR   return FHIR.Dosage.DoseAndRate{     type: dR.type,     dose: dR.dose,     rate: dR.rate   }</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"nhsnacutecarehospitalmonthlyinitialpopulation-coverageresource\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> NHSNAcuteCareHospitalMonthlyInitialPopulation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">define function CoverageResource(coverage Coverage, profileURLs List&lt;FHIR.canonical&gt;):   coverage c   return Coverage{     id: FHIR.id{value: 'LCR-' + c.id},     meta: SharedResource.MetaElement(c, profileURLs),     extension: c.extension,     status: c.status,     type: c.type,     beneficiary: c.beneficiary,     period: c.period,     payor: c.payor   }</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"nhsnacutecarehospitalmonthlyinitialpopulation-procedureresource\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> NHSNAcuteCareHospitalMonthlyInitialPopulation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">define function ProcedureResource(procedure Procedure, profileURLs List&lt;FHIR.canonical&gt;, acceptedCategories List&lt;System.Code&gt;):   procedure p   return Procedure{     id: FHIR.id {value: 'LCR-' + p.id},     meta: SharedResource.MetaElement(p, profileURLs),     extension: GetProcedureExtensions(p),      basedOn: p.basedOn,     partOf: p.partOf,     status: p.status,     category: FilterCodeableConcepts({p.category}, acceptedCategories)[0],     code: p.code,     subject: p.subject,     encounter: p.encounter,     performed: p.performed,     location: p.location,     reasonCode: p.reasonCode,     reasonReference: p.reasonReference,     bodySite: p.bodySite   }</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"nhsnacutecarehospitalmonthlyinitialpopulation-getprocedureextensions\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> NHSNAcuteCareHospitalMonthlyInitialPopulation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">define function &quot;GetProcedureExtensions&quot;(domainResource DomainResource):   domainResource.extension E     where E.url != 'http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-recorded'      return E</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"fhirhelpers-tostring\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> FHIRHelpers</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">define function ToString(value uri): value.value</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"nhsnacutecarehospitalmonthlyinitialpopulation-deviceresource\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> NHSNAcuteCareHospitalMonthlyInitialPopulation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">define function DeviceResource(device Device, profileURLs List&lt;FHIR.canonical&gt;):   device d   return Device{     id: FHIR.id{value: 'LCR-' + d.id},     meta: SharedResource.MetaElement(d, profileURLs),     extension: d.extension,     status: d.status,     expirationDate: d.expirationDate,     lotNumber: d.lotNumber,     serialNumber: d.serialNumber,     modelNumber: d.modelNumber,     partNumber: d.partNumber,     type: d.type,     patient: d.patient,     parent: d.parent   }</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"nhsnacutecarehospitalmonthlyinitialpopulation-observationlabresource\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> NHSNAcuteCareHospitalMonthlyInitialPopulation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">define function ObservationLabResource(observation Observation, profileURLs List&lt;FHIR.canonical&gt;, acceptedCategories List&lt;System.Code&gt;):   observation o   return Observation{     id: FHIR.id {value: 'LCR-' + o.id},     meta: SharedResource.MetaElement(o, profileURLs),     extension: o.extension,     partOf: o.partOf,     status: o.status,     category: FilterCodeableConcepts(ObservationLabCategory(o.category), acceptedCategories),     code: o.code,     subject: o.subject,     encounter: o.encounter,     effective: o.effective,     issued: o.issued,     value: o.value,     dataAbsentReason: o.dataAbsentReason,     interpretation: o.interpretation,     bodySite: o.bodySite,     method: o.method,     specimen: o.specimen,     referenceRange: ObservationLabReferenceRange(o.referenceRange),     hasMember: o.hasMember,     derivedFrom: o.derivedFrom,     component: SharedResource.ObservationComponent(o.component)   }</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"nhsnacutecarehospitalmonthlyinitialpopulation-observationlabcategory\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> NHSNAcuteCareHospitalMonthlyInitialPopulation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">define function ObservationLabCategory(category List&lt;CodeableConcept&gt;):   category c   return CodeableConcept{     coding: ObservationLabCoding(c.coding),     text: c.text   }</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"nhsnacutecarehospitalmonthlyinitialpopulation-observationlabcoding\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> NHSNAcuteCareHospitalMonthlyInitialPopulation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">define function ObservationLabCoding(coding List&lt;Coding&gt;):   coding c   return Coding{     system: c.system,     version: c.version,     code: c.code,     display: c.display,     userSelected: c.userSelected   }</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"nhsnacutecarehospitalmonthlyinitialpopulation-observationlabreferencerange\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> NHSNAcuteCareHospitalMonthlyInitialPopulation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">define function ObservationLabReferenceRange(referenceRange List&lt;FHIR.Observation.ReferenceRange&gt;):   referenceRange rR   return FHIR.Observation.ReferenceRange{     low: rR.low,     high: rR.high,     type: rR.type,     appliesTo: rR.appliesTo,     age: rR.age   }</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"sharedresourcecreation-observationcomponent\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> SharedResourceCreation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">define function ObservationComponent(component List&lt;FHIR.Observation.Component&gt;):   component c   return FHIR.Observation.Component{     code: c.code,     value: c.value,     dataAbsentReason: c.dataAbsentReason,     interpretation: c.interpretation,     referenceRange: c.referenceRange   }</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"nhsnacutecarehospitalmonthlyinitialpopulation-observationvitalsignsresource\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> NHSNAcuteCareHospitalMonthlyInitialPopulation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">define function ObservationVitalSignsResource(observation Observation, profileURLs List&lt;FHIR.canonical&gt;, acceptedCategories List&lt;System.Code&gt;):   observation o   return Observation{     id: FHIR.id {value: 'LCR-' + o.id},     meta: SharedResource.MetaElement(o, profileURLs),     extension: o.extension,     partOf: o.partOf,     status: o.status,     category: FilterCodeableConcepts(ObservationVitalSignsCategory(o.category), acceptedCategories),     code: o.code,     subject: o.subject,     encounter: o.encounter,     effective: o.effective,     issued: o.issued,     value: o.value,     dataAbsentReason: o.dataAbsentReason,     interpretation: o.interpretation,     bodySite: o.bodySite,     method: o.method,     specimen: o.specimen,     referenceRange: ObservationVitalSignsReferenceRange(o.referenceRange),     hasMember: o.hasMember,     derivedFrom: o.derivedFrom,     component: ObservationVitalSignsComponent(o.component)   }</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"nhsnacutecarehospitalmonthlyinitialpopulation-observationvitalsignscategory\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> NHSNAcuteCareHospitalMonthlyInitialPopulation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">define function ObservationVitalSignsCategory(category List&lt;CodeableConcept&gt;):   category c   return CodeableConcept{     coding: ObservationVitalSignsCoding(c.coding),     text: c.text   }</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"nhsnacutecarehospitalmonthlyinitialpopulation-observationvitalsignscoding\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> NHSNAcuteCareHospitalMonthlyInitialPopulation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">define function ObservationVitalSignsCoding(coding List&lt;Coding&gt;):   coding c   return Coding{     system: c.system,     version: c.version,     code: c.code,     display: c.display,     userSelected: c.userSelected   }</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"nhsnacutecarehospitalmonthlyinitialpopulation-observationvitalsignsreferencerange\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> NHSNAcuteCareHospitalMonthlyInitialPopulation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">define function ObservationVitalSignsReferenceRange(referenceRange List&lt;FHIR.Observation.ReferenceRange&gt;):   referenceRange rR   return FHIR.Observation.ReferenceRange{     low: rR.low,     high: rR.high,     type: rR.type,     appliesTo: rR.appliesTo,     age: rR.age   }</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"nhsnacutecarehospitalmonthlyinitialpopulation-observationvitalsignscomponent\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> NHSNAcuteCareHospitalMonthlyInitialPopulation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">define function ObservationVitalSignsComponent(component List&lt;FHIR.Observation.Component&gt;):   component c   return FHIR.Observation.Component{     code: c.code,     value: c.value,     dataAbsentReason: c.dataAbsentReason,     interpretation: c.interpretation,     referenceRange: SharedResource.ObservationReferenceRange(c.referenceRange)   }</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"sharedresourcecreation-observationreferencerange\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> SharedResourceCreation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">define function ObservationReferenceRange(referenceRange List&lt;FHIR.Observation.ReferenceRange&gt;):   referenceRange rR   return FHIR.Observation.ReferenceRange{     low: rR.low,     high: rR.high,     type: rR.type,     appliesTo: rR.appliesTo,     age: rR.age,     text: rR.text   }</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"nhsnacutecarehospitalmonthlyinitialpopulation-diagnosticreportresource\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> NHSNAcuteCareHospitalMonthlyInitialPopulation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">define function DiagnosticReportResource(diagnosticReport DiagnosticReport, profileURLs List&lt;FHIR.canonical&gt;, acceptedCategories List&lt;System.Code&gt;):   diagnosticReport d   return DiagnosticReport{     id: FHIR.id{value: 'LCR-' + d.id},     meta: SharedResource.MetaElement(d, profileURLs),     extension: d.extension,     basedOn: d.basedOn,     status: d.status,     category: FilterCodeableConcepts(d.category, acceptedCategories),     code: d.code,     subject: d.subject,     encounter: d.encounter,     effective: d.effective,     issued: d.issued,     specimen: d.specimen,     result: d.result,     conclusion: d.conclusion,     conclusionCode: d.conclusionCode   }</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"nhsnacutecarehospitalmonthlyinitialpopulation-medicationadministrationresource\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> NHSNAcuteCareHospitalMonthlyInitialPopulation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">define function MedicationAdministrationResource(medicationAdministration MedicationAdministration, profileURLs List&lt;FHIR.canonical&gt;, acceptedCategories List&lt;System.Code&gt;):   medicationAdministration m   return MedicationAdministration{     id: FHIR.id {value: 'LCR-' + m.id},     meta: SharedResource.MetaElement(m, profileURLs),     extension: m.extension,     instantiates: m.instantiates,     partOf: m.partOf,     status: m.status,     statusReason: m.statusReason,     category: FilterCodeableConcepts({m.category}, acceptedCategories)[0],     medication: m.medication,     subject: m.subject,     context: m.context,     supportingInformation: m.supportingInformation,     effective: m.effective,     performer: SharedResource.MedicationAdministrationPerformer(m.performer),     reasonCode: m.reasonCode,     reasonReference: m.reasonReference,     request: m.request,     device: m.device,     note: m.note,     dosage: SharedResource.MedicationAdministrationDosage(m.dosage),     eventHistory: m.eventHistory   }</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"sharedresourcecreation-medicationadministrationperformer\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> SharedResourceCreation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">define function MedicationAdministrationPerformer(performer List&lt;FHIR.MedicationAdministration.Performer&gt;):   performer p   return FHIR.MedicationAdministration.Performer{     function: p.function,     actor: p.actor   }</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"sharedresourcecreation-medicationadministrationdosage\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> SharedResourceCreation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">define function MedicationAdministrationDosage(dosage FHIR.MedicationAdministration.Dosage):   dosage d   return FHIR.MedicationAdministration.Dosage{     text: d.text,     site: d.site,     route: d.route,     method: d.method,     dose: d.dose,     rate: d.rate   }</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"nhsnacutecarehospitalmonthlyinitialpopulation-observationresource\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> NHSNAcuteCareHospitalMonthlyInitialPopulation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">define function ObservationResource(observation Observation, profileURLs List&lt;FHIR.canonical&gt;, acceptedCategories List&lt;System.Code&gt;):   observation o   return Observation{     id: FHIR.id {value: 'LCR-' + o.id},     meta: SharedResource.MetaElement(o, profileURLs),     extension: o.extension,     partOf: o.partOf,     status: o.status,     category: FilterCodeableConcepts(o.category, acceptedCategories),     code: o.code,     subject: o.subject,     encounter: o.encounter,     effective: o.effective,     issued: o.issued,     value: o.value,     dataAbsentReason: o.dataAbsentReason,     interpretation: o.interpretation,     bodySite: o.bodySite,     method: o.method,     specimen: o.specimen,     referenceRange: ObservationReferenceRange(o.referenceRange),     hasMember: o.hasMember,     derivedFrom: o.derivedFrom,     component: SharedResource.ObservationComponent(o.component)   }</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"nhsnacutecarehospitalmonthlyinitialpopulation-observationreferencerange\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> NHSNAcuteCareHospitalMonthlyInitialPopulation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">define function ObservationReferenceRange(referenceRange List&lt;FHIR.Observation.ReferenceRange&gt;):   referenceRange rR   return FHIR.Observation.ReferenceRange{     low: rR.low,     high: rR.high,     type: rR.type,     appliesTo: rR.appliesTo,     age: rR.age   }</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"nhsnacutecarehospitalmonthlyinitialpopulation-conditionresource\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> NHSNAcuteCareHospitalMonthlyInitialPopulation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">// //Measure Specific Resource Creation Functions //  define function ConditionResource(condition Condition, profileURLs List&lt;FHIR.canonical&gt;, acceptedCategories List&lt;System.Code&gt;):   condition c   return Condition{     id: FHIR.id {value: 'LCR-' + c.id},     meta: SharedResource.MetaElement(c, profileURLs),     extension: c.extension,     clinicalStatus: c.clinicalStatus,     verificationStatus: c.verificationStatus,     category: FilterCodeableConcepts(c.category, acceptedCategories),     code: c.code,     subject: c.subject,     encounter: c.encounter,     onset: c.onset,     abatement: c.abatement,     recordedDate: c.recordedDate   }</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"nhsnacutecarehospitalmonthlyinitialpopulation-diagnosticreportlabresource\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> NHSNAcuteCareHospitalMonthlyInitialPopulation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">define function DiagnosticReportLabResource(diagnosticReport DiagnosticReport, profileURLs List&lt;FHIR.canonical&gt;, acceptedCategories List&lt;System.Code&gt;):   diagnosticReport d   return DiagnosticReport{     id: FHIR.id{value: 'LCR-' + d.id},     meta: SharedResource.MetaElement(d, profileURLs),     extension: d.extension,     basedOn: d.basedOn,     status: d.status,     category: FilterCodeableConcepts(DiagnosticReportCategory(d.category), acceptedCategories),     code: d.code,     subject: d.subject,     encounter: d.encounter,     effective: d.effective,     issued: d.issued,     specimen: d.specimen,     result: d.result,     conclusion: d.conclusion,     conclusionCode: d.conclusionCode   }</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"nhsnacutecarehospitalmonthlyinitialpopulation-diagnosticreportcategory\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> NHSNAcuteCareHospitalMonthlyInitialPopulation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">define function DiagnosticReportCategory(category List&lt;CodeableConcept&gt;):   category c   return CodeableConcept{     coding: DiagnosticReportCoding(c.coding)   }</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"nhsnacutecarehospitalmonthlyinitialpopulation-diagnosticreportcoding\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> NHSNAcuteCareHospitalMonthlyInitialPopulation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">define function DiagnosticReportCoding(coding List&lt;Coding&gt;):   coding c   return Coding{     system: c.system,     version: c.version,     code: c.code,     display: c.display   }</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"nhsnacutecarehospitalmonthlyinitialpopulation-locationresource\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> NHSNAcuteCareHospitalMonthlyInitialPopulation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">define function LocationResource(location Location, profileURLs List&lt;FHIR.canonical&gt;):   location l   return Location{     id: FHIR.id {value: 'LCR-' + l.id},     meta: SharedResource.MetaElement(l, profileURLs),     extension: l.extension,     status: l.status,     name: l.name,     alias: l.alias,     type: l.type,     physicalType: l.physicalType,     managingOrganization: l.managingOrganization,     partOf: l.partOf   }</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"nhsnacutecarehospitalmonthlyinitialpopulation-servicerequestresource\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> NHSNAcuteCareHospitalMonthlyInitialPopulation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">define function ServiceRequestResource(serviceRequest ServiceRequest, profileURLs List&lt;FHIR.canonical&gt;, acceptedCategories List&lt;System.Code&gt;):   serviceRequest sR   return ServiceRequest{     id: FHIR.id {value: 'LCR-' + sR.id},     meta: SharedResource.MetaElement(sR, profileURLs),     extension: sR.extension,     basedOn: sR.basedOn,     status: sR.status,     intent: sR.intent,     category: FilterCodeableConcepts(sR.category, acceptedCategories),     priority: sR.priority,     doNotPerform: sR.doNotPerform,     code: sR.code,     quantity: sR.quantity,     subject: sR.subject,     encounter: sR.encounter,     occurrence: sR.occurrence,     asNeeded: sR.asNeeded,     authoredOn: sR.authoredOn,     specimen: sR.specimen   }</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"sharedresourcecreation-patientresource\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> SharedResourceCreation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">define function PatientResource(patient Patient, profileURLs List&lt;FHIR.canonical&gt;):   patient p   return Patient{     id: FHIR.id{value: 'LCR-' + p.id},     meta: MetaElement(p, profileURLs),     extension: GetPatientExtensions(p),     identifier: p.identifier,     active: p.active,     name: PatientName(p.name),     telecom: PatientTelecom(p.telecom),     gender: p.gender,     birthDate: p.birthDate,     deceased: p.deceased,     address: PatientAddress(p.address),     maritalStatus: p.maritalStatus,     multipleBirth: p.multipleBirth,     contact: PatientContact(p.contact),     communication: PatientCommunication(p.communication),     link: PatientLink(p.link)   }</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"sharedresourcecreation-getpatientextensions\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> SharedResourceCreation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">define function &quot;GetPatientExtensions&quot;(domainResource DomainResource):   domainResource.extension E   where E.url = 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-race'     or E.url = 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity'     or E.url = 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-tribal-affiliation'     or E.url = 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-birthsex'     or E.url = 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-sex'     or E.url = 'http://www.cdc.gov/nhsn/fhirportal/dqm/ig/StructureDefinition/link-original-resource-id-extension'   return E</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"sharedresourcecreation-patientname\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> SharedResourceCreation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">/* No longer needed but saving in case it's useful later define function PatientIdentifier(identifier List&lt;FHIR.Identifier&gt;):   identifier i   return FHIR.Identifier{     id: i.id,     extension: i.extension,     use: i.use,     type: i.type,     system: i.system,     value: i.value,     period: i.period,     assigner: i.assigner   }*/  define function PatientName(name List&lt;FHIR.HumanName&gt;):   name n   return FHIR.HumanName{     id: n.id,     extension: n.extension,     use: n.use,     text: n.text,     family: n.family,     given: n.given,     prefix: n.prefix,     suffix: n.suffix,     period: n.period   }</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"sharedresourcecreation-patienttelecom\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> SharedResourceCreation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">define function PatientTelecom(telecom List&lt;FHIR.ContactPoint&gt;):   telecom t   return FHIR.ContactPoint{     system: t.system,     value: t.value,     use: t.use,     rank: t.rank,     period: t.period   }</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"sharedresourcecreation-patientaddress\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> SharedResourceCreation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">define function PatientAddress(address List&lt;FHIR.Address&gt;):   address a   return FHIR.Address{     use: a.use,     type: a.type,     text: a.text,     line: a.line,     city: a.city,     district: a.district,     state: a.state,     postalCode: a.postalCode,     country: a.country,     period: a.period   }</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"sharedresourcecreation-patientcontact\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> SharedResourceCreation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">define function PatientContact(contact List&lt;FHIR.Patient.Contact&gt;):   contact c   return FHIR.Patient.Contact{     relationship: c.relationship,     name: c.name,     telecom: c.telecom,     address: c.address,     gender: c.gender,     organization: c.organization,     period: c.period   }</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"sharedresourcecreation-patientcommunication\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> SharedResourceCreation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">define function PatientCommunication(communication List&lt;FHIR.Patient.Communication&gt;):   communication c   return FHIR.Patient.Communication{     language: c.language,     preferred: c.preferred   }</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"sharedresourcecreation-patientlink\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> SharedResourceCreation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">define function PatientLink(link List&lt;FHIR.Patient.Link&gt;):   link l   return FHIR.Patient.Link{     extension: l.extension,     modifierExtension: l.modifierExtension,     other: l.other,     type: l.type   }</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"sharedresourcecreation-medicationresource\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> SharedResourceCreation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">define function MedicationResource(medication Medication, profileURLs List&lt;FHIR.canonical&gt;):   medication m   return Medication{     id: FHIR.id {value: 'LCR-' + m.id},     meta: MetaElement(m, profileURLs),     extension: m.extension,     code: m.code,     status: m.status,     manufacturer: m.manufacturer,     form: m.form,     amount: m.amount,     ingredient: MedicationIngredient(m.ingredient),     batch: MedicationBatch(m.batch)   }</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"sharedresourcecreation-medicationingredient\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> SharedResourceCreation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">define function MedicationIngredient(ingredient List&lt;FHIR.Medication.Ingredient&gt;):   ingredient i   return FHIR.Medication.Ingredient{     item: i.item,     strength: i.strength   }</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"sharedresourcecreation-medicationbatch\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> SharedResourceCreation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">define function MedicationBatch(batch FHIR.Medication.Batch):   batch b   return FHIR.Medication.Batch{     lotNumber: b.lotNumber,     expirationDate: b.expirationDate   }</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"nhsnacutecarehospitalmonthlyinitialpopulation-specimenresource\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> NHSNAcuteCareHospitalMonthlyInitialPopulation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">define function SpecimenResource(specimen Specimen, profileURLs List&lt;FHIR.canonical&gt;):   specimen s   return Specimen{     id: FHIR.id {value: 'LCR-' + s.id},     meta: SharedResource.MetaElement(s, profileURLs),     extension: s.extension,     identifier: s.identifier,     accessionIdentifier: s.accessionIdentifier,     status: s.status,     type: s.type,     subject: s.subject,     parent: s.parent,     request: s.request,     collection: SpecimenCollection(s.collection),     note: s.note   }</code></pre>\n  </td>\n\n</tr>\n        \n<tr>\n  <th scope=\"row\" rowspan=\"2\" class=\"row-header\">\n    \n      \n      <a name=\"nhsnacutecarehospitalmonthlyinitialpopulation-specimencollection\"> </a>\n    \n    Logic Definition\n  </th>\n\n  <td class=\"content-container\"><em>Library Name:</em> NHSNAcuteCareHospitalMonthlyInitialPopulation</td>\n\n</tr>\n<tr>\n\n  <td>\n    <pre style=\"border: none;\" class=\"content-container highlight language-cql\"><code class=\"language-cql\">define function SpecimenCollection(collection FHIR.Specimen.Collection):   collection c   return FHIR.Specimen.Collection{     collector: c.collector,     collected: c.collected,     quantity: c.quantity,     bodySite: c.bodySite   }</code></pre>\n  </td>\n\n</tr>\n\n  \n\n<tr>\n  <th colspan=\"2\" scope=\"row\" class=\"row-header\">Generated using version 0.4.6 of the sample-content-ig Liquid templates</th>\n</tr>\n    </tbody>\n  </table>\n</div>"
+        },
         "contained": [
           {
             "resourceType": "Library",
             "id": "effective-data-requirements",
             "extension": [
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-directReferenceCode",
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-directReferenceCode",
                 "valueCoding": {
                   "system": "http://terminology.hl7.org/CodeSystem/v3-ActCode",
                   "code": "EMER",
@@ -165,7 +169,7 @@
                 }
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-directReferenceCode",
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-directReferenceCode",
                 "valueCoding": {
                   "system": "http://terminology.hl7.org/CodeSystem/v3-ActCode",
                   "code": "OBSENC",
@@ -173,7 +177,39 @@
                 }
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-directReferenceCode",
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-directReferenceCode",
+                "valueCoding": {
+                  "system": "http://terminology.hl7.org/CodeSystem/medicationrequest-category",
+                  "code": "inpatient",
+                  "display": "Inpatient"
+                }
+              },
+              {
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-directReferenceCode",
+                "valueCoding": {
+                  "system": "http://terminology.hl7.org/CodeSystem/medicationrequest-category",
+                  "code": "outpatient",
+                  "display": "Outpatient"
+                }
+              },
+              {
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-directReferenceCode",
+                "valueCoding": {
+                  "system": "http://snomed.info/sct",
+                  "code": "387713003",
+                  "display": "Surgical procedure"
+                }
+              },
+              {
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-directReferenceCode",
+                "valueCoding": {
+                  "system": "http://snomed.info/sct",
+                  "code": "103693007",
+                  "display": "Diagnostic procedure"
+                }
+              },
+              {
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-directReferenceCode",
                 "valueCoding": {
                   "system": "http://terminology.hl7.org/CodeSystem/observation-category",
                   "code": "laboratory",
@@ -181,63 +217,7 @@
                 }
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-directReferenceCode",
-                "valueCoding": {
-                  "system": "http://terminology.hl7.org/CodeSystem/observation-category",
-                  "code": "vital-signs",
-                  "display": "Vital Signs"
-                }
-              },
-              {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-directReferenceCode",
-                "valueCoding": {
-                  "system": "http://loinc.org",
-                  "code": "LP29684-5",
-                  "display": "Radiology"
-                }
-              },
-              {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-directReferenceCode",
-                "valueCoding": {
-                  "system": "http://loinc.org",
-                  "code": "LP7839-6",
-                  "display": "Pathology"
-                }
-              },
-              {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-directReferenceCode",
-                "valueCoding": {
-                  "system": "http://loinc.org",
-                  "code": "LP29708-2",
-                  "display": "Cardiology"
-                }
-              },
-              {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-directReferenceCode",
-                "valueCoding": {
-                  "system": "http://terminology.hl7.org/CodeSystem/v2-0074",
-                  "code": "LAB",
-                  "display": "Laboratory"
-                }
-              },
-              {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-directReferenceCode",
-                "valueCoding": {
-                  "system": "http://terminology.hl7.org/CodeSystem/observation-category",
-                  "code": "social-history",
-                  "display": "Social History"
-                }
-              },
-              {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-directReferenceCode",
-                "valueCoding": {
-                  "system": "http://terminology.hl7.org/CodeSystem/observation-category",
-                  "code": "survey",
-                  "display": "Survey"
-                }
-              },
-              {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-directReferenceCode",
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-directReferenceCode",
                 "valueCoding": {
                   "system": "http://terminology.hl7.org/CodeSystem/observation-category",
                   "code": "imaging",
@@ -245,7 +225,7 @@
                 }
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-directReferenceCode",
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-directReferenceCode",
                 "valueCoding": {
                   "system": "http://terminology.hl7.org/CodeSystem/observation-category",
                   "code": "procedure",
@@ -253,23 +233,47 @@
                 }
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-directReferenceCode",
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-directReferenceCode",
                 "valueCoding": {
-                  "system": "http://terminology.hl7.org/CodeSystem/condition-category",
-                  "code": "problem-list-item",
-                  "display": "Problem List Item"
+                  "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                  "code": "vital-signs",
+                  "display": "Vital Signs"
                 }
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-directReferenceCode",
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-directReferenceCode",
                 "valueCoding": {
-                  "system": "http://terminology.hl7.org/CodeSystem/condition-clinical",
-                  "code": "active",
-                  "display": "active"
+                  "system": "http://loinc.org",
+                  "code": "LP29684-5",
+                  "display": "Radiology"
                 }
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-directReferenceCode",
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-directReferenceCode",
+                "valueCoding": {
+                  "system": "http://loinc.org",
+                  "code": "LP7839-6",
+                  "display": "Pathology"
+                }
+              },
+              {
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-directReferenceCode",
+                "valueCoding": {
+                  "system": "http://loinc.org",
+                  "code": "LP29708-2",
+                  "display": "Cardiology"
+                }
+              },
+              {
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-directReferenceCode",
+                "valueCoding": {
+                  "system": "http://terminology.hl7.org/CodeSystem/v2-0074",
+                  "code": "LAB",
+                  "display": "Laboratory"
+                }
+              },
+              {
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-directReferenceCode",
                 "valueCoding": {
                   "system": "http://terminology.hl7.org/CodeSystem/condition-category",
                   "code": "encounter-diagnosis",
@@ -277,15 +281,22 @@
                 }
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-directReferenceCode",
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-directReferenceCode",
                 "valueCoding": {
-                  "system": "http://hl7.org/fhir/us/core/CodeSystem/condition-category",
-                  "code": "health-concern",
-                  "display": "Health Concern"
+                  "system": "http://snomed.info/sct",
+                  "code": "108252007",
+                  "display": "Laboratory procedure"
                 }
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-directReferenceCode",
+                "valueCoding": {
+                  "system": "http://snomed.info/sct",
+                  "code": "363679005",
+                  "display": "Imaging"
+                }
+              },
+              {
                 "extension": [
                   {
                     "url": "libraryName",
@@ -303,10 +314,10 @@
                     "url": "displaySequence",
                     "valueInteger": 0
                   }
-                ]
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
                 "extension": [
                   {
                     "url": "libraryName",
@@ -324,10 +335,10 @@
                     "url": "displaySequence",
                     "valueInteger": 1
                   }
-                ]
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
                 "extension": [
                   {
                     "url": "libraryName",
@@ -345,10 +356,10 @@
                     "url": "displaySequence",
                     "valueInteger": 2
                   }
-                ]
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
                 "extension": [
                   {
                     "url": "libraryName",
@@ -366,10 +377,10 @@
                     "url": "displaySequence",
                     "valueInteger": 3
                   }
-                ]
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
                 "extension": [
                   {
                     "url": "libraryName",
@@ -381,16 +392,16 @@
                   },
                   {
                     "url": "statement",
-                    "valueString": "//#End DiagnosticReport block  define \"SDE Encounter\":    \"Encounters\" Encounters   where not CheckIP(Encounters)   and exists(     \"Initial Population\" IP     where Encounters.period overlaps IP.period)   return SharedResource.EncounterResource(Encounters,   {FHIR.canonical{value: 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-encounter'}})"
+                    "valueString": "//#End DiagnosticReport block  define \"SDE Encounter\":    \"Encounters\" Encounters   where not CheckIP(Encounters)   and exists(     \"Initial Population\" IP     where Encounters.period overlaps IP.period)   return EncounterResource(Encounters,   {FHIR.canonical{value: 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-encounter'}})"
                   },
                   {
                     "url": "displaySequence",
                     "valueInteger": 4
                   }
-                ]
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
                 "extension": [
                   {
                     "url": "libraryName",
@@ -402,16 +413,16 @@
                   },
                   {
                     "url": "statement",
-                    "valueString": "define \"SDE Medication Request\":   [MedicationRequest] MedicationRequests    where exists(     \"Initial Population\" IP     where MedicationRequests.authoredOn during IP.period)   return SharedResource.MedicationRequestResource(MedicationRequests,   {FHIR.canonical{value: 'http://www.cdc.gov/nhsn/fhirportal/dqm/ig/StructureDefinition/ach-monthly-medicationrequest'}})"
+                    "valueString": "define \"SDE Medication Request\":   [MedicationRequest] MedicationRequests    where exists(     \"Initial Population\" IP     where MedicationRequests.authoredOn during IP.period)   return MedicationRequestResource(MedicationRequests,   {FHIR.canonical{value: 'http://www.cdc.gov/nhsn/fhirportal/dqm/ig/StructureDefinition/ach-monthly-medicationrequest'}},   {\"inpatient\", \"outpatient\"})"
                   },
                   {
                     "url": "displaySequence",
                     "valueInteger": 5
                   }
-                ]
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
                 "extension": [
                   {
                     "url": "libraryName",
@@ -423,16 +434,16 @@
                   },
                   {
                     "url": "statement",
-                    "valueString": "define \"SDE Coverage\":   [Coverage] Coverages   where exists(     \"Initial Population\" IP     where Coverages.period overlaps IP.period)   return SharedResource.CoverageResource(Coverages,   {FHIR.canonical{value: 'http://www.cdc.gov/nhsn/fhirportal/dqm/ig/StructureDefinition/ach-monthly-coverage'}})"
+                    "valueString": "define \"SDE Coverage\":   [Coverage] Coverages   where exists(     \"Initial Population\" IP     where Coverages.period overlaps IP.period)   return CoverageResource(Coverages,   {FHIR.canonical{value: 'http://www.cdc.gov/nhsn/fhirportal/dqm/ig/StructureDefinition/ach-monthly-coverage'}})"
                   },
                   {
                     "url": "displaySequence",
                     "valueInteger": 6
                   }
-                ]
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
                 "extension": [
                   {
                     "url": "libraryName",
@@ -444,16 +455,16 @@
                   },
                   {
                     "url": "statement",
-                    "valueString": "define \"SDE Procedure\":   [Procedure] Procedures    where exists(     \"Initial Population\" IP     where NHSNHelpers.\"Normalize Interval\"(Procedures.performed) overlaps IP.period)   return SharedResource.ProcedureResource(Procedures,   {FHIR.canonical{value: 'http://www.cdc.gov/nhsn/fhirportal/dqm/ig/StructureDefinition/ach-monthly-procedure'}})"
+                    "valueString": "define \"SDE Procedure\":   [Procedure] Procedures    where exists(     \"Initial Population\" IP     where NHSNHelpers.\"Normalize Interval\"(Procedures.performed) overlaps IP.period)      return ProcedureResource(Procedures,   {FHIR.canonical{value: 'http://www.cdc.gov/nhsn/fhirportal/dqm/ig/StructureDefinition/ach-monthly-procedure'}},   {\"Surgical procedure\", \"Diagnostic procedure\"})"
                   },
                   {
                     "url": "displaySequence",
                     "valueInteger": 7
                   }
-                ]
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
                 "extension": [
                   {
                     "url": "libraryName",
@@ -465,16 +476,16 @@
                   },
                   {
                     "url": "statement",
-                    "valueString": "define \"SDE IP Encounters\":   \"Initial Population\" IP   return SharedResource.EncounterResource(IP,    {FHIR.canonical{value: 'http://www.cdc.gov/nhsn/fhirportal/dqm/ig/StructureDefinition/ach-monthly-encounter'}})"
+                    "valueString": "define \"SDE IP Encounters\":   \"Initial Population\" IP   return EncounterResource(IP,    {FHIR.canonical{value: 'http://www.cdc.gov/nhsn/fhirportal/dqm/ig/StructureDefinition/ach-monthly-encounter'}})"
                   },
                   {
                     "url": "displaySequence",
                     "valueInteger": 8
                   }
-                ]
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
                 "extension": [
                   {
                     "url": "libraryName",
@@ -492,10 +503,10 @@
                     "url": "displaySequence",
                     "valueInteger": 9
                   }
-                ]
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
                 "extension": [
                   {
                     "url": "libraryName",
@@ -513,10 +524,10 @@
                     "url": "displaySequence",
                     "valueInteger": 10
                   }
-                ]
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
                 "extension": [
                   {
                     "url": "libraryName",
@@ -528,16 +539,16 @@
                   },
                   {
                     "url": "statement",
-                    "valueString": "define \"SDE Observation Lab Category\":   \"Observations\" Observations    where (exists(Observations.category Category where Category ~ \"laboratory\"))     and exists(       \"Initial Population\" IP       where NHSNHelpers.\"Normalize Interval\"(Observations.effective) overlaps IP.period)   return SharedResource.ObservationLabResource(Observations,   {FHIR.canonical{value: 'http://www.cdc.gov/nhsn/fhirportal/dqm/ig/StructureDefinition/ach-monthly-observation-lab'}})"
+                    "valueString": "define \"SDE Observation Lab Category\":   \"Observations\" Observations    where (exists(Observations.category Category where Category ~ \"laboratory\"))     and exists(       \"Initial Population\" IP       where NHSNHelpers.\"Normalize Interval\"(Observations.effective) overlaps IP.period)   return ObservationLabResource(Observations,   {FHIR.canonical{value: 'http://www.cdc.gov/nhsn/fhirportal/dqm/ig/StructureDefinition/ach-monthly-observation-lab'}},   {\"imaging\", \"procedure\", \"vital-signs\", \"laboratory\"})"
                   },
                   {
                     "url": "displaySequence",
                     "valueInteger": 11
                   }
-                ]
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
                 "extension": [
                   {
                     "url": "libraryName",
@@ -549,16 +560,16 @@
                   },
                   {
                     "url": "statement",
-                    "valueString": "//Vital Signs Observation has its own profile in FHIR Base define \"SDE Observation Vital Signs Category\":   \"Observations\" Observations    where (exists(Observations.category Category where Category ~ \"vital-signs\"))     and exists(       \"Initial Population\" IP       where NHSNHelpers.\"Normalize Interval\"(Observations.effective) overlaps IP.period)   return ObservationVitalSignsResource(Observations,   {FHIR.canonical{value: 'http://www.cdc.gov/nhsn/fhirportal/dqm/ig/StructureDefinition/ach-monthly-observation-vitals'}})"
+                    "valueString": "//Vital Signs Observation has its own profile in FHIR Base define \"SDE Observation Vital Signs Category\":   \"Observations\" Observations    where (exists(Observations.category Category where Category ~ \"vital-signs\"))     and exists(       \"Initial Population\" IP       where NHSNHelpers.\"Normalize Interval\"(Observations.effective) overlaps IP.period)   return ObservationVitalSignsResource(Observations,   {FHIR.canonical{value: 'http://www.cdc.gov/nhsn/fhirportal/dqm/ig/StructureDefinition/ach-monthly-observation-vitals'}},   {\"imaging\", \"procedure\", \"vital-signs\", \"laboratory\"})"
                   },
                   {
                     "url": "displaySequence",
                     "valueInteger": 12
                   }
-                ]
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
                 "extension": [
                   {
                     "url": "libraryName",
@@ -570,16 +581,16 @@
                   },
                   {
                     "url": "statement",
-                    "valueString": "define \"SDE DiagnosticReport Others\":   [DiagnosticReport] DiagnosticReports   where not ((exists(DiagnosticReports.category Category where Category ~ \"Radiology\"))     or exists((DiagnosticReports.category Category where Category ~ \"Pathology\"))     or exists((DiagnosticReports.category Category where Category ~ \"Cardiology\"))     or exists(DiagnosticReports.category Category where Category ~ \"LAB\"))     and exists(\"Initial Population\" IP       where NHSNHelpers.\"Normalize Interval\"(DiagnosticReports.effective) overlaps IP.period)   return DiagnosticReportResource(DiagnosticReports,   {FHIR.canonical{value: 'http://www.cdc.gov/nhsn/fhirportal/dqm/ig/StructureDefinition/ach-monthly-diagnosticreport'}})"
+                    "valueString": "define \"SDE DiagnosticReport Others\":   [DiagnosticReport] DiagnosticReports   where not ((exists(DiagnosticReports.category Category where Category ~ \"Radiology\"))     or exists((DiagnosticReports.category Category where Category ~ \"Pathology\"))     or exists((DiagnosticReports.category Category where Category ~ \"Cardiology\"))     or exists(DiagnosticReports.category Category where Category ~ \"LAB\"))     and exists(\"Initial Population\" IP       where NHSNHelpers.\"Normalize Interval\"(DiagnosticReports.effective) overlaps IP.period)   return DiagnosticReportResource(DiagnosticReports,   {FHIR.canonical{value: 'http://www.cdc.gov/nhsn/fhirportal/dqm/ig/StructureDefinition/ach-monthly-diagnosticreport'}},   {\"Radiology\", \"Pathology\", \"Cardiology\", \"LAB\"})"
                   },
                   {
                     "url": "displaySequence",
                     "valueInteger": 13
                   }
-                ]
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
                 "extension": [
                   {
                     "url": "libraryName",
@@ -591,16 +602,16 @@
                   },
                   {
                     "url": "statement",
-                    "valueString": "define \"SDE Medication Administration\":   [MedicationAdministration] MedicationAdministrations    where exists(     \"Initial Population\" IP     where NHSNHelpers.\"Normalize Interval\"(MedicationAdministrations.effective) overlaps IP.period)   return SharedResource.MedicationAdministrationResource(MedicationAdministrations,   {FHIR.canonical{value: 'http://www.cdc.gov/nhsn/fhirportal/dqm/ig/StructureDefinition/ach-monthly-medicationadministration'}})"
+                    "valueString": "define \"SDE Medication Administration\":   [MedicationAdministration] MedicationAdministrations    where exists(     \"Initial Population\" IP     where NHSNHelpers.\"Normalize Interval\"(MedicationAdministrations.effective) overlaps IP.period)   return MedicationAdministrationResource(MedicationAdministrations,   {FHIR.canonical{value: 'http://www.cdc.gov/nhsn/fhirportal/dqm/ig/StructureDefinition/ach-monthly-medicationadministration'}},   {\"inpatient\", \"outpatient\"})"
                   },
                   {
                     "url": "displaySequence",
                     "valueInteger": 14
                   }
-                ]
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
                 "extension": [
                   {
                     "url": "libraryName",
@@ -612,16 +623,16 @@
                   },
                   {
                     "url": "statement",
-                    "valueString": "//Defaulting to base FHIR profile as there are no individual profiles in US Core 3.1.1 that cover these Observation categories define \"SDE Observation Category\":   \"Observations\" Observations    where ((exists(Observations.category Category where Category ~ \"social-history\"))     or (exists(Observations.category Category where Category ~ \"survey\"))     or (exists(Observations.category Category where Category ~ \"imaging\"))     or (exists(Observations.category Category where Category ~ \"procedure\")))     and exists(       \"Initial Population\" IP       where NHSNHelpers.\"Normalize Interval\"(Observations.effective) overlaps IP.period)   return ObservationResource(Observations,   {FHIR.canonical{value: 'http://www.cdc.gov/nhsn/fhirportal/dqm/ig/StructureDefinition/ach-monthly-observation'}})"
+                    "valueString": "//Defaulting to base FHIR profile as there are no individual profiles in US Core 3.1.1 that cover these Observation categories define \"SDE Observation Category\":   \"Observations\" Observations    where (/*(exists(Observations.category Category where Category ~ \"social-history\"))     or (exists(Observations.category Category where Category ~ \"survey\"))     or */(exists(Observations.category Category where Category ~ \"imaging\"))     or (exists(Observations.category Category where Category ~ \"procedure\")))     and exists(       \"Initial Population\" IP       where NHSNHelpers.\"Normalize Interval\"(Observations.effective) overlaps IP.period)   return ObservationResource(Observations,   {FHIR.canonical{value: 'http://www.cdc.gov/nhsn/fhirportal/dqm/ig/StructureDefinition/ach-monthly-observation'}},   {\"imaging\", \"procedure\", \"vital-signs\", \"laboratory\"})"
                   },
                   {
                     "url": "displaySequence",
                     "valueInteger": 15
                   }
-                ]
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
                 "extension": [
                   {
                     "url": "libraryName",
@@ -639,10 +650,10 @@
                     "url": "displaySequence",
                     "valueInteger": 16
                   }
-                ]
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
                 "extension": [
                   {
                     "url": "libraryName",
@@ -654,16 +665,16 @@
                   },
                   {
                     "url": "statement",
-                    "valueString": "//============================================================================ //Supplemental Data Element //When FHIR.canonical value is present, US Core 3.1.1 profiles are used //When FHIR.canonical value is not present, FHIR Base profiles are used //============================================================================ define \"SDE Condition\":   \"Conditions\" Conditions    where exists(     \"Initial Population\" IP     //Check for Problem List Conditions that were recorded before or during IP     where (       Conditions.recordedDate before end of IP.period       and exists(Conditions.category categories         where categories ~ \"problem-list-item\")       and Conditions.clinicalStatus ~ \"active\"     )     //Check for Encounter Diagnosis Conditions that reference an IP encounter     or (       (exists(IP.diagnosis Diagnoses           where GetCondition(Diagnoses.condition).id = Conditions.id         )         or GetEncounter(Conditions.encounter).id = IP.id       )       and exists (Conditions.category categories         where categories ~ \"encounter-diagnosis\"           or categories ~ \"health-concern\")     )   )   return SharedResource.ConditionResource(Conditions,   {FHIR.canonical{value: 'http://www.cdc.gov/nhsn/fhirportal/dqm/ig/StructureDefinition/ach-monthly-condition'}})"
+                    "valueString": "//============================================================================ //Supplemental Data Element //When FHIR.canonical value is present, US Core 3.1.1 profiles are used //When FHIR.canonical value is not present, FHIR Base profiles are used //============================================================================ define \"SDE Condition\":   \"Conditions\" Conditions      where exists(     \"Initial Population\" IP //Check for Problem List Conditions that were recorded before or during IP       where        (exists(IP.diagnosis Diagnoses           where NHSNHelpers.GetId(Diagnoses.condition.reference) = Conditions.id         )         or NHSNHelpers.GetId(Conditions.encounter.reference) = IP.id       )       and exists (Conditions.category categories         where categories ~ \"encounter-diagnosis\"     )   )   return ConditionResource(Conditions,   {FHIR.canonical{value: 'http://www.cdc.gov/nhsn/fhirportal/dqm/ig/StructureDefinition/ach-monthly-condition'}},    {\"encounter-diagnosis\"})"
                   },
                   {
                     "url": "displaySequence",
                     "valueInteger": 17
                   }
-                ]
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
                 "extension": [
                   {
                     "url": "libraryName",
@@ -681,10 +692,10 @@
                     "url": "displaySequence",
                     "valueInteger": 18
                   }
-                ]
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
                 "extension": [
                   {
                     "url": "libraryName",
@@ -696,16 +707,16 @@
                   },
                   {
                     "url": "statement",
-                    "valueString": "//This block collects all DiagnosticReport resources while also marking Lab and Note DiagnosticReports with the appropriate profiles //#Start DiagnosticReport block define \"SDE DiagnosticReport Lab\":   \"DiagnosticReports\" DiagnosticReports   where (exists(DiagnosticReports.category Category where Category ~ \"LAB\")     and exists(       \"Initial Population\" IP       where NHSNHelpers.\"Normalize Interval\"(DiagnosticReports.effective) overlaps IP.period))   return SharedResource.DiagnosticReportLabResource(DiagnosticReports,   {FHIR.canonical{value: 'http://www.cdc.gov/nhsn/fhirportal/dqm/ig/StructureDefinition/ach-monthly-diagnosticreport-lab'}})"
+                    "valueString": "//This block collects all DiagnosticReport resources while also marking Lab and Note DiagnosticReports with the appropriate profiles //#Start DiagnosticReport block define \"SDE DiagnosticReport Lab\":   \"DiagnosticReports\" DiagnosticReports   where (exists(DiagnosticReports.category Category where Category ~ \"LAB\")     and exists(       \"Initial Population\" IP       where NHSNHelpers.\"Normalize Interval\"(DiagnosticReports.effective) overlaps IP.period))   return DiagnosticReportLabResource(DiagnosticReports,   {FHIR.canonical{value: 'http://www.cdc.gov/nhsn/fhirportal/dqm/ig/StructureDefinition/ach-monthly-diagnosticreport-lab'}},   {\"LAB\", \"Radiology\", \"Pathology\", \"Cardiology\"})"
                   },
                   {
                     "url": "displaySequence",
                     "valueInteger": 19
                   }
-                ]
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
                 "extension": [
                   {
                     "url": "libraryName",
@@ -723,10 +734,10 @@
                     "url": "displaySequence",
                     "valueInteger": 20
                   }
-                ]
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
                 "extension": [
                   {
                     "url": "libraryName",
@@ -738,16 +749,16 @@
                   },
                   {
                     "url": "statement",
-                    "valueString": "define \"SDE Location\":   \"Get Locations from IP Encounters in Measurement Period\" Locations   where exists(\"Initial Population\")   and Locations is not null   return SharedResource.LocationResource(Locations,   {FHIR.canonical{value: 'http://www.cdc.gov/nhsn/fhirportal/dqm/ig/StructureDefinition/ach-monthly-location'}})"
+                    "valueString": "define \"SDE Location\":   \"Get Locations from IP Encounters in Measurement Period\" Locations   where exists(\"Initial Population\")   and Locations is not null   return LocationResource(Locations,   {FHIR.canonical{value: 'http://www.cdc.gov/nhsn/fhirportal/dqm/ig/StructureDefinition/ach-monthly-location'}})"
                   },
                   {
                     "url": "displaySequence",
                     "valueInteger": 21
                   }
-                ]
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
                 "extension": [
                   {
                     "url": "libraryName",
@@ -759,16 +770,16 @@
                   },
                   {
                     "url": "statement",
-                    "valueString": "define \"SDE Service Request\":   [ServiceRequest] ServiceRequests   where exists(\"Initial Population\" IP     where ServiceRequests.authoredOn during IP.period)   return SharedResource.ServiceRequestResource(ServiceRequests,   {FHIR.canonical{value: 'http://www.cdc.gov/nhsn/fhirportal/dqm/ig/StructureDefinition/ach-monthly-servicerequest'}})"
+                    "valueString": "define \"SDE Service Request\":   [ServiceRequest] ServiceRequests   where exists(\"Initial Population\" IP     where ServiceRequests.authoredOn during IP.period)   return ServiceRequestResource(ServiceRequests,   {FHIR.canonical{value: 'http://www.cdc.gov/nhsn/fhirportal/dqm/ig/StructureDefinition/ach-monthly-servicerequest'}},   {\"Laboratory procedure\", \"Surgical procedure\", \"Imaging\"})"
                   },
                   {
                     "url": "displaySequence",
                     "valueInteger": 22
                   }
-                ]
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
                 "extension": [
                   {
                     "url": "libraryName",
@@ -780,16 +791,16 @@
                   },
                   {
                     "url": "statement",
-                    "valueString": "define \"SDE DiagnosticReport Note\":   \"DiagnosticReports\" DiagnosticReports   where ((exists(DiagnosticReports.category Category where Category ~ \"Radiology\"))     or exists((DiagnosticReports.category Category where Category ~ \"Pathology\"))     or exists((DiagnosticReports.category Category where Category ~ \"Cardiology\")))     and exists(       \"Initial Population\" IP       where NHSNHelpers.\"Normalize Interval\"(DiagnosticReports.effective) overlaps IP.period)   return DiagnosticReportResource(DiagnosticReports,   {FHIR.canonical{value: 'http://www.cdc.gov/nhsn/fhirportal/dqm/ig/StructureDefinition/ach-monthly-diagnosticreport-note'}})"
+                    "valueString": "define \"SDE DiagnosticReport Note\":   \"DiagnosticReports\" DiagnosticReports   where ((exists(DiagnosticReports.category Category where Category ~ \"Radiology\"))     or exists((DiagnosticReports.category Category where Category ~ \"Pathology\"))     or exists((DiagnosticReports.category Category where Category ~ \"Cardiology\")))     and exists(       \"Initial Population\" IP       where NHSNHelpers.\"Normalize Interval\"(DiagnosticReports.effective) overlaps IP.period)   return DiagnosticReportResource(DiagnosticReports,   {FHIR.canonical{value: 'http://www.cdc.gov/nhsn/fhirportal/dqm/ig/StructureDefinition/ach-monthly-diagnosticreport-note'}},   {\"Radiology\", \"Pathology\", \"Cardiology\", \"LAB\"})"
                   },
                   {
                     "url": "displaySequence",
                     "valueInteger": 23
                   }
-                ]
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
                 "extension": [
                   {
                     "url": "libraryName",
@@ -807,10 +818,31 @@
                     "url": "displaySequence",
                     "valueInteger": 24
                   }
-                ]
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
+                "extension": [
+                  {
+                    "url": "libraryName",
+                    "valueString": "NHSNAcuteCareHospitalMonthlyInitialPopulation"
+                  },
+                  {
+                    "url": "name",
+                    "valueString": "Medication IDs"
+                  },
+                  {
+                    "url": "statement",
+                    "valueString": "define \"Medication IDs\":   (\"SDE Medication Request\"   union \"SDE Medication Administration\") MedReqOrAdmin   where MedReqOrAdmin.medication is FHIR.Reference     and exists(\"Initial Population\") //No longer need to check for timing here because it's checked in SDE Medication Request/Administriation   return NHSNHelpers.GetId(MedReqOrAdmin.medication.reference)"
+                  },
+                  {
+                    "url": "displaySequence",
+                    "valueInteger": 25
+                  }
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
+              },
+              {
                 "extension": [
                   {
                     "url": "libraryName",
@@ -822,16 +854,16 @@
                   },
                   {
                     "url": "statement",
-                    "valueString": "define \"SDE Medication\":   (\"SDE Medication Request\"   union \"SDE Medication Administration\") MedReqOrAdmin   where MedReqOrAdmin.medication is FHIR.Reference   and exists(\"Initial Population\") //No longer need to check for timing here because it's checked in SDE Medication Request/Administriation   return SharedResource.MedicationResource(GetMedicationFrom(MedReqOrAdmin.medication),   {FHIR.canonical{value: 'http://www.cdc.gov/nhsn/fhirportal/dqm/ig/StructureDefinition/ach-monthly-medication'}})"
+                    "valueString": "define \"SDE Medication\":   [Medication] Medications   where Medications.id in \"Medication IDs\"   return SharedResource.MedicationResource(Medications,   {FHIR.canonical{value: 'http://www.cdc.gov/nhsn/fhirportal/dqm/ig/StructureDefinition/ach-monthly-medication'}})"
                   },
                   {
                     "url": "displaySequence",
-                    "valueInteger": 25
+                    "valueInteger": 26
                   }
-                ]
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
                 "extension": [
                   {
                     "url": "libraryName",
@@ -843,16 +875,16 @@
                   },
                   {
                     "url": "statement",
-                    "valueString": "define \"SDE Specimen\":   [Specimen] Specimens   where exists(     \"Initial Population\" IP     where NHSNHelpers.\"Normalize Interval\"(Specimens.collection.collected) overlaps IP.period   )   return SharedResource.SpecimenResource(Specimens,   {FHIR.canonical{value: 'http://www.cdc.gov/nhsn/fhirportal/dqm/ig/StructureDefinition/ach-monthly-specimen'}})"
+                    "valueString": "define \"SDE Specimen\":   [Specimen] Specimens   where exists(     \"Initial Population\" IP     where NHSNHelpers.\"Normalize Interval\"(Specimens.collection.collected) overlaps IP.period   )   return SpecimenResource(Specimens,   {FHIR.canonical{value: 'http://www.cdc.gov/nhsn/fhirportal/dqm/ig/StructureDefinition/ach-monthly-specimen'}})"
                   },
                   {
                     "url": "displaySequence",
-                    "valueInteger": 26
+                    "valueInteger": 27
                   }
-                ]
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
                 "extension": [
                   {
                     "url": "libraryName",
@@ -868,12 +900,12 @@
                   },
                   {
                     "url": "displaySequence",
-                    "valueInteger": 27
+                    "valueInteger": 28
                   }
-                ]
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
                 "extension": [
                   {
                     "url": "libraryName",
@@ -889,12 +921,12 @@
                   },
                   {
                     "url": "displaySequence",
-                    "valueInteger": 28
+                    "valueInteger": 29
                   }
-                ]
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
                 "extension": [
                   {
                     "url": "libraryName",
@@ -910,12 +942,12 @@
                   },
                   {
                     "url": "displaySequence",
-                    "valueInteger": 29
+                    "valueInteger": 30
                   }
-                ]
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
                 "extension": [
                   {
                     "url": "libraryName",
@@ -931,12 +963,33 @@
                   },
                   {
                     "url": "displaySequence",
-                    "valueInteger": 30
+                    "valueInteger": 31
                   }
-                ]
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
+                "extension": [
+                  {
+                    "url": "libraryName",
+                    "valueString": "FHIRHelpers"
+                  },
+                  {
+                    "url": "name",
+                    "valueString": "ToString"
+                  },
+                  {
+                    "url": "statement",
+                    "valueString": "define function ToString(value string): value.value"
+                  },
+                  {
+                    "url": "displaySequence",
+                    "valueInteger": 32
+                  }
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
+              },
+              {
                 "extension": [
                   {
                     "url": "libraryName",
@@ -952,12 +1005,12 @@
                   },
                   {
                     "url": "displaySequence",
-                    "valueInteger": 31
+                    "valueInteger": 33
                   }
-                ]
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
                 "extension": [
                   {
                     "url": "libraryName",
@@ -973,16 +1026,37 @@
                   },
                   {
                     "url": "displaySequence",
-                    "valueInteger": 32
+                    "valueInteger": 34
                   }
-                ]
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
                 "extension": [
                   {
                     "url": "libraryName",
-                    "valueString": "SharedResourceCreation"
+                    "valueString": "FHIRHelpers"
+                  },
+                  {
+                    "url": "name",
+                    "valueString": "ToCode"
+                  },
+                  {
+                    "url": "statement",
+                    "valueString": "define function ToCode(coding FHIR.Coding):     if coding is null then         null     else         System.Code {           code: coding.code.value,           system: coding.system.value,           version: coding.version.value,           display: coding.display.value         }"
+                  },
+                  {
+                    "url": "displaySequence",
+                    "valueInteger": 35
+                  }
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
+              },
+              {
+                "extension": [
+                  {
+                    "url": "libraryName",
+                    "valueString": "NHSNAcuteCareHospitalMonthlyInitialPopulation"
                   },
                   {
                     "url": "name",
@@ -990,16 +1064,16 @@
                   },
                   {
                     "url": "statement",
-                    "valueString": "define function EncounterResource(encounter Encounter, profileURLs List<FHIR.canonical>):   encounter e   return Encounter{     id: FHIR.id{value: 'LCR-' + e.id},     meta: MetaElement(e, profileURLs),     extension: e.extension,     identifier: EncounterIdentifier(e.identifier),     status: e.status,     statusHistory: EncounterStatusHistory(e.statusHistory),     class: e.class,     classHistory: EncounterClassHistory(e.classHistory),     type: e.type,     serviceType: e.serviceType,     priority: e.priority,     subject: e.subject,     period: e.period,     length: e.length,     reasonCode: e.reasonCode,     reasonReference: e.reasonReference,     diagnosis: EncounterDiagnosis(e.diagnosis),     account: e.account,     hospitalization: EncounterHospitalization(e.hospitalization),     location: EncounterLocation(e.location),     partOf: e.partOf   }"
+                    "valueString": "define function EncounterResource(encounter Encounter, profileURLs List<FHIR.canonical>):   encounter e   return Encounter{     id: FHIR.id{value: 'LCR-' + e.id},     meta: SharedResource.MetaElement(e, profileURLs),     extension: e.extension,     identifier: SharedResource.EncounterIdentifier(e.identifier),     status: e.status,     statusHistory: SharedResource.EncounterStatusHistory(e.statusHistory),     class: e.class,     classHistory: SharedResource.EncounterClassHistory(e.classHistory),     type: e.type,     subject: e.subject,     period: e.period,     reasonCode: e.reasonCode,     diagnosis: SharedResource.EncounterDiagnosis(e.diagnosis),     hospitalization: EncounterHospitalization(e.hospitalization),     location: SharedResource.EncounterLocation(e.location),     partOf: e.partOf   }"
                   },
                   {
                     "url": "displaySequence",
-                    "valueInteger": 33
+                    "valueInteger": 36
                   }
-                ]
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
                 "extension": [
                   {
                     "url": "libraryName",
@@ -1015,12 +1089,12 @@
                   },
                   {
                     "url": "displaySequence",
-                    "valueInteger": 34
+                    "valueInteger": 37
                   }
-                ]
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
                 "extension": [
                   {
                     "url": "libraryName",
@@ -1036,12 +1110,12 @@
                   },
                   {
                     "url": "displaySequence",
-                    "valueInteger": 35
+                    "valueInteger": 38
                   }
-                ]
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
                 "extension": [
                   {
                     "url": "libraryName",
@@ -1057,12 +1131,12 @@
                   },
                   {
                     "url": "displaySequence",
-                    "valueInteger": 36
+                    "valueInteger": 39
                   }
-                ]
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
                 "extension": [
                   {
                     "url": "libraryName",
@@ -1078,12 +1152,12 @@
                   },
                   {
                     "url": "displaySequence",
-                    "valueInteger": 37
+                    "valueInteger": 40
                   }
-                ]
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
                 "extension": [
                   {
                     "url": "libraryName",
@@ -1099,16 +1173,16 @@
                   },
                   {
                     "url": "displaySequence",
-                    "valueInteger": 38
+                    "valueInteger": 41
                   }
-                ]
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
                 "extension": [
                   {
                     "url": "libraryName",
-                    "valueString": "SharedResourceCreation"
+                    "valueString": "NHSNAcuteCareHospitalMonthlyInitialPopulation"
                   },
                   {
                     "url": "name",
@@ -1116,16 +1190,16 @@
                   },
                   {
                     "url": "statement",
-                    "valueString": "define function EncounterHospitalization(hospitalization FHIR.Encounter.Hospitalization):   hospitalization h   return FHIR.Encounter.Hospitalization{     preAdmissionIdentifier: h.preAdmissionIdentifier,     origin: h.origin,     admitSource: h.admitSource,     reAdmission: h.reAdmission,     dietPreference: h.dietPreference,     specialCourtesy: h.specialCourtesy,     specialArrangement: h.specialArrangement,     destination: h.destination,     dischargeDisposition: h.dischargeDisposition   }"
+                    "valueString": "define function EncounterHospitalization(hospitalization FHIR.Encounter.Hospitalization):   hospitalization h   return FHIR.Encounter.Hospitalization{     origin: h.origin,     admitSource: h.admitSource,     reAdmission: h.reAdmission,     dietPreference: h.dietPreference,     dischargeDisposition: h.dischargeDisposition   }"
                   },
                   {
                     "url": "displaySequence",
-                    "valueInteger": 39
+                    "valueInteger": 42
                   }
-                ]
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
                 "extension": [
                   {
                     "url": "libraryName",
@@ -1141,12 +1215,12 @@
                   },
                   {
                     "url": "displaySequence",
-                    "valueInteger": 40
+                    "valueInteger": 43
                   }
-                ]
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
                 "extension": [
                   {
                     "url": "libraryName",
@@ -1162,16 +1236,16 @@
                   },
                   {
                     "url": "displaySequence",
-                    "valueInteger": 41
+                    "valueInteger": 44
                   }
-                ]
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
                 "extension": [
                   {
                     "url": "libraryName",
-                    "valueString": "SharedResourceCreation"
+                    "valueString": "NHSNAcuteCareHospitalMonthlyInitialPopulation"
                   },
                   {
                     "url": "name",
@@ -1179,16 +1253,58 @@
                   },
                   {
                     "url": "statement",
-                    "valueString": "define function MedicationRequestResource(medicationRequest MedicationRequest, profileURLs List<FHIR.canonical>):   medicationRequest m   return MedicationRequest{     id: FHIR.id {value: 'LCR-' + m.id},     meta: MetaElement(medicationRequest, profileURLs),     extension: m.extension,     status: m.status,     statusReason: m.statusReason,     intent: m.intent,     category: m.category,     priority: m.priority,     doNotPerform: m.doNotPerform,     reported: m.reported,     medication: m.medication,     subject: m.subject,     encounter: m.encounter,     authoredOn: m.authoredOn,     requester: m.requester,     recorder: m.recorder,     reasonCode: m.reasonCode,     reasonReference: m.reasonReference,     instantiatesCanonical: m.instantiatesCanonical,     instantiatesUri: m.instantiatesUri,     courseOfTherapyType: m.courseOfTherapyType,     dosageInstruction: MedicationRequestDosageInstruction(m.dosageInstruction)   }"
+                    "valueString": "define function MedicationRequestResource(medicationRequest MedicationRequest, profileURLs List<FHIR.canonical>, acceptedCategories List<System.Code>):   medicationRequest m   return MedicationRequest{     id: FHIR.id {value: 'LCR-' + m.id},     meta: SharedResource.MetaElement(medicationRequest, profileURLs),     extension: m.extension,     status: m.status,     statusReason: m.statusReason,     intent: m.intent,     category: FilterCodeableConcepts(m.category, acceptedCategories),     priority: m.priority,     doNotPerform: m.doNotPerform,     reported: m.reported,     medication: m.medication,     subject: m.subject,     encounter: m.encounter,     authoredOn: m.authoredOn,     requester: m.requester,     recorder: m.recorder,     reasonCode: m.reasonCode,     reasonReference: m.reasonReference,     instantiatesCanonical: m.instantiatesCanonical,     instantiatesUri: m.instantiatesUri,     courseOfTherapyType: m.courseOfTherapyType,     dosageInstruction: SharedResource.MedicationRequestDosageInstruction(m.dosageInstruction)   }"
                   },
                   {
                     "url": "displaySequence",
-                    "valueInteger": 42
+                    "valueInteger": 45
                   }
-                ]
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
+                "extension": [
+                  {
+                    "url": "libraryName",
+                    "valueString": "NHSNAcuteCareHospitalMonthlyInitialPopulation"
+                  },
+                  {
+                    "url": "name",
+                    "valueString": "FilterCodeableConcepts"
+                  },
+                  {
+                    "url": "statement",
+                    "valueString": "define function FilterCodeableConcepts(codes List<FHIR.CodeableConcept>, accepted List<System.Code>):   if Count(accepted) > 0     then RemoveUnaccepted(codes, accepted)   else codes"
+                  },
+                  {
+                    "url": "displaySequence",
+                    "valueInteger": 46
+                  }
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
+              },
+              {
+                "extension": [
+                  {
+                    "url": "libraryName",
+                    "valueString": "NHSNAcuteCareHospitalMonthlyInitialPopulation"
+                  },
+                  {
+                    "url": "name",
+                    "valueString": "RemoveUnaccepted"
+                  },
+                  {
+                    "url": "statement",
+                    "valueString": "define function RemoveUnaccepted(codes List<FHIR.CodeableConcept>, accepted List<System.Code>):   codes c   where exists(     accepted a     where c ~ a   )"
+                  },
+                  {
+                    "url": "displaySequence",
+                    "valueInteger": 47
+                  }
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
+              },
+              {
                 "extension": [
                   {
                     "url": "libraryName",
@@ -1204,12 +1320,12 @@
                   },
                   {
                     "url": "displaySequence",
-                    "valueInteger": 43
+                    "valueInteger": 48
                   }
-                ]
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
                 "extension": [
                   {
                     "url": "libraryName",
@@ -1225,16 +1341,16 @@
                   },
                   {
                     "url": "displaySequence",
-                    "valueInteger": 44
+                    "valueInteger": 49
                   }
-                ]
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
                 "extension": [
                   {
                     "url": "libraryName",
-                    "valueString": "SharedResourceCreation"
+                    "valueString": "NHSNAcuteCareHospitalMonthlyInitialPopulation"
                   },
                   {
                     "url": "name",
@@ -1242,41 +1358,20 @@
                   },
                   {
                     "url": "statement",
-                    "valueString": "define function CoverageResource(coverage Coverage, profileURLs List<FHIR.canonical>):   coverage c   return Coverage{     id: FHIR.id{value: 'LCR-' + c.id},     meta: MetaElement(c, profileURLs),     extension: c.extension,     status: c.status,     type: c.type,     policyHolder: c.policyHolder,     subscriber: c.subscriber,     subscriberId: c.subscriberId,     beneficiary: c.beneficiary,     dependent: c.dependent,     relationship: c.relationship,     period: c.period,     payor: c.payor,     class: CoverageClass(c.class),     order: c.order,     network: c.network,     subrogation: c.subrogation,     contract: c.contract   }"
+                    "valueString": "define function CoverageResource(coverage Coverage, profileURLs List<FHIR.canonical>):   coverage c   return Coverage{     id: FHIR.id{value: 'LCR-' + c.id},     meta: SharedResource.MetaElement(c, profileURLs),     extension: c.extension,     status: c.status,     type: c.type,     beneficiary: c.beneficiary,     period: c.period,     payor: c.payor   }"
                   },
                   {
                     "url": "displaySequence",
-                    "valueInteger": 45
+                    "valueInteger": 50
                   }
-                ]
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
                 "extension": [
                   {
                     "url": "libraryName",
-                    "valueString": "SharedResourceCreation"
-                  },
-                  {
-                    "url": "name",
-                    "valueString": "CoverageClass"
-                  },
-                  {
-                    "url": "statement",
-                    "valueString": "define function CoverageClass(class List<FHIR.Coverage.Class>):   class c   return FHIR.Coverage.Class{     value: c.value,     name: c.name   }"
-                  },
-                  {
-                    "url": "displaySequence",
-                    "valueInteger": 46
-                  }
-                ]
-              },
-              {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
-                "extension": [
-                  {
-                    "url": "libraryName",
-                    "valueString": "SharedResourceCreation"
+                    "valueString": "NHSNAcuteCareHospitalMonthlyInitialPopulation"
                   },
                   {
                     "url": "name",
@@ -1284,58 +1379,58 @@
                   },
                   {
                     "url": "statement",
-                    "valueString": "define function ProcedureResource(procedure Procedure, profileURLs List<FHIR.canonical>):   procedure p   return Procedure{     id: FHIR.id {value: 'LCR-' + p.id},     meta: MetaElement(p, profileURLs),     extension: p.extension,     instantiatesCanonical: p.instantiatesCanonical,     instantiatesUri: p.instantiatesUri,     basedOn: p.basedOn,     partOf: p.partOf,     status: p.status,     statusReason: p.statusReason,     category: p.category,     code: p.code,     subject: p.subject,     encounter: p.encounter,     performed: p.performed,     recorder: p.recorder,     asserter: p.asserter,     performer: ProcedurePerformer(p.performer),     location: p.location,     reasonCode: p.reasonCode,     reasonReference: p.reasonReference,     bodySite: p.bodySite,     outcome: p.outcome,     report: p.report,     complication: p.complication,     complicationDetail: p.complicationDetail,     followUp: p.followUp,     note: p.note,     focalDevice: ProcedureFocalDevice(p.focalDevice),     usedReference: p.usedReference,     usedCode: p.usedCode   }"
+                    "valueString": "define function ProcedureResource(procedure Procedure, profileURLs List<FHIR.canonical>, acceptedCategories List<System.Code>):   procedure p   return Procedure{     id: FHIR.id {value: 'LCR-' + p.id},     meta: SharedResource.MetaElement(p, profileURLs),     extension: GetProcedureExtensions(p),      basedOn: p.basedOn,     partOf: p.partOf,     status: p.status,     category: FilterCodeableConcepts({p.category}, acceptedCategories)[0],     code: p.code,     subject: p.subject,     encounter: p.encounter,     performed: p.performed,     location: p.location,     reasonCode: p.reasonCode,     reasonReference: p.reasonReference,     bodySite: p.bodySite   }"
                   },
                   {
                     "url": "displaySequence",
-                    "valueInteger": 47
+                    "valueInteger": 51
                   }
-                ]
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
                 "extension": [
                   {
                     "url": "libraryName",
-                    "valueString": "SharedResourceCreation"
+                    "valueString": "NHSNAcuteCareHospitalMonthlyInitialPopulation"
                   },
                   {
                     "url": "name",
-                    "valueString": "ProcedurePerformer"
+                    "valueString": "GetProcedureExtensions"
                   },
                   {
                     "url": "statement",
-                    "valueString": "define function ProcedurePerformer(performer List<FHIR.Procedure.Performer>):   performer p   return FHIR.Procedure.Performer{     function: p.function,     actor: p.actor,     onBehalfOf: p.onBehalfOf   }"
+                    "valueString": "define function \"GetProcedureExtensions\"(domainResource DomainResource):   domainResource.extension E     where E.url != 'http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-recorded'      return E"
                   },
                   {
                     "url": "displaySequence",
-                    "valueInteger": 48
+                    "valueInteger": 52
                   }
-                ]
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
                 "extension": [
                   {
                     "url": "libraryName",
-                    "valueString": "SharedResourceCreation"
+                    "valueString": "FHIRHelpers"
                   },
                   {
                     "url": "name",
-                    "valueString": "ProcedureFocalDevice"
+                    "valueString": "ToString"
                   },
                   {
                     "url": "statement",
-                    "valueString": "define function ProcedureFocalDevice(device List<FHIR.Procedure.FocalDevice>):   device d   return FHIR.Procedure.FocalDevice{     action: d.action,     manipulated: d.manipulated   }"
+                    "valueString": "define function ToString(value uri): value.value"
                   },
                   {
                     "url": "displaySequence",
-                    "valueInteger": 49
+                    "valueInteger": 53
                   }
-                ]
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
                 "extension": [
                   {
                     "url": "libraryName",
@@ -1347,125 +1442,20 @@
                   },
                   {
                     "url": "statement",
-                    "valueString": "define function DeviceResource(device Device, profileURLs List<FHIR.canonical>):   device d   return Device{     id: FHIR.id{value: 'LCR-' + d.id},     meta: SharedResource.MetaElement(d, profileURLs),     extension: d.extension,     definition: d.definition,     udiCarrier: DeviceUdiCarrier(d.udiCarrier),     status: d.status,     statusReason: d.statusReason,     distinctIdentifier: d.distinctIdentifier,     manufacturer: d.manufacturer,     manufactureDate: d.manufactureDate,     expirationDate: d.expirationDate,     lotNumber: d.lotNumber,     serialNumber: d.serialNumber,     deviceName: DeviceDeviceName(d.deviceName),     modelNumber: d.modelNumber,     partNumber: d.partNumber,     type: d.type,     specialization: DeviceSpecialization(d.specialization),     version: DeviceVersion(d.version),     property: DeviceProperty(d.property),     patient: d.patient,     owner: d.owner,     contact: d.contact,     location: d.location,     url: d.url,     note: d.note,     safety: d.safety,     parent: d.parent   }"
-                  },
-                  {
-                    "url": "displaySequence",
-                    "valueInteger": 50
-                  }
-                ]
-              },
-              {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
-                "extension": [
-                  {
-                    "url": "libraryName",
-                    "valueString": "NHSNAcuteCareHospitalMonthlyInitialPopulation"
-                  },
-                  {
-                    "url": "name",
-                    "valueString": "DeviceUdiCarrier"
-                  },
-                  {
-                    "url": "statement",
-                    "valueString": "// //Measure Specific Resource Creation Functions // define function DeviceUdiCarrier(udiCarrier List<FHIR.Device.UdiCarrier>):   udiCarrier u   return FHIR.Device.UdiCarrier{     deviceIdentifier: u.deviceIdentifier,     issuer: u.issuer,     jurisdiction: u.jurisdiction,     carrierAIDC: u.carrierAIDC,     carrierHRF: u.carrierHRF,     entryType: u.entryType   }"
-                  },
-                  {
-                    "url": "displaySequence",
-                    "valueInteger": 51
-                  }
-                ]
-              },
-              {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
-                "extension": [
-                  {
-                    "url": "libraryName",
-                    "valueString": "NHSNAcuteCareHospitalMonthlyInitialPopulation"
-                  },
-                  {
-                    "url": "name",
-                    "valueString": "DeviceDeviceName"
-                  },
-                  {
-                    "url": "statement",
-                    "valueString": "define function DeviceDeviceName(deviceName List<FHIR.Device.DeviceName>):   deviceName d   return FHIR.Device.DeviceName{     name: d.name,     type: d.type   }"
-                  },
-                  {
-                    "url": "displaySequence",
-                    "valueInteger": 52
-                  }
-                ]
-              },
-              {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
-                "extension": [
-                  {
-                    "url": "libraryName",
-                    "valueString": "NHSNAcuteCareHospitalMonthlyInitialPopulation"
-                  },
-                  {
-                    "url": "name",
-                    "valueString": "DeviceSpecialization"
-                  },
-                  {
-                    "url": "statement",
-                    "valueString": "define function DeviceSpecialization(specialization List<FHIR.Device.Specialization>):   specialization s   return FHIR.Device.Specialization{     systemType: s.systemType,     version: s.version   }"
-                  },
-                  {
-                    "url": "displaySequence",
-                    "valueInteger": 53
-                  }
-                ]
-              },
-              {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
-                "extension": [
-                  {
-                    "url": "libraryName",
-                    "valueString": "NHSNAcuteCareHospitalMonthlyInitialPopulation"
-                  },
-                  {
-                    "url": "name",
-                    "valueString": "DeviceVersion"
-                  },
-                  {
-                    "url": "statement",
-                    "valueString": "define function DeviceVersion(version List<FHIR.Device.Version>):   version v   return FHIR.Device.Version{     type: v.type,     component: v.component,     value: v.value   }"
+                    "valueString": "define function DeviceResource(device Device, profileURLs List<FHIR.canonical>):   device d   return Device{     id: FHIR.id{value: 'LCR-' + d.id},     meta: SharedResource.MetaElement(d, profileURLs),     extension: d.extension,     status: d.status,     expirationDate: d.expirationDate,     lotNumber: d.lotNumber,     serialNumber: d.serialNumber,     modelNumber: d.modelNumber,     partNumber: d.partNumber,     type: d.type,     patient: d.patient,     parent: d.parent   }"
                   },
                   {
                     "url": "displaySequence",
                     "valueInteger": 54
                   }
-                ]
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
                 "extension": [
                   {
                     "url": "libraryName",
                     "valueString": "NHSNAcuteCareHospitalMonthlyInitialPopulation"
-                  },
-                  {
-                    "url": "name",
-                    "valueString": "DeviceProperty"
-                  },
-                  {
-                    "url": "statement",
-                    "valueString": "define function DeviceProperty(deviceProperty List<FHIR.Device.Property>):   deviceProperty d   return FHIR.Device.Property{     id: d.id,     type: d.type,     valueQuantity: d.valueQuantity,     valueCode: d.valueCode   }"
-                  },
-                  {
-                    "url": "displaySequence",
-                    "valueInteger": 55
-                  }
-                ]
-              },
-              {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
-                "extension": [
-                  {
-                    "url": "libraryName",
-                    "valueString": "SharedResourceCreation"
                   },
                   {
                     "url": "name",
@@ -1473,20 +1463,20 @@
                   },
                   {
                     "url": "statement",
-                    "valueString": "define function ObservationLabResource(observation Observation, profileURLs List<FHIR.canonical>):   observation o   return Observation{     id: FHIR.id {value: 'LCR-' + o.id},     meta: MetaElement(o, profileURLs),     extension: o.extension,     basedOn: o.basedOn,     partOf: o.partOf,     status: o.status,     category: ObservationLabCategory(o.category),     code: o.code,     subject: o.subject,     focus: o.focus,     encounter: o.encounter,     effective: o.effective,     issued: o.issued,     performer: o.performer,     value: o.value,     dataAbsentReason: o.dataAbsentReason,     interpretation: o.interpretation,     note: o.note,     bodySite: o.bodySite,     method: o.method,     specimen: o.specimen,     device: o.device,     referenceRange: ObservationReferenceRange(o.referenceRange),     hasMember: o.hasMember,     derivedFrom: o.derivedFrom,     component: ObservationComponent(o.component)   }"
+                    "valueString": "define function ObservationLabResource(observation Observation, profileURLs List<FHIR.canonical>, acceptedCategories List<System.Code>):   observation o   return Observation{     id: FHIR.id {value: 'LCR-' + o.id},     meta: SharedResource.MetaElement(o, profileURLs),     extension: o.extension,     partOf: o.partOf,     status: o.status,     category: FilterCodeableConcepts(ObservationLabCategory(o.category), acceptedCategories),     code: o.code,     subject: o.subject,     encounter: o.encounter,     effective: o.effective,     issued: o.issued,     value: o.value,     dataAbsentReason: o.dataAbsentReason,     interpretation: o.interpretation,     bodySite: o.bodySite,     method: o.method,     specimen: o.specimen,     referenceRange: ObservationLabReferenceRange(o.referenceRange),     hasMember: o.hasMember,     derivedFrom: o.derivedFrom,     component: SharedResource.ObservationComponent(o.component)   }"
                   },
                   {
                     "url": "displaySequence",
-                    "valueInteger": 56
+                    "valueInteger": 55
                   }
-                ]
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
                 "extension": [
                   {
                     "url": "libraryName",
-                    "valueString": "SharedResourceCreation"
+                    "valueString": "NHSNAcuteCareHospitalMonthlyInitialPopulation"
                   },
                   {
                     "url": "name",
@@ -1498,16 +1488,16 @@
                   },
                   {
                     "url": "displaySequence",
-                    "valueInteger": 57
+                    "valueInteger": 56
                   }
-                ]
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
                 "extension": [
                   {
                     "url": "libraryName",
-                    "valueString": "SharedResourceCreation"
+                    "valueString": "NHSNAcuteCareHospitalMonthlyInitialPopulation"
                   },
                   {
                     "url": "name",
@@ -1515,37 +1505,37 @@
                   },
                   {
                     "url": "statement",
-                    "valueString": "define function ObservationLabCoding(coding List<Coding>):   coding c   return Coding{     id: c.id,     extension: c.extension,     system: c.system,     version: c.version,     code: c.code,     display: c.display,     userSelected: c.userSelected   }"
+                    "valueString": "define function ObservationLabCoding(coding List<Coding>):   coding c   return Coding{     system: c.system,     version: c.version,     code: c.code,     display: c.display,     userSelected: c.userSelected   }"
+                  },
+                  {
+                    "url": "displaySequence",
+                    "valueInteger": 57
+                  }
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
+              },
+              {
+                "extension": [
+                  {
+                    "url": "libraryName",
+                    "valueString": "NHSNAcuteCareHospitalMonthlyInitialPopulation"
+                  },
+                  {
+                    "url": "name",
+                    "valueString": "ObservationLabReferenceRange"
+                  },
+                  {
+                    "url": "statement",
+                    "valueString": "define function ObservationLabReferenceRange(referenceRange List<FHIR.Observation.ReferenceRange>):   referenceRange rR   return FHIR.Observation.ReferenceRange{     low: rR.low,     high: rR.high,     type: rR.type,     appliesTo: rR.appliesTo,     age: rR.age   }"
                   },
                   {
                     "url": "displaySequence",
                     "valueInteger": 58
                   }
-                ]
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
-                "extension": [
-                  {
-                    "url": "libraryName",
-                    "valueString": "SharedResourceCreation"
-                  },
-                  {
-                    "url": "name",
-                    "valueString": "ObservationReferenceRange"
-                  },
-                  {
-                    "url": "statement",
-                    "valueString": "define function ObservationReferenceRange(referenceRange List<FHIR.Observation.ReferenceRange>):   referenceRange rR   return FHIR.Observation.ReferenceRange{     low: rR.low,     high: rR.high,     type: rR.type,     appliesTo: rR.appliesTo,     age: rR.age,     text: rR.text   }"
-                  },
-                  {
-                    "url": "displaySequence",
-                    "valueInteger": 59
-                  }
-                ]
-              },
-              {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
                 "extension": [
                   {
                     "url": "libraryName",
@@ -1561,12 +1551,12 @@
                   },
                   {
                     "url": "displaySequence",
-                    "valueInteger": 60
+                    "valueInteger": 59
                   }
-                ]
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
                 "extension": [
                   {
                     "url": "libraryName",
@@ -1578,16 +1568,16 @@
                   },
                   {
                     "url": "statement",
-                    "valueString": "define function ObservationVitalSignsResource(observation Observation, profileURLs List<FHIR.canonical>):   observation o   return Observation{     id: FHIR.id {value: 'LCR-' + o.id},     meta: SharedResource.MetaElement(o, profileURLs),     extension: o.extension,     partOf: o.partOf,     status: o.status,     category: ObservationVitalSignsCategory(o.category),     code: o.code,     subject: o.subject,     focus: o.focus,     encounter: o.encounter,     effective: o.effective,     issued: o.issued,     performer: o.performer,     value: o.value,     dataAbsentReason: o.dataAbsentReason,     interpretation: o.interpretation,     note: o.note,     bodySite: o.bodySite,     method: o.method,     specimen: o.specimen,     device: o.device,     referenceRange: SharedResource.ObservationReferenceRange(o.referenceRange),     hasMember: o.hasMember,     derivedFrom: o.derivedFrom,     component: ObservationVitalSignsComponent(o.component)   }"
+                    "valueString": "define function ObservationVitalSignsResource(observation Observation, profileURLs List<FHIR.canonical>, acceptedCategories List<System.Code>):   observation o   return Observation{     id: FHIR.id {value: 'LCR-' + o.id},     meta: SharedResource.MetaElement(o, profileURLs),     extension: o.extension,     partOf: o.partOf,     status: o.status,     category: FilterCodeableConcepts(ObservationVitalSignsCategory(o.category), acceptedCategories),     code: o.code,     subject: o.subject,     encounter: o.encounter,     effective: o.effective,     issued: o.issued,     value: o.value,     dataAbsentReason: o.dataAbsentReason,     interpretation: o.interpretation,     bodySite: o.bodySite,     method: o.method,     specimen: o.specimen,     referenceRange: ObservationVitalSignsReferenceRange(o.referenceRange),     hasMember: o.hasMember,     derivedFrom: o.derivedFrom,     component: ObservationVitalSignsComponent(o.component)   }"
                   },
                   {
                     "url": "displaySequence",
-                    "valueInteger": 61
+                    "valueInteger": 60
                   }
-                ]
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
                 "extension": [
                   {
                     "url": "libraryName",
@@ -1603,12 +1593,12 @@
                   },
                   {
                     "url": "displaySequence",
-                    "valueInteger": 62
+                    "valueInteger": 61
                   }
-                ]
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
                 "extension": [
                   {
                     "url": "libraryName",
@@ -1624,12 +1614,33 @@
                   },
                   {
                     "url": "displaySequence",
-                    "valueInteger": 63
+                    "valueInteger": 62
                   }
-                ]
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
+                "extension": [
+                  {
+                    "url": "libraryName",
+                    "valueString": "NHSNAcuteCareHospitalMonthlyInitialPopulation"
+                  },
+                  {
+                    "url": "name",
+                    "valueString": "ObservationVitalSignsReferenceRange"
+                  },
+                  {
+                    "url": "statement",
+                    "valueString": "define function ObservationVitalSignsReferenceRange(referenceRange List<FHIR.Observation.ReferenceRange>):   referenceRange rR   return FHIR.Observation.ReferenceRange{     low: rR.low,     high: rR.high,     type: rR.type,     appliesTo: rR.appliesTo,     age: rR.age   }"
+                  },
+                  {
+                    "url": "displaySequence",
+                    "valueInteger": 63
+                  }
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
+              },
+              {
                 "extension": [
                   {
                     "url": "libraryName",
@@ -1647,10 +1658,31 @@
                     "url": "displaySequence",
                     "valueInteger": 64
                   }
-                ]
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
+                "extension": [
+                  {
+                    "url": "libraryName",
+                    "valueString": "SharedResourceCreation"
+                  },
+                  {
+                    "url": "name",
+                    "valueString": "ObservationReferenceRange"
+                  },
+                  {
+                    "url": "statement",
+                    "valueString": "define function ObservationReferenceRange(referenceRange List<FHIR.Observation.ReferenceRange>):   referenceRange rR   return FHIR.Observation.ReferenceRange{     low: rR.low,     high: rR.high,     type: rR.type,     appliesTo: rR.appliesTo,     age: rR.age,     text: rR.text   }"
+                  },
+                  {
+                    "url": "displaySequence",
+                    "valueInteger": 65
+                  }
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
+              },
+              {
                 "extension": [
                   {
                     "url": "libraryName",
@@ -1662,20 +1694,20 @@
                   },
                   {
                     "url": "statement",
-                    "valueString": "define function DiagnosticReportResource(diagnosticReport DiagnosticReport, profileURLs List<FHIR.canonical>):   diagnosticReport d   return DiagnosticReport{     id: FHIR.id{value: 'LCR-' + d.id},     meta: SharedResource.MetaElement(d, profileURLs),     extension: d.extension,     basedOn: d.basedOn,     status: d.status,     category: d.category,     code: d.code,     subject: d.subject,     encounter: d.encounter,     effective: d.effective,     issued: d.issued,     performer: d.performer,     resultsInterpreter: d.resultsInterpreter,     specimen: d.specimen,     result: d.result,     conclusion: d.conclusion,     conclusionCode: d.conclusionCode   }"
+                    "valueString": "define function DiagnosticReportResource(diagnosticReport DiagnosticReport, profileURLs List<FHIR.canonical>, acceptedCategories List<System.Code>):   diagnosticReport d   return DiagnosticReport{     id: FHIR.id{value: 'LCR-' + d.id},     meta: SharedResource.MetaElement(d, profileURLs),     extension: d.extension,     basedOn: d.basedOn,     status: d.status,     category: FilterCodeableConcepts(d.category, acceptedCategories),     code: d.code,     subject: d.subject,     encounter: d.encounter,     effective: d.effective,     issued: d.issued,     specimen: d.specimen,     result: d.result,     conclusion: d.conclusion,     conclusionCode: d.conclusionCode   }"
                   },
                   {
                     "url": "displaySequence",
-                    "valueInteger": 65
+                    "valueInteger": 66
                   }
-                ]
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
                 "extension": [
                   {
                     "url": "libraryName",
-                    "valueString": "SharedResourceCreation"
+                    "valueString": "NHSNAcuteCareHospitalMonthlyInitialPopulation"
                   },
                   {
                     "url": "name",
@@ -1683,16 +1715,16 @@
                   },
                   {
                     "url": "statement",
-                    "valueString": "define function MedicationAdministrationResource(medicationAdministration MedicationAdministration, profileURLs List<FHIR.canonical>):   medicationAdministration m   return MedicationAdministration{     id: FHIR.id {value: 'LCR-' + m.id},     meta: MetaElement(m, profileURLs),     extension: m.extension,     instantiates: m.instantiates,     partOf: m.partOf,     status: m.status,     statusReason: m.statusReason,     category: m.category,     medication: m.medication,     subject: m.subject,     context: m.context,     supportingInformation: m.supportingInformation,     effective: m.effective,     performer: MedicationAdministrationPerformer(m.performer),     reasonCode: m.reasonCode,     reasonReference: m.reasonReference,     request: m.request,     device: m.device,     note: m.note,     dosage: MedicationAdministrationDosage(m.dosage),     eventHistory: m.eventHistory   }"
+                    "valueString": "define function MedicationAdministrationResource(medicationAdministration MedicationAdministration, profileURLs List<FHIR.canonical>, acceptedCategories List<System.Code>):   medicationAdministration m   return MedicationAdministration{     id: FHIR.id {value: 'LCR-' + m.id},     meta: SharedResource.MetaElement(m, profileURLs),     extension: m.extension,     instantiates: m.instantiates,     partOf: m.partOf,     status: m.status,     statusReason: m.statusReason,     category: FilterCodeableConcepts({m.category}, acceptedCategories)[0],     medication: m.medication,     subject: m.subject,     context: m.context,     supportingInformation: m.supportingInformation,     effective: m.effective,     performer: SharedResource.MedicationAdministrationPerformer(m.performer),     reasonCode: m.reasonCode,     reasonReference: m.reasonReference,     request: m.request,     device: m.device,     note: m.note,     dosage: SharedResource.MedicationAdministrationDosage(m.dosage),     eventHistory: m.eventHistory   }"
                   },
                   {
                     "url": "displaySequence",
-                    "valueInteger": 66
+                    "valueInteger": 67
                   }
-                ]
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
                 "extension": [
                   {
                     "url": "libraryName",
@@ -1708,12 +1740,12 @@
                   },
                   {
                     "url": "displaySequence",
-                    "valueInteger": 67
+                    "valueInteger": 68
                   }
-                ]
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
                 "extension": [
                   {
                     "url": "libraryName",
@@ -1729,12 +1761,12 @@
                   },
                   {
                     "url": "displaySequence",
-                    "valueInteger": 68
+                    "valueInteger": 69
                   }
-                ]
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
                 "extension": [
                   {
                     "url": "libraryName",
@@ -1746,37 +1778,16 @@
                   },
                   {
                     "url": "statement",
-                    "valueString": "define function ObservationResource(observation Observation, profileURLs List<FHIR.canonical>):   observation o   return Observation{     id: FHIR.id {value: 'LCR-' + o.id},     meta: SharedResource.MetaElement(o, profileURLs),     extension: o.extension,     partOf: o.partOf,     status: o.status,     category: o.category,     code: o.code,     subject: o.subject,     focus: o.focus,     encounter: o.encounter,     effective: o.effective,     issued: o.issued,     performer: o.performer,     value: o.value,     dataAbsentReason: o.dataAbsentReason,     interpretation: o.interpretation,     note: o.note,     bodySite: o.bodySite,     method: o.method,     specimen: o.specimen,     device: o.device,     referenceRange: SharedResource.ObservationReferenceRange(o.referenceRange),     hasMember: o.hasMember,     derivedFrom: o.derivedFrom,     component: SharedResource.ObservationComponent(o.component)   }"
-                  },
-                  {
-                    "url": "displaySequence",
-                    "valueInteger": 69
-                  }
-                ]
-              },
-              {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
-                "extension": [
-                  {
-                    "url": "libraryName",
-                    "valueString": "NHSNAcuteCareHospitalMonthlyInitialPopulation"
-                  },
-                  {
-                    "url": "name",
-                    "valueString": "GetCondition"
-                  },
-                  {
-                    "url": "statement",
-                    "valueString": "define function \"GetCondition\"(reference Reference):   singleton from (     \"Conditions\" Conditions     where Conditions.id = NHSNHelpers.GetId(reference.reference)   )"
+                    "valueString": "define function ObservationResource(observation Observation, profileURLs List<FHIR.canonical>, acceptedCategories List<System.Code>):   observation o   return Observation{     id: FHIR.id {value: 'LCR-' + o.id},     meta: SharedResource.MetaElement(o, profileURLs),     extension: o.extension,     partOf: o.partOf,     status: o.status,     category: FilterCodeableConcepts(o.category, acceptedCategories),     code: o.code,     subject: o.subject,     encounter: o.encounter,     effective: o.effective,     issued: o.issued,     value: o.value,     dataAbsentReason: o.dataAbsentReason,     interpretation: o.interpretation,     bodySite: o.bodySite,     method: o.method,     specimen: o.specimen,     referenceRange: ObservationReferenceRange(o.referenceRange),     hasMember: o.hasMember,     derivedFrom: o.derivedFrom,     component: SharedResource.ObservationComponent(o.component)   }"
                   },
                   {
                     "url": "displaySequence",
                     "valueInteger": 70
                   }
-                ]
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
                 "extension": [
                   {
                     "url": "libraryName",
@@ -1784,24 +1795,24 @@
                   },
                   {
                     "url": "name",
-                    "valueString": "GetEncounter"
+                    "valueString": "ObservationReferenceRange"
                   },
                   {
                     "url": "statement",
-                    "valueString": "define function \"GetEncounter\"(reference Reference):   singleton from (     \"Encounters\" Encounters     where Encounters.id = NHSNHelpers.GetId(reference.reference)   )"
+                    "valueString": "define function ObservationReferenceRange(referenceRange List<FHIR.Observation.ReferenceRange>):   referenceRange rR   return FHIR.Observation.ReferenceRange{     low: rR.low,     high: rR.high,     type: rR.type,     appliesTo: rR.appliesTo,     age: rR.age   }"
                   },
                   {
                     "url": "displaySequence",
                     "valueInteger": 71
                   }
-                ]
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
                 "extension": [
                   {
                     "url": "libraryName",
-                    "valueString": "SharedResourceCreation"
+                    "valueString": "NHSNAcuteCareHospitalMonthlyInitialPopulation"
                   },
                   {
                     "url": "name",
@@ -1809,62 +1820,20 @@
                   },
                   {
                     "url": "statement",
-                    "valueString": "define function ConditionResource(condition Condition, profileURLs List<FHIR.canonical>):   condition c   return Condition{     id: FHIR.id {value: 'LCR-' + c.id},     meta: MetaElement(c, profileURLs),     extension: c.extension,     clinicalStatus: c.clinicalStatus,     verificationStatus: c.verificationStatus,     category: c.category,     severity: c.severity,     code: c.code,     bodySite: c.bodySite,     subject: c.subject,     encounter: c.encounter,     onset: c.onset,     abatement: c.abatement,     recordedDate: c.recordedDate,     stage: ConditionStage(c.stage),     evidence: ConditionEvidence(c.evidence),     note: c.note   }"
+                    "valueString": "// //Measure Specific Resource Creation Functions //  define function ConditionResource(condition Condition, profileURLs List<FHIR.canonical>, acceptedCategories List<System.Code>):   condition c   return Condition{     id: FHIR.id {value: 'LCR-' + c.id},     meta: SharedResource.MetaElement(c, profileURLs),     extension: c.extension,     clinicalStatus: c.clinicalStatus,     verificationStatus: c.verificationStatus,     category: FilterCodeableConcepts(c.category, acceptedCategories),     code: c.code,     subject: c.subject,     encounter: c.encounter,     onset: c.onset,     abatement: c.abatement,     recordedDate: c.recordedDate   }"
                   },
                   {
                     "url": "displaySequence",
                     "valueInteger": 72
                   }
-                ]
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
                 "extension": [
                   {
                     "url": "libraryName",
-                    "valueString": "SharedResourceCreation"
-                  },
-                  {
-                    "url": "name",
-                    "valueString": "ConditionStage"
-                  },
-                  {
-                    "url": "statement",
-                    "valueString": "define function ConditionStage(stage List<FHIR.Condition.Stage>):   stage s   return FHIR.Condition.Stage{     summary: s.summary,     assessment: s.assessment,     type: s.type   }"
-                  },
-                  {
-                    "url": "displaySequence",
-                    "valueInteger": 73
-                  }
-                ]
-              },
-              {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
-                "extension": [
-                  {
-                    "url": "libraryName",
-                    "valueString": "SharedResourceCreation"
-                  },
-                  {
-                    "url": "name",
-                    "valueString": "ConditionEvidence"
-                  },
-                  {
-                    "url": "statement",
-                    "valueString": "define function ConditionEvidence(evidence List<FHIR.Condition.Evidence>):   evidence e   return FHIR.Condition.Evidence{     code: e.code,     detail: e.detail   }"
-                  },
-                  {
-                    "url": "displaySequence",
-                    "valueInteger": 74
-                  }
-                ]
-              },
-              {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
-                "extension": [
-                  {
-                    "url": "libraryName",
-                    "valueString": "SharedResourceCreation"
+                    "valueString": "NHSNAcuteCareHospitalMonthlyInitialPopulation"
                   },
                   {
                     "url": "name",
@@ -1872,20 +1841,20 @@
                   },
                   {
                     "url": "statement",
-                    "valueString": "define function DiagnosticReportLabResource(diagnosticReport DiagnosticReport, profileURLs List<FHIR.canonical>):   diagnosticReport d   return DiagnosticReport{     id: FHIR.id{value: 'LCR-' + d.id},     meta: MetaElement(d, profileURLs),     extension: d.extension,     basedOn: d.basedOn,     status: d.status,     category: DiagnosticReportCategory(d.category),     code: d.code,     subject: d.subject,     encounter: d.encounter,     effective: d.effective,     issued: d.issued,     performer: d.performer,     resultsInterpreter: d.resultsInterpreter,     specimen: d.specimen,     result: d.result,     conclusion: d.conclusion,     conclusionCode: d.conclusionCode   }"
+                    "valueString": "define function DiagnosticReportLabResource(diagnosticReport DiagnosticReport, profileURLs List<FHIR.canonical>, acceptedCategories List<System.Code>):   diagnosticReport d   return DiagnosticReport{     id: FHIR.id{value: 'LCR-' + d.id},     meta: SharedResource.MetaElement(d, profileURLs),     extension: d.extension,     basedOn: d.basedOn,     status: d.status,     category: FilterCodeableConcepts(DiagnosticReportCategory(d.category), acceptedCategories),     code: d.code,     subject: d.subject,     encounter: d.encounter,     effective: d.effective,     issued: d.issued,     specimen: d.specimen,     result: d.result,     conclusion: d.conclusion,     conclusionCode: d.conclusionCode   }"
                   },
                   {
                     "url": "displaySequence",
-                    "valueInteger": 75
+                    "valueInteger": 73
                   }
-                ]
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
                 "extension": [
                   {
                     "url": "libraryName",
-                    "valueString": "SharedResourceCreation"
+                    "valueString": "NHSNAcuteCareHospitalMonthlyInitialPopulation"
                   },
                   {
                     "url": "name",
@@ -1897,16 +1866,16 @@
                   },
                   {
                     "url": "displaySequence",
-                    "valueInteger": 76
+                    "valueInteger": 74
                   }
-                ]
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
                 "extension": [
                   {
                     "url": "libraryName",
-                    "valueString": "SharedResourceCreation"
+                    "valueString": "NHSNAcuteCareHospitalMonthlyInitialPopulation"
                   },
                   {
                     "url": "name",
@@ -1914,20 +1883,20 @@
                   },
                   {
                     "url": "statement",
-                    "valueString": "define function DiagnosticReportCoding(coding List<Coding>):   coding c   return Coding{     system: c.system,     version: c.version,     code: c.code,     display: c.display,     userSelected: c.userSelected   }"
+                    "valueString": "define function DiagnosticReportCoding(coding List<Coding>):   coding c   return Coding{     system: c.system,     version: c.version,     code: c.code,     display: c.display   }"
                   },
                   {
                     "url": "displaySequence",
-                    "valueInteger": 77
+                    "valueInteger": 75
                   }
-                ]
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
                 "extension": [
                   {
                     "url": "libraryName",
-                    "valueString": "SharedResourceCreation"
+                    "valueString": "NHSNAcuteCareHospitalMonthlyInitialPopulation"
                   },
                   {
                     "url": "name",
@@ -1935,83 +1904,20 @@
                   },
                   {
                     "url": "statement",
-                    "valueString": "define function LocationResource(location Location, profileURLs List<FHIR.canonical>):   location l   return Location{     id: FHIR.id {value: 'LCR-' + l.id},     meta: MetaElement(l, profileURLs),     extension: l.extension,     status: l.status,     operationalStatus: l.operationalStatus,     name: l.name,     alias: l.alias,     description: l.description,     mode: l.mode,     type: l.type,     telecom: l.telecom,     address: LocationAddress(l.address),     physicalType: l.physicalType,     position: LocationPosition(l.position),     managingOrganization: l.managingOrganization,     partOf: l.partOf,     hoursOfOperation: LocationHoursOfOperation(l.hoursOfOperation),     availabilityExceptions: l.availabilityExceptions,     endpoint: l.endpoint   }"
+                    "valueString": "define function LocationResource(location Location, profileURLs List<FHIR.canonical>):   location l   return Location{     id: FHIR.id {value: 'LCR-' + l.id},     meta: SharedResource.MetaElement(l, profileURLs),     extension: l.extension,     status: l.status,     name: l.name,     alias: l.alias,     type: l.type,     physicalType: l.physicalType,     managingOrganization: l.managingOrganization,     partOf: l.partOf   }"
                   },
                   {
                     "url": "displaySequence",
-                    "valueInteger": 78
+                    "valueInteger": 76
                   }
-                ]
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
                 "extension": [
                   {
                     "url": "libraryName",
-                    "valueString": "SharedResourceCreation"
-                  },
-                  {
-                    "url": "name",
-                    "valueString": "LocationAddress"
-                  },
-                  {
-                    "url": "statement",
-                    "valueString": "define function LocationAddress(address FHIR.Address):   address a   return FHIR.Address{     use: a.use,     type: a.type,     text: a.text,     line: a.line,     city: a.city,     district: a.district,     state: a.state,     postalCode: a.postalCode,     country: a.country,     period: a.period   }"
-                  },
-                  {
-                    "url": "displaySequence",
-                    "valueInteger": 79
-                  }
-                ]
-              },
-              {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
-                "extension": [
-                  {
-                    "url": "libraryName",
-                    "valueString": "SharedResourceCreation"
-                  },
-                  {
-                    "url": "name",
-                    "valueString": "LocationPosition"
-                  },
-                  {
-                    "url": "statement",
-                    "valueString": "define function LocationPosition(position FHIR.Location.Position):   position p   return FHIR.Location.Position{     longitude: p.longitude,     latitude: p.latitude,     altitude: p.altitude   }"
-                  },
-                  {
-                    "url": "displaySequence",
-                    "valueInteger": 80
-                  }
-                ]
-              },
-              {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
-                "extension": [
-                  {
-                    "url": "libraryName",
-                    "valueString": "SharedResourceCreation"
-                  },
-                  {
-                    "url": "name",
-                    "valueString": "LocationHoursOfOperation"
-                  },
-                  {
-                    "url": "statement",
-                    "valueString": "define function LocationHoursOfOperation(hoursOfOperation List<FHIR.Location.HoursOfOperation>):   hoursOfOperation hOO   return FHIR.Location.HoursOfOperation{     daysOfWeek: hOO.daysOfWeek,     allDay: hOO.allDay,     openingTime: hOO.openingTime,     closingTime: hOO.closingTime   }"
-                  },
-                  {
-                    "url": "displaySequence",
-                    "valueInteger": 81
-                  }
-                ]
-              },
-              {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
-                "extension": [
-                  {
-                    "url": "libraryName",
-                    "valueString": "SharedResourceCreation"
+                    "valueString": "NHSNAcuteCareHospitalMonthlyInitialPopulation"
                   },
                   {
                     "url": "name",
@@ -2019,16 +1925,16 @@
                   },
                   {
                     "url": "statement",
-                    "valueString": "define function ServiceRequestResource(serviceRequest ServiceRequest, profileURLs List<FHIR.canonical>):   serviceRequest sR   return ServiceRequest{     id: FHIR.id {value: 'LCR-' + sR.id},     meta: MetaElement(sR, profileURLs),     extension: sR.extension,     instantiatesCanonical: sR.instantiatesCanonical,     instantiatesUri: sR.instantiatesUri,     basedOn: sR.basedOn,     replaces: sR.replaces,     requisition: sR.requisition,     status: sR.status,     intent: sR.intent,     category: sR.category,     priority: sR.priority,     doNotPerform: sR.doNotPerform,     code: sR.code,     orderDetail: sR.orderDetail,     quantity: sR.quantity,     subject: sR.subject,     encounter: sR.encounter,     occurrence: sR.occurrence,     asNeeded: sR.asNeeded,     authoredOn: sR.authoredOn,     requester: sR.requester,     performerType: sR.performerType,     performer: sR.performer,     locationCode: sR.locationCode,     locationReference: sR.locationReference,     reasonCode: sR.reasonCode,     reasonReference: sR.reasonReference,     insurance: sR.insurance,     supportingInfo: sR.supportingInfo,     specimen: sR.specimen,     bodySite: sR.bodySite,     note: sR.note,     patientInstruction: sR.patientInstruction,     relevantHistory: sR.relevantHistory   }"
+                    "valueString": "define function ServiceRequestResource(serviceRequest ServiceRequest, profileURLs List<FHIR.canonical>, acceptedCategories List<System.Code>):   serviceRequest sR   return ServiceRequest{     id: FHIR.id {value: 'LCR-' + sR.id},     meta: SharedResource.MetaElement(sR, profileURLs),     extension: sR.extension,     basedOn: sR.basedOn,     status: sR.status,     intent: sR.intent,     category: FilterCodeableConcepts(sR.category, acceptedCategories),     priority: sR.priority,     doNotPerform: sR.doNotPerform,     code: sR.code,     quantity: sR.quantity,     subject: sR.subject,     encounter: sR.encounter,     occurrence: sR.occurrence,     asNeeded: sR.asNeeded,     authoredOn: sR.authoredOn,     specimen: sR.specimen   }"
                   },
                   {
                     "url": "displaySequence",
-                    "valueInteger": 82
+                    "valueInteger": 77
                   }
-                ]
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
                 "extension": [
                   {
                     "url": "libraryName",
@@ -2040,16 +1946,16 @@
                   },
                   {
                     "url": "statement",
-                    "valueString": "define function PatientResource(patient Patient, profileURLs List<FHIR.canonical>):   patient p   return Patient{     id: FHIR.id{value: 'LCR-' + p.id},     meta: MetaElement(p, profileURLs),     extension: GetPatientExtensions(p) union GetIdExtensions(p),     identifier: p.identifier,     active: p.active,     name: PatientName(p.name),     telecom: PatientTelecom(p.telecom),     gender: p.gender,     birthDate: p.birthDate,     deceased: p.deceased,     address: PatientAddress(p.address),     maritalStatus: p.maritalStatus,     multipleBirth: p.multipleBirth,     photo: p.photo,     contact: PatientContact(p.contact),     communication: PatientCommunication(p.communication),     generalPractitioner: p.generalPractitioner,     managingOrganization: p.managingOrganization,     link: PatientLink(p.link)   }"
+                    "valueString": "define function PatientResource(patient Patient, profileURLs List<FHIR.canonical>):   patient p   return Patient{     id: FHIR.id{value: 'LCR-' + p.id},     meta: MetaElement(p, profileURLs),     extension: GetPatientExtensions(p),     identifier: p.identifier,     active: p.active,     name: PatientName(p.name),     telecom: PatientTelecom(p.telecom),     gender: p.gender,     birthDate: p.birthDate,     deceased: p.deceased,     address: PatientAddress(p.address),     maritalStatus: p.maritalStatus,     multipleBirth: p.multipleBirth,     contact: PatientContact(p.contact),     communication: PatientCommunication(p.communication),     link: PatientLink(p.link)   }"
                   },
                   {
                     "url": "displaySequence",
-                    "valueInteger": 83
+                    "valueInteger": 78
                   }
-                ]
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
                 "extension": [
                   {
                     "url": "libraryName",
@@ -2061,37 +1967,16 @@
                   },
                   {
                     "url": "statement",
-                    "valueString": "define function \"GetPatientExtensions\"(domainResource DomainResource):   domainResource.extension E   where E.url.value = 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-race'     or E.url.value = 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity'     or E.url.value = 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-birthsex'     or E.url.value = 'http://www.cdc.gov/nhsn/fhirportal/dqm/ig/StructureDefinition/link-original-resource-id-extension'   return E"
+                    "valueString": "define function \"GetPatientExtensions\"(domainResource DomainResource):   domainResource.extension E   where E.url = 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-race'     or E.url = 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity'     or E.url = 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-tribal-affiliation'     or E.url = 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-birthsex'     or E.url = 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-sex'     or E.url = 'http://www.cdc.gov/nhsn/fhirportal/dqm/ig/StructureDefinition/link-original-resource-id-extension'   return E"
                   },
                   {
                     "url": "displaySequence",
-                    "valueInteger": 84
+                    "valueInteger": 79
                   }
-                ]
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
-                "extension": [
-                  {
-                    "url": "libraryName",
-                    "valueString": "SharedResourceCreation"
-                  },
-                  {
-                    "url": "name",
-                    "valueString": "GetIdExtensions"
-                  },
-                  {
-                    "url": "statement",
-                    "valueString": "define function \"GetIdExtensions\"(domainResource DomainResource):   domainResource.extension E   where E.url.value = 'http://www.cdc.gov/nhsn/fhirportal/dqm/ig/StructureDefinition/link-original-resource-id-extension'   return E"
-                  },
-                  {
-                    "url": "displaySequence",
-                    "valueInteger": 85
-                  }
-                ]
-              },
-              {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
                 "extension": [
                   {
                     "url": "libraryName",
@@ -2107,12 +1992,12 @@
                   },
                   {
                     "url": "displaySequence",
-                    "valueInteger": 86
+                    "valueInteger": 80
                   }
-                ]
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
                 "extension": [
                   {
                     "url": "libraryName",
@@ -2128,12 +2013,12 @@
                   },
                   {
                     "url": "displaySequence",
-                    "valueInteger": 87
+                    "valueInteger": 81
                   }
-                ]
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
                 "extension": [
                   {
                     "url": "libraryName",
@@ -2145,16 +2030,16 @@
                   },
                   {
                     "url": "statement",
-                    "valueString": "define function PatientAddress(address List<FHIR.Address>):   address a   return FHIR.Address{     id: a.id,     extension: a.extension,     use: a.use,     type: a.type,     text: a.text,     line: a.line,     city: a.city,     district: a.district,     state: a.state,     postalCode: a.postalCode,     country: a.country,     period: a.period   }"
+                    "valueString": "define function PatientAddress(address List<FHIR.Address>):   address a   return FHIR.Address{     use: a.use,     type: a.type,     text: a.text,     line: a.line,     city: a.city,     district: a.district,     state: a.state,     postalCode: a.postalCode,     country: a.country,     period: a.period   }"
                   },
                   {
                     "url": "displaySequence",
-                    "valueInteger": 88
+                    "valueInteger": 82
                   }
-                ]
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
                 "extension": [
                   {
                     "url": "libraryName",
@@ -2166,16 +2051,16 @@
                   },
                   {
                     "url": "statement",
-                    "valueString": "define function PatientContact(contact List<FHIR.Patient.Contact>):   contact c   return FHIR.Patient.Contact{     id: c.id,     extension: c.extension,     relationship: c.relationship,     name: c.name,     telecom: c.telecom,     address: c.address,     gender: c.gender,     organization: c.organization,     period: c.period   }"
+                    "valueString": "define function PatientContact(contact List<FHIR.Patient.Contact>):   contact c   return FHIR.Patient.Contact{     relationship: c.relationship,     name: c.name,     telecom: c.telecom,     address: c.address,     gender: c.gender,     organization: c.organization,     period: c.period   }"
                   },
                   {
                     "url": "displaySequence",
-                    "valueInteger": 89
+                    "valueInteger": 83
                   }
-                ]
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
                 "extension": [
                   {
                     "url": "libraryName",
@@ -2187,16 +2072,16 @@
                   },
                   {
                     "url": "statement",
-                    "valueString": "define function PatientCommunication(communication List<FHIR.Patient.Communication>):   communication c   return FHIR.Patient.Communication{     id: c.id,     extension: c.extension,     language: c.language,     preferred: c.preferred   }"
+                    "valueString": "define function PatientCommunication(communication List<FHIR.Patient.Communication>):   communication c   return FHIR.Patient.Communication{     language: c.language,     preferred: c.preferred   }"
                   },
                   {
                     "url": "displaySequence",
-                    "valueInteger": 90
+                    "valueInteger": 84
                   }
-                ]
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
                 "extension": [
                   {
                     "url": "libraryName",
@@ -2208,16 +2093,16 @@
                   },
                   {
                     "url": "statement",
-                    "valueString": "define function PatientLink(link List<FHIR.Patient.Link>):   link l   return FHIR.Patient.Link{     id: l.id,     extension: l.extension,     modifierExtension: l.modifierExtension,     other: l.other,     type: l.type   }"
+                    "valueString": "define function PatientLink(link List<FHIR.Patient.Link>):   link l   return FHIR.Patient.Link{     extension: l.extension,     modifierExtension: l.modifierExtension,     other: l.other,     type: l.type   }"
                   },
                   {
                     "url": "displaySequence",
-                    "valueInteger": 91
+                    "valueInteger": 85
                   }
-                ]
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
                 "extension": [
                   {
                     "url": "libraryName",
@@ -2233,12 +2118,12 @@
                   },
                   {
                     "url": "displaySequence",
-                    "valueInteger": 92
+                    "valueInteger": 86
                   }
-                ]
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
                 "extension": [
                   {
                     "url": "libraryName",
@@ -2254,12 +2139,12 @@
                   },
                   {
                     "url": "displaySequence",
-                    "valueInteger": 93
+                    "valueInteger": 87
                   }
-                ]
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
                 "extension": [
                   {
                     "url": "libraryName",
@@ -2275,58 +2160,16 @@
                   },
                   {
                     "url": "displaySequence",
-                    "valueInteger": 94
+                    "valueInteger": 88
                   }
-                ]
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
                 "extension": [
                   {
                     "url": "libraryName",
                     "valueString": "NHSNAcuteCareHospitalMonthlyInitialPopulation"
-                  },
-                  {
-                    "url": "name",
-                    "valueString": "GetMedicationFrom"
-                  },
-                  {
-                    "url": "statement",
-                    "valueString": "define function \"GetMedicationFrom\"(choice Choice<FHIR.CodeableConcept, FHIR.Reference>):   case     when choice is FHIR.Reference then       GetMedication(choice as FHIR.Reference)     else       null   end"
-                  },
-                  {
-                    "url": "displaySequence",
-                    "valueInteger": 95
-                  }
-                ]
-              },
-              {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
-                "extension": [
-                  {
-                    "url": "libraryName",
-                    "valueString": "NHSNAcuteCareHospitalMonthlyInitialPopulation"
-                  },
-                  {
-                    "url": "name",
-                    "valueString": "GetMedication"
-                  },
-                  {
-                    "url": "statement",
-                    "valueString": "define function \"GetMedication\"(reference Reference):   singleton from (     [Medication] Medications     where Medications.id = NHSNHelpers.GetId(reference.reference)   )"
-                  },
-                  {
-                    "url": "displaySequence",
-                    "valueInteger": 96
-                  }
-                ]
-              },
-              {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
-                "extension": [
-                  {
-                    "url": "libraryName",
-                    "valueString": "SharedResourceCreation"
                   },
                   {
                     "url": "name",
@@ -2334,20 +2177,20 @@
                   },
                   {
                     "url": "statement",
-                    "valueString": "define function SpecimenResource(specimen Specimen, profileURLs List<FHIR.canonical>):   specimen s   return Specimen{     id: FHIR.id {value: 'LCR-' + s.id},     meta: MetaElement(s, profileURLs),     extension: s.extension,     identifier: s.identifier,     accessionIdentifier: s.accessionIdentifier,     status: s.status,     type: s.type,     subject: s.subject,     receivedTime: s.receivedTime,     parent: s.parent,     request: s.request,     collection: SpecimenCollection(s.collection),     processing: SpecimenProcessing(s.processing),     container: SpecimenContainer(s.container),     condition: s.condition,     note: s.note   }"
+                    "valueString": "define function SpecimenResource(specimen Specimen, profileURLs List<FHIR.canonical>):   specimen s   return Specimen{     id: FHIR.id {value: 'LCR-' + s.id},     meta: SharedResource.MetaElement(s, profileURLs),     extension: s.extension,     identifier: s.identifier,     accessionIdentifier: s.accessionIdentifier,     status: s.status,     type: s.type,     subject: s.subject,     parent: s.parent,     request: s.request,     collection: SpecimenCollection(s.collection),     note: s.note   }"
                   },
                   {
                     "url": "displaySequence",
-                    "valueInteger": 97
+                    "valueInteger": 89
                   }
-                ]
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
               },
               {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
                 "extension": [
                   {
                     "url": "libraryName",
-                    "valueString": "SharedResourceCreation"
+                    "valueString": "NHSNAcuteCareHospitalMonthlyInitialPopulation"
                   },
                   {
                     "url": "name",
@@ -2355,55 +2198,14 @@
                   },
                   {
                     "url": "statement",
-                    "valueString": "define function SpecimenCollection(collection FHIR.Specimen.Collection):   collection c   return FHIR.Specimen.Collection{     collector: c.collector,     collected: c.collected,     \"duration\": c.\"duration\",     quantity: c.quantity,     method: c.method,     bodySite: c.bodySite,     fastingStatus: c.fastingStatus   }"
+                    "valueString": "define function SpecimenCollection(collection FHIR.Specimen.Collection):   collection c   return FHIR.Specimen.Collection{     collector: c.collector,     collected: c.collected,     quantity: c.quantity,     bodySite: c.bodySite   }"
                   },
                   {
                     "url": "displaySequence",
-                    "valueInteger": 98
+                    "valueInteger": 90
                   }
-                ]
-              },
-              {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
-                "extension": [
-                  {
-                    "url": "libraryName",
-                    "valueString": "SharedResourceCreation"
-                  },
-                  {
-                    "url": "name",
-                    "valueString": "SpecimenProcessing"
-                  },
-                  {
-                    "url": "statement",
-                    "valueString": "define function SpecimenProcessing(processing List<FHIR.Specimen.Processing>):   processing p   return FHIR.Specimen.Processing{     description: p.description,     procedure: p.procedure,     additive: p.additive,     time: p.time   }"
-                  },
-                  {
-                    "url": "displaySequence",
-                    "valueInteger": 99
-                  }
-                ]
-              },
-              {
-                "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-logicDefinition",
-                "extension": [
-                  {
-                    "url": "libraryName",
-                    "valueString": "SharedResourceCreation"
-                  },
-                  {
-                    "url": "name",
-                    "valueString": "SpecimenContainer"
-                  },
-                  {
-                    "url": "statement",
-                    "valueString": "define function SpecimenContainer(container List<FHIR.Specimen.Container>):   container c   return FHIR.Specimen.Container{     description: c.description,     type: c.type,     capacity: c.capacity,     specimenQuantity: c.specimenQuantity,     additive: c.additive   }"
-                  },
-                  {
-                    "url": "displaySequence",
-                    "valueInteger": 100
-                  }
-                ]
+                ],
+                "url": "http://hl7.org/fhir/StructureDefinition/cqf-logicDefinition"
               }
             ],
             "name": "EffectiveDataRequirements",
@@ -2419,6 +2221,11 @@
             "relatedArtifact": [
               {
                 "type": "depends-on",
+                "display": "FHIR model information",
+                "resource": "http://fhir.org/guides/cqf/common/Library/FHIR-ModelInfo|4.0.1"
+              },
+              {
+                "type": "depends-on",
                 "display": "Library FHIRHelpers",
                 "resource": "http://www.cdc.gov/nhsn/fhirportal/dqm/ig/Library/FHIRHelpers|4.0.2"
               },
@@ -2430,17 +2237,27 @@
               {
                 "type": "depends-on",
                 "display": "Library SharedResource",
-                "resource": "http://www.cdc.gov/nhsn/fhirportal/dqm/ig/Library/SharedResourceCreation|0.1.009"
+                "resource": "http://www.cdc.gov/nhsn/fhirportal/dqm/ig/Library/SharedResourceCreation|0.1.010"
               },
               {
                 "type": "depends-on",
                 "display": "Code system ActCode",
-                "resource": "http://terminology.hl7.org/CodeSystem/v3-ActCode"
+                "resource": "http://terminology.hl7.org/CodeSystem/v3-ActCode|9.0.0"
+              },
+              {
+                "type": "depends-on",
+                "display": "Code system MedicationRequest Category",
+                "resource": "http://terminology.hl7.org/CodeSystem/medicationrequest-category|1.0.0"
+              },
+              {
+                "type": "depends-on",
+                "display": "Code system SNOMEDCT",
+                "resource": "http://snomed.info/sct"
               },
               {
                 "type": "depends-on",
                 "display": "Code system Observation Category",
-                "resource": "http://terminology.hl7.org/CodeSystem/observation-category"
+                "resource": "http://terminology.hl7.org/CodeSystem/observation-category|2.0.0"
               },
               {
                 "type": "depends-on",
@@ -2450,22 +2267,12 @@
               {
                 "type": "depends-on",
                 "display": "Code system V2-0074",
-                "resource": "http://terminology.hl7.org/CodeSystem/v2-0074"
+                "resource": "http://terminology.hl7.org/CodeSystem/v2-0074|3.0.0"
               },
               {
                 "type": "depends-on",
                 "display": "Code system Condition Category",
-                "resource": "http://terminology.hl7.org/CodeSystem/condition-category"
-              },
-              {
-                "type": "depends-on",
-                "display": "Code system Condition Clinical Status",
-                "resource": "http://terminology.hl7.org/CodeSystem/condition-clinical"
-              },
-              {
-                "type": "depends-on",
-                "display": "Code system US Core Condition Category",
-                "resource": "http://hl7.org/fhir/us/core/CodeSystem/condition-category"
+                "resource": "http://terminology.hl7.org/CodeSystem/condition-category|2.0.0"
               },
               {
                 "type": "depends-on",
@@ -2658,14 +2465,9 @@
                   "statusHistory",
                   "class",
                   "classHistory",
-                  "serviceType",
-                  "priority",
                   "subject",
-                  "length",
                   "reasonCode",
-                  "reasonReference",
                   "diagnosis",
-                  "account",
                   "hospitalization",
                   "location",
                   "partOf"
@@ -2692,14 +2494,9 @@
                   "statusHistory",
                   "class",
                   "classHistory",
-                  "serviceType",
-                  "priority",
                   "subject",
-                  "length",
                   "reasonCode",
-                  "reasonReference",
                   "diagnosis",
-                  "account",
                   "hospitalization",
                   "location",
                   "partOf"
@@ -2726,14 +2523,9 @@
                   "statusHistory",
                   "class",
                   "classHistory",
-                  "serviceType",
-                  "priority",
                   "subject",
-                  "length",
                   "reasonCode",
-                  "reasonReference",
                   "diagnosis",
-                  "account",
                   "hospitalization",
                   "location",
                   "partOf"
@@ -2760,14 +2552,9 @@
                   "statusHistory",
                   "classHistory",
                   "type",
-                  "serviceType",
-                  "priority",
                   "subject",
-                  "length",
                   "reasonCode",
-                  "reasonReference",
                   "diagnosis",
-                  "account",
                   "hospitalization",
                   "location",
                   "partOf"
@@ -2794,14 +2581,9 @@
                   "statusHistory",
                   "classHistory",
                   "type",
-                  "serviceType",
-                  "priority",
                   "subject",
-                  "length",
                   "reasonCode",
-                  "reasonReference",
                   "diagnosis",
-                  "account",
                   "hospitalization",
                   "location",
                   "partOf"
@@ -2834,14 +2616,9 @@
                   "statusHistory",
                   "classHistory",
                   "type",
-                  "serviceType",
-                  "priority",
                   "subject",
-                  "length",
                   "reasonCode",
-                  "reasonReference",
                   "diagnosis",
-                  "account",
                   "hospitalization",
                   "location",
                   "partOf"
@@ -2874,14 +2651,9 @@
                   "class",
                   "classHistory",
                   "type",
-                  "serviceType",
-                  "priority",
                   "subject",
-                  "length",
                   "reasonCode",
-                  "reasonReference",
                   "diagnosis",
-                  "account",
                   "hospitalization",
                   "location",
                   "partOf"
@@ -2896,21 +2668,12 @@
                   "id",
                   "extension",
                   "status",
-                  "operationalStatus",
                   "name",
                   "alias",
-                  "description",
-                  "mode",
                   "type",
-                  "telecom",
-                  "address",
                   "physicalType",
-                  "position",
                   "managingOrganization",
-                  "partOf",
-                  "hoursOfOperation",
-                  "availabilityExceptions",
-                  "endpoint"
+                  "partOf"
                 ]
               },
               {
@@ -2953,18 +2716,8 @@
                   "extension",
                   "status",
                   "type",
-                  "policyHolder",
-                  "subscriber",
-                  "subscriberId",
                   "beneficiary",
-                  "dependent",
-                  "relationship",
-                  "payor",
-                  "class",
-                  "order",
-                  "network",
-                  "subrogation",
-                  "contract"
+                  "payor"
                 ]
               },
               {
@@ -2975,33 +2728,17 @@
                 "mustSupport": [
                   "performed",
                   "id",
-                  "extension",
-                  "instantiatesCanonical",
-                  "instantiatesUri",
                   "basedOn",
                   "partOf",
                   "status",
-                  "statusReason",
                   "category",
                   "code",
                   "subject",
                   "encounter",
-                  "recorder",
-                  "asserter",
-                  "performer",
                   "location",
                   "reasonCode",
                   "reasonReference",
-                  "bodySite",
-                  "outcome",
-                  "report",
-                  "complication",
-                  "complicationDetail",
-                  "followUp",
-                  "note",
-                  "focalDevice",
-                  "usedReference",
-                  "usedCode"
+                  "bodySite"
                 ]
               },
               {
@@ -3012,30 +2749,14 @@
                 "mustSupport": [
                   "id",
                   "extension",
-                  "definition",
-                  "udiCarrier",
                   "status",
-                  "statusReason",
-                  "distinctIdentifier",
-                  "manufacturer",
-                  "manufactureDate",
                   "expirationDate",
                   "lotNumber",
                   "serialNumber",
-                  "deviceName",
                   "modelNumber",
                   "partNumber",
                   "type",
-                  "specialization",
-                  "version",
-                  "property",
                   "patient",
-                  "owner",
-                  "contact",
-                  "location",
-                  "url",
-                  "note",
-                  "safety",
                   "parent"
                 ]
               },
@@ -3047,25 +2768,20 @@
                 "mustSupport": [
                   "id",
                   "extension",
-                  "basedOn",
                   "partOf",
                   "status",
                   "category",
                   "code",
                   "subject",
-                  "focus",
                   "encounter",
                   "effective",
                   "issued",
-                  "performer",
                   "value",
                   "dataAbsentReason",
                   "interpretation",
-                  "note",
                   "bodySite",
                   "method",
                   "specimen",
-                  "device",
                   "referenceRange",
                   "hasMember",
                   "derivedFrom",
@@ -3088,8 +2804,6 @@
                   "subject",
                   "encounter",
                   "issued",
-                  "performer",
-                  "resultsInterpreter",
                   "specimen",
                   "result",
                   "conclusion",
@@ -3135,18 +2849,13 @@
                   "clinicalStatus",
                   "verificationStatus",
                   "category",
-                  "severity",
                   "code",
-                  "bodySite",
                   "subject",
                   "encounter",
                   "onset",
                   "abatement",
                   "recordedDate",
-                  "stage",
-                  "evidence",
-                  "note",
-                  "encounter.id"
+                  "encounter.reference"
                 ]
               },
               {
@@ -3158,37 +2867,19 @@
                   "authoredOn",
                   "id",
                   "extension",
-                  "instantiatesCanonical",
-                  "instantiatesUri",
                   "basedOn",
-                  "replaces",
-                  "requisition",
                   "status",
                   "intent",
                   "category",
                   "priority",
                   "doNotPerform",
                   "code",
-                  "orderDetail",
                   "quantity",
                   "subject",
                   "encounter",
                   "occurrence",
                   "asNeeded",
-                  "requester",
-                  "performerType",
-                  "performer",
-                  "locationCode",
-                  "locationReference",
-                  "reasonCode",
-                  "reasonReference",
-                  "insurance",
-                  "supportingInfo",
-                  "specimen",
-                  "bodySite",
-                  "note",
-                  "patientInstruction",
-                  "relevantHistory"
+                  "specimen"
                 ]
               },
               {
@@ -3208,11 +2899,8 @@
                   "address",
                   "maritalStatus",
                   "multipleBirth",
-                  "photo",
                   "contact",
                   "communication",
-                  "generalPractitioner",
-                  "managingOrganization",
                   "link"
                 ]
               },
@@ -3248,12 +2936,8 @@
                   "status",
                   "type",
                   "subject",
-                  "receivedTime",
                   "parent",
                   "request",
-                  "processing",
-                  "container",
-                  "condition",
                   "note"
                 ]
               }
@@ -3266,16 +2950,13 @@
             "valueCode": "Encounter"
           },
           {
-            "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-softwaresystem",
-            "valueReference": {
-              "reference": "Device/cqf-tooling"
-            }
+            "url": "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-effectiveDataRequirements",
+            "valueCanonical": "#effective-data-requirements"
           },
           {
-            "id": "effective-data-requirements",
-            "url": "http://hl7.org/fhir/us/cqfmeasures/StructureDefinition/cqfm-effectiveDataRequirements",
+            "url": "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-softwaresystem",
             "valueReference": {
-              "reference": "#effective-data-requirements"
+              "reference": "Device/cqf-tooling"
             }
           }
         ],
@@ -3286,14 +2967,39 @@
             "value": "NHSNAcuteCareHospitalMonthlyInitialPopulation"
           }
         ],
-        "version": "1.0.0-dev",
+        "version": "2.0.0-cibuild",
         "name": "NHSNAcuteCareHospitalMonthlyInitialPopulation",
         "title": "NHSN dQM Acute Care Hospital Monthly Initial Population",
         "status": "draft",
         "experimental": false,
-        "date": "2025-05-12T12:59:43-05:00",
-        "publisher": "Lantana Consulting Group",
+        "date": "2026-01-08T09:28:49-05:00",
+        "publisher": "CDC National Healthcare Safety Network (NHSN)",
+        "contact": [
+          {
+            "name": "CDC National Healthcare Safety Network (NHSN)",
+            "telecom": [
+              {
+                "system": "url",
+                "value": "http://www.cdc.gov/nhsn"
+              },
+              {
+                "system": "email",
+                "value": "nhsn@cdc.gov"
+              }
+            ]
+          }
+        ],
         "description": "The Acute Care Hospital Monthly Initial Population includes all encounters for patients of any age in an ED, observation, or inpatient location or all encounters for patients of any age with an ED, observation, inpatient, or short stay status during the measurement period.",
+        "jurisdiction": [
+          {
+            "coding": [
+              {
+                "system": "urn:iso:std:iso:3166",
+                "code": "US"
+              }
+            ]
+          }
+        ],
         "copyright": "Limited proprietary coding is contained in the Measure specifications for user convenience. Users of proprietary code sets should obtain all necessary licenses from the owners of the code sets.",
         "relatedArtifact": [
           {
@@ -3308,7 +3014,7 @@
         "library": [
           "http://www.cdc.gov/nhsn/fhirportal/dqm/ig/Library/NHSNAcuteCareHospitalMonthlyInitialPopulation"
         ],
-        "disclaimer": "This performance measure is not a clinical guideline, does not establish a standard of medical care and has not been tested for all potential applications.        THE MEASURES AND SPECIFICATIONS ARE PROVIDED “AS IS�? WITHOUT WARRANTY OF ANY KIND.        This measure and specifications are subject to further revisions.",
+        "disclaimer": "This performance measure is not a clinical guideline, does not establish a standard of medical care and has not been tested for all potential applications.        THE MEASURES AND SPECIFICATIONS ARE PROVIDED “AS IS” WITHOUT WARRANTY OF ANY KIND.        This measure and specifications are subject to further revisions.",
         "scoring": {
           "coding": [
             {
@@ -3707,6 +3413,10 @@
       "resource": {
         "resourceType": "Library",
         "id": "NHSNAcuteCareHospitalMonthlyInitialPopulation",
+        "text": {
+          "status": "extensions",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n<div>\n    <table class=\"grid dict\">\n        \n        \n\n        \n        \n        <tr>\n            <th scope=\"row\"><b>Id: </b></th>\n            <td style=\"padding-left: 4px;\">NHSNAcuteCareHospitalMonthlyInitialPopulation</td>\n        </tr>\n        \n\n        \n        \n        <tr>\n            <th scope=\"row\"><b>Version: </b></th>\n            <td style=\"padding-left: 4px;\">2.0.0-cibuild</td>\n        </tr>\n        \n\n        \n        <tr>\n            <th scope=\"row\"><b>Url: </b></th>\n            <td style=\"padding-left: 4px;\"><a href=\"Library-NHSNAcuteCareHospitalMonthlyInitialPopulation.html\">NHSNAcuteCareHospitalMonthlyInitialPopulation</a></td>\n        </tr>\n        \n\n        \n\n        \n\n        \n        <tr>\n            <th scope=\"row\"><b>Status: </b></th>\n            <td style=\"padding-left: 4px;\">draft</td>\n        </tr>\n        \n\n        \n\n        \n        <tr>\n            <th scope=\"row\"><b>Type: </b></th>\n            <td style=\"padding-left: 4px;\">\n                \n                    \n                        \n                        <p style=\"margin-bottom: 5px;\">\n                            <b>system: </b> <span><a href=\"http://terminology.hl7.org/7.0.1/CodeSystem-library-type.html\">http://terminology.hl7.org/CodeSystem/library-type</a></span>\n                        </p>\n                        \n                        \n                        <p style=\"margin-bottom: 5px;\">\n                            <b>code: </b> <span>logic-library</span>\n                        </p>\n                        \n                        \n                    \n                \n                \n            </td>\n        </tr>\n        \n\n        \n\n        \n        <tr>\n            <th scope=\"row\"><b>Date: </b></th>\n            <td style=\"padding-left: 4px;\">2026-01-08 14:28:51+0000</td>\n        </tr>\n        \n\n        \n        <tr>\n            <th scope=\"row\"><b>Publisher: </b></th>\n            <td style=\"padding-left: 4px;\">CDC National Healthcare Safety Network (NHSN)</td>\n        </tr>\n        \n\n        \n\n        \n\n        \n\n        \n\n        \n        <tr>\n            <th scope=\"row\"><b>Jurisdiction: </b></th>\n            <td style=\"padding-left: 4px;\">US</td>\n        </tr>\n        \n\n        \n\n        \n\n        \n\n        \n\n        \n\n        \n\n        \n        <tr>\n            <th scope=\"row\"><b>Related Artifacts: </b></th>\n            <td style=\"padding-left: 4px;\">\n                \n                \n                \n                <p><b>Dependencies</b></p>\n                <ul>\n                  \n                    <li><a href=\"http://fhir.org/guides/cqf/common/4.0.1/4.0.1/Library-FHIR-ModelInfo.html\">http://fhir.org/guides/cqf/common/Library/FHIR-ModelInfo|4.0.1</a></li>\n                  \n                    <li><code>http://www.cdc.gov/nhsn/fhirportal/dqm/ig/Library/FHIRHelpers|4.0.2</code></li>\n                  \n                    <li><code>http://www.cdc.gov/nhsn/fhirportal/dqm/ig/Library/NHSNHelpers|0.0.002</code></li>\n                  \n                    <li><code>http://www.cdc.gov/nhsn/fhirportal/dqm/ig/Library/SharedResourceCreation|0.1.010</code></li>\n                  \n                    <li><a href=\"http://terminology.hl7.org/7.0.1/CodeSystem-v3-ActCode.html\">ActCodeversion: null9.0.0)</a></li>\n                  \n                    <li><a href=\"http://terminology.hl7.org/7.0.1/CodeSystem-observation-category.html\">Observation Category Codesversion: null2.0.0)</a></li>\n                  \n                    <li><a href=\"http://terminology.hl7.org/6.5.0/CodeSystem-v3-loinc.html\">Logical Observation Identifiers, Names and Codes (LOINC)</a></li>\n                  \n                    <li><a href=\"http://terminology.hl7.org/7.0.1/CodeSystem-v2-0074.html\">diagnosticServiceSectionIdversion: null3.0.0)</a></li>\n                  \n                    <li><a href=\"http://terminology.hl7.org/7.0.1/CodeSystem-condition-category.html\">Condition Category Codesversion: null2.0.0)</a></li>\n                  \n                    <li><a href=\"http://hl7.org/fhir/us/core/STU6.1/CodeSystem-condition-category.html\">US Core Condition Category Extension Codesversion: null6.1.0)</a></li>\n                  \n                    <li><a href=\"http://terminology.hl7.org/7.0.1/CodeSystem-condition-clinical.html\">Condition Clinical Status Codesversion: null3.0.0)</a></li>\n                  \n                    <li><code>http://www.snomed.org/</code></li>\n                  \n                    <li><a href=\"https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1046.265/expansion\">Inpatient, Emergency, and Observation Locations</a></li>\n                  \n                    <li><a href=\"https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.3.117.1.7.1.292/expansion\">Emergency Department Visit</a></li>\n                  \n                    <li><a href=\"https://vsac.nlm.nih.gov/valueset/2.16.840.1.113883.3.666.5.307/expansion\">Encounter Inpatient</a></li>\n                  \n                    <li><a href=\"https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1111.143/expansion\">Observation Services</a></li>\n                  \n                    <li><a href=\"https://vsac.nlm.nih.gov/valueset/2.16.840.1.113762.1.4.1046.274/expansion\">NHSN Inpatient Encounter Class Codes</a></li>\n                  \n                </ul>\n                \n                \n                \n                \n                \n            </td>\n        </tr>\n        \n\n        \n        <tr>\n          <th scope=\"row\"><b>Parameters: </b></th>\n          <td style=\"padding-left: 4px;\">\n            <table class=\"grid-dict\">\n              <tr><th><b>Name</b></th><th><b>Type</b></th><th><b>Min</b></th><th><b>Max</b></th><th><b>In/Out</b></th></tr>\n              \n                <tr><th>Measurement Period</th><th>Period</th><th>0</th><th>1</th><th>In</th></tr>\n              \n                <tr><th>Patient</th><th>Patient</th><th>0</th><th>1</th><th>Out</th></tr>\n              \n                <tr><th>Qualifying Encounters During Measurement Period</th><th>Encounter</th><th>0</th><th>*</th><th>Out</th></tr>\n              \n                <tr><th>Encounters</th><th>Encounter</th><th>0</th><th>*</th><th>Out</th></tr>\n              \n                <tr><th>Encounters with Patient Hospital Locations</th><th>Encounter</th><th>0</th><th>*</th><th>Out</th></tr>\n              \n                <tr><th>Initial Population</th><th>Encounter</th><th>0</th><th>*</th><th>Out</th></tr>\n              \n                <tr><th>Conditions</th><th>Condition</th><th>0</th><th>*</th><th>Out</th></tr>\n              \n                <tr><th>DiagnosticReports</th><th>DiagnosticReport</th><th>0</th><th>*</th><th>Out</th></tr>\n              \n                <tr><th>Observations</th><th>Observation</th><th>0</th><th>*</th><th>Out</th></tr>\n              \n                <tr><th>Get Locations from IP Encounters in Measurement Period</th><th>Location</th><th>0</th><th>*</th><th>Out</th></tr>\n              \n                <tr><th>SDE Condition</th><th>Condition</th><th>0</th><th>*</th><th>Out</th></tr>\n              \n                <tr><th>SDE Coverage</th><th>Coverage</th><th>0</th><th>*</th><th>Out</th></tr>\n              \n                <tr><th>SDE Device</th><th>Device</th><th>0</th><th>*</th><th>Out</th></tr>\n              \n                <tr><th>SDE DiagnosticReport Lab</th><th>DiagnosticReport</th><th>0</th><th>*</th><th>Out</th></tr>\n              \n                <tr><th>SDE DiagnosticReport Note</th><th>DiagnosticReport</th><th>0</th><th>*</th><th>Out</th></tr>\n              \n                <tr><th>SDE DiagnosticReport Others</th><th>DiagnosticReport</th><th>0</th><th>*</th><th>Out</th></tr>\n              \n                <tr><th>SDE Encounter</th><th>Encounter</th><th>0</th><th>*</th><th>Out</th></tr>\n              \n                <tr><th>SDE IP Encounters</th><th>Encounter</th><th>0</th><th>*</th><th>Out</th></tr>\n              \n                <tr><th>SDE Location</th><th>Location</th><th>0</th><th>*</th><th>Out</th></tr>\n              \n                <tr><th>SDE Medication Administration</th><th>MedicationAdministration</th><th>0</th><th>*</th><th>Out</th></tr>\n              \n                <tr><th>SDE Medication Request</th><th>MedicationRequest</th><th>0</th><th>*</th><th>Out</th></tr>\n              \n                <tr><th>SDE Medication</th><th>Medication</th><th>0</th><th>*</th><th>Out</th></tr>\n              \n                <tr><th>SDE Observation Lab Category</th><th>Observation</th><th>0</th><th>*</th><th>Out</th></tr>\n              \n                <tr><th>SDE Observation Vital Signs Category</th><th>Observation</th><th>0</th><th>*</th><th>Out</th></tr>\n              \n                <tr><th>SDE Observation Category</th><th>Observation</th><th>0</th><th>*</th><th>Out</th></tr>\n              \n                <tr><th>SDE Procedure</th><th>Procedure</th><th>0</th><th>*</th><th>Out</th></tr>\n              \n                <tr><th>SDE Specimen</th><th>Specimen</th><th>0</th><th>*</th><th>Out</th></tr>\n              \n                <tr><th>SDE Service Request</th><th>ServiceRequest</th><th>0</th><th>*</th><th>Out</th></tr>\n              \n                <tr><th>SDE Minimal Patient</th><th>Patient</th><th>0</th><th>1</th><th>Out</th></tr>\n              \n            </table>\n          </td>\n        </tr>\n        \n\n        \n        <tr>\n          <th scope=\"row\"><b>Data Requirements:</b></th>\n          <td style=\"padding-left: 4px;\">\n            <table class=\"grid-dict\">\n              <tr><th><b>Type</b></th><th><b>Profile</b></th><th><b>MS</b></th><th><b>Code Filter</b></th></tr>\n              \n                <tr>\n                  <th>Patient</th>\n                  <th>http://hl7.org/fhir/StructureDefinition/Patient</th>\n                  <th>;;;;;;;;;;;;;;;;;</th>\n                  <th>\n                    \n                  </th>\n                </tr>\n              \n                <tr>\n                  <th>Encounter</th>\n                  <th>http://hl7.org/fhir/StructureDefinition/Encounter</th>\n                  <th>;;;;;;;;;;;;;;;;;;;;</th>\n                  <th>\n                    \n                      <b>code filter: </b>\n                      \n                      <br/>\n                      \n                      \n                      <span style=\"padding-left: 4px;\">\n                          <b>path: </b><span>type</span>\n                      </span>\n                      \n                      <br/>\n                      \n                      \n                      \n                      <span style=\"padding-left: 4px;\">\n                          <b>value set: </b><span>http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307</span>\n                      </span>\n                      \n                      \n                    \n                  </th>\n                </tr>\n              \n                <tr>\n                  <th>Encounter</th>\n                  <th>http://hl7.org/fhir/StructureDefinition/Encounter</th>\n                  <th>;;;;;;;;;;;;;;;;;;;;</th>\n                  <th>\n                    \n                      <b>code filter: </b>\n                      \n                      <br/>\n                      \n                      \n                      <span style=\"padding-left: 4px;\">\n                          <b>path: </b><span>type</span>\n                      </span>\n                      \n                      <br/>\n                      \n                      \n                      \n                      <span style=\"padding-left: 4px;\">\n                          <b>value set: </b><span>http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.292</span>\n                      </span>\n                      \n                      \n                    \n                  </th>\n                </tr>\n              \n                <tr>\n                  <th>Encounter</th>\n                  <th>http://hl7.org/fhir/StructureDefinition/Encounter</th>\n                  <th>;;;;;;;;;;;;;;;;;;;;</th>\n                  <th>\n                    \n                      <b>code filter: </b>\n                      \n                      <br/>\n                      \n                      \n                      <span style=\"padding-left: 4px;\">\n                          <b>path: </b><span>type</span>\n                      </span>\n                      \n                      <br/>\n                      \n                      \n                      \n                      <span style=\"padding-left: 4px;\">\n                          <b>value set: </b><span>http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1111.143</span>\n                      </span>\n                      \n                      \n                    \n                  </th>\n                </tr>\n              \n                <tr>\n                  <th>Encounter</th>\n                  <th>http://hl7.org/fhir/StructureDefinition/Encounter</th>\n                  <th>;;;;;;;;;;;;;;;;;;;;</th>\n                  <th>\n                    \n                      <b>code filter: </b>\n                      \n                      <br/>\n                      \n                      \n                      <span style=\"padding-left: 4px;\">\n                          <b>path: </b><span>class</span>\n                      </span>\n                      \n                      <br/>\n                      \n                      \n                      \n                      <span style=\"padding-left: 4px;\">\n                          <b>value set: </b><span>http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1046.274</span>\n                      </span>\n                      \n                      \n                    \n                  </th>\n                </tr>\n              \n                <tr>\n                  <th>Encounter</th>\n                  <th>http://hl7.org/fhir/StructureDefinition/Encounter</th>\n                  <th>;;;;;;;;;;;;;;;;;;;;</th>\n                  <th>\n                    \n                      <b>code filter: </b>\n                      \n                      <br/>\n                      \n                      \n                      <span style=\"padding-left: 4px;\">\n                          <b>path: </b><span>class</span>\n                      </span>\n                      \n                      <br/>\n                      \n                      \n                      \n                      \n                          \n                          <p style=\"margin-bottom: 5px;\">\n                              <b>system: </b> <span><a href=\"http://terminology.hl7.org/7.0.1/CodeSystem-v3-ActCode.html\">http://terminology.hl7.org/CodeSystem/v3-ActCode</a></span>\n                          </p>\n                          \n                          \n                          <p style=\"margin-bottom: 5px;\">\n                              <b>code: </b> <span>EMER</span>\n                          </p>\n                          \n                          \n                          <p style=\"margin-bottom: 5px;\">\n                              <b>display: </b> <span>emergency</span>\n                          </p>\n                          \n                      \n                    \n                  </th>\n                </tr>\n              \n                <tr>\n                  <th>Encounter</th>\n                  <th>http://hl7.org/fhir/StructureDefinition/Encounter</th>\n                  <th>;;;;;;;;;;;;;;;;;;;;</th>\n                  <th>\n                    \n                      <b>code filter: </b>\n                      \n                      <br/>\n                      \n                      \n                      <span style=\"padding-left: 4px;\">\n                          <b>path: </b><span>class</span>\n                      </span>\n                      \n                      <br/>\n                      \n                      \n                      \n                      \n                          \n                          <p style=\"margin-bottom: 5px;\">\n                              <b>system: </b> <span><a href=\"http://terminology.hl7.org/7.0.1/CodeSystem-v3-ActCode.html\">http://terminology.hl7.org/CodeSystem/v3-ActCode</a></span>\n                          </p>\n                          \n                          \n                          <p style=\"margin-bottom: 5px;\">\n                              <b>code: </b> <span>OBSENC</span>\n                          </p>\n                          \n                          \n                          <p style=\"margin-bottom: 5px;\">\n                              <b>display: </b> <span>observation encounter</span>\n                          </p>\n                          \n                      \n                    \n                  </th>\n                </tr>\n              \n                <tr>\n                  <th>Encounter</th>\n                  <th>http://hl7.org/fhir/StructureDefinition/Encounter</th>\n                  <th>;;;;;;;;;;;;;;;;;;;;</th>\n                  <th>\n                    \n                  </th>\n                </tr>\n              \n                <tr>\n                  <th>Location</th>\n                  <th>http://hl7.org/fhir/StructureDefinition/Location</th>\n                  <th>;;;;;;;;;;;;;;;;;;</th>\n                  <th>\n                    \n                  </th>\n                </tr>\n              \n                <tr>\n                  <th>Condition</th>\n                  <th>http://hl7.org/fhir/StructureDefinition/Condition</th>\n                  <th>;;;;;;;;;;;;;;;;;</th>\n                  <th>\n                    \n                  </th>\n                </tr>\n              \n                <tr>\n                  <th>DiagnosticReport</th>\n                  <th>http://hl7.org/fhir/StructureDefinition/DiagnosticReport</th>\n                  <th>;;;;;;;;;;;;;;;;</th>\n                  <th>\n                    \n                  </th>\n                </tr>\n              \n                <tr>\n                  <th>Observation</th>\n                  <th>http://hl7.org/fhir/StructureDefinition/Observation</th>\n                  <th>;;;;;;;;;;;;;;;;;;;;;;;;;</th>\n                  <th>\n                    \n                  </th>\n                </tr>\n              \n                <tr>\n                  <th>Coverage</th>\n                  <th>http://hl7.org/fhir/StructureDefinition/Coverage</th>\n                  <th>;;;;;;;</th>\n                  <th>\n                    \n                  </th>\n                </tr>\n              \n                <tr>\n                  <th>Device</th>\n                  <th>http://hl7.org/fhir/StructureDefinition/Device</th>\n                  <th>;;;;;;;;;;;;;;;;;;;;;;;;;;;</th>\n                  <th>\n                    \n                  </th>\n                </tr>\n              \n                <tr>\n                  <th>MedicationAdministration</th>\n                  <th>http://hl7.org/fhir/StructureDefinition/MedicationAdministration</th>\n                  <th>;;;;;;;;;;;;;;;;;;;;</th>\n                  <th>\n                    \n                  </th>\n                </tr>\n              \n                <tr>\n                  <th>MedicationRequest</th>\n                  <th>http://hl7.org/fhir/StructureDefinition/MedicationRequest</th>\n                  <th>;;;;;;;;;;;;;;;;;;;;;</th>\n                  <th>\n                    \n                  </th>\n                </tr>\n              \n                <tr>\n                  <th>Medication</th>\n                  <th>http://hl7.org/fhir/StructureDefinition/Medication</th>\n                  <th>;;;;;;;;;</th>\n                  <th>\n                    \n                  </th>\n                </tr>\n              \n                <tr>\n                  <th>Procedure</th>\n                  <th>http://hl7.org/fhir/StructureDefinition/Procedure</th>\n                  <th>;;;;;;;;;;;;;;;;;;;;;;;;;;;;;</th>\n                  <th>\n                    \n                  </th>\n                </tr>\n              \n                <tr>\n                  <th>Specimen</th>\n                  <th>http://hl7.org/fhir/StructureDefinition/Specimen</th>\n                  <th>;;;;;;;;;;;;;;;;</th>\n                  <th>\n                    \n                  </th>\n                </tr>\n              \n                <tr>\n                  <th>ServiceRequest</th>\n                  <th>http://hl7.org/fhir/StructureDefinition/ServiceRequest</th>\n                  <th>;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;</th>\n                  <th>\n                    \n                  </th>\n                </tr>\n              \n            </table>\n          </td>\n        </tr>\n        \n\n        \n        \n        <tr>\n          <td colspan=\"2\">\n            <table>\n              <tr><th><a id=\"cql-content\"><b>Content: </b></a> text/cql</th></tr>\n              <tr><td><pre><code class=\"language-cql\">library NHSNAcuteCareHospitalMonthlyInitialPopulation version '2.0.0-cibuild'\n\nusing FHIR version '4.0.1'\n\ninclude FHIRHelpers version '4.0.2' called FHIRHelpers\ninclude NHSNHelpers version '0.0.002' called NHSNHelpers\ninclude SharedResourceCreation version '0.1.010' called SharedResource\n\ncodesystem &quot;ActCode&quot;: 'http://terminology.hl7.org/CodeSystem/v3-ActCode'\ncodesystem &quot;Observation Category&quot;: 'http://terminology.hl7.org/CodeSystem/observation-category'\ncodesystem &quot;LOINC&quot;: 'http://loinc.org' \ncodesystem &quot;V2-0074&quot;: 'http://terminology.hl7.org/CodeSystem/v2-0074'\ncodesystem &quot;Condition Category&quot;: 'http://terminology.hl7.org/CodeSystem/condition-category'\ncodesystem &quot;US Core Condition Category&quot;: 'http://hl7.org/fhir/us/core/CodeSystem/condition-category'\ncodesystem &quot;Condition Clinical Status&quot;: 'http://terminology.hl7.org/CodeSystem/condition-clinical'\ncodesystem &quot;SNOMEDCT&quot;: 'http://snomed.info/sct'\ncodesystem &quot;MedicationRequest Category&quot;: 'http://terminology.hl7.org/CodeSystem/medicationrequest-category'\n\nvalueset &quot;Inpatient, Emergency, and Observation Locations&quot;: 'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1046.265'\nvalueset &quot;Emergency Department Visit&quot;: 'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.292'\nvalueset &quot;Encounter Inpatient&quot;: 'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307'\nvalueset &quot;Observation Services&quot;: 'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1111.143'\nvalueset &quot;NHSN Inpatient Encounter Class Codes&quot;: 'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1046.274'\n\n//code for Observation Category\ncode &quot;laboratory&quot;: 'laboratory' from &quot;Observation Category&quot; display 'Laboratory'\ncode &quot;social-history&quot;: 'social-history' from &quot;Observation Category&quot; display 'Social History'\ncode &quot;vital-signs&quot;: 'vital-signs' from &quot;Observation Category&quot; display 'Vital Signs'\ncode &quot;imaging&quot;: 'imaging' from &quot;Observation Category&quot; display 'Imaging'\ncode &quot;procedure&quot;: 'procedure' from &quot;Observation Category&quot; display 'Procedure'\ncode &quot;survey&quot;: 'survey' from &quot;Observation Category&quot; display 'Survey'\n\n//code for Condition category\n//code &quot;problem-list-item&quot;: 'problem-list-item' from &quot;Condition Category&quot; display 'Problem List Item'\ncode &quot;encounter-diagnosis&quot;: 'encounter-diagnosis' from &quot;Condition Category&quot; display 'Encounter Diagnosis'\n//code &quot;health-concern&quot;: 'health-concern' from &quot;US Core Condition Category&quot; display 'Health Concern'\n\n//code for Diagnostic Report Category\ncode &quot;LAB&quot;: 'LAB' from &quot;V2-0074&quot; display 'Laboratory'\ncode &quot;Radiology&quot;: 'LP29684-5' from &quot;LOINC&quot; display 'Radiology'\ncode &quot;Pathology&quot;: 'LP7839-6' from &quot;LOINC&quot; display 'Pathology'\ncode &quot;Cardiology&quot;: 'LP29708-2' from &quot;LOINC&quot; display 'Cardiology'\n\n//code for Emergency Encounter Class\ncode &quot;emergency&quot;: 'EMER' from &quot;ActCode&quot; display 'emergency'\ncode &quot;observation encounter&quot;: 'OBSENC' from &quot;ActCode&quot; display 'observation encounter'\n\n//code for Condition clinicalStatus\ncode &quot;active&quot;: 'active' from &quot;Condition Clinical Status&quot; display 'active'\n\n//code for Procedure category\ncode &quot;Surgical procedure&quot;: '387713003' from &quot;SNOMEDCT&quot; display 'Surgical procedure'\ncode &quot;Diagnostic procedure&quot;: '103693007' from &quot;SNOMEDCT&quot; display 'Diagnostic procedure'\n\n//code for MedicationRequest category\ncode &quot;inpatient&quot;: 'inpatient' from &quot;MedicationRequest Category&quot; display 'Inpatient'\ncode &quot;outpatient&quot;: 'outpatient' from &quot;MedicationRequest Category&quot; display 'Outpatient'\n\n//code for ServiceRequest category (also uses Surgical procedure from Procedure categories)\ncode &quot;Laboratory procedure&quot;: '108252007' from &quot;SNOMEDCT&quot; display 'Laboratory procedure'\ncode &quot;Imaging&quot;: '363679005' from &quot;SNOMEDCT&quot; display 'Imaging'\n\nparameter &quot;Measurement Period&quot; \n    default Interval[@2022-01-01T00:00:00.0, @2022-01-31T23:59:59.0)\n\ncontext Patient \n\ndefine &quot;Qualifying Encounters During Measurement Period&quot;:\n ( [Encounter: &quot;Encounter Inpatient&quot;]\n  union [Encounter: &quot;Emergency Department Visit&quot;]\n  union [Encounter: &quot;Observation Services&quot;]\n  union [Encounter: class in &quot;NHSN Inpatient Encounter Class Codes&quot;]\n  union [Encounter: class ~ &quot;emergency&quot;]\n  union [Encounter: class ~ &quot;observation encounter&quot;]) QualifyingEncounters\n  where QualifyingEncounters.status in {'in-progress', 'finished', 'triaged', 'onleave', 'entered-in-error'}\n    and QualifyingEncounters.period overlaps &quot;Measurement Period&quot; \n\ndefine &quot;Encounters with Patient Hospital Locations&quot;:\n  &quot;Encounters&quot; Encounters\n  where exists(\n    Encounters.location EncounterLocation\n    where NHSNHelpers.GetLocation(EncounterLocation.location).type in &quot;Inpatient, Emergency, and Observation Locations&quot;\n      and EncounterLocation.period overlaps Encounters.period\n  )\n  and Encounters.status in {'in-progress', 'finished', 'triaged', 'onleave', 'entered-in-error'}\n  and Encounters.period overlaps &quot;Measurement Period&quot;\n\ndefine &quot;Initial Population&quot;:\n  &quot;Qualifying Encounters During Measurement Period&quot;\n  union &quot;Encounters with Patient Hospital Locations&quot;\n\ndefine &quot;Encounters&quot;:\n  [Encounter]\n\ndefine &quot;Conditions&quot;:\n  [Condition]\n\ndefine &quot;DiagnosticReports&quot;:\n  [DiagnosticReport]\n\ndefine &quot;Observations&quot;:\n  [Observation]\n\ndefine &quot;Get Locations from IP Encounters in Measurement Period&quot;:\n  flatten(&quot;Initial Population&quot; IP\n  let locationElements: IP.location\n  return\n    locationElements LE\n    let locationReference: LE.location\n    return NHSNHelpers.GetLocation(locationReference))\n\ndefine &quot;Medication IDs&quot;:\n  (&quot;SDE Medication Request&quot;\n  union &quot;SDE Medication Administration&quot;) MedReqOrAdmin\n  where MedReqOrAdmin.medication is FHIR.Reference\n    and exists(&quot;Initial Population&quot;) //No longer need to check for timing here because it's checked in SDE Medication Request/Administriation\n  return NHSNHelpers.GetId(MedReqOrAdmin.medication.reference)\n\n//============================================================================\n//Supplemental Data Element\n//When FHIR.canonical value is present, US Core 3.1.1 profiles are used\n//When FHIR.canonical value is not present, FHIR Base profiles are used\n//============================================================================\ndefine &quot;SDE Condition&quot;:\n  &quot;Conditions&quot; Conditions \n    where exists(\n    &quot;Initial Population&quot; IP\n//Check for Problem List Conditions that were recorded before or during IP \n     where \n      (exists(IP.diagnosis Diagnoses\n          where NHSNHelpers.GetId(Diagnoses.condition.reference) = Conditions.id\n        )\n        or NHSNHelpers.GetId(Conditions.encounter.reference) = IP.id\n      )\n      and exists (Conditions.category categories\n        where categories ~ &quot;encounter-diagnosis&quot;\n    )\n  )\n  return ConditionResource(Conditions,\n  {FHIR.canonical{value: 'http://www.cdc.gov/nhsn/fhirportal/dqm/ig/StructureDefinition/ach-monthly-condition'}},\n   {&quot;encounter-diagnosis&quot;})\n\ndefine &quot;SDE Coverage&quot;: \n\t[Coverage] Coverages\n  where exists(\n    &quot;Initial Population&quot; IP\n    where Coverages.period overlaps IP.period)\n  return CoverageResource(Coverages,\n  {FHIR.canonical{value: 'http://www.cdc.gov/nhsn/fhirportal/dqm/ig/StructureDefinition/ach-monthly-coverage'}})\n\ndefine &quot;SDE Device&quot;:\n  [Device] Devices \n  where exists(&quot;Initial Population&quot;)\n  return DeviceResource(Devices,\n  {FHIR.canonical{value: 'http://www.cdc.gov/nhsn/fhirportal/dqm/ig/StructureDefinition/ach-monthly-device'}})\n\n//This block collects all DiagnosticReport resources while also marking Lab and Note DiagnosticReports with the appropriate profiles\n//#Start DiagnosticReport block\ndefine &quot;SDE DiagnosticReport Lab&quot;:\n  &quot;DiagnosticReports&quot; DiagnosticReports\n  where (exists(DiagnosticReports.category Category where Category ~ &quot;LAB&quot;)\n    and exists(\n      &quot;Initial Population&quot; IP\n      where NHSNHelpers.&quot;Normalize Interval&quot;(DiagnosticReports.effective) overlaps IP.period))\n  return DiagnosticReportLabResource(DiagnosticReports,\n  {FHIR.canonical{value: 'http://www.cdc.gov/nhsn/fhirportal/dqm/ig/StructureDefinition/ach-monthly-diagnosticreport-lab'}},\n  {&quot;LAB&quot;, &quot;Radiology&quot;, &quot;Pathology&quot;, &quot;Cardiology&quot;})\n \ndefine &quot;SDE DiagnosticReport Note&quot;:\n  &quot;DiagnosticReports&quot; DiagnosticReports\n  where ((exists(DiagnosticReports.category Category where Category ~ &quot;Radiology&quot;))\n    or exists((DiagnosticReports.category Category where Category ~ &quot;Pathology&quot;))\n    or exists((DiagnosticReports.category Category where Category ~ &quot;Cardiology&quot;)))\n    and exists(\n      &quot;Initial Population&quot; IP\n      where NHSNHelpers.&quot;Normalize Interval&quot;(DiagnosticReports.effective) overlaps IP.period)\n  return DiagnosticReportResource(DiagnosticReports,\n  {FHIR.canonical{value: 'http://www.cdc.gov/nhsn/fhirportal/dqm/ig/StructureDefinition/ach-monthly-diagnosticreport-note'}},\n  {&quot;Radiology&quot;, &quot;Pathology&quot;, &quot;Cardiology&quot;, &quot;LAB&quot;})\n\ndefine &quot;SDE DiagnosticReport Others&quot;:\n  [DiagnosticReport] DiagnosticReports\n  where not ((exists(DiagnosticReports.category Category where Category ~ &quot;Radiology&quot;))\n    or exists((DiagnosticReports.category Category where Category ~ &quot;Pathology&quot;))\n    or exists((DiagnosticReports.category Category where Category ~ &quot;Cardiology&quot;))\n    or exists(DiagnosticReports.category Category where Category ~ &quot;LAB&quot;))\n    and exists(&quot;Initial Population&quot; IP\n      where NHSNHelpers.&quot;Normalize Interval&quot;(DiagnosticReports.effective) overlaps IP.period)\n  return DiagnosticReportResource(DiagnosticReports,\n  {FHIR.canonical{value: 'http://www.cdc.gov/nhsn/fhirportal/dqm/ig/StructureDefinition/ach-monthly-diagnosticreport'}},\n  {&quot;Radiology&quot;, &quot;Pathology&quot;, &quot;Cardiology&quot;, &quot;LAB&quot;})\n//#End DiagnosticReport block\n\ndefine &quot;SDE Encounter&quot;: \n  &quot;Encounters&quot; Encounters\n  where not CheckIP(Encounters)\n  and exists(\n    &quot;Initial Population&quot; IP\n    where Encounters.period overlaps IP.period)\n  return EncounterResource(Encounters,\n  {FHIR.canonical{value: 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-encounter'}})\n\ndefine &quot;SDE IP Encounters&quot;:\n  &quot;Initial Population&quot; IP\n  return EncounterResource(IP, \n  {FHIR.canonical{value: 'http://www.cdc.gov/nhsn/fhirportal/dqm/ig/StructureDefinition/ach-monthly-encounter'}})\n\ndefine &quot;SDE Location&quot;:\n  &quot;Get Locations from IP Encounters in Measurement Period&quot; Locations\n  where exists(&quot;Initial Population&quot;)\n  and Locations is not null\n  return LocationResource(Locations,\n  {FHIR.canonical{value: 'http://www.cdc.gov/nhsn/fhirportal/dqm/ig/StructureDefinition/ach-monthly-location'}})\n \ndefine &quot;SDE Medication Administration&quot;:\n  [MedicationAdministration] MedicationAdministrations \n  where exists(\n    &quot;Initial Population&quot; IP\n    where NHSNHelpers.&quot;Normalize Interval&quot;(MedicationAdministrations.effective) overlaps IP.period)\n  return MedicationAdministrationResource(MedicationAdministrations,\n  {FHIR.canonical{value: 'http://www.cdc.gov/nhsn/fhirportal/dqm/ig/StructureDefinition/ach-monthly-medicationadministration'}},\n  {&quot;inpatient&quot;, &quot;outpatient&quot;})\n \ndefine &quot;SDE Medication Request&quot;:\n  [MedicationRequest] MedicationRequests \n  where exists(\n    &quot;Initial Population&quot; IP\n    where MedicationRequests.authoredOn during IP.period)\n  return MedicationRequestResource(MedicationRequests,\n  {FHIR.canonical{value: 'http://www.cdc.gov/nhsn/fhirportal/dqm/ig/StructureDefinition/ach-monthly-medicationrequest'}},\n  {&quot;inpatient&quot;, &quot;outpatient&quot;})\n  \ndefine &quot;SDE Medication&quot;:\n  [Medication] Medications\n  where Medications.id in &quot;Medication IDs&quot;\n  return SharedResource.MedicationResource(Medications,\n  {FHIR.canonical{value: 'http://www.cdc.gov/nhsn/fhirportal/dqm/ig/StructureDefinition/ach-monthly-medication'}})\n\ndefine &quot;SDE Observation Lab Category&quot;:\n  &quot;Observations&quot; Observations \n  where (exists(Observations.category Category where Category ~ &quot;laboratory&quot;))\n    and exists(\n      &quot;Initial Population&quot; IP\n      where NHSNHelpers.&quot;Normalize Interval&quot;(Observations.effective) overlaps IP.period)\n  return ObservationLabResource(Observations,\n  {FHIR.canonical{value: 'http://www.cdc.gov/nhsn/fhirportal/dqm/ig/StructureDefinition/ach-monthly-observation-lab'}},\n  {&quot;imaging&quot;, &quot;procedure&quot;, &quot;vital-signs&quot;, &quot;laboratory&quot;})\n\n//Vital Signs Observation has its own profile in FHIR Base\ndefine &quot;SDE Observation Vital Signs Category&quot;:\n  &quot;Observations&quot; Observations \n  where (exists(Observations.category Category where Category ~ &quot;vital-signs&quot;))\n    and exists(\n      &quot;Initial Population&quot; IP\n      where NHSNHelpers.&quot;Normalize Interval&quot;(Observations.effective) overlaps IP.period)\n  return ObservationVitalSignsResource(Observations,\n  {FHIR.canonical{value: 'http://www.cdc.gov/nhsn/fhirportal/dqm/ig/StructureDefinition/ach-monthly-observation-vitals'}},\n  {&quot;imaging&quot;, &quot;procedure&quot;, &quot;vital-signs&quot;, &quot;laboratory&quot;})\n\n//Defaulting to base FHIR profile as there are no individual profiles in US Core 3.1.1 that cover these Observation categories\ndefine &quot;SDE Observation Category&quot;:\n  &quot;Observations&quot; Observations \n  where (/*(exists(Observations.category Category where Category ~ &quot;social-history&quot;))\n    or (exists(Observations.category Category where Category ~ &quot;survey&quot;))\n    or */(exists(Observations.category Category where Category ~ &quot;imaging&quot;))\n    or (exists(Observations.category Category where Category ~ &quot;procedure&quot;)))\n    and exists(\n      &quot;Initial Population&quot; IP\n      where NHSNHelpers.&quot;Normalize Interval&quot;(Observations.effective) overlaps IP.period)\n  return ObservationResource(Observations,\n  {FHIR.canonical{value: 'http://www.cdc.gov/nhsn/fhirportal/dqm/ig/StructureDefinition/ach-monthly-observation'}},\n  {&quot;imaging&quot;, &quot;procedure&quot;, &quot;vital-signs&quot;, &quot;laboratory&quot;})\n\ndefine &quot;SDE Procedure&quot;:\n  [Procedure] Procedures \n  where exists(\n    &quot;Initial Population&quot; IP\n    where NHSNHelpers.&quot;Normalize Interval&quot;(Procedures.performed) overlaps IP.period)\n     return ProcedureResource(Procedures,\n  {FHIR.canonical{value: 'http://www.cdc.gov/nhsn/fhirportal/dqm/ig/StructureDefinition/ach-monthly-procedure'}},\n  {&quot;Surgical procedure&quot;, &quot;Diagnostic procedure&quot;})\n\ndefine &quot;SDE Specimen&quot;:\n  [Specimen] Specimens\n  where exists(\n    &quot;Initial Population&quot; IP\n    where NHSNHelpers.&quot;Normalize Interval&quot;(Specimens.collection.collected) overlaps IP.period\n  )\n  return SpecimenResource(Specimens,\n  {FHIR.canonical{value: 'http://www.cdc.gov/nhsn/fhirportal/dqm/ig/StructureDefinition/ach-monthly-specimen'}})\n\ndefine &quot;SDE Service Request&quot;:\n  [ServiceRequest] ServiceRequests\n  where exists(&quot;Initial Population&quot; IP\n    where ServiceRequests.authoredOn during IP.period)\n  return ServiceRequestResource(ServiceRequests,\n  {FHIR.canonical{value: 'http://www.cdc.gov/nhsn/fhirportal/dqm/ig/StructureDefinition/ach-monthly-servicerequest'}},\n  {&quot;Laboratory procedure&quot;, &quot;Surgical procedure&quot;, &quot;Imaging&quot;})\n\ndefine &quot;SDE Minimal Patient&quot;:\n  Patient p\n  return SharedResource.PatientResource(p,\n  {FHIR.canonical{value: 'http://www.cdc.gov/nhsn/fhirportal/dqm/ig/StructureDefinition/cross-measure-patient'}})\n\n//\n//Functions\n//\ndefine function &quot;CheckIP&quot;(encounter Encounter):\n  exists(&quot;Initial Population&quot; IP\n  where encounter.id = IP.id)\n\ndefine function &quot;GetMedicationFrom&quot;(choice Choice&lt;FHIR.CodeableConcept, FHIR.Reference&gt;):\n  case\n    when choice is FHIR.Reference then\n      GetMedication(choice as FHIR.Reference)\n    else\n      null\n  end\n\ndefine function &quot;GetMedication&quot;(reference Reference):\n  singleton from (\n    [Medication] Medications\n    where Medications.id = NHSNHelpers.GetId(reference.reference)\n  )\n\ndefine function &quot;GetCondition&quot;(reference Reference):\n  singleton from (\n    &quot;Conditions&quot; Conditions\n    where Conditions.id = NHSNHelpers.GetId(reference.reference)\n  )\n\ndefine function &quot;GetEncounter&quot;(reference Reference):\n  singleton from (\n    &quot;Encounters&quot; Encounters\n    where Encounters.id = NHSNHelpers.GetId(reference.reference)\n  )\n\ndefine function RemoveUnaccepted(codes List&lt;FHIR.CodeableConcept&gt;, accepted List&lt;System.Code&gt;):\n  codes c\n  where exists(\n    accepted a\n    where c ~ a\n  )\n\ndefine function FilterCodeableConcepts(codes List&lt;FHIR.CodeableConcept&gt;, accepted List&lt;System.Code&gt;):\n  if Count(accepted) &gt; 0\n    then RemoveUnaccepted(codes, accepted)\n  else codes    \n\n//\n//Measure Specific Resource Creation Functions\n//\n\ndefine function ConditionResource(condition Condition, profileURLs List&lt;FHIR.canonical&gt;, acceptedCategories List&lt;System.Code&gt;):\n  condition c\n  return Condition{\n    id: FHIR.id {value: 'LCR-' + c.id},\n    meta: SharedResource.MetaElement(c, profileURLs),\n    extension: c.extension,\n    clinicalStatus: c.clinicalStatus,\n    verificationStatus: c.verificationStatus,\n    category: FilterCodeableConcepts(c.category, acceptedCategories),\n    code: c.code,\n    subject: c.subject,\n    encounter: c.encounter,\n    onset: c.onset,\n    abatement: c.abatement,\n    recordedDate: c.recordedDate\n  }\n\ndefine function CoverageResource(coverage Coverage, profileURLs List&lt;FHIR.canonical&gt;):\n  coverage c\n  return Coverage{\n    id: FHIR.id{value: 'LCR-' + c.id},\n    meta: SharedResource.MetaElement(c, profileURLs),\n    extension: c.extension,\n    status: c.status,\n    type: c.type,\n    beneficiary: c.beneficiary,\n    period: c.period,\n    payor: c.payor\n  }\n\ndefine function DeviceResource(device Device, profileURLs List&lt;FHIR.canonical&gt;):\n  device d\n  return Device{\n    id: FHIR.id{value: 'LCR-' + d.id},\n    meta: SharedResource.MetaElement(d, profileURLs),\n    extension: d.extension,\n    status: d.status,\n    expirationDate: d.expirationDate,\n    lotNumber: d.lotNumber,\n    serialNumber: d.serialNumber,\n    modelNumber: d.modelNumber,\n    partNumber: d.partNumber,\n    type: d.type,\n    patient: d.patient,\n    parent: d.parent\n  }\n\ndefine function DiagnosticReportCoding(coding List&lt;Coding&gt;):\n  coding c\n  return Coding{\n    system: c.system,\n    version: c.version,\n    code: c.code,\n    display: c.display\n  }\n\ndefine function DiagnosticReportCategory(category List&lt;CodeableConcept&gt;):\n  category c\n  return CodeableConcept{\n    coding: DiagnosticReportCoding(c.coding)\n  }\n\ndefine function DiagnosticReportLabResource(diagnosticReport DiagnosticReport, profileURLs List&lt;FHIR.canonical&gt;, acceptedCategories List&lt;System.Code&gt;):\n  diagnosticReport d\n  return DiagnosticReport{\n    id: FHIR.id{value: 'LCR-' + d.id},\n    meta: SharedResource.MetaElement(d, profileURLs),\n    extension: d.extension,\n    basedOn: d.basedOn,\n    status: d.status,\n    category: FilterCodeableConcepts(DiagnosticReportCategory(d.category), acceptedCategories),\n    code: d.code,\n    subject: d.subject,\n    encounter: d.encounter,\n    effective: d.effective,\n    issued: d.issued,\n    specimen: d.specimen,\n    result: d.result,\n    conclusion: d.conclusion,\n    conclusionCode: d.conclusionCode\n  }\n\ndefine function DiagnosticReportResource(diagnosticReport DiagnosticReport, profileURLs List&lt;FHIR.canonical&gt;, acceptedCategories List&lt;System.Code&gt;):\n  diagnosticReport d\n  return DiagnosticReport{\n    id: FHIR.id{value: 'LCR-' + d.id},\n    meta: SharedResource.MetaElement(d, profileURLs),\n    extension: d.extension,\n    basedOn: d.basedOn,\n    status: d.status,\n    category: FilterCodeableConcepts(d.category, acceptedCategories),\n    code: d.code,\n    subject: d.subject,\n    encounter: d.encounter,\n    effective: d.effective,\n    issued: d.issued,\n    specimen: d.specimen,\n    result: d.result,\n    conclusion: d.conclusion,\n    conclusionCode: d.conclusionCode\n  }\n\ndefine function EncounterHospitalization(hospitalization FHIR.Encounter.Hospitalization):\n  hospitalization h\n  return FHIR.Encounter.Hospitalization{\n    origin: h.origin,\n    admitSource: h.admitSource,\n    reAdmission: h.reAdmission,\n    dietPreference: h.dietPreference,\n    dischargeDisposition: h.dischargeDisposition\n  }\n\ndefine function EncounterResource(encounter Encounter, profileURLs List&lt;FHIR.canonical&gt;):\n  encounter e\n  return Encounter{\n    id: FHIR.id{value: 'LCR-' + e.id},\n    meta: SharedResource.MetaElement(e, profileURLs),\n    extension: e.extension,\n    identifier: SharedResource.EncounterIdentifier(e.identifier),\n    status: e.status,\n    statusHistory: SharedResource.EncounterStatusHistory(e.statusHistory),\n    class: e.class,\n    classHistory: SharedResource.EncounterClassHistory(e.classHistory),\n    type: e.type,\n    subject: e.subject,\n    period: e.period,\n    reasonCode: e.reasonCode,\n    diagnosis: SharedResource.EncounterDiagnosis(e.diagnosis),\n    hospitalization: EncounterHospitalization(e.hospitalization),\n    location: SharedResource.EncounterLocation(e.location),\n    partOf: e.partOf\n  }\n\ndefine function LocationResource(location Location, profileURLs List&lt;FHIR.canonical&gt;):\n  location l\n  return Location{\n    id: FHIR.id {value: 'LCR-' + l.id},\n    meta: SharedResource.MetaElement(l, profileURLs),\n    extension: l.extension,\n    status: l.status,\n    name: l.name,\n    alias: l.alias,\n    type: l.type,\n    physicalType: l.physicalType,\n    managingOrganization: l.managingOrganization,\n    partOf: l.partOf\n  }\n\ndefine function MedicationRequestRepeat(repeat FHIR.Timing.Repeat):\n  repeat r\n  return FHIR.Timing.Repeat{\n    bounds: r.bounds,\n    count: r.count,\n    countMax: r.countMax,\n    &quot;duration&quot;: r.&quot;duration&quot;,\n    durationMax: r.durationMax,\n    durationUnit: r.durationUnit,\n    frequency: r.frequency,\n    frequencyMax: r.frequencyMax,\n    period: r.period,\n    periodMax: r.periodMax,\n    periodUnit: r.periodUnit,\n    dayOfWeek: r.dayOfWeek,\n    timeOfDay: r.timeOfDay,\n    &quot;when&quot;: r.&quot;when&quot;,\n    offset: r.offset\n  }\n\ndefine function MedicationRequestTiming(timing FHIR.Timing):\n  timing t\n  return FHIR.Timing{\n    event: t.event,\n    repeat: MedicationRequestRepeat(t.repeat),\n    code: t.code\n  }\n\ndefine function MedicationRequestDosageInstruction(dosageInstruction List&lt;FHIR.Dosage&gt;):\n  dosageInstruction dI\n  return FHIR.Dosage{\n    text: dI.text,\n    patientInstruction: dI.patientInstruction,\n    timing: MedicationRequestTiming(dI.timing),\n    asNeeded: dI.asNeeded,\n    site: dI.site,\n    route: dI.route,\n    method: dI.method,\n    doseAndRate: SharedResource.MedicationRequestDoseAndRate(dI.doseAndRate)\n  }\n\ndefine function MedicationRequestResource(medicationRequest MedicationRequest, profileURLs List&lt;FHIR.canonical&gt;, acceptedCategories List&lt;System.Code&gt;):\n  medicationRequest m\n  return MedicationRequest{\n    id: FHIR.id {value: 'LCR-' + m.id},\n    meta: SharedResource.MetaElement(medicationRequest, profileURLs),\n    extension: m.extension,\n    status: m.status,\n    statusReason: m.statusReason,\n    intent: m.intent,\n    category: FilterCodeableConcepts(m.category, acceptedCategories),\n    priority: m.priority,\n    doNotPerform: m.doNotPerform,\n    reported: m.reported,\n    medication: m.medication,\n    subject: m.subject,\n    encounter: m.encounter,\n    authoredOn: m.authoredOn,\n    requester: m.requester,\n    recorder: m.recorder,\n    reasonCode: m.reasonCode,\n    reasonReference: m.reasonReference,\n    instantiatesCanonical: m.instantiatesCanonical,\n    instantiatesUri: m.instantiatesUri,\n    courseOfTherapyType: m.courseOfTherapyType,\n    dosageInstruction: SharedResource.MedicationRequestDosageInstruction(m.dosageInstruction)\n  }\n\n  define function MedicationAdministrationResource(medicationAdministration MedicationAdministration, profileURLs List&lt;FHIR.canonical&gt;, acceptedCategories List&lt;System.Code&gt;):\n  medicationAdministration m\n  return MedicationAdministration{\n    id: FHIR.id {value: 'LCR-' + m.id},\n    meta: SharedResource.MetaElement(m, profileURLs),\n    extension: m.extension,\n    instantiates: m.instantiates,\n    partOf: m.partOf,\n    status: m.status,\n    statusReason: m.statusReason,\n    category: FilterCodeableConcepts({m.category}, acceptedCategories)[0],\n    medication: m.medication,\n    subject: m.subject,\n    context: m.context,\n    supportingInformation: m.supportingInformation,\n    effective: m.effective,\n    performer: SharedResource.MedicationAdministrationPerformer(m.performer),\n    reasonCode: m.reasonCode,\n    reasonReference: m.reasonReference,\n    request: m.request,\n    device: m.device,\n    note: m.note,\n    dosage: SharedResource.MedicationAdministrationDosage(m.dosage),\n    eventHistory: m.eventHistory\n  }\n\ndefine function ObservationLabReferenceRange(referenceRange List&lt;FHIR.Observation.ReferenceRange&gt;):\n  referenceRange rR\n  return FHIR.Observation.ReferenceRange{\n    low: rR.low,\n    high: rR.high,\n    type: rR.type,\n    appliesTo: rR.appliesTo,\n    age: rR.age\n  }\n\ndefine function ObservationLabCoding(coding List&lt;Coding&gt;):\n  coding c\n  return Coding{\n    system: c.system,\n    version: c.version,\n    code: c.code,\n    display: c.display,\n    userSelected: c.userSelected\n  }\n\ndefine function ObservationLabCategory(category List&lt;CodeableConcept&gt;):\n  category c\n  return CodeableConcept{\n    coding: ObservationLabCoding(c.coding),\n    text: c.text\n  }\n\ndefine function ObservationLabResource(observation Observation, profileURLs List&lt;FHIR.canonical&gt;, acceptedCategories List&lt;System.Code&gt;):\n  observation o\n  return Observation{\n    id: FHIR.id {value: 'LCR-' + o.id},\n    meta: SharedResource.MetaElement(o, profileURLs),\n    extension: o.extension,\n    partOf: o.partOf,\n    status: o.status,\n    category: FilterCodeableConcepts(ObservationLabCategory(o.category), acceptedCategories),\n    code: o.code,\n    subject: o.subject,\n    encounter: o.encounter,\n    effective: o.effective,\n    issued: o.issued,\n    value: o.value,\n    dataAbsentReason: o.dataAbsentReason,\n    interpretation: o.interpretation,\n    bodySite: o.bodySite,\n    method: o.method,\n    specimen: o.specimen,\n    referenceRange: ObservationLabReferenceRange(o.referenceRange),\n    hasMember: o.hasMember,\n    derivedFrom: o.derivedFrom,\n    component: SharedResource.ObservationComponent(o.component)\n  }\n\ndefine function ObservationReferenceRange(referenceRange List&lt;FHIR.Observation.ReferenceRange&gt;):\n  referenceRange rR\n  return FHIR.Observation.ReferenceRange{\n    low: rR.low,\n    high: rR.high,\n    type: rR.type,\n    appliesTo: rR.appliesTo,\n    age: rR.age\n  }\n\ndefine function ObservationResource(observation Observation, profileURLs List&lt;FHIR.canonical&gt;, acceptedCategories List&lt;System.Code&gt;):\n  observation o\n  return Observation{\n    id: FHIR.id {value: 'LCR-' + o.id},\n    meta: SharedResource.MetaElement(o, profileURLs),\n    extension: o.extension,\n    partOf: o.partOf,\n    status: o.status,\n    category: FilterCodeableConcepts(o.category, acceptedCategories),\n    code: o.code,\n    subject: o.subject,\n    encounter: o.encounter,\n    effective: o.effective,\n    issued: o.issued,\n    value: o.value,\n    dataAbsentReason: o.dataAbsentReason,\n    interpretation: o.interpretation,\n    bodySite: o.bodySite,\n    method: o.method,\n    specimen: o.specimen,\n    referenceRange: ObservationReferenceRange(o.referenceRange),\n    hasMember: o.hasMember,\n    derivedFrom: o.derivedFrom,\n    component: SharedResource.ObservationComponent(o.component)\n  }\n\ndefine function ObservationVitalSignsCoding(coding List&lt;Coding&gt;):\n  coding c\n  return Coding{\n    system: c.system,\n    version: c.version,\n    code: c.code,\n    display: c.display,\n    userSelected: c.userSelected\n  }\n\ndefine function ObservationVitalSignsCategory(category List&lt;CodeableConcept&gt;):\n  category c\n  return CodeableConcept{\n    coding: ObservationVitalSignsCoding(c.coding),\n    text: c.text\n  }\n\ndefine function ObservationVitalSignsComponent(component List&lt;FHIR.Observation.Component&gt;):\n  component c\n  return FHIR.Observation.Component{\n    code: c.code,\n    value: c.value,\n    dataAbsentReason: c.dataAbsentReason,\n    interpretation: c.interpretation,\n    referenceRange: SharedResource.ObservationReferenceRange(c.referenceRange)\n  }\n\ndefine function ObservationVitalSignsReferenceRange(referenceRange List&lt;FHIR.Observation.ReferenceRange&gt;):\n  referenceRange rR\n  return FHIR.Observation.ReferenceRange{\n    low: rR.low,\n    high: rR.high,\n    type: rR.type,\n    appliesTo: rR.appliesTo,\n    age: rR.age\n  }\n\ndefine function ObservationVitalSignsResource(observation Observation, profileURLs List&lt;FHIR.canonical&gt;, acceptedCategories List&lt;System.Code&gt;):\n  observation o\n  return Observation{\n    id: FHIR.id {value: 'LCR-' + o.id},\n    meta: SharedResource.MetaElement(o, profileURLs),\n    extension: o.extension,\n    partOf: o.partOf,\n    status: o.status,\n    category: FilterCodeableConcepts(ObservationVitalSignsCategory(o.category), acceptedCategories),\n    code: o.code,\n    subject: o.subject,\n    encounter: o.encounter,\n    effective: o.effective,\n    issued: o.issued,\n    value: o.value,\n    dataAbsentReason: o.dataAbsentReason,\n    interpretation: o.interpretation,\n    bodySite: o.bodySite,\n    method: o.method,\n    specimen: o.specimen,\n    referenceRange: ObservationVitalSignsReferenceRange(o.referenceRange),\n    hasMember: o.hasMember,\n    derivedFrom: o.derivedFrom,\n    component: ObservationVitalSignsComponent(o.component)\n  }\n\n define function &quot;GetProcedureExtensions&quot;(domainResource DomainResource):\n  domainResource.extension E\n    where E.url != 'http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-recorded'\n     return E\n \ndefine function ProcedureResource(procedure Procedure, profileURLs List&lt;FHIR.canonical&gt;, acceptedCategories List&lt;System.Code&gt;):\n  procedure p\n  return Procedure{\n    id: FHIR.id {value: 'LCR-' + p.id},\n    meta: SharedResource.MetaElement(p, profileURLs),\n    extension: GetProcedureExtensions(p), \n    basedOn: p.basedOn,\n    partOf: p.partOf,\n    status: p.status,\n    category: FilterCodeableConcepts({p.category}, acceptedCategories)[0],\n    code: p.code,\n    subject: p.subject,\n    encounter: p.encounter,\n    performed: p.performed,\n    location: p.location,\n    reasonCode: p.reasonCode,\n    reasonReference: p.reasonReference,\n    bodySite: p.bodySite\n  }\n\n  define function ServiceRequestResource(serviceRequest ServiceRequest, profileURLs List&lt;FHIR.canonical&gt;, acceptedCategories List&lt;System.Code&gt;):\n  serviceRequest sR\n  return ServiceRequest{\n    id: FHIR.id {value: 'LCR-' + sR.id},\n    meta: SharedResource.MetaElement(sR, profileURLs),\n    extension: sR.extension,\n    basedOn: sR.basedOn,\n    status: sR.status,\n    intent: sR.intent,\n    category: FilterCodeableConcepts(sR.category, acceptedCategories),\n    priority: sR.priority,\n    doNotPerform: sR.doNotPerform,\n    code: sR.code,\n    quantity: sR.quantity,\n    subject: sR.subject,\n    encounter: sR.encounter,\n    occurrence: sR.occurrence,\n    asNeeded: sR.asNeeded,\n    authoredOn: sR.authoredOn,\n    specimen: sR.specimen\n  }\n\n  define function SpecimenCollection(collection FHIR.Specimen.Collection):\n  collection c\n  return FHIR.Specimen.Collection{\n    collector: c.collector,\n    collected: c.collected,\n    quantity: c.quantity,\n    bodySite: c.bodySite\n  }\n\n  define function SpecimenResource(specimen Specimen, profileURLs List&lt;FHIR.canonical&gt;):\n  specimen s\n  return Specimen{\n    id: FHIR.id {value: 'LCR-' + s.id},\n    meta: SharedResource.MetaElement(s, profileURLs),\n    extension: s.extension,\n    identifier: s.identifier,\n    accessionIdentifier: s.accessionIdentifier,\n    status: s.status,\n    type: s.type,\n    subject: s.subject,\n    parent: s.parent,\n    request: s.request,\n    collection: SpecimenCollection(s.collection),\n    note: s.note\n  }</code></pre></td></tr>\n            </table>\n          </td>\n        </tr>\n        \n        \n        \n    </table>\n</div>\n</div>"
+        },
         "contained": [
           {
             "resourceType": "Parameters",
@@ -3777,11 +3487,18 @@
             "valueReference": {
               "reference": "#options"
             }
+          },
+          {
+            "url": "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-softwaresystem",
+            "valueReference": {
+              "reference": "Device/cqf-tooling"
+            }
           }
         ],
         "url": "http://www.cdc.gov/nhsn/fhirportal/dqm/ig/Library/NHSNAcuteCareHospitalMonthlyInitialPopulation",
-        "version": "1.0.0-dev",
+        "version": "2.0.0-cibuild",
         "name": "NHSNAcuteCareHospitalMonthlyInitialPopulation",
+        "status": "draft",
         "type": {
           "coding": [
             {
@@ -3790,6 +3507,33 @@
             }
           ]
         },
+        "date": "2026-01-08T14:28:51+00:00",
+        "publisher": "CDC National Healthcare Safety Network (NHSN)",
+        "contact": [
+          {
+            "name": "CDC National Healthcare Safety Network (NHSN)",
+            "telecom": [
+              {
+                "system": "url",
+                "value": "http://www.cdc.gov/nhsn"
+              },
+              {
+                "system": "email",
+                "value": "nhsn@cdc.gov"
+              }
+            ]
+          }
+        ],
+        "jurisdiction": [
+          {
+            "coding": [
+              {
+                "system": "urn:iso:std:iso:3166",
+                "code": "US"
+              }
+            ]
+          }
+        ],
         "relatedArtifact": [
           {
             "type": "depends-on",
@@ -3809,17 +3553,17 @@
           {
             "type": "depends-on",
             "display": "Library SharedResource",
-            "resource": "http://www.cdc.gov/nhsn/fhirportal/dqm/ig/Library/SharedResourceCreation|0.1.009"
+            "resource": "http://www.cdc.gov/nhsn/fhirportal/dqm/ig/Library/SharedResourceCreation|0.1.010"
           },
           {
             "type": "depends-on",
             "display": "Code system ActCode",
-            "resource": "http://terminology.hl7.org/CodeSystem/v3-ActCode"
+            "resource": "http://terminology.hl7.org/CodeSystem/v3-ActCode|9.0.0"
           },
           {
             "type": "depends-on",
             "display": "Code system Observation Category",
-            "resource": "http://terminology.hl7.org/CodeSystem/observation-category"
+            "resource": "http://terminology.hl7.org/CodeSystem/observation-category|2.0.0"
           },
           {
             "type": "depends-on",
@@ -3829,22 +3573,27 @@
           {
             "type": "depends-on",
             "display": "Code system V2-0074",
-            "resource": "http://terminology.hl7.org/CodeSystem/v2-0074"
+            "resource": "http://terminology.hl7.org/CodeSystem/v2-0074|3.0.0"
           },
           {
             "type": "depends-on",
             "display": "Code system Condition Category",
-            "resource": "http://terminology.hl7.org/CodeSystem/condition-category"
+            "resource": "http://terminology.hl7.org/CodeSystem/condition-category|2.0.0"
           },
           {
             "type": "depends-on",
             "display": "Code system US Core Condition Category",
-            "resource": "http://hl7.org/fhir/us/core/CodeSystem/condition-category"
+            "resource": "http://hl7.org/fhir/us/core/CodeSystem/condition-category|6.1.0"
           },
           {
             "type": "depends-on",
             "display": "Code system Condition Clinical Status",
-            "resource": "http://terminology.hl7.org/CodeSystem/condition-clinical"
+            "resource": "http://terminology.hl7.org/CodeSystem/condition-clinical|3.0.0"
+          },
+          {
+            "type": "depends-on",
+            "display": "Code system SNOMEDCT",
+            "resource": "http://www.snomed.org/"
           },
           {
             "type": "depends-on",
@@ -3951,6 +3700,13 @@
             "type": "Condition"
           },
           {
+            "name": "SDE Coverage",
+            "use": "out",
+            "min": 0,
+            "max": "*",
+            "type": "Coverage"
+          },
+          {
             "name": "SDE Device",
             "use": "out",
             "min": 0,
@@ -4040,13 +3796,6 @@
             "min": 0,
             "max": "*",
             "type": "Observation"
-          },
-          {
-            "name": "SDE Coverage",
-            "use": "out",
-            "min": 0,
-            "max": "*",
-            "type": "Coverage"
           },
           {
             "name": "SDE Procedure",
@@ -4456,6 +4205,21 @@
             ]
           },
           {
+            "type": "Coverage",
+            "profile": [
+              "http://hl7.org/fhir/StructureDefinition/Coverage"
+            ],
+            "mustSupport": [
+              "period",
+              "id",
+              "extension",
+              "status",
+              "type",
+              "beneficiary",
+              "payor"
+            ]
+          },
+          {
             "type": "Device",
             "profile": [
               "http://hl7.org/fhir/StructureDefinition/Device"
@@ -4565,31 +4329,6 @@
             ]
           },
           {
-            "type": "Coverage",
-            "profile": [
-              "http://hl7.org/fhir/StructureDefinition/Coverage"
-            ],
-            "mustSupport": [
-              "period",
-              "id",
-              "extension",
-              "status",
-              "type",
-              "policyHolder",
-              "subscriber",
-              "subscriberId",
-              "beneficiary",
-              "dependent",
-              "relationship",
-              "payor",
-              "class",
-              "order",
-              "network",
-              "subrogation",
-              "contract"
-            ]
-          },
-          {
             "type": "Procedure",
             "profile": [
               "http://hl7.org/fhir/StructureDefinition/Procedure"
@@ -4696,7 +4435,8 @@
         "content": [
           {
             "contentType": "text/cql",
-            "data": "bGlicmFyeSBOSFNOQWN1dGVDYXJlSG9zcGl0YWxNb250aGx5SW5pdGlhbFBvcHVsYXRpb24gdmVyc2lvbiAnMS4wLjAtZGV2JwoKdXNpbmcgRkhJUiB2ZXJzaW9uICc0LjAuMScKCmluY2x1ZGUgRkhJUkhlbHBlcnMgdmVyc2lvbiAnNC4wLjInIGNhbGxlZCBGSElSSGVscGVycwppbmNsdWRlIE5IU05IZWxwZXJzIHZlcnNpb24gJzAuMC4wMDInIGNhbGxlZCBOSFNOSGVscGVycwppbmNsdWRlIFNoYXJlZFJlc291cmNlQ3JlYXRpb24gdmVyc2lvbiAnMC4xLjAwOScgY2FsbGVkIFNoYXJlZFJlc291cmNlCgpjb2Rlc3lzdGVtICJBY3RDb2RlIjogJ2h0dHA6Ly90ZXJtaW5vbG9neS5obDcub3JnL0NvZGVTeXN0ZW0vdjMtQWN0Q29kZScKY29kZXN5c3RlbSAiT2JzZXJ2YXRpb24gQ2F0ZWdvcnkiOiAnaHR0cDovL3Rlcm1pbm9sb2d5LmhsNy5vcmcvQ29kZVN5c3RlbS9vYnNlcnZhdGlvbi1jYXRlZ29yeScKY29kZXN5c3RlbSAiTE9JTkMiOiAnaHR0cDovL2xvaW5jLm9yZycgCmNvZGVzeXN0ZW0gIlYyLTAwNzQiOiAnaHR0cDovL3Rlcm1pbm9sb2d5LmhsNy5vcmcvQ29kZVN5c3RlbS92Mi0wMDc0Jwpjb2Rlc3lzdGVtICJDb25kaXRpb24gQ2F0ZWdvcnkiOiAnaHR0cDovL3Rlcm1pbm9sb2d5LmhsNy5vcmcvQ29kZVN5c3RlbS9jb25kaXRpb24tY2F0ZWdvcnknCmNvZGVzeXN0ZW0gIlVTIENvcmUgQ29uZGl0aW9uIENhdGVnb3J5IjogJ2h0dHA6Ly9obDcub3JnL2ZoaXIvdXMvY29yZS9Db2RlU3lzdGVtL2NvbmRpdGlvbi1jYXRlZ29yeScKY29kZXN5c3RlbSAiQ29uZGl0aW9uIENsaW5pY2FsIFN0YXR1cyI6ICdodHRwOi8vdGVybWlub2xvZ3kuaGw3Lm9yZy9Db2RlU3lzdGVtL2NvbmRpdGlvbi1jbGluaWNhbCcKCnZhbHVlc2V0ICJJbnBhdGllbnQsIEVtZXJnZW5jeSwgYW5kIE9ic2VydmF0aW9uIExvY2F0aW9ucyI6ICdodHRwOi8vY3RzLm5sbS5uaWguZ292L2ZoaXIvVmFsdWVTZXQvMi4xNi44NDAuMS4xMTM3NjIuMS40LjEwNDYuMjY1Jwp2YWx1ZXNldCAiRW1lcmdlbmN5IERlcGFydG1lbnQgVmlzaXQiOiAnaHR0cDovL2N0cy5ubG0ubmloLmdvdi9maGlyL1ZhbHVlU2V0LzIuMTYuODQwLjEuMTEzODgzLjMuMTE3LjEuNy4xLjI5MicKdmFsdWVzZXQgIkVuY291bnRlciBJbnBhdGllbnQiOiAnaHR0cDovL2N0cy5ubG0ubmloLmdvdi9maGlyL1ZhbHVlU2V0LzIuMTYuODQwLjEuMTEzODgzLjMuNjY2LjUuMzA3Jwp2YWx1ZXNldCAiT2JzZXJ2YXRpb24gU2VydmljZXMiOiAnaHR0cDovL2N0cy5ubG0ubmloLmdvdi9maGlyL1ZhbHVlU2V0LzIuMTYuODQwLjEuMTEzNzYyLjEuNC4xMTExLjE0MycKdmFsdWVzZXQgIk5IU04gSW5wYXRpZW50IEVuY291bnRlciBDbGFzcyBDb2RlcyI6ICdodHRwOi8vY3RzLm5sbS5uaWguZ292L2ZoaXIvVmFsdWVTZXQvMi4xNi44NDAuMS4xMTM3NjIuMS40LjEwNDYuMjc0JwoKLy9jb2RlIGZvciBPYnNlcnZhdGlvbiBDYXRlZ29yeQpjb2RlICJsYWJvcmF0b3J5IjogJ2xhYm9yYXRvcnknIGZyb20gIk9ic2VydmF0aW9uIENhdGVnb3J5IiBkaXNwbGF5ICdMYWJvcmF0b3J5Jwpjb2RlICJzb2NpYWwtaGlzdG9yeSI6ICdzb2NpYWwtaGlzdG9yeScgZnJvbSAiT2JzZXJ2YXRpb24gQ2F0ZWdvcnkiIGRpc3BsYXkgJ1NvY2lhbCBIaXN0b3J5Jwpjb2RlICJ2aXRhbC1zaWducyI6ICd2aXRhbC1zaWducycgZnJvbSAiT2JzZXJ2YXRpb24gQ2F0ZWdvcnkiIGRpc3BsYXkgJ1ZpdGFsIFNpZ25zJwpjb2RlICJpbWFnaW5nIjogJ2ltYWdpbmcnIGZyb20gIk9ic2VydmF0aW9uIENhdGVnb3J5IiBkaXNwbGF5ICdJbWFnaW5nJwpjb2RlICJwcm9jZWR1cmUiOiAncHJvY2VkdXJlJyBmcm9tICJPYnNlcnZhdGlvbiBDYXRlZ29yeSIgZGlzcGxheSAnUHJvY2VkdXJlJwpjb2RlICJzdXJ2ZXkiOiAnc3VydmV5JyBmcm9tICJPYnNlcnZhdGlvbiBDYXRlZ29yeSIgZGlzcGxheSAnU3VydmV5JwoKLy9jb2RlIGZvciBDb25kaXRpb24gY2F0ZWdvcnkKY29kZSAicHJvYmxlbS1saXN0LWl0ZW0iOiAncHJvYmxlbS1saXN0LWl0ZW0nIGZyb20gIkNvbmRpdGlvbiBDYXRlZ29yeSIgZGlzcGxheSAnUHJvYmxlbSBMaXN0IEl0ZW0nCmNvZGUgImVuY291bnRlci1kaWFnbm9zaXMiOiAnZW5jb3VudGVyLWRpYWdub3NpcycgZnJvbSAiQ29uZGl0aW9uIENhdGVnb3J5IiBkaXNwbGF5ICdFbmNvdW50ZXIgRGlhZ25vc2lzJwpjb2RlICJoZWFsdGgtY29uY2VybiI6ICdoZWFsdGgtY29uY2VybicgZnJvbSAiVVMgQ29yZSBDb25kaXRpb24gQ2F0ZWdvcnkiIGRpc3BsYXkgJ0hlYWx0aCBDb25jZXJuJwoKLy9jb2RlIGZvciBEaWFnbm9zdGljIFJlcG9ydCBDYXRlZ29yeQpjb2RlICJMQUIiOiAnTEFCJyBmcm9tICJWMi0wMDc0IiBkaXNwbGF5ICdMYWJvcmF0b3J5Jwpjb2RlICJSYWRpb2xvZ3kiOiAnTFAyOTY4NC01JyBmcm9tICJMT0lOQyIgZGlzcGxheSAnUmFkaW9sb2d5Jwpjb2RlICJQYXRob2xvZ3kiOiAnTFA3ODM5LTYnIGZyb20gIkxPSU5DIiBkaXNwbGF5ICdQYXRob2xvZ3knCmNvZGUgIkNhcmRpb2xvZ3kiOiAnTFAyOTcwOC0yJyBmcm9tICJMT0lOQyIgZGlzcGxheSAnQ2FyZGlvbG9neScKCi8vY29kZSBmb3IgRW1lcmdlbmN5IEVuY291bnRlciBDbGFzcwpjb2RlICJlbWVyZ2VuY3kiOiAnRU1FUicgZnJvbSAiQWN0Q29kZSIgZGlzcGxheSAnZW1lcmdlbmN5Jwpjb2RlICJvYnNlcnZhdGlvbiBlbmNvdW50ZXIiOiAnT0JTRU5DJyBmcm9tICJBY3RDb2RlIiBkaXNwbGF5ICdvYnNlcnZhdGlvbiBlbmNvdW50ZXInCgovL2NvZGUgZm9yIENvbmRpdGlvbiBjbGluaWNhbFN0YXR1cwpjb2RlICJhY3RpdmUiOiAnYWN0aXZlJyBmcm9tICJDb25kaXRpb24gQ2xpbmljYWwgU3RhdHVzIiBkaXNwbGF5ICdhY3RpdmUnCgpwYXJhbWV0ZXIgIk1lYXN1cmVtZW50IFBlcmlvZCIgCiAgICBkZWZhdWx0IEludGVydmFsW0AyMDIyLTAxLTAxVDAwOjAwOjAwLjAsIEAyMDIyLTAxLTMxVDIzOjU5OjU5LjApCgpjb250ZXh0IFBhdGllbnQgCgpkZWZpbmUgIlF1YWxpZnlpbmcgRW5jb3VudGVycyBEdXJpbmcgTWVhc3VyZW1lbnQgUGVyaW9kIjoKICggW0VuY291bnRlcjogIkVuY291bnRlciBJbnBhdGllbnQiXQogIHVuaW9uIFtFbmNvdW50ZXI6ICJFbWVyZ2VuY3kgRGVwYXJ0bWVudCBWaXNpdCJdCiAgdW5pb24gW0VuY291bnRlcjogIk9ic2VydmF0aW9uIFNlcnZpY2VzIl0KICB1bmlvbiBbRW5jb3VudGVyOiBjbGFzcyBpbiAiTkhTTiBJbnBhdGllbnQgRW5jb3VudGVyIENsYXNzIENvZGVzIl0KICB1bmlvbiBbRW5jb3VudGVyOiBjbGFzcyB+ICJlbWVyZ2VuY3kiXQogIHVuaW9uIFtFbmNvdW50ZXI6IGNsYXNzIH4gIm9ic2VydmF0aW9uIGVuY291bnRlciJdKSBRdWFsaWZ5aW5nRW5jb3VudGVycwogIHdoZXJlIFF1YWxpZnlpbmdFbmNvdW50ZXJzLnN0YXR1cyBpbiB7J2luLXByb2dyZXNzJywgJ2ZpbmlzaGVkJywgJ3RyaWFnZWQnLCAnb25sZWF2ZScsICdlbnRlcmVkLWluLWVycm9yJ30KICAgIGFuZCBRdWFsaWZ5aW5nRW5jb3VudGVycy5wZXJpb2Qgb3ZlcmxhcHMgIk1lYXN1cmVtZW50IFBlcmlvZCIgCgpkZWZpbmUgIkVuY291bnRlcnMgd2l0aCBQYXRpZW50IEhvc3BpdGFsIExvY2F0aW9ucyI6CiAgIkVuY291bnRlcnMiIEVuY291bnRlcnMKICB3aGVyZSBleGlzdHMoCiAgICBFbmNvdW50ZXJzLmxvY2F0aW9uIEVuY291bnRlckxvY2F0aW9uCiAgICB3aGVyZSBOSFNOSGVscGVycy5HZXRMb2NhdGlvbihFbmNvdW50ZXJMb2NhdGlvbi5sb2NhdGlvbikudHlwZSBpbiAiSW5wYXRpZW50LCBFbWVyZ2VuY3ksIGFuZCBPYnNlcnZhdGlvbiBMb2NhdGlvbnMiCiAgICAgIGFuZCBFbmNvdW50ZXJMb2NhdGlvbi5wZXJpb2Qgb3ZlcmxhcHMgRW5jb3VudGVycy5wZXJpb2QKICApCiAgYW5kIEVuY291bnRlcnMuc3RhdHVzIGluIHsnaW4tcHJvZ3Jlc3MnLCAnZmluaXNoZWQnLCAndHJpYWdlZCcsICdvbmxlYXZlJywgJ2VudGVyZWQtaW4tZXJyb3InfQogIGFuZCBFbmNvdW50ZXJzLnBlcmlvZCBvdmVybGFwcyAiTWVhc3VyZW1lbnQgUGVyaW9kIgoKZGVmaW5lICJJbml0aWFsIFBvcHVsYXRpb24iOgogICJRdWFsaWZ5aW5nIEVuY291bnRlcnMgRHVyaW5nIE1lYXN1cmVtZW50IFBlcmlvZCIKICB1bmlvbiAiRW5jb3VudGVycyB3aXRoIFBhdGllbnQgSG9zcGl0YWwgTG9jYXRpb25zIgoKZGVmaW5lICJFbmNvdW50ZXJzIjoKICBbRW5jb3VudGVyXQoKZGVmaW5lICJDb25kaXRpb25zIjoKICBbQ29uZGl0aW9uXQoKZGVmaW5lICJEaWFnbm9zdGljUmVwb3J0cyI6CiAgW0RpYWdub3N0aWNSZXBvcnRdCgpkZWZpbmUgIk9ic2VydmF0aW9ucyI6CiAgW09ic2VydmF0aW9uXQoKZGVmaW5lICJHZXQgTG9jYXRpb25zIGZyb20gSVAgRW5jb3VudGVycyBpbiBNZWFzdXJlbWVudCBQZXJpb2QiOgogIGZsYXR0ZW4oIkluaXRpYWwgUG9wdWxhdGlvbiIgSVAKICBsZXQgbG9jYXRpb25FbGVtZW50czogSVAubG9jYXRpb24KICByZXR1cm4KICAgIGxvY2F0aW9uRWxlbWVudHMgTEUKICAgIGxldCBsb2NhdGlvblJlZmVyZW5jZTogTEUubG9jYXRpb24KICAgIHJldHVybiBOSFNOSGVscGVycy5HZXRMb2NhdGlvbihsb2NhdGlvblJlZmVyZW5jZSkpCgovLz09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT0KLy9TdXBwbGVtZW50YWwgRGF0YSBFbGVtZW50Ci8vV2hlbiBGSElSLmNhbm9uaWNhbCB2YWx1ZSBpcyBwcmVzZW50LCBVUyBDb3JlIDMuMS4xIHByb2ZpbGVzIGFyZSB1c2VkCi8vV2hlbiBGSElSLmNhbm9uaWNhbCB2YWx1ZSBpcyBub3QgcHJlc2VudCwgRkhJUiBCYXNlIHByb2ZpbGVzIGFyZSB1c2VkCi8vPT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PQpkZWZpbmUgIlNERSBDb25kaXRpb24iOgogICJDb25kaXRpb25zIiBDb25kaXRpb25zIAogIHdoZXJlIGV4aXN0cygKICAgICJJbml0aWFsIFBvcHVsYXRpb24iIElQCiAgICAvL0NoZWNrIGZvciBQcm9ibGVtIExpc3QgQ29uZGl0aW9ucyB0aGF0IHdlcmUgcmVjb3JkZWQgYmVmb3JlIG9yIGR1cmluZyBJUAogICAgd2hlcmUgKAogICAgICBDb25kaXRpb25zLnJlY29yZGVkRGF0ZSBiZWZvcmUgZW5kIG9mIElQLnBlcmlvZAogICAgICBhbmQgZXhpc3RzKENvbmRpdGlvbnMuY2F0ZWdvcnkgY2F0ZWdvcmllcwogICAgICAgIHdoZXJlIGNhdGVnb3JpZXMgfiAicHJvYmxlbS1saXN0LWl0ZW0iKQogICAgICBhbmQgQ29uZGl0aW9ucy5jbGluaWNhbFN0YXR1cyB+ICJhY3RpdmUiCiAgICApCiAgICAvL0NoZWNrIGZvciBFbmNvdW50ZXIgRGlhZ25vc2lzIENvbmRpdGlvbnMgdGhhdCByZWZlcmVuY2UgYW4gSVAgZW5jb3VudGVyCiAgICBvciAoCiAgICAgIChleGlzdHMoSVAuZGlhZ25vc2lzIERpYWdub3NlcwogICAgICAgICAgd2hlcmUgR2V0Q29uZGl0aW9uKERpYWdub3Nlcy5jb25kaXRpb24pLmlkID0gQ29uZGl0aW9ucy5pZAogICAgICAgICkKICAgICAgICBvciBHZXRFbmNvdW50ZXIoQ29uZGl0aW9ucy5lbmNvdW50ZXIpLmlkID0gSVAuaWQKICAgICAgKQogICAgICBhbmQgZXhpc3RzIChDb25kaXRpb25zLmNhdGVnb3J5IGNhdGVnb3JpZXMKICAgICAgICB3aGVyZSBjYXRlZ29yaWVzIH4gImVuY291bnRlci1kaWFnbm9zaXMiCiAgICAgICAgICBvciBjYXRlZ29yaWVzIH4gImhlYWx0aC1jb25jZXJuIikKICAgICkKICApCiAgcmV0dXJuIFNoYXJlZFJlc291cmNlLkNvbmRpdGlvblJlc291cmNlKENvbmRpdGlvbnMsCiAge0ZISVIuY2Fub25pY2Fse3ZhbHVlOiAnaHR0cDovL3d3dy5jZGMuZ292L25oc24vZmhpcnBvcnRhbC9kcW0vaWcvU3RydWN0dXJlRGVmaW5pdGlvbi9hY2gtbW9udGhseS1jb25kaXRpb24nfX0pCgpkZWZpbmUgIlNERSBEZXZpY2UiOgogIFtEZXZpY2VdIERldmljZXMgCiAgd2hlcmUgZXhpc3RzKCJJbml0aWFsIFBvcHVsYXRpb24iKQogIHJldHVybiBEZXZpY2VSZXNvdXJjZShEZXZpY2VzLAogIHtGSElSLmNhbm9uaWNhbHt2YWx1ZTogJ2h0dHA6Ly93d3cuY2RjLmdvdi9uaHNuL2ZoaXJwb3J0YWwvZHFtL2lnL1N0cnVjdHVyZURlZmluaXRpb24vYWNoLW1vbnRobHktZGV2aWNlJ319KQoKLy9UaGlzIGJsb2NrIGNvbGxlY3RzIGFsbCBEaWFnbm9zdGljUmVwb3J0IHJlc291cmNlcyB3aGlsZSBhbHNvIG1hcmtpbmcgTGFiIGFuZCBOb3RlIERpYWdub3N0aWNSZXBvcnRzIHdpdGggdGhlIGFwcHJvcHJpYXRlIHByb2ZpbGVzCi8vI1N0YXJ0IERpYWdub3N0aWNSZXBvcnQgYmxvY2sKZGVmaW5lICJTREUgRGlhZ25vc3RpY1JlcG9ydCBMYWIiOgogICJEaWFnbm9zdGljUmVwb3J0cyIgRGlhZ25vc3RpY1JlcG9ydHMKICB3aGVyZSAoZXhpc3RzKERpYWdub3N0aWNSZXBvcnRzLmNhdGVnb3J5IENhdGVnb3J5IHdoZXJlIENhdGVnb3J5IH4gIkxBQiIpCiAgICBhbmQgZXhpc3RzKAogICAgICAiSW5pdGlhbCBQb3B1bGF0aW9uIiBJUAogICAgICB3aGVyZSBOSFNOSGVscGVycy4iTm9ybWFsaXplIEludGVydmFsIihEaWFnbm9zdGljUmVwb3J0cy5lZmZlY3RpdmUpIG92ZXJsYXBzIElQLnBlcmlvZCkpCiAgcmV0dXJuIFNoYXJlZFJlc291cmNlLkRpYWdub3N0aWNSZXBvcnRMYWJSZXNvdXJjZShEaWFnbm9zdGljUmVwb3J0cywKICB7RkhJUi5jYW5vbmljYWx7dmFsdWU6ICdodHRwOi8vd3d3LmNkYy5nb3Yvbmhzbi9maGlycG9ydGFsL2RxbS9pZy9TdHJ1Y3R1cmVEZWZpbml0aW9uL2FjaC1tb250aGx5LWRpYWdub3N0aWNyZXBvcnQtbGFiJ319KQogCmRlZmluZSAiU0RFIERpYWdub3N0aWNSZXBvcnQgTm90ZSI6CiAgIkRpYWdub3N0aWNSZXBvcnRzIiBEaWFnbm9zdGljUmVwb3J0cwogIHdoZXJlICgoZXhpc3RzKERpYWdub3N0aWNSZXBvcnRzLmNhdGVnb3J5IENhdGVnb3J5IHdoZXJlIENhdGVnb3J5IH4gIlJhZGlvbG9neSIpKQogICAgb3IgZXhpc3RzKChEaWFnbm9zdGljUmVwb3J0cy5jYXRlZ29yeSBDYXRlZ29yeSB3aGVyZSBDYXRlZ29yeSB+ICJQYXRob2xvZ3kiKSkKICAgIG9yIGV4aXN0cygoRGlhZ25vc3RpY1JlcG9ydHMuY2F0ZWdvcnkgQ2F0ZWdvcnkgd2hlcmUgQ2F0ZWdvcnkgfiAiQ2FyZGlvbG9neSIpKSkKICAgIGFuZCBleGlzdHMoCiAgICAgICJJbml0aWFsIFBvcHVsYXRpb24iIElQCiAgICAgIHdoZXJlIE5IU05IZWxwZXJzLiJOb3JtYWxpemUgSW50ZXJ2YWwiKERpYWdub3N0aWNSZXBvcnRzLmVmZmVjdGl2ZSkgb3ZlcmxhcHMgSVAucGVyaW9kKQogIHJldHVybiBEaWFnbm9zdGljUmVwb3J0UmVzb3VyY2UoRGlhZ25vc3RpY1JlcG9ydHMsCiAge0ZISVIuY2Fub25pY2Fse3ZhbHVlOiAnaHR0cDovL3d3dy5jZGMuZ292L25oc24vZmhpcnBvcnRhbC9kcW0vaWcvU3RydWN0dXJlRGVmaW5pdGlvbi9hY2gtbW9udGhseS1kaWFnbm9zdGljcmVwb3J0LW5vdGUnfX0pCgpkZWZpbmUgIlNERSBEaWFnbm9zdGljUmVwb3J0IE90aGVycyI6CiAgW0RpYWdub3N0aWNSZXBvcnRdIERpYWdub3N0aWNSZXBvcnRzCiAgd2hlcmUgbm90ICgoZXhpc3RzKERpYWdub3N0aWNSZXBvcnRzLmNhdGVnb3J5IENhdGVnb3J5IHdoZXJlIENhdGVnb3J5IH4gIlJhZGlvbG9neSIpKQogICAgb3IgZXhpc3RzKChEaWFnbm9zdGljUmVwb3J0cy5jYXRlZ29yeSBDYXRlZ29yeSB3aGVyZSBDYXRlZ29yeSB+ICJQYXRob2xvZ3kiKSkKICAgIG9yIGV4aXN0cygoRGlhZ25vc3RpY1JlcG9ydHMuY2F0ZWdvcnkgQ2F0ZWdvcnkgd2hlcmUgQ2F0ZWdvcnkgfiAiQ2FyZGlvbG9neSIpKQogICAgb3IgZXhpc3RzKERpYWdub3N0aWNSZXBvcnRzLmNhdGVnb3J5IENhdGVnb3J5IHdoZXJlIENhdGVnb3J5IH4gIkxBQiIpKQogICAgYW5kIGV4aXN0cygiSW5pdGlhbCBQb3B1bGF0aW9uIiBJUAogICAgICB3aGVyZSBOSFNOSGVscGVycy4iTm9ybWFsaXplIEludGVydmFsIihEaWFnbm9zdGljUmVwb3J0cy5lZmZlY3RpdmUpIG92ZXJsYXBzIElQLnBlcmlvZCkKICByZXR1cm4gRGlhZ25vc3RpY1JlcG9ydFJlc291cmNlKERpYWdub3N0aWNSZXBvcnRzLAogIHtGSElSLmNhbm9uaWNhbHt2YWx1ZTogJ2h0dHA6Ly93d3cuY2RjLmdvdi9uaHNuL2ZoaXJwb3J0YWwvZHFtL2lnL1N0cnVjdHVyZURlZmluaXRpb24vYWNoLW1vbnRobHktZGlhZ25vc3RpY3JlcG9ydCd9fSkKLy8jRW5kIERpYWdub3N0aWNSZXBvcnQgYmxvY2sKCmRlZmluZSAiU0RFIEVuY291bnRlciI6IAogICJFbmNvdW50ZXJzIiBFbmNvdW50ZXJzCiAgd2hlcmUgbm90IENoZWNrSVAoRW5jb3VudGVycykKICBhbmQgZXhpc3RzKAogICAgIkluaXRpYWwgUG9wdWxhdGlvbiIgSVAKICAgIHdoZXJlIEVuY291bnRlcnMucGVyaW9kIG92ZXJsYXBzIElQLnBlcmlvZCkKICByZXR1cm4gU2hhcmVkUmVzb3VyY2UuRW5jb3VudGVyUmVzb3VyY2UoRW5jb3VudGVycywKICB7RkhJUi5jYW5vbmljYWx7dmFsdWU6ICdodHRwOi8vaGw3Lm9yZy9maGlyL3VzL2NvcmUvU3RydWN0dXJlRGVmaW5pdGlvbi91cy1jb3JlLWVuY291bnRlcid9fSkKCmRlZmluZSAiU0RFIElQIEVuY291bnRlcnMiOgogICJJbml0aWFsIFBvcHVsYXRpb24iIElQCiAgcmV0dXJuIFNoYXJlZFJlc291cmNlLkVuY291bnRlclJlc291cmNlKElQLCAKICB7RkhJUi5jYW5vbmljYWx7dmFsdWU6ICdodHRwOi8vd3d3LmNkYy5nb3Yvbmhzbi9maGlycG9ydGFsL2RxbS9pZy9TdHJ1Y3R1cmVEZWZpbml0aW9uL2FjaC1tb250aGx5LWVuY291bnRlcid9fSkKCmRlZmluZSAiU0RFIExvY2F0aW9uIjoKICAiR2V0IExvY2F0aW9ucyBmcm9tIElQIEVuY291bnRlcnMgaW4gTWVhc3VyZW1lbnQgUGVyaW9kIiBMb2NhdGlvbnMKICB3aGVyZSBleGlzdHMoIkluaXRpYWwgUG9wdWxhdGlvbiIpCiAgYW5kIExvY2F0aW9ucyBpcyBub3QgbnVsbAogIHJldHVybiBTaGFyZWRSZXNvdXJjZS5Mb2NhdGlvblJlc291cmNlKExvY2F0aW9ucywKICB7RkhJUi5jYW5vbmljYWx7dmFsdWU6ICdodHRwOi8vd3d3LmNkYy5nb3Yvbmhzbi9maGlycG9ydGFsL2RxbS9pZy9TdHJ1Y3R1cmVEZWZpbml0aW9uL2FjaC1tb250aGx5LWxvY2F0aW9uJ319KQogCmRlZmluZSAiU0RFIE1lZGljYXRpb24gQWRtaW5pc3RyYXRpb24iOgogIFtNZWRpY2F0aW9uQWRtaW5pc3RyYXRpb25dIE1lZGljYXRpb25BZG1pbmlzdHJhdGlvbnMgCiAgd2hlcmUgZXhpc3RzKAogICAgIkluaXRpYWwgUG9wdWxhdGlvbiIgSVAKICAgIHdoZXJlIE5IU05IZWxwZXJzLiJOb3JtYWxpemUgSW50ZXJ2YWwiKE1lZGljYXRpb25BZG1pbmlzdHJhdGlvbnMuZWZmZWN0aXZlKSBvdmVybGFwcyBJUC5wZXJpb2QpCiAgcmV0dXJuIFNoYXJlZFJlc291cmNlLk1lZGljYXRpb25BZG1pbmlzdHJhdGlvblJlc291cmNlKE1lZGljYXRpb25BZG1pbmlzdHJhdGlvbnMsCiAge0ZISVIuY2Fub25pY2Fse3ZhbHVlOiAnaHR0cDovL3d3dy5jZGMuZ292L25oc24vZmhpcnBvcnRhbC9kcW0vaWcvU3RydWN0dXJlRGVmaW5pdGlvbi9hY2gtbW9udGhseS1tZWRpY2F0aW9uYWRtaW5pc3RyYXRpb24nfX0pCiAKZGVmaW5lICJTREUgTWVkaWNhdGlvbiBSZXF1ZXN0IjoKICBbTWVkaWNhdGlvblJlcXVlc3RdIE1lZGljYXRpb25SZXF1ZXN0cyAKICB3aGVyZSBleGlzdHMoCiAgICAiSW5pdGlhbCBQb3B1bGF0aW9uIiBJUAogICAgd2hlcmUgTWVkaWNhdGlvblJlcXVlc3RzLmF1dGhvcmVkT24gZHVyaW5nIElQLnBlcmlvZCkKICByZXR1cm4gU2hhcmVkUmVzb3VyY2UuTWVkaWNhdGlvblJlcXVlc3RSZXNvdXJjZShNZWRpY2F0aW9uUmVxdWVzdHMsCiAge0ZISVIuY2Fub25pY2Fse3ZhbHVlOiAnaHR0cDovL3d3dy5jZGMuZ292L25oc24vZmhpcnBvcnRhbC9kcW0vaWcvU3RydWN0dXJlRGVmaW5pdGlvbi9hY2gtbW9udGhseS1tZWRpY2F0aW9ucmVxdWVzdCd9fSkKCmRlZmluZSAiU0RFIE1lZGljYXRpb24iOgogICgiU0RFIE1lZGljYXRpb24gUmVxdWVzdCIKICB1bmlvbiAiU0RFIE1lZGljYXRpb24gQWRtaW5pc3RyYXRpb24iKSBNZWRSZXFPckFkbWluCiAgd2hlcmUgTWVkUmVxT3JBZG1pbi5tZWRpY2F0aW9uIGlzIEZISVIuUmVmZXJlbmNlCiAgYW5kIGV4aXN0cygiSW5pdGlhbCBQb3B1bGF0aW9uIikgLy9ObyBsb25nZXIgbmVlZCB0byBjaGVjayBmb3IgdGltaW5nIGhlcmUgYmVjYXVzZSBpdCdzIGNoZWNrZWQgaW4gU0RFIE1lZGljYXRpb24gUmVxdWVzdC9BZG1pbmlzdHJpYXRpb24KICByZXR1cm4gU2hhcmVkUmVzb3VyY2UuTWVkaWNhdGlvblJlc291cmNlKEdldE1lZGljYXRpb25Gcm9tKE1lZFJlcU9yQWRtaW4ubWVkaWNhdGlvbiksCiAge0ZISVIuY2Fub25pY2Fse3ZhbHVlOiAnaHR0cDovL3d3dy5jZGMuZ292L25oc24vZmhpcnBvcnRhbC9kcW0vaWcvU3RydWN0dXJlRGVmaW5pdGlvbi9hY2gtbW9udGhseS1tZWRpY2F0aW9uJ319KQoKZGVmaW5lICJTREUgT2JzZXJ2YXRpb24gTGFiIENhdGVnb3J5IjoKICAiT2JzZXJ2YXRpb25zIiBPYnNlcnZhdGlvbnMgCiAgd2hlcmUgKGV4aXN0cyhPYnNlcnZhdGlvbnMuY2F0ZWdvcnkgQ2F0ZWdvcnkgd2hlcmUgQ2F0ZWdvcnkgfiAibGFib3JhdG9yeSIpKQogICAgYW5kIGV4aXN0cygKICAgICAgIkluaXRpYWwgUG9wdWxhdGlvbiIgSVAKICAgICAgd2hlcmUgTkhTTkhlbHBlcnMuIk5vcm1hbGl6ZSBJbnRlcnZhbCIoT2JzZXJ2YXRpb25zLmVmZmVjdGl2ZSkgb3ZlcmxhcHMgSVAucGVyaW9kKQogIHJldHVybiBTaGFyZWRSZXNvdXJjZS5PYnNlcnZhdGlvbkxhYlJlc291cmNlKE9ic2VydmF0aW9ucywKICB7RkhJUi5jYW5vbmljYWx7dmFsdWU6ICdodHRwOi8vd3d3LmNkYy5nb3Yvbmhzbi9maGlycG9ydGFsL2RxbS9pZy9TdHJ1Y3R1cmVEZWZpbml0aW9uL2FjaC1tb250aGx5LW9ic2VydmF0aW9uLWxhYid9fSkKCi8vVml0YWwgU2lnbnMgT2JzZXJ2YXRpb24gaGFzIGl0cyBvd24gcHJvZmlsZSBpbiBGSElSIEJhc2UKZGVmaW5lICJTREUgT2JzZXJ2YXRpb24gVml0YWwgU2lnbnMgQ2F0ZWdvcnkiOgogICJPYnNlcnZhdGlvbnMiIE9ic2VydmF0aW9ucyAKICB3aGVyZSAoZXhpc3RzKE9ic2VydmF0aW9ucy5jYXRlZ29yeSBDYXRlZ29yeSB3aGVyZSBDYXRlZ29yeSB+ICJ2aXRhbC1zaWducyIpKQogICAgYW5kIGV4aXN0cygKICAgICAgIkluaXRpYWwgUG9wdWxhdGlvbiIgSVAKICAgICAgd2hlcmUgTkhTTkhlbHBlcnMuIk5vcm1hbGl6ZSBJbnRlcnZhbCIoT2JzZXJ2YXRpb25zLmVmZmVjdGl2ZSkgb3ZlcmxhcHMgSVAucGVyaW9kKQogIHJldHVybiBPYnNlcnZhdGlvblZpdGFsU2lnbnNSZXNvdXJjZShPYnNlcnZhdGlvbnMsCiAge0ZISVIuY2Fub25pY2Fse3ZhbHVlOiAnaHR0cDovL3d3dy5jZGMuZ292L25oc24vZmhpcnBvcnRhbC9kcW0vaWcvU3RydWN0dXJlRGVmaW5pdGlvbi9hY2gtbW9udGhseS1vYnNlcnZhdGlvbi12aXRhbHMnfX0pCgovL0RlZmF1bHRpbmcgdG8gYmFzZSBGSElSIHByb2ZpbGUgYXMgdGhlcmUgYXJlIG5vIGluZGl2aWR1YWwgcHJvZmlsZXMgaW4gVVMgQ29yZSAzLjEuMSB0aGF0IGNvdmVyIHRoZXNlIE9ic2VydmF0aW9uIGNhdGVnb3JpZXMKZGVmaW5lICJTREUgT2JzZXJ2YXRpb24gQ2F0ZWdvcnkiOgogICJPYnNlcnZhdGlvbnMiIE9ic2VydmF0aW9ucyAKICB3aGVyZSAoKGV4aXN0cyhPYnNlcnZhdGlvbnMuY2F0ZWdvcnkgQ2F0ZWdvcnkgd2hlcmUgQ2F0ZWdvcnkgfiAic29jaWFsLWhpc3RvcnkiKSkKICAgIG9yIChleGlzdHMoT2JzZXJ2YXRpb25zLmNhdGVnb3J5IENhdGVnb3J5IHdoZXJlIENhdGVnb3J5IH4gInN1cnZleSIpKQogICAgb3IgKGV4aXN0cyhPYnNlcnZhdGlvbnMuY2F0ZWdvcnkgQ2F0ZWdvcnkgd2hlcmUgQ2F0ZWdvcnkgfiAiaW1hZ2luZyIpKQogICAgb3IgKGV4aXN0cyhPYnNlcnZhdGlvbnMuY2F0ZWdvcnkgQ2F0ZWdvcnkgd2hlcmUgQ2F0ZWdvcnkgfiAicHJvY2VkdXJlIikpKQogICAgYW5kIGV4aXN0cygKICAgICAgIkluaXRpYWwgUG9wdWxhdGlvbiIgSVAKICAgICAgd2hlcmUgTkhTTkhlbHBlcnMuIk5vcm1hbGl6ZSBJbnRlcnZhbCIoT2JzZXJ2YXRpb25zLmVmZmVjdGl2ZSkgb3ZlcmxhcHMgSVAucGVyaW9kKQogIHJldHVybiBPYnNlcnZhdGlvblJlc291cmNlKE9ic2VydmF0aW9ucywKICB7RkhJUi5jYW5vbmljYWx7dmFsdWU6ICdodHRwOi8vd3d3LmNkYy5nb3Yvbmhzbi9maGlycG9ydGFsL2RxbS9pZy9TdHJ1Y3R1cmVEZWZpbml0aW9uL2FjaC1tb250aGx5LW9ic2VydmF0aW9uJ319KQoKZGVmaW5lICJTREUgQ292ZXJhZ2UiOiAKCVtDb3ZlcmFnZV0gQ292ZXJhZ2VzCiAgd2hlcmUgZXhpc3RzKAogICAgIkluaXRpYWwgUG9wdWxhdGlvbiIgSVAKICAgIHdoZXJlIENvdmVyYWdlcy5wZXJpb2Qgb3ZlcmxhcHMgSVAucGVyaW9kKQogIHJldHVybiBTaGFyZWRSZXNvdXJjZS5Db3ZlcmFnZVJlc291cmNlKENvdmVyYWdlcywKICB7RkhJUi5jYW5vbmljYWx7dmFsdWU6ICdodHRwOi8vd3d3LmNkYy5nb3Yvbmhzbi9maGlycG9ydGFsL2RxbS9pZy9TdHJ1Y3R1cmVEZWZpbml0aW9uL2FjaC1tb250aGx5LWNvdmVyYWdlJ319KQoKZGVmaW5lICJTREUgUHJvY2VkdXJlIjoKICBbUHJvY2VkdXJlXSBQcm9jZWR1cmVzIAogIHdoZXJlIGV4aXN0cygKICAgICJJbml0aWFsIFBvcHVsYXRpb24iIElQCiAgICB3aGVyZSBOSFNOSGVscGVycy4iTm9ybWFsaXplIEludGVydmFsIihQcm9jZWR1cmVzLnBlcmZvcm1lZCkgb3ZlcmxhcHMgSVAucGVyaW9kKQogIHJldHVybiBTaGFyZWRSZXNvdXJjZS5Qcm9jZWR1cmVSZXNvdXJjZShQcm9jZWR1cmVzLAogIHtGSElSLmNhbm9uaWNhbHt2YWx1ZTogJ2h0dHA6Ly93d3cuY2RjLmdvdi9uaHNuL2ZoaXJwb3J0YWwvZHFtL2lnL1N0cnVjdHVyZURlZmluaXRpb24vYWNoLW1vbnRobHktcHJvY2VkdXJlJ319KQoKZGVmaW5lICJTREUgU3BlY2ltZW4iOgogIFtTcGVjaW1lbl0gU3BlY2ltZW5zCiAgd2hlcmUgZXhpc3RzKAogICAgIkluaXRpYWwgUG9wdWxhdGlvbiIgSVAKICAgIHdoZXJlIE5IU05IZWxwZXJzLiJOb3JtYWxpemUgSW50ZXJ2YWwiKFNwZWNpbWVucy5jb2xsZWN0aW9uLmNvbGxlY3RlZCkgb3ZlcmxhcHMgSVAucGVyaW9kCiAgKQogIHJldHVybiBTaGFyZWRSZXNvdXJjZS5TcGVjaW1lblJlc291cmNlKFNwZWNpbWVucywKICB7RkhJUi5jYW5vbmljYWx7dmFsdWU6ICdodHRwOi8vd3d3LmNkYy5nb3Yvbmhzbi9maGlycG9ydGFsL2RxbS9pZy9TdHJ1Y3R1cmVEZWZpbml0aW9uL2FjaC1tb250aGx5LXNwZWNpbWVuJ319KQoKZGVmaW5lICJTREUgU2VydmljZSBSZXF1ZXN0IjoKICBbU2VydmljZVJlcXVlc3RdIFNlcnZpY2VSZXF1ZXN0cwogIHdoZXJlIGV4aXN0cygiSW5pdGlhbCBQb3B1bGF0aW9uIiBJUAogICAgd2hlcmUgU2VydmljZVJlcXVlc3RzLmF1dGhvcmVkT24gZHVyaW5nIElQLnBlcmlvZCkKICByZXR1cm4gU2hhcmVkUmVzb3VyY2UuU2VydmljZVJlcXVlc3RSZXNvdXJjZShTZXJ2aWNlUmVxdWVzdHMsCiAge0ZISVIuY2Fub25pY2Fse3ZhbHVlOiAnaHR0cDovL3d3dy5jZGMuZ292L25oc24vZmhpcnBvcnRhbC9kcW0vaWcvU3RydWN0dXJlRGVmaW5pdGlvbi9hY2gtbW9udGhseS1zZXJ2aWNlcmVxdWVzdCd9fSkKCmRlZmluZSAiU0RFIE1pbmltYWwgUGF0aWVudCI6CiAgUGF0aWVudCBwCiAgcmV0dXJuIFNoYXJlZFJlc291cmNlLlBhdGllbnRSZXNvdXJjZShwLAogIHtGSElSLmNhbm9uaWNhbHt2YWx1ZTogJ2h0dHA6Ly93d3cuY2RjLmdvdi9uaHNuL2ZoaXJwb3J0YWwvZHFtL2lnL1N0cnVjdHVyZURlZmluaXRpb24vY3Jvc3MtbWVhc3VyZS1wYXRpZW50J319KQoKLy8KLy9GdW5jdGlvbnMKLy8KZGVmaW5lIGZ1bmN0aW9uICJDaGVja0lQIihlbmNvdW50ZXIgRW5jb3VudGVyKToKICBleGlzdHMoIkluaXRpYWwgUG9wdWxhdGlvbiIgSVAKICB3aGVyZSBlbmNvdW50ZXIuaWQgPSBJUC5pZCkKCmRlZmluZSBmdW5jdGlvbiAiR2V0TWVkaWNhdGlvbkZyb20iKGNob2ljZSBDaG9pY2U8RkhJUi5Db2RlYWJsZUNvbmNlcHQsIEZISVIuUmVmZXJlbmNlPik6CiAgY2FzZQogICAgd2hlbiBjaG9pY2UgaXMgRkhJUi5SZWZlcmVuY2UgdGhlbgogICAgICBHZXRNZWRpY2F0aW9uKGNob2ljZSBhcyBGSElSLlJlZmVyZW5jZSkKICAgIGVsc2UKICAgICAgbnVsbAogIGVuZAoKZGVmaW5lIGZ1bmN0aW9uICJHZXRNZWRpY2F0aW9uIihyZWZlcmVuY2UgUmVmZXJlbmNlKToKICBzaW5nbGV0b24gZnJvbSAoCiAgICBbTWVkaWNhdGlvbl0gTWVkaWNhdGlvbnMKICAgIHdoZXJlIE1lZGljYXRpb25zLmlkID0gTkhTTkhlbHBlcnMuR2V0SWQocmVmZXJlbmNlLnJlZmVyZW5jZSkKICApCgpkZWZpbmUgZnVuY3Rpb24gIkdldENvbmRpdGlvbiIocmVmZXJlbmNlIFJlZmVyZW5jZSk6CiAgc2luZ2xldG9uIGZyb20gKAogICAgIkNvbmRpdGlvbnMiIENvbmRpdGlvbnMKICAgIHdoZXJlIENvbmRpdGlvbnMuaWQgPSBOSFNOSGVscGVycy5HZXRJZChyZWZlcmVuY2UucmVmZXJlbmNlKQogICkKCmRlZmluZSBmdW5jdGlvbiAiR2V0RW5jb3VudGVyIihyZWZlcmVuY2UgUmVmZXJlbmNlKToKICBzaW5nbGV0b24gZnJvbSAoCiAgICAiRW5jb3VudGVycyIgRW5jb3VudGVycwogICAgd2hlcmUgRW5jb3VudGVycy5pZCA9IE5IU05IZWxwZXJzLkdldElkKHJlZmVyZW5jZS5yZWZlcmVuY2UpCiAgKQoKLy8KLy9NZWFzdXJlIFNwZWNpZmljIFJlc291cmNlIENyZWF0aW9uIEZ1bmN0aW9ucwovLwpkZWZpbmUgZnVuY3Rpb24gRGV2aWNlVWRpQ2Fycmllcih1ZGlDYXJyaWVyIExpc3Q8RkhJUi5EZXZpY2UuVWRpQ2Fycmllcj4pOgogIHVkaUNhcnJpZXIgdQogIHJldHVybiBGSElSLkRldmljZS5VZGlDYXJyaWVyewogICAgZGV2aWNlSWRlbnRpZmllcjogdS5kZXZpY2VJZGVudGlmaWVyLAogICAgaXNzdWVyOiB1Lmlzc3VlciwKICAgIGp1cmlzZGljdGlvbjogdS5qdXJpc2RpY3Rpb24sCiAgICBjYXJyaWVyQUlEQzogdS5jYXJyaWVyQUlEQywKICAgIGNhcnJpZXJIUkY6IHUuY2FycmllckhSRiwKICAgIGVudHJ5VHlwZTogdS5lbnRyeVR5cGUKICB9CgpkZWZpbmUgZnVuY3Rpb24gRGV2aWNlRGV2aWNlTmFtZShkZXZpY2VOYW1lIExpc3Q8RkhJUi5EZXZpY2UuRGV2aWNlTmFtZT4pOgogIGRldmljZU5hbWUgZAogIHJldHVybiBGSElSLkRldmljZS5EZXZpY2VOYW1lewogICAgbmFtZTogZC5uYW1lLAogICAgdHlwZTogZC50eXBlCiAgfQoKZGVmaW5lIGZ1bmN0aW9uIERldmljZVNwZWNpYWxpemF0aW9uKHNwZWNpYWxpemF0aW9uIExpc3Q8RkhJUi5EZXZpY2UuU3BlY2lhbGl6YXRpb24+KToKICBzcGVjaWFsaXphdGlvbiBzCiAgcmV0dXJuIEZISVIuRGV2aWNlLlNwZWNpYWxpemF0aW9uewogICAgc3lzdGVtVHlwZTogcy5zeXN0ZW1UeXBlLAogICAgdmVyc2lvbjogcy52ZXJzaW9uCiAgfQoKZGVmaW5lIGZ1bmN0aW9uIERldmljZVZlcnNpb24odmVyc2lvbiBMaXN0PEZISVIuRGV2aWNlLlZlcnNpb24+KToKICB2ZXJzaW9uIHYKICByZXR1cm4gRkhJUi5EZXZpY2UuVmVyc2lvbnsKICAgIHR5cGU6IHYudHlwZSwKICAgIGNvbXBvbmVudDogdi5jb21wb25lbnQsCiAgICB2YWx1ZTogdi52YWx1ZQogIH0KCmRlZmluZSBmdW5jdGlvbiBEZXZpY2VQcm9wZXJ0eShkZXZpY2VQcm9wZXJ0eSBMaXN0PEZISVIuRGV2aWNlLlByb3BlcnR5Pik6CiAgZGV2aWNlUHJvcGVydHkgZAogIHJldHVybiBGSElSLkRldmljZS5Qcm9wZXJ0eXsKICAgIGlkOiBkLmlkLAogICAgdHlwZTogZC50eXBlLAogICAgdmFsdWVRdWFudGl0eTogZC52YWx1ZVF1YW50aXR5LAogICAgdmFsdWVDb2RlOiBkLnZhbHVlQ29kZQogIH0KCmRlZmluZSBmdW5jdGlvbiBEZXZpY2VSZXNvdXJjZShkZXZpY2UgRGV2aWNlLCBwcm9maWxlVVJMcyBMaXN0PEZISVIuY2Fub25pY2FsPik6CiAgZGV2aWNlIGQKICByZXR1cm4gRGV2aWNlewogICAgaWQ6IEZISVIuaWR7dmFsdWU6ICdMQ1ItJyArIGQuaWR9LAogICAgbWV0YTogU2hhcmVkUmVzb3VyY2UuTWV0YUVsZW1lbnQoZCwgcHJvZmlsZVVSTHMpLAogICAgZXh0ZW5zaW9uOiBkLmV4dGVuc2lvbiwKICAgIGRlZmluaXRpb246IGQuZGVmaW5pdGlvbiwKICAgIHVkaUNhcnJpZXI6IERldmljZVVkaUNhcnJpZXIoZC51ZGlDYXJyaWVyKSwKICAgIHN0YXR1czogZC5zdGF0dXMsCiAgICBzdGF0dXNSZWFzb246IGQuc3RhdHVzUmVhc29uLAogICAgZGlzdGluY3RJZGVudGlmaWVyOiBkLmRpc3RpbmN0SWRlbnRpZmllciwKICAgIG1hbnVmYWN0dXJlcjogZC5tYW51ZmFjdHVyZXIsCiAgICBtYW51ZmFjdHVyZURhdGU6IGQubWFudWZhY3R1cmVEYXRlLAogICAgZXhwaXJhdGlvbkRhdGU6IGQuZXhwaXJhdGlvbkRhdGUsCiAgICBsb3ROdW1iZXI6IGQubG90TnVtYmVyLAogICAgc2VyaWFsTnVtYmVyOiBkLnNlcmlhbE51bWJlciwKICAgIGRldmljZU5hbWU6IERldmljZURldmljZU5hbWUoZC5kZXZpY2VOYW1lKSwKICAgIG1vZGVsTnVtYmVyOiBkLm1vZGVsTnVtYmVyLAogICAgcGFydE51bWJlcjogZC5wYXJ0TnVtYmVyLAogICAgdHlwZTogZC50eXBlLAogICAgc3BlY2lhbGl6YXRpb246IERldmljZVNwZWNpYWxpemF0aW9uKGQuc3BlY2lhbGl6YXRpb24pLAogICAgdmVyc2lvbjogRGV2aWNlVmVyc2lvbihkLnZlcnNpb24pLAogICAgcHJvcGVydHk6IERldmljZVByb3BlcnR5KGQucHJvcGVydHkpLAogICAgcGF0aWVudDogZC5wYXRpZW50LAogICAgb3duZXI6IGQub3duZXIsCiAgICBjb250YWN0OiBkLmNvbnRhY3QsCiAgICBsb2NhdGlvbjogZC5sb2NhdGlvbiwKICAgIHVybDogZC51cmwsCiAgICBub3RlOiBkLm5vdGUsCiAgICBzYWZldHk6IGQuc2FmZXR5LAogICAgcGFyZW50OiBkLnBhcmVudAogIH0KCmRlZmluZSBmdW5jdGlvbiBEaWFnbm9zdGljUmVwb3J0UmVzb3VyY2UoZGlhZ25vc3RpY1JlcG9ydCBEaWFnbm9zdGljUmVwb3J0LCBwcm9maWxlVVJMcyBMaXN0PEZISVIuY2Fub25pY2FsPik6CiAgZGlhZ25vc3RpY1JlcG9ydCBkCiAgcmV0dXJuIERpYWdub3N0aWNSZXBvcnR7CiAgICBpZDogRkhJUi5pZHt2YWx1ZTogJ0xDUi0nICsgZC5pZH0sCiAgICBtZXRhOiBTaGFyZWRSZXNvdXJjZS5NZXRhRWxlbWVudChkLCBwcm9maWxlVVJMcyksCiAgICBleHRlbnNpb246IGQuZXh0ZW5zaW9uLAogICAgYmFzZWRPbjogZC5iYXNlZE9uLAogICAgc3RhdHVzOiBkLnN0YXR1cywKICAgIGNhdGVnb3J5OiBkLmNhdGVnb3J5LAogICAgY29kZTogZC5jb2RlLAogICAgc3ViamVjdDogZC5zdWJqZWN0LAogICAgZW5jb3VudGVyOiBkLmVuY291bnRlciwKICAgIGVmZmVjdGl2ZTogZC5lZmZlY3RpdmUsCiAgICBpc3N1ZWQ6IGQuaXNzdWVkLAogICAgcGVyZm9ybWVyOiBkLnBlcmZvcm1lciwKICAgIHJlc3VsdHNJbnRlcnByZXRlcjogZC5yZXN1bHRzSW50ZXJwcmV0ZXIsCiAgICBzcGVjaW1lbjogZC5zcGVjaW1lbiwKICAgIHJlc3VsdDogZC5yZXN1bHQsCiAgICBjb25jbHVzaW9uOiBkLmNvbmNsdXNpb24sCiAgICBjb25jbHVzaW9uQ29kZTogZC5jb25jbHVzaW9uQ29kZQogIH0KCmRlZmluZSBmdW5jdGlvbiBPYnNlcnZhdGlvblJlc291cmNlKG9ic2VydmF0aW9uIE9ic2VydmF0aW9uLCBwcm9maWxlVVJMcyBMaXN0PEZISVIuY2Fub25pY2FsPik6CiAgb2JzZXJ2YXRpb24gbwogIHJldHVybiBPYnNlcnZhdGlvbnsKICAgIGlkOiBGSElSLmlkIHt2YWx1ZTogJ0xDUi0nICsgby5pZH0sCiAgICBtZXRhOiBTaGFyZWRSZXNvdXJjZS5NZXRhRWxlbWVudChvLCBwcm9maWxlVVJMcyksCiAgICBleHRlbnNpb246IG8uZXh0ZW5zaW9uLAogICAgcGFydE9mOiBvLnBhcnRPZiwKICAgIHN0YXR1czogby5zdGF0dXMsCiAgICBjYXRlZ29yeTogby5jYXRlZ29yeSwKICAgIGNvZGU6IG8uY29kZSwKICAgIHN1YmplY3Q6IG8uc3ViamVjdCwKICAgIGZvY3VzOiBvLmZvY3VzLAogICAgZW5jb3VudGVyOiBvLmVuY291bnRlciwKICAgIGVmZmVjdGl2ZTogby5lZmZlY3RpdmUsCiAgICBpc3N1ZWQ6IG8uaXNzdWVkLAogICAgcGVyZm9ybWVyOiBvLnBlcmZvcm1lciwKICAgIHZhbHVlOiBvLnZhbHVlLAogICAgZGF0YUFic2VudFJlYXNvbjogby5kYXRhQWJzZW50UmVhc29uLAogICAgaW50ZXJwcmV0YXRpb246IG8uaW50ZXJwcmV0YXRpb24sCiAgICBub3RlOiBvLm5vdGUsCiAgICBib2R5U2l0ZTogby5ib2R5U2l0ZSwKICAgIG1ldGhvZDogby5tZXRob2QsCiAgICBzcGVjaW1lbjogby5zcGVjaW1lbiwKICAgIGRldmljZTogby5kZXZpY2UsCiAgICByZWZlcmVuY2VSYW5nZTogU2hhcmVkUmVzb3VyY2UuT2JzZXJ2YXRpb25SZWZlcmVuY2VSYW5nZShvLnJlZmVyZW5jZVJhbmdlKSwKICAgIGhhc01lbWJlcjogby5oYXNNZW1iZXIsCiAgICBkZXJpdmVkRnJvbTogby5kZXJpdmVkRnJvbSwKICAgIGNvbXBvbmVudDogU2hhcmVkUmVzb3VyY2UuT2JzZXJ2YXRpb25Db21wb25lbnQoby5jb21wb25lbnQpCiAgfQoKZGVmaW5lIGZ1bmN0aW9uIE9ic2VydmF0aW9uVml0YWxTaWduc0NvZGluZyhjb2RpbmcgTGlzdDxDb2Rpbmc+KToKICBjb2RpbmcgYwogIHJldHVybiBDb2Rpbmd7CiAgICBzeXN0ZW06IGMuc3lzdGVtLAogICAgdmVyc2lvbjogYy52ZXJzaW9uLAogICAgY29kZTogYy5jb2RlLAogICAgZGlzcGxheTogYy5kaXNwbGF5LAogICAgdXNlclNlbGVjdGVkOiBjLnVzZXJTZWxlY3RlZAogIH0KCmRlZmluZSBmdW5jdGlvbiBPYnNlcnZhdGlvblZpdGFsU2lnbnNDYXRlZ29yeShjYXRlZ29yeSBMaXN0PENvZGVhYmxlQ29uY2VwdD4pOgogIGNhdGVnb3J5IGMKICByZXR1cm4gQ29kZWFibGVDb25jZXB0ewogICAgY29kaW5nOiBPYnNlcnZhdGlvblZpdGFsU2lnbnNDb2RpbmcoYy5jb2RpbmcpLAogICAgdGV4dDogYy50ZXh0CiAgfQoKZGVmaW5lIGZ1bmN0aW9uIE9ic2VydmF0aW9uVml0YWxTaWduc0NvbXBvbmVudChjb21wb25lbnQgTGlzdDxGSElSLk9ic2VydmF0aW9uLkNvbXBvbmVudD4pOgogIGNvbXBvbmVudCBjCiAgcmV0dXJuIEZISVIuT2JzZXJ2YXRpb24uQ29tcG9uZW50ewogICAgY29kZTogYy5jb2RlLAogICAgdmFsdWU6IGMudmFsdWUsCiAgICBkYXRhQWJzZW50UmVhc29uOiBjLmRhdGFBYnNlbnRSZWFzb24sCiAgICBpbnRlcnByZXRhdGlvbjogYy5pbnRlcnByZXRhdGlvbiwKICAgIHJlZmVyZW5jZVJhbmdlOiBTaGFyZWRSZXNvdXJjZS5PYnNlcnZhdGlvblJlZmVyZW5jZVJhbmdlKGMucmVmZXJlbmNlUmFuZ2UpCiAgfQoKZGVmaW5lIGZ1bmN0aW9uIE9ic2VydmF0aW9uVml0YWxTaWduc1Jlc291cmNlKG9ic2VydmF0aW9uIE9ic2VydmF0aW9uLCBwcm9maWxlVVJMcyBMaXN0PEZISVIuY2Fub25pY2FsPik6CiAgb2JzZXJ2YXRpb24gbwogIHJldHVybiBPYnNlcnZhdGlvbnsKICAgIGlkOiBGSElSLmlkIHt2YWx1ZTogJ0xDUi0nICsgby5pZH0sCiAgICBtZXRhOiBTaGFyZWRSZXNvdXJjZS5NZXRhRWxlbWVudChvLCBwcm9maWxlVVJMcyksCiAgICBleHRlbnNpb246IG8uZXh0ZW5zaW9uLAogICAgcGFydE9mOiBvLnBhcnRPZiwKICAgIHN0YXR1czogby5zdGF0dXMsCiAgICBjYXRlZ29yeTogT2JzZXJ2YXRpb25WaXRhbFNpZ25zQ2F0ZWdvcnkoby5jYXRlZ29yeSksCiAgICBjb2RlOiBvLmNvZGUsCiAgICBzdWJqZWN0OiBvLnN1YmplY3QsCiAgICBmb2N1czogby5mb2N1cywKICAgIGVuY291bnRlcjogby5lbmNvdW50ZXIsCiAgICBlZmZlY3RpdmU6IG8uZWZmZWN0aXZlLAogICAgaXNzdWVkOiBvLmlzc3VlZCwKICAgIHBlcmZvcm1lcjogby5wZXJmb3JtZXIsCiAgICB2YWx1ZTogby52YWx1ZSwKICAgIGRhdGFBYnNlbnRSZWFzb246IG8uZGF0YUFic2VudFJlYXNvbiwKICAgIGludGVycHJldGF0aW9uOiBvLmludGVycHJldGF0aW9uLAogICAgbm90ZTogby5ub3RlLAogICAgYm9keVNpdGU6IG8uYm9keVNpdGUsCiAgICBtZXRob2Q6IG8ubWV0aG9kLAogICAgc3BlY2ltZW46IG8uc3BlY2ltZW4sCiAgICBkZXZpY2U6IG8uZGV2aWNlLAogICAgcmVmZXJlbmNlUmFuZ2U6IFNoYXJlZFJlc291cmNlLk9ic2VydmF0aW9uUmVmZXJlbmNlUmFuZ2Uoby5yZWZlcmVuY2VSYW5nZSksCiAgICBoYXNNZW1iZXI6IG8uaGFzTWVtYmVyLAogICAgZGVyaXZlZEZyb206IG8uZGVyaXZlZEZyb20sCiAgICBjb21wb25lbnQ6IE9ic2VydmF0aW9uVml0YWxTaWduc0NvbXBvbmVudChvLmNvbXBvbmVudCkKICB9"
+            "data": "bGlicmFyeSBOSFNOQWN1dGVDYXJlSG9zcGl0YWxNb250aGx5SW5pdGlhbFBvcHVsYXRpb24gdmVyc2lvbiAnMi4wLjAtY2lidWlsZCcKCnVzaW5nIEZISVIgdmVyc2lvbiAnNC4wLjEnCgppbmNsdWRlIEZISVJIZWxwZXJzIHZlcnNpb24gJzQuMC4yJyBjYWxsZWQgRkhJUkhlbHBlcnMKaW5jbHVkZSBOSFNOSGVscGVycyB2ZXJzaW9uICcwLjAuMDAyJyBjYWxsZWQgTkhTTkhlbHBlcnMKaW5jbHVkZSBTaGFyZWRSZXNvdXJjZUNyZWF0aW9uIHZlcnNpb24gJzAuMS4wMTAnIGNhbGxlZCBTaGFyZWRSZXNvdXJjZQoKY29kZXN5c3RlbSAiQWN0Q29kZSI6ICdodHRwOi8vdGVybWlub2xvZ3kuaGw3Lm9yZy9Db2RlU3lzdGVtL3YzLUFjdENvZGUnCmNvZGVzeXN0ZW0gIk9ic2VydmF0aW9uIENhdGVnb3J5IjogJ2h0dHA6Ly90ZXJtaW5vbG9neS5obDcub3JnL0NvZGVTeXN0ZW0vb2JzZXJ2YXRpb24tY2F0ZWdvcnknCmNvZGVzeXN0ZW0gIkxPSU5DIjogJ2h0dHA6Ly9sb2luYy5vcmcnIApjb2Rlc3lzdGVtICJWMi0wMDc0IjogJ2h0dHA6Ly90ZXJtaW5vbG9neS5obDcub3JnL0NvZGVTeXN0ZW0vdjItMDA3NCcKY29kZXN5c3RlbSAiQ29uZGl0aW9uIENhdGVnb3J5IjogJ2h0dHA6Ly90ZXJtaW5vbG9neS5obDcub3JnL0NvZGVTeXN0ZW0vY29uZGl0aW9uLWNhdGVnb3J5Jwpjb2Rlc3lzdGVtICJVUyBDb3JlIENvbmRpdGlvbiBDYXRlZ29yeSI6ICdodHRwOi8vaGw3Lm9yZy9maGlyL3VzL2NvcmUvQ29kZVN5c3RlbS9jb25kaXRpb24tY2F0ZWdvcnknCmNvZGVzeXN0ZW0gIkNvbmRpdGlvbiBDbGluaWNhbCBTdGF0dXMiOiAnaHR0cDovL3Rlcm1pbm9sb2d5LmhsNy5vcmcvQ29kZVN5c3RlbS9jb25kaXRpb24tY2xpbmljYWwnCmNvZGVzeXN0ZW0gIlNOT01FRENUIjogJ2h0dHA6Ly9zbm9tZWQuaW5mby9zY3QnCmNvZGVzeXN0ZW0gIk1lZGljYXRpb25SZXF1ZXN0IENhdGVnb3J5IjogJ2h0dHA6Ly90ZXJtaW5vbG9neS5obDcub3JnL0NvZGVTeXN0ZW0vbWVkaWNhdGlvbnJlcXVlc3QtY2F0ZWdvcnknCgp2YWx1ZXNldCAiSW5wYXRpZW50LCBFbWVyZ2VuY3ksIGFuZCBPYnNlcnZhdGlvbiBMb2NhdGlvbnMiOiAnaHR0cDovL2N0cy5ubG0ubmloLmdvdi9maGlyL1ZhbHVlU2V0LzIuMTYuODQwLjEuMTEzNzYyLjEuNC4xMDQ2LjI2NScKdmFsdWVzZXQgIkVtZXJnZW5jeSBEZXBhcnRtZW50IFZpc2l0IjogJ2h0dHA6Ly9jdHMubmxtLm5paC5nb3YvZmhpci9WYWx1ZVNldC8yLjE2Ljg0MC4xLjExMzg4My4zLjExNy4xLjcuMS4yOTInCnZhbHVlc2V0ICJFbmNvdW50ZXIgSW5wYXRpZW50IjogJ2h0dHA6Ly9jdHMubmxtLm5paC5nb3YvZmhpci9WYWx1ZVNldC8yLjE2Ljg0MC4xLjExMzg4My4zLjY2Ni41LjMwNycKdmFsdWVzZXQgIk9ic2VydmF0aW9uIFNlcnZpY2VzIjogJ2h0dHA6Ly9jdHMubmxtLm5paC5nb3YvZmhpci9WYWx1ZVNldC8yLjE2Ljg0MC4xLjExMzc2Mi4xLjQuMTExMS4xNDMnCnZhbHVlc2V0ICJOSFNOIElucGF0aWVudCBFbmNvdW50ZXIgQ2xhc3MgQ29kZXMiOiAnaHR0cDovL2N0cy5ubG0ubmloLmdvdi9maGlyL1ZhbHVlU2V0LzIuMTYuODQwLjEuMTEzNzYyLjEuNC4xMDQ2LjI3NCcKCi8vY29kZSBmb3IgT2JzZXJ2YXRpb24gQ2F0ZWdvcnkKY29kZSAibGFib3JhdG9yeSI6ICdsYWJvcmF0b3J5JyBmcm9tICJPYnNlcnZhdGlvbiBDYXRlZ29yeSIgZGlzcGxheSAnTGFib3JhdG9yeScKY29kZSAic29jaWFsLWhpc3RvcnkiOiAnc29jaWFsLWhpc3RvcnknIGZyb20gIk9ic2VydmF0aW9uIENhdGVnb3J5IiBkaXNwbGF5ICdTb2NpYWwgSGlzdG9yeScKY29kZSAidml0YWwtc2lnbnMiOiAndml0YWwtc2lnbnMnIGZyb20gIk9ic2VydmF0aW9uIENhdGVnb3J5IiBkaXNwbGF5ICdWaXRhbCBTaWducycKY29kZSAiaW1hZ2luZyI6ICdpbWFnaW5nJyBmcm9tICJPYnNlcnZhdGlvbiBDYXRlZ29yeSIgZGlzcGxheSAnSW1hZ2luZycKY29kZSAicHJvY2VkdXJlIjogJ3Byb2NlZHVyZScgZnJvbSAiT2JzZXJ2YXRpb24gQ2F0ZWdvcnkiIGRpc3BsYXkgJ1Byb2NlZHVyZScKY29kZSAic3VydmV5IjogJ3N1cnZleScgZnJvbSAiT2JzZXJ2YXRpb24gQ2F0ZWdvcnkiIGRpc3BsYXkgJ1N1cnZleScKCi8vY29kZSBmb3IgQ29uZGl0aW9uIGNhdGVnb3J5Ci8vY29kZSAicHJvYmxlbS1saXN0LWl0ZW0iOiAncHJvYmxlbS1saXN0LWl0ZW0nIGZyb20gIkNvbmRpdGlvbiBDYXRlZ29yeSIgZGlzcGxheSAnUHJvYmxlbSBMaXN0IEl0ZW0nCmNvZGUgImVuY291bnRlci1kaWFnbm9zaXMiOiAnZW5jb3VudGVyLWRpYWdub3NpcycgZnJvbSAiQ29uZGl0aW9uIENhdGVnb3J5IiBkaXNwbGF5ICdFbmNvdW50ZXIgRGlhZ25vc2lzJwovL2NvZGUgImhlYWx0aC1jb25jZXJuIjogJ2hlYWx0aC1jb25jZXJuJyBmcm9tICJVUyBDb3JlIENvbmRpdGlvbiBDYXRlZ29yeSIgZGlzcGxheSAnSGVhbHRoIENvbmNlcm4nCgovL2NvZGUgZm9yIERpYWdub3N0aWMgUmVwb3J0IENhdGVnb3J5CmNvZGUgIkxBQiI6ICdMQUInIGZyb20gIlYyLTAwNzQiIGRpc3BsYXkgJ0xhYm9yYXRvcnknCmNvZGUgIlJhZGlvbG9neSI6ICdMUDI5Njg0LTUnIGZyb20gIkxPSU5DIiBkaXNwbGF5ICdSYWRpb2xvZ3knCmNvZGUgIlBhdGhvbG9neSI6ICdMUDc4MzktNicgZnJvbSAiTE9JTkMiIGRpc3BsYXkgJ1BhdGhvbG9neScKY29kZSAiQ2FyZGlvbG9neSI6ICdMUDI5NzA4LTInIGZyb20gIkxPSU5DIiBkaXNwbGF5ICdDYXJkaW9sb2d5JwoKLy9jb2RlIGZvciBFbWVyZ2VuY3kgRW5jb3VudGVyIENsYXNzCmNvZGUgImVtZXJnZW5jeSI6ICdFTUVSJyBmcm9tICJBY3RDb2RlIiBkaXNwbGF5ICdlbWVyZ2VuY3knCmNvZGUgIm9ic2VydmF0aW9uIGVuY291bnRlciI6ICdPQlNFTkMnIGZyb20gIkFjdENvZGUiIGRpc3BsYXkgJ29ic2VydmF0aW9uIGVuY291bnRlcicKCi8vY29kZSBmb3IgQ29uZGl0aW9uIGNsaW5pY2FsU3RhdHVzCmNvZGUgImFjdGl2ZSI6ICdhY3RpdmUnIGZyb20gIkNvbmRpdGlvbiBDbGluaWNhbCBTdGF0dXMiIGRpc3BsYXkgJ2FjdGl2ZScKCi8vY29kZSBmb3IgUHJvY2VkdXJlIGNhdGVnb3J5CmNvZGUgIlN1cmdpY2FsIHByb2NlZHVyZSI6ICczODc3MTMwMDMnIGZyb20gIlNOT01FRENUIiBkaXNwbGF5ICdTdXJnaWNhbCBwcm9jZWR1cmUnCmNvZGUgIkRpYWdub3N0aWMgcHJvY2VkdXJlIjogJzEwMzY5MzAwNycgZnJvbSAiU05PTUVEQ1QiIGRpc3BsYXkgJ0RpYWdub3N0aWMgcHJvY2VkdXJlJwoKLy9jb2RlIGZvciBNZWRpY2F0aW9uUmVxdWVzdCBjYXRlZ29yeQpjb2RlICJpbnBhdGllbnQiOiAnaW5wYXRpZW50JyBmcm9tICJNZWRpY2F0aW9uUmVxdWVzdCBDYXRlZ29yeSIgZGlzcGxheSAnSW5wYXRpZW50Jwpjb2RlICJvdXRwYXRpZW50IjogJ291dHBhdGllbnQnIGZyb20gIk1lZGljYXRpb25SZXF1ZXN0IENhdGVnb3J5IiBkaXNwbGF5ICdPdXRwYXRpZW50JwoKLy9jb2RlIGZvciBTZXJ2aWNlUmVxdWVzdCBjYXRlZ29yeSAoYWxzbyB1c2VzIFN1cmdpY2FsIHByb2NlZHVyZSBmcm9tIFByb2NlZHVyZSBjYXRlZ29yaWVzKQpjb2RlICJMYWJvcmF0b3J5IHByb2NlZHVyZSI6ICcxMDgyNTIwMDcnIGZyb20gIlNOT01FRENUIiBkaXNwbGF5ICdMYWJvcmF0b3J5IHByb2NlZHVyZScKY29kZSAiSW1hZ2luZyI6ICczNjM2NzkwMDUnIGZyb20gIlNOT01FRENUIiBkaXNwbGF5ICdJbWFnaW5nJwoKcGFyYW1ldGVyICJNZWFzdXJlbWVudCBQZXJpb2QiIAogICAgZGVmYXVsdCBJbnRlcnZhbFtAMjAyMi0wMS0wMVQwMDowMDowMC4wLCBAMjAyMi0wMS0zMVQyMzo1OTo1OS4wKQoKY29udGV4dCBQYXRpZW50IAoKZGVmaW5lICJRdWFsaWZ5aW5nIEVuY291bnRlcnMgRHVyaW5nIE1lYXN1cmVtZW50IFBlcmlvZCI6CiAoIFtFbmNvdW50ZXI6ICJFbmNvdW50ZXIgSW5wYXRpZW50Il0KICB1bmlvbiBbRW5jb3VudGVyOiAiRW1lcmdlbmN5IERlcGFydG1lbnQgVmlzaXQiXQogIHVuaW9uIFtFbmNvdW50ZXI6ICJPYnNlcnZhdGlvbiBTZXJ2aWNlcyJdCiAgdW5pb24gW0VuY291bnRlcjogY2xhc3MgaW4gIk5IU04gSW5wYXRpZW50IEVuY291bnRlciBDbGFzcyBDb2RlcyJdCiAgdW5pb24gW0VuY291bnRlcjogY2xhc3MgfiAiZW1lcmdlbmN5Il0KICB1bmlvbiBbRW5jb3VudGVyOiBjbGFzcyB+ICJvYnNlcnZhdGlvbiBlbmNvdW50ZXIiXSkgUXVhbGlmeWluZ0VuY291bnRlcnMKICB3aGVyZSBRdWFsaWZ5aW5nRW5jb3VudGVycy5zdGF0dXMgaW4geydpbi1wcm9ncmVzcycsICdmaW5pc2hlZCcsICd0cmlhZ2VkJywgJ29ubGVhdmUnLCAnZW50ZXJlZC1pbi1lcnJvcid9CiAgICBhbmQgUXVhbGlmeWluZ0VuY291bnRlcnMucGVyaW9kIG92ZXJsYXBzICJNZWFzdXJlbWVudCBQZXJpb2QiIAoKZGVmaW5lICJFbmNvdW50ZXJzIHdpdGggUGF0aWVudCBIb3NwaXRhbCBMb2NhdGlvbnMiOgogICJFbmNvdW50ZXJzIiBFbmNvdW50ZXJzCiAgd2hlcmUgZXhpc3RzKAogICAgRW5jb3VudGVycy5sb2NhdGlvbiBFbmNvdW50ZXJMb2NhdGlvbgogICAgd2hlcmUgTkhTTkhlbHBlcnMuR2V0TG9jYXRpb24oRW5jb3VudGVyTG9jYXRpb24ubG9jYXRpb24pLnR5cGUgaW4gIklucGF0aWVudCwgRW1lcmdlbmN5LCBhbmQgT2JzZXJ2YXRpb24gTG9jYXRpb25zIgogICAgICBhbmQgRW5jb3VudGVyTG9jYXRpb24ucGVyaW9kIG92ZXJsYXBzIEVuY291bnRlcnMucGVyaW9kCiAgKQogIGFuZCBFbmNvdW50ZXJzLnN0YXR1cyBpbiB7J2luLXByb2dyZXNzJywgJ2ZpbmlzaGVkJywgJ3RyaWFnZWQnLCAnb25sZWF2ZScsICdlbnRlcmVkLWluLWVycm9yJ30KICBhbmQgRW5jb3VudGVycy5wZXJpb2Qgb3ZlcmxhcHMgIk1lYXN1cmVtZW50IFBlcmlvZCIKCmRlZmluZSAiSW5pdGlhbCBQb3B1bGF0aW9uIjoKICAiUXVhbGlmeWluZyBFbmNvdW50ZXJzIER1cmluZyBNZWFzdXJlbWVudCBQZXJpb2QiCiAgdW5pb24gIkVuY291bnRlcnMgd2l0aCBQYXRpZW50IEhvc3BpdGFsIExvY2F0aW9ucyIKCmRlZmluZSAiRW5jb3VudGVycyI6CiAgW0VuY291bnRlcl0KCmRlZmluZSAiQ29uZGl0aW9ucyI6CiAgW0NvbmRpdGlvbl0KCmRlZmluZSAiRGlhZ25vc3RpY1JlcG9ydHMiOgogIFtEaWFnbm9zdGljUmVwb3J0XQoKZGVmaW5lICJPYnNlcnZhdGlvbnMiOgogIFtPYnNlcnZhdGlvbl0KCmRlZmluZSAiR2V0IExvY2F0aW9ucyBmcm9tIElQIEVuY291bnRlcnMgaW4gTWVhc3VyZW1lbnQgUGVyaW9kIjoKICBmbGF0dGVuKCJJbml0aWFsIFBvcHVsYXRpb24iIElQCiAgbGV0IGxvY2F0aW9uRWxlbWVudHM6IElQLmxvY2F0aW9uCiAgcmV0dXJuCiAgICBsb2NhdGlvbkVsZW1lbnRzIExFCiAgICBsZXQgbG9jYXRpb25SZWZlcmVuY2U6IExFLmxvY2F0aW9uCiAgICByZXR1cm4gTkhTTkhlbHBlcnMuR2V0TG9jYXRpb24obG9jYXRpb25SZWZlcmVuY2UpKQoKZGVmaW5lICJNZWRpY2F0aW9uIElEcyI6CiAgKCJTREUgTWVkaWNhdGlvbiBSZXF1ZXN0IgogIHVuaW9uICJTREUgTWVkaWNhdGlvbiBBZG1pbmlzdHJhdGlvbiIpIE1lZFJlcU9yQWRtaW4KICB3aGVyZSBNZWRSZXFPckFkbWluLm1lZGljYXRpb24gaXMgRkhJUi5SZWZlcmVuY2UKICAgIGFuZCBleGlzdHMoIkluaXRpYWwgUG9wdWxhdGlvbiIpIC8vTm8gbG9uZ2VyIG5lZWQgdG8gY2hlY2sgZm9yIHRpbWluZyBoZXJlIGJlY2F1c2UgaXQncyBjaGVja2VkIGluIFNERSBNZWRpY2F0aW9uIFJlcXVlc3QvQWRtaW5pc3RyaWF0aW9uCiAgcmV0dXJuIE5IU05IZWxwZXJzLkdldElkKE1lZFJlcU9yQWRtaW4ubWVkaWNhdGlvbi5yZWZlcmVuY2UpCgovLz09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT0KLy9TdXBwbGVtZW50YWwgRGF0YSBFbGVtZW50Ci8vV2hlbiBGSElSLmNhbm9uaWNhbCB2YWx1ZSBpcyBwcmVzZW50LCBVUyBDb3JlIDMuMS4xIHByb2ZpbGVzIGFyZSB1c2VkCi8vV2hlbiBGSElSLmNhbm9uaWNhbCB2YWx1ZSBpcyBub3QgcHJlc2VudCwgRkhJUiBCYXNlIHByb2ZpbGVzIGFyZSB1c2VkCi8vPT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PT09PQpkZWZpbmUgIlNERSBDb25kaXRpb24iOgogICJDb25kaXRpb25zIiBDb25kaXRpb25zIAogICAgd2hlcmUgZXhpc3RzKAogICAgIkluaXRpYWwgUG9wdWxhdGlvbiIgSVAKLy9DaGVjayBmb3IgUHJvYmxlbSBMaXN0IENvbmRpdGlvbnMgdGhhdCB3ZXJlIHJlY29yZGVkIGJlZm9yZSBvciBkdXJpbmcgSVAgCiAgICAgd2hlcmUgCiAgICAgIChleGlzdHMoSVAuZGlhZ25vc2lzIERpYWdub3NlcwogICAgICAgICAgd2hlcmUgTkhTTkhlbHBlcnMuR2V0SWQoRGlhZ25vc2VzLmNvbmRpdGlvbi5yZWZlcmVuY2UpID0gQ29uZGl0aW9ucy5pZAogICAgICAgICkKICAgICAgICBvciBOSFNOSGVscGVycy5HZXRJZChDb25kaXRpb25zLmVuY291bnRlci5yZWZlcmVuY2UpID0gSVAuaWQKICAgICAgKQogICAgICBhbmQgZXhpc3RzIChDb25kaXRpb25zLmNhdGVnb3J5IGNhdGVnb3JpZXMKICAgICAgICB3aGVyZSBjYXRlZ29yaWVzIH4gImVuY291bnRlci1kaWFnbm9zaXMiCiAgICApCiAgKQogIHJldHVybiBDb25kaXRpb25SZXNvdXJjZShDb25kaXRpb25zLAogIHtGSElSLmNhbm9uaWNhbHt2YWx1ZTogJ2h0dHA6Ly93d3cuY2RjLmdvdi9uaHNuL2ZoaXJwb3J0YWwvZHFtL2lnL1N0cnVjdHVyZURlZmluaXRpb24vYWNoLW1vbnRobHktY29uZGl0aW9uJ319LAogICB7ImVuY291bnRlci1kaWFnbm9zaXMifSkKCmRlZmluZSAiU0RFIENvdmVyYWdlIjogCglbQ292ZXJhZ2VdIENvdmVyYWdlcwogIHdoZXJlIGV4aXN0cygKICAgICJJbml0aWFsIFBvcHVsYXRpb24iIElQCiAgICB3aGVyZSBDb3ZlcmFnZXMucGVyaW9kIG92ZXJsYXBzIElQLnBlcmlvZCkKICByZXR1cm4gQ292ZXJhZ2VSZXNvdXJjZShDb3ZlcmFnZXMsCiAge0ZISVIuY2Fub25pY2Fse3ZhbHVlOiAnaHR0cDovL3d3dy5jZGMuZ292L25oc24vZmhpcnBvcnRhbC9kcW0vaWcvU3RydWN0dXJlRGVmaW5pdGlvbi9hY2gtbW9udGhseS1jb3ZlcmFnZSd9fSkKCmRlZmluZSAiU0RFIERldmljZSI6CiAgW0RldmljZV0gRGV2aWNlcyAKICB3aGVyZSBleGlzdHMoIkluaXRpYWwgUG9wdWxhdGlvbiIpCiAgcmV0dXJuIERldmljZVJlc291cmNlKERldmljZXMsCiAge0ZISVIuY2Fub25pY2Fse3ZhbHVlOiAnaHR0cDovL3d3dy5jZGMuZ292L25oc24vZmhpcnBvcnRhbC9kcW0vaWcvU3RydWN0dXJlRGVmaW5pdGlvbi9hY2gtbW9udGhseS1kZXZpY2UnfX0pCgovL1RoaXMgYmxvY2sgY29sbGVjdHMgYWxsIERpYWdub3N0aWNSZXBvcnQgcmVzb3VyY2VzIHdoaWxlIGFsc28gbWFya2luZyBMYWIgYW5kIE5vdGUgRGlhZ25vc3RpY1JlcG9ydHMgd2l0aCB0aGUgYXBwcm9wcmlhdGUgcHJvZmlsZXMKLy8jU3RhcnQgRGlhZ25vc3RpY1JlcG9ydCBibG9jawpkZWZpbmUgIlNERSBEaWFnbm9zdGljUmVwb3J0IExhYiI6CiAgIkRpYWdub3N0aWNSZXBvcnRzIiBEaWFnbm9zdGljUmVwb3J0cwogIHdoZXJlIChleGlzdHMoRGlhZ25vc3RpY1JlcG9ydHMuY2F0ZWdvcnkgQ2F0ZWdvcnkgd2hlcmUgQ2F0ZWdvcnkgfiAiTEFCIikKICAgIGFuZCBleGlzdHMoCiAgICAgICJJbml0aWFsIFBvcHVsYXRpb24iIElQCiAgICAgIHdoZXJlIE5IU05IZWxwZXJzLiJOb3JtYWxpemUgSW50ZXJ2YWwiKERpYWdub3N0aWNSZXBvcnRzLmVmZmVjdGl2ZSkgb3ZlcmxhcHMgSVAucGVyaW9kKSkKICByZXR1cm4gRGlhZ25vc3RpY1JlcG9ydExhYlJlc291cmNlKERpYWdub3N0aWNSZXBvcnRzLAogIHtGSElSLmNhbm9uaWNhbHt2YWx1ZTogJ2h0dHA6Ly93d3cuY2RjLmdvdi9uaHNuL2ZoaXJwb3J0YWwvZHFtL2lnL1N0cnVjdHVyZURlZmluaXRpb24vYWNoLW1vbnRobHktZGlhZ25vc3RpY3JlcG9ydC1sYWInfX0sCiAgeyJMQUIiLCAiUmFkaW9sb2d5IiwgIlBhdGhvbG9neSIsICJDYXJkaW9sb2d5In0pCiAKZGVmaW5lICJTREUgRGlhZ25vc3RpY1JlcG9ydCBOb3RlIjoKICAiRGlhZ25vc3RpY1JlcG9ydHMiIERpYWdub3N0aWNSZXBvcnRzCiAgd2hlcmUgKChleGlzdHMoRGlhZ25vc3RpY1JlcG9ydHMuY2F0ZWdvcnkgQ2F0ZWdvcnkgd2hlcmUgQ2F0ZWdvcnkgfiAiUmFkaW9sb2d5IikpCiAgICBvciBleGlzdHMoKERpYWdub3N0aWNSZXBvcnRzLmNhdGVnb3J5IENhdGVnb3J5IHdoZXJlIENhdGVnb3J5IH4gIlBhdGhvbG9neSIpKQogICAgb3IgZXhpc3RzKChEaWFnbm9zdGljUmVwb3J0cy5jYXRlZ29yeSBDYXRlZ29yeSB3aGVyZSBDYXRlZ29yeSB+ICJDYXJkaW9sb2d5IikpKQogICAgYW5kIGV4aXN0cygKICAgICAgIkluaXRpYWwgUG9wdWxhdGlvbiIgSVAKICAgICAgd2hlcmUgTkhTTkhlbHBlcnMuIk5vcm1hbGl6ZSBJbnRlcnZhbCIoRGlhZ25vc3RpY1JlcG9ydHMuZWZmZWN0aXZlKSBvdmVybGFwcyBJUC5wZXJpb2QpCiAgcmV0dXJuIERpYWdub3N0aWNSZXBvcnRSZXNvdXJjZShEaWFnbm9zdGljUmVwb3J0cywKICB7RkhJUi5jYW5vbmljYWx7dmFsdWU6ICdodHRwOi8vd3d3LmNkYy5nb3Yvbmhzbi9maGlycG9ydGFsL2RxbS9pZy9TdHJ1Y3R1cmVEZWZpbml0aW9uL2FjaC1tb250aGx5LWRpYWdub3N0aWNyZXBvcnQtbm90ZSd9fSwKICB7IlJhZGlvbG9neSIsICJQYXRob2xvZ3kiLCAiQ2FyZGlvbG9neSIsICJMQUIifSkKCmRlZmluZSAiU0RFIERpYWdub3N0aWNSZXBvcnQgT3RoZXJzIjoKICBbRGlhZ25vc3RpY1JlcG9ydF0gRGlhZ25vc3RpY1JlcG9ydHMKICB3aGVyZSBub3QgKChleGlzdHMoRGlhZ25vc3RpY1JlcG9ydHMuY2F0ZWdvcnkgQ2F0ZWdvcnkgd2hlcmUgQ2F0ZWdvcnkgfiAiUmFkaW9sb2d5IikpCiAgICBvciBleGlzdHMoKERpYWdub3N0aWNSZXBvcnRzLmNhdGVnb3J5IENhdGVnb3J5IHdoZXJlIENhdGVnb3J5IH4gIlBhdGhvbG9neSIpKQogICAgb3IgZXhpc3RzKChEaWFnbm9zdGljUmVwb3J0cy5jYXRlZ29yeSBDYXRlZ29yeSB3aGVyZSBDYXRlZ29yeSB+ICJDYXJkaW9sb2d5IikpCiAgICBvciBleGlzdHMoRGlhZ25vc3RpY1JlcG9ydHMuY2F0ZWdvcnkgQ2F0ZWdvcnkgd2hlcmUgQ2F0ZWdvcnkgfiAiTEFCIikpCiAgICBhbmQgZXhpc3RzKCJJbml0aWFsIFBvcHVsYXRpb24iIElQCiAgICAgIHdoZXJlIE5IU05IZWxwZXJzLiJOb3JtYWxpemUgSW50ZXJ2YWwiKERpYWdub3N0aWNSZXBvcnRzLmVmZmVjdGl2ZSkgb3ZlcmxhcHMgSVAucGVyaW9kKQogIHJldHVybiBEaWFnbm9zdGljUmVwb3J0UmVzb3VyY2UoRGlhZ25vc3RpY1JlcG9ydHMsCiAge0ZISVIuY2Fub25pY2Fse3ZhbHVlOiAnaHR0cDovL3d3dy5jZGMuZ292L25oc24vZmhpcnBvcnRhbC9kcW0vaWcvU3RydWN0dXJlRGVmaW5pdGlvbi9hY2gtbW9udGhseS1kaWFnbm9zdGljcmVwb3J0J319LAogIHsiUmFkaW9sb2d5IiwgIlBhdGhvbG9neSIsICJDYXJkaW9sb2d5IiwgIkxBQiJ9KQovLyNFbmQgRGlhZ25vc3RpY1JlcG9ydCBibG9jawoKZGVmaW5lICJTREUgRW5jb3VudGVyIjogCiAgIkVuY291bnRlcnMiIEVuY291bnRlcnMKICB3aGVyZSBub3QgQ2hlY2tJUChFbmNvdW50ZXJzKQogIGFuZCBleGlzdHMoCiAgICAiSW5pdGlhbCBQb3B1bGF0aW9uIiBJUAogICAgd2hlcmUgRW5jb3VudGVycy5wZXJpb2Qgb3ZlcmxhcHMgSVAucGVyaW9kKQogIHJldHVybiBFbmNvdW50ZXJSZXNvdXJjZShFbmNvdW50ZXJzLAogIHtGSElSLmNhbm9uaWNhbHt2YWx1ZTogJ2h0dHA6Ly9obDcub3JnL2ZoaXIvdXMvY29yZS9TdHJ1Y3R1cmVEZWZpbml0aW9uL3VzLWNvcmUtZW5jb3VudGVyJ319KQoKZGVmaW5lICJTREUgSVAgRW5jb3VudGVycyI6CiAgIkluaXRpYWwgUG9wdWxhdGlvbiIgSVAKICByZXR1cm4gRW5jb3VudGVyUmVzb3VyY2UoSVAsIAogIHtGSElSLmNhbm9uaWNhbHt2YWx1ZTogJ2h0dHA6Ly93d3cuY2RjLmdvdi9uaHNuL2ZoaXJwb3J0YWwvZHFtL2lnL1N0cnVjdHVyZURlZmluaXRpb24vYWNoLW1vbnRobHktZW5jb3VudGVyJ319KQoKZGVmaW5lICJTREUgTG9jYXRpb24iOgogICJHZXQgTG9jYXRpb25zIGZyb20gSVAgRW5jb3VudGVycyBpbiBNZWFzdXJlbWVudCBQZXJpb2QiIExvY2F0aW9ucwogIHdoZXJlIGV4aXN0cygiSW5pdGlhbCBQb3B1bGF0aW9uIikKICBhbmQgTG9jYXRpb25zIGlzIG5vdCBudWxsCiAgcmV0dXJuIExvY2F0aW9uUmVzb3VyY2UoTG9jYXRpb25zLAogIHtGSElSLmNhbm9uaWNhbHt2YWx1ZTogJ2h0dHA6Ly93d3cuY2RjLmdvdi9uaHNuL2ZoaXJwb3J0YWwvZHFtL2lnL1N0cnVjdHVyZURlZmluaXRpb24vYWNoLW1vbnRobHktbG9jYXRpb24nfX0pCiAKZGVmaW5lICJTREUgTWVkaWNhdGlvbiBBZG1pbmlzdHJhdGlvbiI6CiAgW01lZGljYXRpb25BZG1pbmlzdHJhdGlvbl0gTWVkaWNhdGlvbkFkbWluaXN0cmF0aW9ucyAKICB3aGVyZSBleGlzdHMoCiAgICAiSW5pdGlhbCBQb3B1bGF0aW9uIiBJUAogICAgd2hlcmUgTkhTTkhlbHBlcnMuIk5vcm1hbGl6ZSBJbnRlcnZhbCIoTWVkaWNhdGlvbkFkbWluaXN0cmF0aW9ucy5lZmZlY3RpdmUpIG92ZXJsYXBzIElQLnBlcmlvZCkKICByZXR1cm4gTWVkaWNhdGlvbkFkbWluaXN0cmF0aW9uUmVzb3VyY2UoTWVkaWNhdGlvbkFkbWluaXN0cmF0aW9ucywKICB7RkhJUi5jYW5vbmljYWx7dmFsdWU6ICdodHRwOi8vd3d3LmNkYy5nb3Yvbmhzbi9maGlycG9ydGFsL2RxbS9pZy9TdHJ1Y3R1cmVEZWZpbml0aW9uL2FjaC1tb250aGx5LW1lZGljYXRpb25hZG1pbmlzdHJhdGlvbid9fSwKICB7ImlucGF0aWVudCIsICJvdXRwYXRpZW50In0pCiAKZGVmaW5lICJTREUgTWVkaWNhdGlvbiBSZXF1ZXN0IjoKICBbTWVkaWNhdGlvblJlcXVlc3RdIE1lZGljYXRpb25SZXF1ZXN0cyAKICB3aGVyZSBleGlzdHMoCiAgICAiSW5pdGlhbCBQb3B1bGF0aW9uIiBJUAogICAgd2hlcmUgTWVkaWNhdGlvblJlcXVlc3RzLmF1dGhvcmVkT24gZHVyaW5nIElQLnBlcmlvZCkKICByZXR1cm4gTWVkaWNhdGlvblJlcXVlc3RSZXNvdXJjZShNZWRpY2F0aW9uUmVxdWVzdHMsCiAge0ZISVIuY2Fub25pY2Fse3ZhbHVlOiAnaHR0cDovL3d3dy5jZGMuZ292L25oc24vZmhpcnBvcnRhbC9kcW0vaWcvU3RydWN0dXJlRGVmaW5pdGlvbi9hY2gtbW9udGhseS1tZWRpY2F0aW9ucmVxdWVzdCd9fSwKICB7ImlucGF0aWVudCIsICJvdXRwYXRpZW50In0pCiAgCmRlZmluZSAiU0RFIE1lZGljYXRpb24iOgogIFtNZWRpY2F0aW9uXSBNZWRpY2F0aW9ucwogIHdoZXJlIE1lZGljYXRpb25zLmlkIGluICJNZWRpY2F0aW9uIElEcyIKICByZXR1cm4gU2hhcmVkUmVzb3VyY2UuTWVkaWNhdGlvblJlc291cmNlKE1lZGljYXRpb25zLAogIHtGSElSLmNhbm9uaWNhbHt2YWx1ZTogJ2h0dHA6Ly93d3cuY2RjLmdvdi9uaHNuL2ZoaXJwb3J0YWwvZHFtL2lnL1N0cnVjdHVyZURlZmluaXRpb24vYWNoLW1vbnRobHktbWVkaWNhdGlvbid9fSkKCmRlZmluZSAiU0RFIE9ic2VydmF0aW9uIExhYiBDYXRlZ29yeSI6CiAgIk9ic2VydmF0aW9ucyIgT2JzZXJ2YXRpb25zIAogIHdoZXJlIChleGlzdHMoT2JzZXJ2YXRpb25zLmNhdGVnb3J5IENhdGVnb3J5IHdoZXJlIENhdGVnb3J5IH4gImxhYm9yYXRvcnkiKSkKICAgIGFuZCBleGlzdHMoCiAgICAgICJJbml0aWFsIFBvcHVsYXRpb24iIElQCiAgICAgIHdoZXJlIE5IU05IZWxwZXJzLiJOb3JtYWxpemUgSW50ZXJ2YWwiKE9ic2VydmF0aW9ucy5lZmZlY3RpdmUpIG92ZXJsYXBzIElQLnBlcmlvZCkKICByZXR1cm4gT2JzZXJ2YXRpb25MYWJSZXNvdXJjZShPYnNlcnZhdGlvbnMsCiAge0ZISVIuY2Fub25pY2Fse3ZhbHVlOiAnaHR0cDovL3d3dy5jZGMuZ292L25oc24vZmhpcnBvcnRhbC9kcW0vaWcvU3RydWN0dXJlRGVmaW5pdGlvbi9hY2gtbW9udGhseS1vYnNlcnZhdGlvbi1sYWInfX0sCiAgeyJpbWFnaW5nIiwgInByb2NlZHVyZSIsICJ2aXRhbC1zaWducyIsICJsYWJvcmF0b3J5In0pCgovL1ZpdGFsIFNpZ25zIE9ic2VydmF0aW9uIGhhcyBpdHMgb3duIHByb2ZpbGUgaW4gRkhJUiBCYXNlCmRlZmluZSAiU0RFIE9ic2VydmF0aW9uIFZpdGFsIFNpZ25zIENhdGVnb3J5IjoKICAiT2JzZXJ2YXRpb25zIiBPYnNlcnZhdGlvbnMgCiAgd2hlcmUgKGV4aXN0cyhPYnNlcnZhdGlvbnMuY2F0ZWdvcnkgQ2F0ZWdvcnkgd2hlcmUgQ2F0ZWdvcnkgfiAidml0YWwtc2lnbnMiKSkKICAgIGFuZCBleGlzdHMoCiAgICAgICJJbml0aWFsIFBvcHVsYXRpb24iIElQCiAgICAgIHdoZXJlIE5IU05IZWxwZXJzLiJOb3JtYWxpemUgSW50ZXJ2YWwiKE9ic2VydmF0aW9ucy5lZmZlY3RpdmUpIG92ZXJsYXBzIElQLnBlcmlvZCkKICByZXR1cm4gT2JzZXJ2YXRpb25WaXRhbFNpZ25zUmVzb3VyY2UoT2JzZXJ2YXRpb25zLAogIHtGSElSLmNhbm9uaWNhbHt2YWx1ZTogJ2h0dHA6Ly93d3cuY2RjLmdvdi9uaHNuL2ZoaXJwb3J0YWwvZHFtL2lnL1N0cnVjdHVyZURlZmluaXRpb24vYWNoLW1vbnRobHktb2JzZXJ2YXRpb24tdml0YWxzJ319LAogIHsiaW1hZ2luZyIsICJwcm9jZWR1cmUiLCAidml0YWwtc2lnbnMiLCAibGFib3JhdG9yeSJ9KQoKLy9EZWZhdWx0aW5nIHRvIGJhc2UgRkhJUiBwcm9maWxlIGFzIHRoZXJlIGFyZSBubyBpbmRpdmlkdWFsIHByb2ZpbGVzIGluIFVTIENvcmUgMy4xLjEgdGhhdCBjb3ZlciB0aGVzZSBPYnNlcnZhdGlvbiBjYXRlZ29yaWVzCmRlZmluZSAiU0RFIE9ic2VydmF0aW9uIENhdGVnb3J5IjoKICAiT2JzZXJ2YXRpb25zIiBPYnNlcnZhdGlvbnMgCiAgd2hlcmUgKC8qKGV4aXN0cyhPYnNlcnZhdGlvbnMuY2F0ZWdvcnkgQ2F0ZWdvcnkgd2hlcmUgQ2F0ZWdvcnkgfiAic29jaWFsLWhpc3RvcnkiKSkKICAgIG9yIChleGlzdHMoT2JzZXJ2YXRpb25zLmNhdGVnb3J5IENhdGVnb3J5IHdoZXJlIENhdGVnb3J5IH4gInN1cnZleSIpKQogICAgb3IgKi8oZXhpc3RzKE9ic2VydmF0aW9ucy5jYXRlZ29yeSBDYXRlZ29yeSB3aGVyZSBDYXRlZ29yeSB+ICJpbWFnaW5nIikpCiAgICBvciAoZXhpc3RzKE9ic2VydmF0aW9ucy5jYXRlZ29yeSBDYXRlZ29yeSB3aGVyZSBDYXRlZ29yeSB+ICJwcm9jZWR1cmUiKSkpCiAgICBhbmQgZXhpc3RzKAogICAgICAiSW5pdGlhbCBQb3B1bGF0aW9uIiBJUAogICAgICB3aGVyZSBOSFNOSGVscGVycy4iTm9ybWFsaXplIEludGVydmFsIihPYnNlcnZhdGlvbnMuZWZmZWN0aXZlKSBvdmVybGFwcyBJUC5wZXJpb2QpCiAgcmV0dXJuIE9ic2VydmF0aW9uUmVzb3VyY2UoT2JzZXJ2YXRpb25zLAogIHtGSElSLmNhbm9uaWNhbHt2YWx1ZTogJ2h0dHA6Ly93d3cuY2RjLmdvdi9uaHNuL2ZoaXJwb3J0YWwvZHFtL2lnL1N0cnVjdHVyZURlZmluaXRpb24vYWNoLW1vbnRobHktb2JzZXJ2YXRpb24nfX0sCiAgeyJpbWFnaW5nIiwgInByb2NlZHVyZSIsICJ2aXRhbC1zaWducyIsICJsYWJvcmF0b3J5In0pCgpkZWZpbmUgIlNERSBQcm9jZWR1cmUiOgogIFtQcm9jZWR1cmVdIFByb2NlZHVyZXMgCiAgd2hlcmUgZXhpc3RzKAogICAgIkluaXRpYWwgUG9wdWxhdGlvbiIgSVAKICAgIHdoZXJlIE5IU05IZWxwZXJzLiJOb3JtYWxpemUgSW50ZXJ2YWwiKFByb2NlZHVyZXMucGVyZm9ybWVkKSBvdmVybGFwcyBJUC5wZXJpb2QpCiAgICAgcmV0dXJuIFByb2NlZHVyZVJlc291cmNlKFByb2NlZHVyZXMsCiAge0ZISVIuY2Fub25pY2Fse3ZhbHVlOiAnaHR0cDovL3d3dy5jZGMuZ292L25oc24vZmhpcnBvcnRhbC9kcW0vaWcvU3RydWN0dXJlRGVmaW5pdGlvbi9hY2gtbW9udGhseS1wcm9jZWR1cmUnfX0sCiAgeyJTdXJnaWNhbCBwcm9jZWR1cmUiLCAiRGlhZ25vc3RpYyBwcm9jZWR1cmUifSkKCmRlZmluZSAiU0RFIFNwZWNpbWVuIjoKICBbU3BlY2ltZW5dIFNwZWNpbWVucwogIHdoZXJlIGV4aXN0cygKICAgICJJbml0aWFsIFBvcHVsYXRpb24iIElQCiAgICB3aGVyZSBOSFNOSGVscGVycy4iTm9ybWFsaXplIEludGVydmFsIihTcGVjaW1lbnMuY29sbGVjdGlvbi5jb2xsZWN0ZWQpIG92ZXJsYXBzIElQLnBlcmlvZAogICkKICByZXR1cm4gU3BlY2ltZW5SZXNvdXJjZShTcGVjaW1lbnMsCiAge0ZISVIuY2Fub25pY2Fse3ZhbHVlOiAnaHR0cDovL3d3dy5jZGMuZ292L25oc24vZmhpcnBvcnRhbC9kcW0vaWcvU3RydWN0dXJlRGVmaW5pdGlvbi9hY2gtbW9udGhseS1zcGVjaW1lbid9fSkKCmRlZmluZSAiU0RFIFNlcnZpY2UgUmVxdWVzdCI6CiAgW1NlcnZpY2VSZXF1ZXN0XSBTZXJ2aWNlUmVxdWVzdHMKICB3aGVyZSBleGlzdHMoIkluaXRpYWwgUG9wdWxhdGlvbiIgSVAKICAgIHdoZXJlIFNlcnZpY2VSZXF1ZXN0cy5hdXRob3JlZE9uIGR1cmluZyBJUC5wZXJpb2QpCiAgcmV0dXJuIFNlcnZpY2VSZXF1ZXN0UmVzb3VyY2UoU2VydmljZVJlcXVlc3RzLAogIHtGSElSLmNhbm9uaWNhbHt2YWx1ZTogJ2h0dHA6Ly93d3cuY2RjLmdvdi9uaHNuL2ZoaXJwb3J0YWwvZHFtL2lnL1N0cnVjdHVyZURlZmluaXRpb24vYWNoLW1vbnRobHktc2VydmljZXJlcXVlc3QnfX0sCiAgeyJMYWJvcmF0b3J5IHByb2NlZHVyZSIsICJTdXJnaWNhbCBwcm9jZWR1cmUiLCAiSW1hZ2luZyJ9KQoKZGVmaW5lICJTREUgTWluaW1hbCBQYXRpZW50IjoKICBQYXRpZW50IHAKICByZXR1cm4gU2hhcmVkUmVzb3VyY2UuUGF0aWVudFJlc291cmNlKHAsCiAge0ZISVIuY2Fub25pY2Fse3ZhbHVlOiAnaHR0cDovL3d3dy5jZGMuZ292L25oc24vZmhpcnBvcnRhbC9kcW0vaWcvU3RydWN0dXJlRGVmaW5pdGlvbi9jcm9zcy1tZWFzdXJlLXBhdGllbnQnfX0pCgovLwovL0Z1bmN0aW9ucwovLwpkZWZpbmUgZnVuY3Rpb24gIkNoZWNrSVAiKGVuY291bnRlciBFbmNvdW50ZXIpOgogIGV4aXN0cygiSW5pdGlhbCBQb3B1bGF0aW9uIiBJUAogIHdoZXJlIGVuY291bnRlci5pZCA9IElQLmlkKQoKZGVmaW5lIGZ1bmN0aW9uICJHZXRNZWRpY2F0aW9uRnJvbSIoY2hvaWNlIENob2ljZTxGSElSLkNvZGVhYmxlQ29uY2VwdCwgRkhJUi5SZWZlcmVuY2U+KToKICBjYXNlCiAgICB3aGVuIGNob2ljZSBpcyBGSElSLlJlZmVyZW5jZSB0aGVuCiAgICAgIEdldE1lZGljYXRpb24oY2hvaWNlIGFzIEZISVIuUmVmZXJlbmNlKQogICAgZWxzZQogICAgICBudWxsCiAgZW5kCgpkZWZpbmUgZnVuY3Rpb24gIkdldE1lZGljYXRpb24iKHJlZmVyZW5jZSBSZWZlcmVuY2UpOgogIHNpbmdsZXRvbiBmcm9tICgKICAgIFtNZWRpY2F0aW9uXSBNZWRpY2F0aW9ucwogICAgd2hlcmUgTWVkaWNhdGlvbnMuaWQgPSBOSFNOSGVscGVycy5HZXRJZChyZWZlcmVuY2UucmVmZXJlbmNlKQogICkKCmRlZmluZSBmdW5jdGlvbiAiR2V0Q29uZGl0aW9uIihyZWZlcmVuY2UgUmVmZXJlbmNlKToKICBzaW5nbGV0b24gZnJvbSAoCiAgICAiQ29uZGl0aW9ucyIgQ29uZGl0aW9ucwogICAgd2hlcmUgQ29uZGl0aW9ucy5pZCA9IE5IU05IZWxwZXJzLkdldElkKHJlZmVyZW5jZS5yZWZlcmVuY2UpCiAgKQoKZGVmaW5lIGZ1bmN0aW9uICJHZXRFbmNvdW50ZXIiKHJlZmVyZW5jZSBSZWZlcmVuY2UpOgogIHNpbmdsZXRvbiBmcm9tICgKICAgICJFbmNvdW50ZXJzIiBFbmNvdW50ZXJzCiAgICB3aGVyZSBFbmNvdW50ZXJzLmlkID0gTkhTTkhlbHBlcnMuR2V0SWQocmVmZXJlbmNlLnJlZmVyZW5jZSkKICApCgpkZWZpbmUgZnVuY3Rpb24gUmVtb3ZlVW5hY2NlcHRlZChjb2RlcyBMaXN0PEZISVIuQ29kZWFibGVDb25jZXB0PiwgYWNjZXB0ZWQgTGlzdDxTeXN0ZW0uQ29kZT4pOgogIGNvZGVzIGMKICB3aGVyZSBleGlzdHMoCiAgICBhY2NlcHRlZCBhCiAgICB3aGVyZSBjIH4gYQogICkKCmRlZmluZSBmdW5jdGlvbiBGaWx0ZXJDb2RlYWJsZUNvbmNlcHRzKGNvZGVzIExpc3Q8RkhJUi5Db2RlYWJsZUNvbmNlcHQ+LCBhY2NlcHRlZCBMaXN0PFN5c3RlbS5Db2RlPik6CiAgaWYgQ291bnQoYWNjZXB0ZWQpID4gMAogICAgdGhlbiBSZW1vdmVVbmFjY2VwdGVkKGNvZGVzLCBhY2NlcHRlZCkKICBlbHNlIGNvZGVzICAgIAoKLy8KLy9NZWFzdXJlIFNwZWNpZmljIFJlc291cmNlIENyZWF0aW9uIEZ1bmN0aW9ucwovLwoKZGVmaW5lIGZ1bmN0aW9uIENvbmRpdGlvblJlc291cmNlKGNvbmRpdGlvbiBDb25kaXRpb24sIHByb2ZpbGVVUkxzIExpc3Q8RkhJUi5jYW5vbmljYWw+LCBhY2NlcHRlZENhdGVnb3JpZXMgTGlzdDxTeXN0ZW0uQ29kZT4pOgogIGNvbmRpdGlvbiBjCiAgcmV0dXJuIENvbmRpdGlvbnsKICAgIGlkOiBGSElSLmlkIHt2YWx1ZTogJ0xDUi0nICsgYy5pZH0sCiAgICBtZXRhOiBTaGFyZWRSZXNvdXJjZS5NZXRhRWxlbWVudChjLCBwcm9maWxlVVJMcyksCiAgICBleHRlbnNpb246IGMuZXh0ZW5zaW9uLAogICAgY2xpbmljYWxTdGF0dXM6IGMuY2xpbmljYWxTdGF0dXMsCiAgICB2ZXJpZmljYXRpb25TdGF0dXM6IGMudmVyaWZpY2F0aW9uU3RhdHVzLAogICAgY2F0ZWdvcnk6IEZpbHRlckNvZGVhYmxlQ29uY2VwdHMoYy5jYXRlZ29yeSwgYWNjZXB0ZWRDYXRlZ29yaWVzKSwKICAgIGNvZGU6IGMuY29kZSwKICAgIHN1YmplY3Q6IGMuc3ViamVjdCwKICAgIGVuY291bnRlcjogYy5lbmNvdW50ZXIsCiAgICBvbnNldDogYy5vbnNldCwKICAgIGFiYXRlbWVudDogYy5hYmF0ZW1lbnQsCiAgICByZWNvcmRlZERhdGU6IGMucmVjb3JkZWREYXRlCiAgfQoKZGVmaW5lIGZ1bmN0aW9uIENvdmVyYWdlUmVzb3VyY2UoY292ZXJhZ2UgQ292ZXJhZ2UsIHByb2ZpbGVVUkxzIExpc3Q8RkhJUi5jYW5vbmljYWw+KToKICBjb3ZlcmFnZSBjCiAgcmV0dXJuIENvdmVyYWdlewogICAgaWQ6IEZISVIuaWR7dmFsdWU6ICdMQ1ItJyArIGMuaWR9LAogICAgbWV0YTogU2hhcmVkUmVzb3VyY2UuTWV0YUVsZW1lbnQoYywgcHJvZmlsZVVSTHMpLAogICAgZXh0ZW5zaW9uOiBjLmV4dGVuc2lvbiwKICAgIHN0YXR1czogYy5zdGF0dXMsCiAgICB0eXBlOiBjLnR5cGUsCiAgICBiZW5lZmljaWFyeTogYy5iZW5lZmljaWFyeSwKICAgIHBlcmlvZDogYy5wZXJpb2QsCiAgICBwYXlvcjogYy5wYXlvcgogIH0KCmRlZmluZSBmdW5jdGlvbiBEZXZpY2VSZXNvdXJjZShkZXZpY2UgRGV2aWNlLCBwcm9maWxlVVJMcyBMaXN0PEZISVIuY2Fub25pY2FsPik6CiAgZGV2aWNlIGQKICByZXR1cm4gRGV2aWNlewogICAgaWQ6IEZISVIuaWR7dmFsdWU6ICdMQ1ItJyArIGQuaWR9LAogICAgbWV0YTogU2hhcmVkUmVzb3VyY2UuTWV0YUVsZW1lbnQoZCwgcHJvZmlsZVVSTHMpLAogICAgZXh0ZW5zaW9uOiBkLmV4dGVuc2lvbiwKICAgIHN0YXR1czogZC5zdGF0dXMsCiAgICBleHBpcmF0aW9uRGF0ZTogZC5leHBpcmF0aW9uRGF0ZSwKICAgIGxvdE51bWJlcjogZC5sb3ROdW1iZXIsCiAgICBzZXJpYWxOdW1iZXI6IGQuc2VyaWFsTnVtYmVyLAogICAgbW9kZWxOdW1iZXI6IGQubW9kZWxOdW1iZXIsCiAgICBwYXJ0TnVtYmVyOiBkLnBhcnROdW1iZXIsCiAgICB0eXBlOiBkLnR5cGUsCiAgICBwYXRpZW50OiBkLnBhdGllbnQsCiAgICBwYXJlbnQ6IGQucGFyZW50CiAgfQoKZGVmaW5lIGZ1bmN0aW9uIERpYWdub3N0aWNSZXBvcnRDb2RpbmcoY29kaW5nIExpc3Q8Q29kaW5nPik6CiAgY29kaW5nIGMKICByZXR1cm4gQ29kaW5newogICAgc3lzdGVtOiBjLnN5c3RlbSwKICAgIHZlcnNpb246IGMudmVyc2lvbiwKICAgIGNvZGU6IGMuY29kZSwKICAgIGRpc3BsYXk6IGMuZGlzcGxheQogIH0KCmRlZmluZSBmdW5jdGlvbiBEaWFnbm9zdGljUmVwb3J0Q2F0ZWdvcnkoY2F0ZWdvcnkgTGlzdDxDb2RlYWJsZUNvbmNlcHQ+KToKICBjYXRlZ29yeSBjCiAgcmV0dXJuIENvZGVhYmxlQ29uY2VwdHsKICAgIGNvZGluZzogRGlhZ25vc3RpY1JlcG9ydENvZGluZyhjLmNvZGluZykKICB9CgpkZWZpbmUgZnVuY3Rpb24gRGlhZ25vc3RpY1JlcG9ydExhYlJlc291cmNlKGRpYWdub3N0aWNSZXBvcnQgRGlhZ25vc3RpY1JlcG9ydCwgcHJvZmlsZVVSTHMgTGlzdDxGSElSLmNhbm9uaWNhbD4sIGFjY2VwdGVkQ2F0ZWdvcmllcyBMaXN0PFN5c3RlbS5Db2RlPik6CiAgZGlhZ25vc3RpY1JlcG9ydCBkCiAgcmV0dXJuIERpYWdub3N0aWNSZXBvcnR7CiAgICBpZDogRkhJUi5pZHt2YWx1ZTogJ0xDUi0nICsgZC5pZH0sCiAgICBtZXRhOiBTaGFyZWRSZXNvdXJjZS5NZXRhRWxlbWVudChkLCBwcm9maWxlVVJMcyksCiAgICBleHRlbnNpb246IGQuZXh0ZW5zaW9uLAogICAgYmFzZWRPbjogZC5iYXNlZE9uLAogICAgc3RhdHVzOiBkLnN0YXR1cywKICAgIGNhdGVnb3J5OiBGaWx0ZXJDb2RlYWJsZUNvbmNlcHRzKERpYWdub3N0aWNSZXBvcnRDYXRlZ29yeShkLmNhdGVnb3J5KSwgYWNjZXB0ZWRDYXRlZ29yaWVzKSwKICAgIGNvZGU6IGQuY29kZSwKICAgIHN1YmplY3Q6IGQuc3ViamVjdCwKICAgIGVuY291bnRlcjogZC5lbmNvdW50ZXIsCiAgICBlZmZlY3RpdmU6IGQuZWZmZWN0aXZlLAogICAgaXNzdWVkOiBkLmlzc3VlZCwKICAgIHNwZWNpbWVuOiBkLnNwZWNpbWVuLAogICAgcmVzdWx0OiBkLnJlc3VsdCwKICAgIGNvbmNsdXNpb246IGQuY29uY2x1c2lvbiwKICAgIGNvbmNsdXNpb25Db2RlOiBkLmNvbmNsdXNpb25Db2RlCiAgfQoKZGVmaW5lIGZ1bmN0aW9uIERpYWdub3N0aWNSZXBvcnRSZXNvdXJjZShkaWFnbm9zdGljUmVwb3J0IERpYWdub3N0aWNSZXBvcnQsIHByb2ZpbGVVUkxzIExpc3Q8RkhJUi5jYW5vbmljYWw+LCBhY2NlcHRlZENhdGVnb3JpZXMgTGlzdDxTeXN0ZW0uQ29kZT4pOgogIGRpYWdub3N0aWNSZXBvcnQgZAogIHJldHVybiBEaWFnbm9zdGljUmVwb3J0ewogICAgaWQ6IEZISVIuaWR7dmFsdWU6ICdMQ1ItJyArIGQuaWR9LAogICAgbWV0YTogU2hhcmVkUmVzb3VyY2UuTWV0YUVsZW1lbnQoZCwgcHJvZmlsZVVSTHMpLAogICAgZXh0ZW5zaW9uOiBkLmV4dGVuc2lvbiwKICAgIGJhc2VkT246IGQuYmFzZWRPbiwKICAgIHN0YXR1czogZC5zdGF0dXMsCiAgICBjYXRlZ29yeTogRmlsdGVyQ29kZWFibGVDb25jZXB0cyhkLmNhdGVnb3J5LCBhY2NlcHRlZENhdGVnb3JpZXMpLAogICAgY29kZTogZC5jb2RlLAogICAgc3ViamVjdDogZC5zdWJqZWN0LAogICAgZW5jb3VudGVyOiBkLmVuY291bnRlciwKICAgIGVmZmVjdGl2ZTogZC5lZmZlY3RpdmUsCiAgICBpc3N1ZWQ6IGQuaXNzdWVkLAogICAgc3BlY2ltZW46IGQuc3BlY2ltZW4sCiAgICByZXN1bHQ6IGQucmVzdWx0LAogICAgY29uY2x1c2lvbjogZC5jb25jbHVzaW9uLAogICAgY29uY2x1c2lvbkNvZGU6IGQuY29uY2x1c2lvbkNvZGUKICB9CgpkZWZpbmUgZnVuY3Rpb24gRW5jb3VudGVySG9zcGl0YWxpemF0aW9uKGhvc3BpdGFsaXphdGlvbiBGSElSLkVuY291bnRlci5Ib3NwaXRhbGl6YXRpb24pOgogIGhvc3BpdGFsaXphdGlvbiBoCiAgcmV0dXJuIEZISVIuRW5jb3VudGVyLkhvc3BpdGFsaXphdGlvbnsKICAgIG9yaWdpbjogaC5vcmlnaW4sCiAgICBhZG1pdFNvdXJjZTogaC5hZG1pdFNvdXJjZSwKICAgIHJlQWRtaXNzaW9uOiBoLnJlQWRtaXNzaW9uLAogICAgZGlldFByZWZlcmVuY2U6IGguZGlldFByZWZlcmVuY2UsCiAgICBkaXNjaGFyZ2VEaXNwb3NpdGlvbjogaC5kaXNjaGFyZ2VEaXNwb3NpdGlvbgogIH0KCmRlZmluZSBmdW5jdGlvbiBFbmNvdW50ZXJSZXNvdXJjZShlbmNvdW50ZXIgRW5jb3VudGVyLCBwcm9maWxlVVJMcyBMaXN0PEZISVIuY2Fub25pY2FsPik6CiAgZW5jb3VudGVyIGUKICByZXR1cm4gRW5jb3VudGVyewogICAgaWQ6IEZISVIuaWR7dmFsdWU6ICdMQ1ItJyArIGUuaWR9LAogICAgbWV0YTogU2hhcmVkUmVzb3VyY2UuTWV0YUVsZW1lbnQoZSwgcHJvZmlsZVVSTHMpLAogICAgZXh0ZW5zaW9uOiBlLmV4dGVuc2lvbiwKICAgIGlkZW50aWZpZXI6IFNoYXJlZFJlc291cmNlLkVuY291bnRlcklkZW50aWZpZXIoZS5pZGVudGlmaWVyKSwKICAgIHN0YXR1czogZS5zdGF0dXMsCiAgICBzdGF0dXNIaXN0b3J5OiBTaGFyZWRSZXNvdXJjZS5FbmNvdW50ZXJTdGF0dXNIaXN0b3J5KGUuc3RhdHVzSGlzdG9yeSksCiAgICBjbGFzczogZS5jbGFzcywKICAgIGNsYXNzSGlzdG9yeTogU2hhcmVkUmVzb3VyY2UuRW5jb3VudGVyQ2xhc3NIaXN0b3J5KGUuY2xhc3NIaXN0b3J5KSwKICAgIHR5cGU6IGUudHlwZSwKICAgIHN1YmplY3Q6IGUuc3ViamVjdCwKICAgIHBlcmlvZDogZS5wZXJpb2QsCiAgICByZWFzb25Db2RlOiBlLnJlYXNvbkNvZGUsCiAgICBkaWFnbm9zaXM6IFNoYXJlZFJlc291cmNlLkVuY291bnRlckRpYWdub3NpcyhlLmRpYWdub3NpcyksCiAgICBob3NwaXRhbGl6YXRpb246IEVuY291bnRlckhvc3BpdGFsaXphdGlvbihlLmhvc3BpdGFsaXphdGlvbiksCiAgICBsb2NhdGlvbjogU2hhcmVkUmVzb3VyY2UuRW5jb3VudGVyTG9jYXRpb24oZS5sb2NhdGlvbiksCiAgICBwYXJ0T2Y6IGUucGFydE9mCiAgfQoKZGVmaW5lIGZ1bmN0aW9uIExvY2F0aW9uUmVzb3VyY2UobG9jYXRpb24gTG9jYXRpb24sIHByb2ZpbGVVUkxzIExpc3Q8RkhJUi5jYW5vbmljYWw+KToKICBsb2NhdGlvbiBsCiAgcmV0dXJuIExvY2F0aW9uewogICAgaWQ6IEZISVIuaWQge3ZhbHVlOiAnTENSLScgKyBsLmlkfSwKICAgIG1ldGE6IFNoYXJlZFJlc291cmNlLk1ldGFFbGVtZW50KGwsIHByb2ZpbGVVUkxzKSwKICAgIGV4dGVuc2lvbjogbC5leHRlbnNpb24sCiAgICBzdGF0dXM6IGwuc3RhdHVzLAogICAgbmFtZTogbC5uYW1lLAogICAgYWxpYXM6IGwuYWxpYXMsCiAgICB0eXBlOiBsLnR5cGUsCiAgICBwaHlzaWNhbFR5cGU6IGwucGh5c2ljYWxUeXBlLAogICAgbWFuYWdpbmdPcmdhbml6YXRpb246IGwubWFuYWdpbmdPcmdhbml6YXRpb24sCiAgICBwYXJ0T2Y6IGwucGFydE9mCiAgfQoKZGVmaW5lIGZ1bmN0aW9uIE1lZGljYXRpb25SZXF1ZXN0UmVwZWF0KHJlcGVhdCBGSElSLlRpbWluZy5SZXBlYXQpOgogIHJlcGVhdCByCiAgcmV0dXJuIEZISVIuVGltaW5nLlJlcGVhdHsKICAgIGJvdW5kczogci5ib3VuZHMsCiAgICBjb3VudDogci5jb3VudCwKICAgIGNvdW50TWF4OiByLmNvdW50TWF4LAogICAgImR1cmF0aW9uIjogci4iZHVyYXRpb24iLAogICAgZHVyYXRpb25NYXg6IHIuZHVyYXRpb25NYXgsCiAgICBkdXJhdGlvblVuaXQ6IHIuZHVyYXRpb25Vbml0LAogICAgZnJlcXVlbmN5OiByLmZyZXF1ZW5jeSwKICAgIGZyZXF1ZW5jeU1heDogci5mcmVxdWVuY3lNYXgsCiAgICBwZXJpb2Q6IHIucGVyaW9kLAogICAgcGVyaW9kTWF4OiByLnBlcmlvZE1heCwKICAgIHBlcmlvZFVuaXQ6IHIucGVyaW9kVW5pdCwKICAgIGRheU9mV2Vlazogci5kYXlPZldlZWssCiAgICB0aW1lT2ZEYXk6IHIudGltZU9mRGF5LAogICAgIndoZW4iOiByLiJ3aGVuIiwKICAgIG9mZnNldDogci5vZmZzZXQKICB9CgpkZWZpbmUgZnVuY3Rpb24gTWVkaWNhdGlvblJlcXVlc3RUaW1pbmcodGltaW5nIEZISVIuVGltaW5nKToKICB0aW1pbmcgdAogIHJldHVybiBGSElSLlRpbWluZ3sKICAgIGV2ZW50OiB0LmV2ZW50LAogICAgcmVwZWF0OiBNZWRpY2F0aW9uUmVxdWVzdFJlcGVhdCh0LnJlcGVhdCksCiAgICBjb2RlOiB0LmNvZGUKICB9CgpkZWZpbmUgZnVuY3Rpb24gTWVkaWNhdGlvblJlcXVlc3REb3NhZ2VJbnN0cnVjdGlvbihkb3NhZ2VJbnN0cnVjdGlvbiBMaXN0PEZISVIuRG9zYWdlPik6CiAgZG9zYWdlSW5zdHJ1Y3Rpb24gZEkKICByZXR1cm4gRkhJUi5Eb3NhZ2V7CiAgICB0ZXh0OiBkSS50ZXh0LAogICAgcGF0aWVudEluc3RydWN0aW9uOiBkSS5wYXRpZW50SW5zdHJ1Y3Rpb24sCiAgICB0aW1pbmc6IE1lZGljYXRpb25SZXF1ZXN0VGltaW5nKGRJLnRpbWluZyksCiAgICBhc05lZWRlZDogZEkuYXNOZWVkZWQsCiAgICBzaXRlOiBkSS5zaXRlLAogICAgcm91dGU6IGRJLnJvdXRlLAogICAgbWV0aG9kOiBkSS5tZXRob2QsCiAgICBkb3NlQW5kUmF0ZTogU2hhcmVkUmVzb3VyY2UuTWVkaWNhdGlvblJlcXVlc3REb3NlQW5kUmF0ZShkSS5kb3NlQW5kUmF0ZSkKICB9CgpkZWZpbmUgZnVuY3Rpb24gTWVkaWNhdGlvblJlcXVlc3RSZXNvdXJjZShtZWRpY2F0aW9uUmVxdWVzdCBNZWRpY2F0aW9uUmVxdWVzdCwgcHJvZmlsZVVSTHMgTGlzdDxGSElSLmNhbm9uaWNhbD4sIGFjY2VwdGVkQ2F0ZWdvcmllcyBMaXN0PFN5c3RlbS5Db2RlPik6CiAgbWVkaWNhdGlvblJlcXVlc3QgbQogIHJldHVybiBNZWRpY2F0aW9uUmVxdWVzdHsKICAgIGlkOiBGSElSLmlkIHt2YWx1ZTogJ0xDUi0nICsgbS5pZH0sCiAgICBtZXRhOiBTaGFyZWRSZXNvdXJjZS5NZXRhRWxlbWVudChtZWRpY2F0aW9uUmVxdWVzdCwgcHJvZmlsZVVSTHMpLAogICAgZXh0ZW5zaW9uOiBtLmV4dGVuc2lvbiwKICAgIHN0YXR1czogbS5zdGF0dXMsCiAgICBzdGF0dXNSZWFzb246IG0uc3RhdHVzUmVhc29uLAogICAgaW50ZW50OiBtLmludGVudCwKICAgIGNhdGVnb3J5OiBGaWx0ZXJDb2RlYWJsZUNvbmNlcHRzKG0uY2F0ZWdvcnksIGFjY2VwdGVkQ2F0ZWdvcmllcyksCiAgICBwcmlvcml0eTogbS5wcmlvcml0eSwKICAgIGRvTm90UGVyZm9ybTogbS5kb05vdFBlcmZvcm0sCiAgICByZXBvcnRlZDogbS5yZXBvcnRlZCwKICAgIG1lZGljYXRpb246IG0ubWVkaWNhdGlvbiwKICAgIHN1YmplY3Q6IG0uc3ViamVjdCwKICAgIGVuY291bnRlcjogbS5lbmNvdW50ZXIsCiAgICBhdXRob3JlZE9uOiBtLmF1dGhvcmVkT24sCiAgICByZXF1ZXN0ZXI6IG0ucmVxdWVzdGVyLAogICAgcmVjb3JkZXI6IG0ucmVjb3JkZXIsCiAgICByZWFzb25Db2RlOiBtLnJlYXNvbkNvZGUsCiAgICByZWFzb25SZWZlcmVuY2U6IG0ucmVhc29uUmVmZXJlbmNlLAogICAgaW5zdGFudGlhdGVzQ2Fub25pY2FsOiBtLmluc3RhbnRpYXRlc0Nhbm9uaWNhbCwKICAgIGluc3RhbnRpYXRlc1VyaTogbS5pbnN0YW50aWF0ZXNVcmksCiAgICBjb3Vyc2VPZlRoZXJhcHlUeXBlOiBtLmNvdXJzZU9mVGhlcmFweVR5cGUsCiAgICBkb3NhZ2VJbnN0cnVjdGlvbjogU2hhcmVkUmVzb3VyY2UuTWVkaWNhdGlvblJlcXVlc3REb3NhZ2VJbnN0cnVjdGlvbihtLmRvc2FnZUluc3RydWN0aW9uKQogIH0KCiAgZGVmaW5lIGZ1bmN0aW9uIE1lZGljYXRpb25BZG1pbmlzdHJhdGlvblJlc291cmNlKG1lZGljYXRpb25BZG1pbmlzdHJhdGlvbiBNZWRpY2F0aW9uQWRtaW5pc3RyYXRpb24sIHByb2ZpbGVVUkxzIExpc3Q8RkhJUi5jYW5vbmljYWw+LCBhY2NlcHRlZENhdGVnb3JpZXMgTGlzdDxTeXN0ZW0uQ29kZT4pOgogIG1lZGljYXRpb25BZG1pbmlzdHJhdGlvbiBtCiAgcmV0dXJuIE1lZGljYXRpb25BZG1pbmlzdHJhdGlvbnsKICAgIGlkOiBGSElSLmlkIHt2YWx1ZTogJ0xDUi0nICsgbS5pZH0sCiAgICBtZXRhOiBTaGFyZWRSZXNvdXJjZS5NZXRhRWxlbWVudChtLCBwcm9maWxlVVJMcyksCiAgICBleHRlbnNpb246IG0uZXh0ZW5zaW9uLAogICAgaW5zdGFudGlhdGVzOiBtLmluc3RhbnRpYXRlcywKICAgIHBhcnRPZjogbS5wYXJ0T2YsCiAgICBzdGF0dXM6IG0uc3RhdHVzLAogICAgc3RhdHVzUmVhc29uOiBtLnN0YXR1c1JlYXNvbiwKICAgIGNhdGVnb3J5OiBGaWx0ZXJDb2RlYWJsZUNvbmNlcHRzKHttLmNhdGVnb3J5fSwgYWNjZXB0ZWRDYXRlZ29yaWVzKVswXSwKICAgIG1lZGljYXRpb246IG0ubWVkaWNhdGlvbiwKICAgIHN1YmplY3Q6IG0uc3ViamVjdCwKICAgIGNvbnRleHQ6IG0uY29udGV4dCwKICAgIHN1cHBvcnRpbmdJbmZvcm1hdGlvbjogbS5zdXBwb3J0aW5nSW5mb3JtYXRpb24sCiAgICBlZmZlY3RpdmU6IG0uZWZmZWN0aXZlLAogICAgcGVyZm9ybWVyOiBTaGFyZWRSZXNvdXJjZS5NZWRpY2F0aW9uQWRtaW5pc3RyYXRpb25QZXJmb3JtZXIobS5wZXJmb3JtZXIpLAogICAgcmVhc29uQ29kZTogbS5yZWFzb25Db2RlLAogICAgcmVhc29uUmVmZXJlbmNlOiBtLnJlYXNvblJlZmVyZW5jZSwKICAgIHJlcXVlc3Q6IG0ucmVxdWVzdCwKICAgIGRldmljZTogbS5kZXZpY2UsCiAgICBub3RlOiBtLm5vdGUsCiAgICBkb3NhZ2U6IFNoYXJlZFJlc291cmNlLk1lZGljYXRpb25BZG1pbmlzdHJhdGlvbkRvc2FnZShtLmRvc2FnZSksCiAgICBldmVudEhpc3Rvcnk6IG0uZXZlbnRIaXN0b3J5CiAgfQoKZGVmaW5lIGZ1bmN0aW9uIE9ic2VydmF0aW9uTGFiUmVmZXJlbmNlUmFuZ2UocmVmZXJlbmNlUmFuZ2UgTGlzdDxGSElSLk9ic2VydmF0aW9uLlJlZmVyZW5jZVJhbmdlPik6CiAgcmVmZXJlbmNlUmFuZ2UgclIKICByZXR1cm4gRkhJUi5PYnNlcnZhdGlvbi5SZWZlcmVuY2VSYW5nZXsKICAgIGxvdzogclIubG93LAogICAgaGlnaDogclIuaGlnaCwKICAgIHR5cGU6IHJSLnR5cGUsCiAgICBhcHBsaWVzVG86IHJSLmFwcGxpZXNUbywKICAgIGFnZTogclIuYWdlCiAgfQoKZGVmaW5lIGZ1bmN0aW9uIE9ic2VydmF0aW9uTGFiQ29kaW5nKGNvZGluZyBMaXN0PENvZGluZz4pOgogIGNvZGluZyBjCiAgcmV0dXJuIENvZGluZ3sKICAgIHN5c3RlbTogYy5zeXN0ZW0sCiAgICB2ZXJzaW9uOiBjLnZlcnNpb24sCiAgICBjb2RlOiBjLmNvZGUsCiAgICBkaXNwbGF5OiBjLmRpc3BsYXksCiAgICB1c2VyU2VsZWN0ZWQ6IGMudXNlclNlbGVjdGVkCiAgfQoKZGVmaW5lIGZ1bmN0aW9uIE9ic2VydmF0aW9uTGFiQ2F0ZWdvcnkoY2F0ZWdvcnkgTGlzdDxDb2RlYWJsZUNvbmNlcHQ+KToKICBjYXRlZ29yeSBjCiAgcmV0dXJuIENvZGVhYmxlQ29uY2VwdHsKICAgIGNvZGluZzogT2JzZXJ2YXRpb25MYWJDb2RpbmcoYy5jb2RpbmcpLAogICAgdGV4dDogYy50ZXh0CiAgfQoKZGVmaW5lIGZ1bmN0aW9uIE9ic2VydmF0aW9uTGFiUmVzb3VyY2Uob2JzZXJ2YXRpb24gT2JzZXJ2YXRpb24sIHByb2ZpbGVVUkxzIExpc3Q8RkhJUi5jYW5vbmljYWw+LCBhY2NlcHRlZENhdGVnb3JpZXMgTGlzdDxTeXN0ZW0uQ29kZT4pOgogIG9ic2VydmF0aW9uIG8KICByZXR1cm4gT2JzZXJ2YXRpb257CiAgICBpZDogRkhJUi5pZCB7dmFsdWU6ICdMQ1ItJyArIG8uaWR9LAogICAgbWV0YTogU2hhcmVkUmVzb3VyY2UuTWV0YUVsZW1lbnQobywgcHJvZmlsZVVSTHMpLAogICAgZXh0ZW5zaW9uOiBvLmV4dGVuc2lvbiwKICAgIHBhcnRPZjogby5wYXJ0T2YsCiAgICBzdGF0dXM6IG8uc3RhdHVzLAogICAgY2F0ZWdvcnk6IEZpbHRlckNvZGVhYmxlQ29uY2VwdHMoT2JzZXJ2YXRpb25MYWJDYXRlZ29yeShvLmNhdGVnb3J5KSwgYWNjZXB0ZWRDYXRlZ29yaWVzKSwKICAgIGNvZGU6IG8uY29kZSwKICAgIHN1YmplY3Q6IG8uc3ViamVjdCwKICAgIGVuY291bnRlcjogby5lbmNvdW50ZXIsCiAgICBlZmZlY3RpdmU6IG8uZWZmZWN0aXZlLAogICAgaXNzdWVkOiBvLmlzc3VlZCwKICAgIHZhbHVlOiBvLnZhbHVlLAogICAgZGF0YUFic2VudFJlYXNvbjogby5kYXRhQWJzZW50UmVhc29uLAogICAgaW50ZXJwcmV0YXRpb246IG8uaW50ZXJwcmV0YXRpb24sCiAgICBib2R5U2l0ZTogby5ib2R5U2l0ZSwKICAgIG1ldGhvZDogby5tZXRob2QsCiAgICBzcGVjaW1lbjogby5zcGVjaW1lbiwKICAgIHJlZmVyZW5jZVJhbmdlOiBPYnNlcnZhdGlvbkxhYlJlZmVyZW5jZVJhbmdlKG8ucmVmZXJlbmNlUmFuZ2UpLAogICAgaGFzTWVtYmVyOiBvLmhhc01lbWJlciwKICAgIGRlcml2ZWRGcm9tOiBvLmRlcml2ZWRGcm9tLAogICAgY29tcG9uZW50OiBTaGFyZWRSZXNvdXJjZS5PYnNlcnZhdGlvbkNvbXBvbmVudChvLmNvbXBvbmVudCkKICB9CgpkZWZpbmUgZnVuY3Rpb24gT2JzZXJ2YXRpb25SZWZlcmVuY2VSYW5nZShyZWZlcmVuY2VSYW5nZSBMaXN0PEZISVIuT2JzZXJ2YXRpb24uUmVmZXJlbmNlUmFuZ2U+KToKICByZWZlcmVuY2VSYW5nZSByUgogIHJldHVybiBGSElSLk9ic2VydmF0aW9uLlJlZmVyZW5jZVJhbmdlewogICAgbG93OiByUi5sb3csCiAgICBoaWdoOiByUi5oaWdoLAogICAgdHlwZTogclIudHlwZSwKICAgIGFwcGxpZXNUbzogclIuYXBwbGllc1RvLAogICAgYWdlOiByUi5hZ2UKICB9CgpkZWZpbmUgZnVuY3Rpb24gT2JzZXJ2YXRpb25SZXNvdXJjZShvYnNlcnZhdGlvbiBPYnNlcnZhdGlvbiwgcHJvZmlsZVVSTHMgTGlzdDxGSElSLmNhbm9uaWNhbD4sIGFjY2VwdGVkQ2F0ZWdvcmllcyBMaXN0PFN5c3RlbS5Db2RlPik6CiAgb2JzZXJ2YXRpb24gbwogIHJldHVybiBPYnNlcnZhdGlvbnsKICAgIGlkOiBGSElSLmlkIHt2YWx1ZTogJ0xDUi0nICsgby5pZH0sCiAgICBtZXRhOiBTaGFyZWRSZXNvdXJjZS5NZXRhRWxlbWVudChvLCBwcm9maWxlVVJMcyksCiAgICBleHRlbnNpb246IG8uZXh0ZW5zaW9uLAogICAgcGFydE9mOiBvLnBhcnRPZiwKICAgIHN0YXR1czogby5zdGF0dXMsCiAgICBjYXRlZ29yeTogRmlsdGVyQ29kZWFibGVDb25jZXB0cyhvLmNhdGVnb3J5LCBhY2NlcHRlZENhdGVnb3JpZXMpLAogICAgY29kZTogby5jb2RlLAogICAgc3ViamVjdDogby5zdWJqZWN0LAogICAgZW5jb3VudGVyOiBvLmVuY291bnRlciwKICAgIGVmZmVjdGl2ZTogby5lZmZlY3RpdmUsCiAgICBpc3N1ZWQ6IG8uaXNzdWVkLAogICAgdmFsdWU6IG8udmFsdWUsCiAgICBkYXRhQWJzZW50UmVhc29uOiBvLmRhdGFBYnNlbnRSZWFzb24sCiAgICBpbnRlcnByZXRhdGlvbjogby5pbnRlcnByZXRhdGlvbiwKICAgIGJvZHlTaXRlOiBvLmJvZHlTaXRlLAogICAgbWV0aG9kOiBvLm1ldGhvZCwKICAgIHNwZWNpbWVuOiBvLnNwZWNpbWVuLAogICAgcmVmZXJlbmNlUmFuZ2U6IE9ic2VydmF0aW9uUmVmZXJlbmNlUmFuZ2Uoby5yZWZlcmVuY2VSYW5nZSksCiAgICBoYXNNZW1iZXI6IG8uaGFzTWVtYmVyLAogICAgZGVyaXZlZEZyb206IG8uZGVyaXZlZEZyb20sCiAgICBjb21wb25lbnQ6IFNoYXJlZFJlc291cmNlLk9ic2VydmF0aW9uQ29tcG9uZW50KG8uY29tcG9uZW50KQogIH0KCmRlZmluZSBmdW5jdGlvbiBPYnNlcnZhdGlvblZpdGFsU2lnbnNDb2RpbmcoY29kaW5nIExpc3Q8Q29kaW5nPik6CiAgY29kaW5nIGMKICByZXR1cm4gQ29kaW5newogICAgc3lzdGVtOiBjLnN5c3RlbSwKICAgIHZlcnNpb246IGMudmVyc2lvbiwKICAgIGNvZGU6IGMuY29kZSwKICAgIGRpc3BsYXk6IGMuZGlzcGxheSwKICAgIHVzZXJTZWxlY3RlZDogYy51c2VyU2VsZWN0ZWQKICB9CgpkZWZpbmUgZnVuY3Rpb24gT2JzZXJ2YXRpb25WaXRhbFNpZ25zQ2F0ZWdvcnkoY2F0ZWdvcnkgTGlzdDxDb2RlYWJsZUNvbmNlcHQ+KToKICBjYXRlZ29yeSBjCiAgcmV0dXJuIENvZGVhYmxlQ29uY2VwdHsKICAgIGNvZGluZzogT2JzZXJ2YXRpb25WaXRhbFNpZ25zQ29kaW5nKGMuY29kaW5nKSwKICAgIHRleHQ6IGMudGV4dAogIH0KCmRlZmluZSBmdW5jdGlvbiBPYnNlcnZhdGlvblZpdGFsU2lnbnNDb21wb25lbnQoY29tcG9uZW50IExpc3Q8RkhJUi5PYnNlcnZhdGlvbi5Db21wb25lbnQ+KToKICBjb21wb25lbnQgYwogIHJldHVybiBGSElSLk9ic2VydmF0aW9uLkNvbXBvbmVudHsKICAgIGNvZGU6IGMuY29kZSwKICAgIHZhbHVlOiBjLnZhbHVlLAogICAgZGF0YUFic2VudFJlYXNvbjogYy5kYXRhQWJzZW50UmVhc29uLAogICAgaW50ZXJwcmV0YXRpb246IGMuaW50ZXJwcmV0YXRpb24sCiAgICByZWZlcmVuY2VSYW5nZTogU2hhcmVkUmVzb3VyY2UuT2JzZXJ2YXRpb25SZWZlcmVuY2VSYW5nZShjLnJlZmVyZW5jZVJhbmdlKQogIH0KCmRlZmluZSBmdW5jdGlvbiBPYnNlcnZhdGlvblZpdGFsU2lnbnNSZWZlcmVuY2VSYW5nZShyZWZlcmVuY2VSYW5nZSBMaXN0PEZISVIuT2JzZXJ2YXRpb24uUmVmZXJlbmNlUmFuZ2U+KToKICByZWZlcmVuY2VSYW5nZSByUgogIHJldHVybiBGSElSLk9ic2VydmF0aW9uLlJlZmVyZW5jZVJhbmdlewogICAgbG93OiByUi5sb3csCiAgICBoaWdoOiByUi5oaWdoLAogICAgdHlwZTogclIudHlwZSwKICAgIGFwcGxpZXNUbzogclIuYXBwbGllc1RvLAogICAgYWdlOiByUi5hZ2UKICB9CgpkZWZpbmUgZnVuY3Rpb24gT2JzZXJ2YXRpb25WaXRhbFNpZ25zUmVzb3VyY2Uob2JzZXJ2YXRpb24gT2JzZXJ2YXRpb24sIHByb2ZpbGVVUkxzIExpc3Q8RkhJUi5jYW5vbmljYWw+LCBhY2NlcHRlZENhdGVnb3JpZXMgTGlzdDxTeXN0ZW0uQ29kZT4pOgogIG9ic2VydmF0aW9uIG8KICByZXR1cm4gT2JzZXJ2YXRpb257CiAgICBpZDogRkhJUi5pZCB7dmFsdWU6ICdMQ1ItJyArIG8uaWR9LAogICAgbWV0YTogU2hhcmVkUmVzb3VyY2UuTWV0YUVsZW1lbnQobywgcHJvZmlsZVVSTHMpLAogICAgZXh0ZW5zaW9uOiBvLmV4dGVuc2lvbiwKICAgIHBhcnRPZjogby5wYXJ0T2YsCiAgICBzdGF0dXM6IG8uc3RhdHVzLAogICAgY2F0ZWdvcnk6IEZpbHRlckNvZGVhYmxlQ29uY2VwdHMoT2JzZXJ2YXRpb25WaXRhbFNpZ25zQ2F0ZWdvcnkoby5jYXRlZ29yeSksIGFjY2VwdGVkQ2F0ZWdvcmllcyksCiAgICBjb2RlOiBvLmNvZGUsCiAgICBzdWJqZWN0OiBvLnN1YmplY3QsCiAgICBlbmNvdW50ZXI6IG8uZW5jb3VudGVyLAogICAgZWZmZWN0aXZlOiBvLmVmZmVjdGl2ZSwKICAgIGlzc3VlZDogby5pc3N1ZWQsCiAgICB2YWx1ZTogby52YWx1ZSwKICAgIGRhdGFBYnNlbnRSZWFzb246IG8uZGF0YUFic2VudFJlYXNvbiwKICAgIGludGVycHJldGF0aW9uOiBvLmludGVycHJldGF0aW9uLAogICAgYm9keVNpdGU6IG8uYm9keVNpdGUsCiAgICBtZXRob2Q6IG8ubWV0aG9kLAogICAgc3BlY2ltZW46IG8uc3BlY2ltZW4sCiAgICByZWZlcmVuY2VSYW5nZTogT2JzZXJ2YXRpb25WaXRhbFNpZ25zUmVmZXJlbmNlUmFuZ2Uoby5yZWZlcmVuY2VSYW5nZSksCiAgICBoYXNNZW1iZXI6IG8uaGFzTWVtYmVyLAogICAgZGVyaXZlZEZyb206IG8uZGVyaXZlZEZyb20sCiAgICBjb21wb25lbnQ6IE9ic2VydmF0aW9uVml0YWxTaWduc0NvbXBvbmVudChvLmNvbXBvbmVudCkKICB9CgogZGVmaW5lIGZ1bmN0aW9uICJHZXRQcm9jZWR1cmVFeHRlbnNpb25zIihkb21haW5SZXNvdXJjZSBEb21haW5SZXNvdXJjZSk6CiAgZG9tYWluUmVzb3VyY2UuZXh0ZW5zaW9uIEUKICAgIHdoZXJlIEUudXJsICE9ICdodHRwOi8vaGw3Lm9yZy9maGlyL3VzL3FpY29yZS9TdHJ1Y3R1cmVEZWZpbml0aW9uL3FpY29yZS1yZWNvcmRlZCcKICAgICByZXR1cm4gRQogCmRlZmluZSBmdW5jdGlvbiBQcm9jZWR1cmVSZXNvdXJjZShwcm9jZWR1cmUgUHJvY2VkdXJlLCBwcm9maWxlVVJMcyBMaXN0PEZISVIuY2Fub25pY2FsPiwgYWNjZXB0ZWRDYXRlZ29yaWVzIExpc3Q8U3lzdGVtLkNvZGU+KToKICBwcm9jZWR1cmUgcAogIHJldHVybiBQcm9jZWR1cmV7CiAgICBpZDogRkhJUi5pZCB7dmFsdWU6ICdMQ1ItJyArIHAuaWR9LAogICAgbWV0YTogU2hhcmVkUmVzb3VyY2UuTWV0YUVsZW1lbnQocCwgcHJvZmlsZVVSTHMpLAogICAgZXh0ZW5zaW9uOiBHZXRQcm9jZWR1cmVFeHRlbnNpb25zKHApLCAKICAgIGJhc2VkT246IHAuYmFzZWRPbiwKICAgIHBhcnRPZjogcC5wYXJ0T2YsCiAgICBzdGF0dXM6IHAuc3RhdHVzLAogICAgY2F0ZWdvcnk6IEZpbHRlckNvZGVhYmxlQ29uY2VwdHMoe3AuY2F0ZWdvcnl9LCBhY2NlcHRlZENhdGVnb3JpZXMpWzBdLAogICAgY29kZTogcC5jb2RlLAogICAgc3ViamVjdDogcC5zdWJqZWN0LAogICAgZW5jb3VudGVyOiBwLmVuY291bnRlciwKICAgIHBlcmZvcm1lZDogcC5wZXJmb3JtZWQsCiAgICBsb2NhdGlvbjogcC5sb2NhdGlvbiwKICAgIHJlYXNvbkNvZGU6IHAucmVhc29uQ29kZSwKICAgIHJlYXNvblJlZmVyZW5jZTogcC5yZWFzb25SZWZlcmVuY2UsCiAgICBib2R5U2l0ZTogcC5ib2R5U2l0ZQogIH0KCiAgZGVmaW5lIGZ1bmN0aW9uIFNlcnZpY2VSZXF1ZXN0UmVzb3VyY2Uoc2VydmljZVJlcXVlc3QgU2VydmljZVJlcXVlc3QsIHByb2ZpbGVVUkxzIExpc3Q8RkhJUi5jYW5vbmljYWw+LCBhY2NlcHRlZENhdGVnb3JpZXMgTGlzdDxTeXN0ZW0uQ29kZT4pOgogIHNlcnZpY2VSZXF1ZXN0IHNSCiAgcmV0dXJuIFNlcnZpY2VSZXF1ZXN0ewogICAgaWQ6IEZISVIuaWQge3ZhbHVlOiAnTENSLScgKyBzUi5pZH0sCiAgICBtZXRhOiBTaGFyZWRSZXNvdXJjZS5NZXRhRWxlbWVudChzUiwgcHJvZmlsZVVSTHMpLAogICAgZXh0ZW5zaW9uOiBzUi5leHRlbnNpb24sCiAgICBiYXNlZE9uOiBzUi5iYXNlZE9uLAogICAgc3RhdHVzOiBzUi5zdGF0dXMsCiAgICBpbnRlbnQ6IHNSLmludGVudCwKICAgIGNhdGVnb3J5OiBGaWx0ZXJDb2RlYWJsZUNvbmNlcHRzKHNSLmNhdGVnb3J5LCBhY2NlcHRlZENhdGVnb3JpZXMpLAogICAgcHJpb3JpdHk6IHNSLnByaW9yaXR5LAogICAgZG9Ob3RQZXJmb3JtOiBzUi5kb05vdFBlcmZvcm0sCiAgICBjb2RlOiBzUi5jb2RlLAogICAgcXVhbnRpdHk6IHNSLnF1YW50aXR5LAogICAgc3ViamVjdDogc1Iuc3ViamVjdCwKICAgIGVuY291bnRlcjogc1IuZW5jb3VudGVyLAogICAgb2NjdXJyZW5jZTogc1Iub2NjdXJyZW5jZSwKICAgIGFzTmVlZGVkOiBzUi5hc05lZWRlZCwKICAgIGF1dGhvcmVkT246IHNSLmF1dGhvcmVkT24sCiAgICBzcGVjaW1lbjogc1Iuc3BlY2ltZW4KICB9CgogIGRlZmluZSBmdW5jdGlvbiBTcGVjaW1lbkNvbGxlY3Rpb24oY29sbGVjdGlvbiBGSElSLlNwZWNpbWVuLkNvbGxlY3Rpb24pOgogIGNvbGxlY3Rpb24gYwogIHJldHVybiBGSElSLlNwZWNpbWVuLkNvbGxlY3Rpb257CiAgICBjb2xsZWN0b3I6IGMuY29sbGVjdG9yLAogICAgY29sbGVjdGVkOiBjLmNvbGxlY3RlZCwKICAgIHF1YW50aXR5OiBjLnF1YW50aXR5LAogICAgYm9keVNpdGU6IGMuYm9keVNpdGUKICB9CgogIGRlZmluZSBmdW5jdGlvbiBTcGVjaW1lblJlc291cmNlKHNwZWNpbWVuIFNwZWNpbWVuLCBwcm9maWxlVVJMcyBMaXN0PEZISVIuY2Fub25pY2FsPik6CiAgc3BlY2ltZW4gcwogIHJldHVybiBTcGVjaW1lbnsKICAgIGlkOiBGSElSLmlkIHt2YWx1ZTogJ0xDUi0nICsgcy5pZH0sCiAgICBtZXRhOiBTaGFyZWRSZXNvdXJjZS5NZXRhRWxlbWVudChzLCBwcm9maWxlVVJMcyksCiAgICBleHRlbnNpb246IHMuZXh0ZW5zaW9uLAogICAgaWRlbnRpZmllcjogcy5pZGVudGlmaWVyLAogICAgYWNjZXNzaW9uSWRlbnRpZmllcjogcy5hY2Nlc3Npb25JZGVudGlmaWVyLAogICAgc3RhdHVzOiBzLnN0YXR1cywKICAgIHR5cGU6IHMudHlwZSwKICAgIHN1YmplY3Q6IHMuc3ViamVjdCwKICAgIHBhcmVudDogcy5wYXJlbnQsCiAgICByZXF1ZXN0OiBzLnJlcXVlc3QsCiAgICBjb2xsZWN0aW9uOiBTcGVjaW1lbkNvbGxlY3Rpb24ocy5jb2xsZWN0aW9uKSwKICAgIG5vdGU6IHMubm90ZQogIH0=",
+            "url": "http://www.cdc.gov/nhsn/fhirportal/dqm/ig/Library-NHSNAcuteCareHospitalMonthlyInitialPopulation.cql"
           }
         ]
       },
@@ -5657,6 +5397,10 @@
       "resource": {
         "resourceType": "Library",
         "id": "SharedResourceCreation",
+        "text": {
+          "status": "extensions",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n<div>\n    <table class=\"grid dict\">\n        \n        \n\n        \n        \n        <tr>\n            <th scope=\"row\"><b>Id: </b></th>\n            <td style=\"padding-left: 4px;\">SharedResourceCreation</td>\n        </tr>\n        \n\n        \n        \n        <tr>\n            <th scope=\"row\"><b>Version: </b></th>\n            <td style=\"padding-left: 4px;\">2.0.0-cibuild</td>\n        </tr>\n        \n\n        \n        <tr>\n            <th scope=\"row\"><b>Url: </b></th>\n            <td style=\"padding-left: 4px;\"><a href=\"Library-SharedResourceCreation.html\">SharedResourceCreation</a></td>\n        </tr>\n        \n\n        \n\n        \n\n        \n        <tr>\n            <th scope=\"row\"><b>Status: </b></th>\n            <td style=\"padding-left: 4px;\">draft</td>\n        </tr>\n        \n\n        \n\n        \n        <tr>\n            <th scope=\"row\"><b>Type: </b></th>\n            <td style=\"padding-left: 4px;\">\n                \n                    \n                        \n                        <p style=\"margin-bottom: 5px;\">\n                            <b>system: </b> <span><a href=\"http://terminology.hl7.org/7.0.1/CodeSystem-library-type.html\">http://terminology.hl7.org/CodeSystem/library-type</a></span>\n                        </p>\n                        \n                        \n                        <p style=\"margin-bottom: 5px;\">\n                            <b>code: </b> <span>logic-library</span>\n                        </p>\n                        \n                        \n                    \n                \n                \n            </td>\n        </tr>\n        \n\n        \n\n        \n        <tr>\n            <th scope=\"row\"><b>Date: </b></th>\n            <td style=\"padding-left: 4px;\">2026-01-08 14:28:51+0000</td>\n        </tr>\n        \n\n        \n        <tr>\n            <th scope=\"row\"><b>Publisher: </b></th>\n            <td style=\"padding-left: 4px;\">CDC National Healthcare Safety Network (NHSN)</td>\n        </tr>\n        \n\n        \n\n        \n\n        \n\n        \n\n        \n        <tr>\n            <th scope=\"row\"><b>Jurisdiction: </b></th>\n            <td style=\"padding-left: 4px;\">US</td>\n        </tr>\n        \n\n        \n\n        \n\n        \n\n        \n\n        \n\n        \n\n        \n        <tr>\n            <th scope=\"row\"><b>Related Artifacts: </b></th>\n            <td style=\"padding-left: 4px;\">\n                \n                \n                \n                <p><b>Dependencies</b></p>\n                <ul>\n                  \n                    <li><a href=\"http://fhir.org/guides/cqf/common/4.0.1/4.0.1/Library-FHIR-ModelInfo.html\">http://fhir.org/guides/cqf/common/Library/FHIR-ModelInfo|4.0.1</a></li>\n                  \n                    <li><code>http://www.cdc.gov/nhsn/fhirportal/dqm/ig/Library/FHIRHelpers|4.0.2</code></li>\n                  \n                </ul>\n                \n                \n                \n                \n                \n            </td>\n        </tr>\n        \n\n        \n\n        \n\n        \n        \n        <tr>\n          <td colspan=\"2\">\n            <table>\n              <tr><th><a id=\"cql-content\"><b>Content: </b></a> text/cql</th></tr>\n              <tr><td><pre><code class=\"language-cql\">library SharedResourceCreation version '0.1.010'\n\ninclude FHIRHelpers version '4.0.2'\n\nusing FHIR version '4.0.1'\n\ndefine function &quot;GetPatientExtensions&quot;(domainResource DomainResource):\n  domainResource.extension E\n  where E.url = 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-race'\n    or E.url = 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity'\n    or E.url = 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-tribal-affiliation'\n    or E.url = 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-birthsex'\n    or E.url = 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-sex'\n    or E.url = 'http://www.cdc.gov/nhsn/fhirportal/dqm/ig/StructureDefinition/link-original-resource-id-extension'\n  return E\n\ndefine function &quot;MetaElement&quot;(resource Resource, profileURLs List&lt;FHIR.canonical&gt;):\n  resource r\n  return FHIR.Meta{\n    extension: r.meta.extension,\n    versionId: r.meta.versionId,\n    lastUpdated: r.meta.lastUpdated,\n    profile: profileURLs,\n    security: r.meta.security,\n    tag: r.meta.tag\n  }\n\ndefine function ConditionStage(stage List&lt;FHIR.Condition.Stage&gt;):\n  stage s\n  return FHIR.Condition.Stage{\n    summary: s.summary,\n    assessment: s.assessment,\n    type: s.type\n  }\n\ndefine function ConditionEvidence(evidence List&lt;FHIR.Condition.Evidence&gt;):\n  evidence e\n  return FHIR.Condition.Evidence{\n    code: e.code,\n    detail: e.detail\n  }\n\ndefine function ConditionResource(condition Condition, profileURLs List&lt;FHIR.canonical&gt;):\n  condition c\n  return Condition{\n    id: FHIR.id {value: 'LCR-' + c.id},\n    meta: MetaElement(c, profileURLs),\n    extension: c.extension,\n    clinicalStatus: c.clinicalStatus,\n    verificationStatus: c.verificationStatus,\n    category: c.category,\n    severity: c.severity,\n    code: c.code,\n    bodySite: c.bodySite,\n    subject: c.subject,\n    encounter: c.encounter,\n    onset: c.onset,\n    abatement: c.abatement,\n    recordedDate: c.recordedDate,\n    stage: ConditionStage(c.stage),\n    evidence: ConditionEvidence(c.evidence),\n    note: c.note\n  }\n\ndefine function CoverageClass(class List&lt;FHIR.Coverage.Class&gt;):\n  class c\n  return FHIR.Coverage.Class{\n    value: c.value,\n    name: c.name\n  }\n\ndefine function CoverageResource(coverage Coverage, profileURLs List&lt;FHIR.canonical&gt;):\n  coverage c\n  return Coverage{\n    id: FHIR.id{value: 'LCR-' + c.id},\n    meta: MetaElement(c, profileURLs),\n    extension: c.extension,\n    status: c.status,\n    type: c.type,\n    policyHolder: c.policyHolder,\n    subscriber: c.subscriber,\n    subscriberId: c.subscriberId,\n    beneficiary: c.beneficiary,\n    dependent: c.dependent,\n    relationship: c.relationship,\n    period: c.period,\n    payor: c.payor,\n    class: CoverageClass(c.class),\n    order: c.order,\n    network: c.network,\n    subrogation: c.subrogation,\n    contract: c.contract\n  }\n\ndefine function DiagnosticReportCoding(coding List&lt;Coding&gt;):\n  coding c\n  return Coding{\n    system: c.system,\n    version: c.version,\n    code: c.code,\n    display: c.display,\n    userSelected: c.userSelected\n  }\n\ndefine function DiagnosticReportCategory(category List&lt;CodeableConcept&gt;):\n  category c\n  return CodeableConcept{\n    coding: DiagnosticReportCoding(c.coding)\n  }\n\ndefine function DiagnosticReportLabResource(diagnosticReport DiagnosticReport, profileURLs List&lt;FHIR.canonical&gt;):\n  diagnosticReport d\n  return DiagnosticReport{\n    id: FHIR.id{value: 'LCR-' + d.id},\n    meta: MetaElement(d, profileURLs),\n    extension: d.extension,\n    basedOn: d.basedOn,\n    status: d.status,\n    category: DiagnosticReportCategory(d.category),\n    code: d.code,\n    subject: d.subject,\n    encounter: d.encounter,\n    effective: d.effective,\n    issued: d.issued,\n    performer: d.performer,\n    resultsInterpreter: d.resultsInterpreter,\n    specimen: d.specimen,\n    result: d.result,\n    conclusion: d.conclusion,\n    conclusionCode: d.conclusionCode\n  }\n\ndefine function EncounterIdentifier(identifier List&lt;FHIR.Identifier&gt;):\n  identifier i\n  return FHIR.Identifier{\n    use: i.use,\n    type: i.type,\n    system: i.system,\n    value: i.value,\n    period: i.period\n  }\n\ndefine function EncounterStatusHistory(statusHistory List&lt;FHIR.Encounter.StatusHistory&gt;):\n  statusHistory sH\n  return FHIR.Encounter.StatusHistory{\n    status: sH.status,\n    period: sH.period\n  }\n\ndefine function EncounterClassHistory(classHistory List&lt;FHIR.Encounter.ClassHistory&gt;):\n  classHistory cH\n  return FHIR.Encounter.ClassHistory{\n    class: cH.class,\n    period: cH.period\n  }\n\n/*No longer needed but saving for potential future use\ndefine function EncounterParticipant(participant List&lt;FHIR.Encounter.Participant&gt;):\n  participant p\n  return FHIR.Encounter.Participant{\n    type: p.type,\n    period: p.period,\n    individual: p.individual\n  }*/\n\ndefine function EncounterDiagnosis(diagnosis List&lt;FHIR.Encounter.Diagnosis&gt;):\n  diagnosis d\n  return FHIR.Encounter.Diagnosis{\n    condition: d.condition,\n    use: d.use,\n    rank: d.rank\n  }\n\ndefine function EncounterHospitalization(hospitalization FHIR.Encounter.Hospitalization):\n  hospitalization h\n  return FHIR.Encounter.Hospitalization{\n    preAdmissionIdentifier: h.preAdmissionIdentifier,\n    origin: h.origin,\n    admitSource: h.admitSource,\n    reAdmission: h.reAdmission,\n    dietPreference: h.dietPreference,\n    specialCourtesy: h.specialCourtesy,\n    specialArrangement: h.specialArrangement,\n    destination: h.destination,\n    dischargeDisposition: h.dischargeDisposition\n  }\n\ndefine function EncounterLocation(location List&lt;FHIR.Encounter.Location&gt;):\n  location l\n  return FHIR.Encounter.Location{\n    location: l.location,\n    status: l.status,\n    physicalType: l.physicalType,\n    period: l.period\n  }\n\ndefine function EncounterResource(encounter Encounter, profileURLs List&lt;FHIR.canonical&gt;):\n  encounter e\n  return Encounter{\n    id: FHIR.id{value: 'LCR-' + e.id},\n    meta: MetaElement(e, profileURLs),\n    extension: e.extension,\n    identifier: EncounterIdentifier(e.identifier),\n    status: e.status,\n    statusHistory: EncounterStatusHistory(e.statusHistory),\n    class: e.class,\n    classHistory: EncounterClassHistory(e.classHistory),\n    type: e.type,\n    serviceType: e.serviceType,\n    priority: e.priority,\n    subject: e.subject,\n    period: e.period,\n    length: e.length,\n    reasonCode: e.reasonCode,\n    reasonReference: e.reasonReference,\n    diagnosis: EncounterDiagnosis(e.diagnosis),\n    account: e.account,\n    hospitalization: EncounterHospitalization(e.hospitalization),\n    location: EncounterLocation(e.location),\n    partOf: e.partOf\n  }\n\ndefine function ObservationLabCoding(coding List&lt;Coding&gt;):\n  coding c\n  return Coding{\n    id: c.id,\n    extension: c.extension,\n    system: c.system,\n    version: c.version,\n    code: c.code,\n    display: c.display,\n    userSelected: c.userSelected\n  }\n\ndefine function ObservationLabCategory(category List&lt;CodeableConcept&gt;):\n  category c\n  return CodeableConcept{\n    coding: ObservationLabCoding(c.coding),\n    text: c.text\n  }\n\ndefine function ObservationReferenceRange(referenceRange List&lt;FHIR.Observation.ReferenceRange&gt;):\n  referenceRange rR\n  return FHIR.Observation.ReferenceRange{\n    low: rR.low,\n    high: rR.high,\n    type: rR.type,\n    appliesTo: rR.appliesTo,\n    age: rR.age,\n    text: rR.text\n  }\n\ndefine function ObservationComponent(component List&lt;FHIR.Observation.Component&gt;):\n  component c\n  return FHIR.Observation.Component{\n    code: c.code,\n    value: c.value,\n    dataAbsentReason: c.dataAbsentReason,\n    interpretation: c.interpretation,\n    referenceRange: c.referenceRange\n  }\n\ndefine function ObservationLabResource(observation Observation, profileURLs List&lt;FHIR.canonical&gt;):\n  observation o\n  return Observation{\n    id: FHIR.id {value: 'LCR-' + o.id},\n    meta: MetaElement(o, profileURLs),\n    extension: o.extension,\n    basedOn: o.basedOn,\n    partOf: o.partOf,\n    status: o.status,\n    category: ObservationLabCategory(o.category),\n    code: o.code,\n    subject: o.subject,\n    focus: o.focus,\n    encounter: o.encounter,\n    effective: o.effective,\n    issued: o.issued,\n    performer: o.performer,\n    value: o.value,\n    dataAbsentReason: o.dataAbsentReason,\n    interpretation: o.interpretation,\n    note: o.note,\n    bodySite: o.bodySite,\n    method: o.method,\n    specimen: o.specimen,\n    device: o.device,\n    referenceRange: ObservationReferenceRange(o.referenceRange),\n    hasMember: o.hasMember,\n    derivedFrom: o.derivedFrom,\n    component: ObservationComponent(o.component)\n  }\n\ndefine function LocationAddress(address FHIR.Address):\n  address a\n  return FHIR.Address{\n    use: a.use,\n    type: a.type,\n    text: a.text,\n    line: a.line,\n    city: a.city,\n    district: a.district,\n    state: a.state,\n    postalCode: a.postalCode,\n    country: a.country,\n    period: a.period\n  }\n\ndefine function LocationPosition(position FHIR.Location.Position):\n  position p\n  return FHIR.Location.Position{\n    longitude: p.longitude,\n    latitude: p.latitude,\n    altitude: p.altitude\n  }\n\ndefine function LocationHoursOfOperation(hoursOfOperation List&lt;FHIR.Location.HoursOfOperation&gt;):\n  hoursOfOperation hOO\n  return FHIR.Location.HoursOfOperation{\n    daysOfWeek: hOO.daysOfWeek,\n    allDay: hOO.allDay,\n    openingTime: hOO.openingTime,\n    closingTime: hOO.closingTime\n  }\n\ndefine function LocationResource(location Location, profileURLs List&lt;FHIR.canonical&gt;):\n  location l\n  return Location{\n    id: FHIR.id {value: 'LCR-' + l.id},\n    meta: MetaElement(l, profileURLs),\n    extension: l.extension,\n    status: l.status,\n    operationalStatus: l.operationalStatus,\n    name: l.name,\n    alias: l.alias,\n    description: l.description,\n    mode: l.mode,\n    type: l.type,\n    telecom: l.telecom,\n    address: LocationAddress(l.address),\n    physicalType: l.physicalType,\n    position: LocationPosition(l.position),\n    managingOrganization: l.managingOrganization,\n    partOf: l.partOf,\n    hoursOfOperation: LocationHoursOfOperation(l.hoursOfOperation),\n    availabilityExceptions: l.availabilityExceptions,\n    endpoint: l.endpoint\n  }\n\ndefine function MedicationIngredient(ingredient List&lt;FHIR.Medication.Ingredient&gt;):\n  ingredient i\n  return FHIR.Medication.Ingredient{\n    item: i.item,\n    strength: i.strength\n  }\n\ndefine function MedicationBatch(batch FHIR.Medication.Batch):\n  batch b\n  return FHIR.Medication.Batch{\n    lotNumber: b.lotNumber,\n    expirationDate: b.expirationDate\n  }\n\ndefine function MedicationResource(medication Medication, profileURLs List&lt;FHIR.canonical&gt;):\n  medication m\n  return Medication{\n    id: FHIR.id {value: 'LCR-' + m.id},\n    meta: MetaElement(m, profileURLs),\n    extension: m.extension,\n    code: m.code,\n    status: m.status,\n    manufacturer: m.manufacturer,\n    form: m.form,\n    amount: m.amount,\n    ingredient: MedicationIngredient(m.ingredient),\n    batch: MedicationBatch(m.batch)\n  }\n\ndefine function MedicationAdministrationPerformer(performer List&lt;FHIR.MedicationAdministration.Performer&gt;):\n  performer p\n  return FHIR.MedicationAdministration.Performer{\n    function: p.function,\n    actor: p.actor\n  }\n\ndefine function MedicationAdministrationDosage(dosage FHIR.MedicationAdministration.Dosage):\n  dosage d\n  return FHIR.MedicationAdministration.Dosage{\n    text: d.text,\n    site: d.site,\n    route: d.route,\n    method: d.method,\n    dose: d.dose,\n    rate: d.rate\n  }\n\ndefine function MedicationAdministrationResource(medicationAdministration MedicationAdministration, profileURLs List&lt;FHIR.canonical&gt;):\n  medicationAdministration m\n  return MedicationAdministration{\n    id: FHIR.id {value: 'LCR-' + m.id},\n    meta: MetaElement(m, profileURLs),\n    extension: m.extension,\n    instantiates: m.instantiates,\n    partOf: m.partOf,\n    status: m.status,\n    statusReason: m.statusReason,\n    category: m.category,\n    medication: m.medication,\n    subject: m.subject,\n    context: m.context,\n    supportingInformation: m.supportingInformation,\n    effective: m.effective,\n    performer: MedicationAdministrationPerformer(m.performer),\n    reasonCode: m.reasonCode,\n    reasonReference: m.reasonReference,\n    request: m.request,\n    device: m.device,\n    note: m.note,\n    dosage: MedicationAdministrationDosage(m.dosage),\n    eventHistory: m.eventHistory\n  }\n\ndefine function MedicationRequestDoseAndRate(doseAndRate List&lt;FHIR.Dosage.DoseAndRate&gt;):\n  doseAndRate dR\n  return FHIR.Dosage.DoseAndRate{\n    type: dR.type,\n    dose: dR.dose,\n    rate: dR.rate\n  }\n\ndefine function MedicationRequestDosageInstruction(dosageInstruction List&lt;FHIR.Dosage&gt;):\n  dosageInstruction dI\n  return FHIR.Dosage{\n    text: dI.text,\n    patientInstruction: dI.patientInstruction,\n    timing: dI.timing,\n    asNeeded: dI.asNeeded,\n    site: dI.site,\n    route: dI.route,\n    method: dI.method,\n    doseAndRate: MedicationRequestDoseAndRate(dI.doseAndRate)\n  }\n\ndefine function MedicationRequestResource(medicationRequest MedicationRequest, profileURLs List&lt;FHIR.canonical&gt;):\n  medicationRequest m\n  return MedicationRequest{\n    id: FHIR.id {value: 'LCR-' + m.id},\n    meta: MetaElement(medicationRequest, profileURLs),\n    extension: m.extension,\n    status: m.status,\n    statusReason: m.statusReason,\n    intent: m.intent,\n    category: m.category,\n    priority: m.priority,\n    doNotPerform: m.doNotPerform,\n    reported: m.reported,\n    medication: m.medication,\n    subject: m.subject,\n    encounter: m.encounter,\n    authoredOn: m.authoredOn,\n    requester: m.requester,\n    recorder: m.recorder,\n    reasonCode: m.reasonCode,\n    reasonReference: m.reasonReference,\n    instantiatesCanonical: m.instantiatesCanonical,\n    instantiatesUri: m.instantiatesUri,\n    courseOfTherapyType: m.courseOfTherapyType,\n    dosageInstruction: MedicationRequestDosageInstruction(m.dosageInstruction)\n  }\n\n/* No longer needed but saving in case it's useful later\ndefine function PatientIdentifier(identifier List&lt;FHIR.Identifier&gt;):\n  identifier i\n  return FHIR.Identifier{\n    id: i.id,\n    extension: i.extension,\n    use: i.use,\n    type: i.type,\n    system: i.system,\n    value: i.value,\n    period: i.period,\n    assigner: i.assigner\n  }*/\n\ndefine function PatientName(name List&lt;FHIR.HumanName&gt;):\n  name n\n  return FHIR.HumanName{\n    id: n.id,\n    extension: n.extension,\n    use: n.use,\n    text: n.text,\n    family: n.family,\n    given: n.given,\n    prefix: n.prefix,\n    suffix: n.suffix,\n    period: n.period\n  }\n\ndefine function PatientTelecom(telecom List&lt;FHIR.ContactPoint&gt;):\n  telecom t\n  return FHIR.ContactPoint{\n    system: t.system,\n    value: t.value,\n    use: t.use,\n    rank: t.rank,\n    period: t.period\n  }\n\ndefine function PatientAddress(address List&lt;FHIR.Address&gt;):\n  address a\n  return FHIR.Address{\n    use: a.use,\n    type: a.type,\n    text: a.text,\n    line: a.line,\n    city: a.city,\n    district: a.district,\n    state: a.state,\n    postalCode: a.postalCode,\n    country: a.country,\n    period: a.period\n  }\n\ndefine function PatientContact(contact List&lt;FHIR.Patient.Contact&gt;):\n  contact c\n  return FHIR.Patient.Contact{\n    relationship: c.relationship,\n    name: c.name,\n    telecom: c.telecom,\n    address: c.address,\n    gender: c.gender,\n    organization: c.organization,\n    period: c.period\n  }\n\ndefine function PatientCommunication(communication List&lt;FHIR.Patient.Communication&gt;):\n  communication c\n  return FHIR.Patient.Communication{\n    language: c.language,\n    preferred: c.preferred\n  }\n\ndefine function PatientLink(link List&lt;FHIR.Patient.Link&gt;):\n  link l\n  return FHIR.Patient.Link{\n    extension: l.extension,\n    modifierExtension: l.modifierExtension,\n    other: l.other,\n    type: l.type\n  }\n\ndefine function PatientResource(patient Patient, profileURLs List&lt;FHIR.canonical&gt;):\n  patient p\n  return Patient{\n    id: FHIR.id{value: 'LCR-' + p.id},\n    meta: MetaElement(p, profileURLs),\n    extension: GetPatientExtensions(p),\n    identifier: p.identifier,\n    active: p.active,\n    name: PatientName(p.name),\n    telecom: PatientTelecom(p.telecom),\n    gender: p.gender,\n    birthDate: p.birthDate,\n    deceased: p.deceased,\n    address: PatientAddress(p.address),\n    maritalStatus: p.maritalStatus,\n    multipleBirth: p.multipleBirth,\n    contact: PatientContact(p.contact),\n    communication: PatientCommunication(p.communication),\n    link: PatientLink(p.link)\n  }\n\ndefine function ProcedurePerformer(performer List&lt;FHIR.Procedure.Performer&gt;):\n  performer p\n  return FHIR.Procedure.Performer{\n    function: p.function,\n    actor: p.actor,\n    onBehalfOf: p.onBehalfOf\n  }\n\ndefine function ProcedureFocalDevice(device List&lt;FHIR.Procedure.FocalDevice&gt;):\n  device d\n  return FHIR.Procedure.FocalDevice{\n    action: d.action,\n    manipulated: d.manipulated\n  }\n\ndefine function ProcedureResource(procedure Procedure, profileURLs List&lt;FHIR.canonical&gt;):\n  procedure p\n  return Procedure{\n    id: FHIR.id {value: 'LCR-' + p.id},\n    meta: MetaElement(p, profileURLs),\n    extension: p.extension,\n    instantiatesCanonical: p.instantiatesCanonical,\n    instantiatesUri: p.instantiatesUri,\n    basedOn: p.basedOn,\n    partOf: p.partOf,\n    status: p.status,\n    statusReason: p.statusReason,\n    category: p.category,\n    code: p.code,\n    subject: p.subject,\n    encounter: p.encounter,\n    performed: p.performed,\n    recorder: p.recorder,\n    asserter: p.asserter,\n    performer: ProcedurePerformer(p.performer),\n    location: p.location,\n    reasonCode: p.reasonCode,\n    reasonReference: p.reasonReference,\n    bodySite: p.bodySite,\n    outcome: p.outcome,\n    report: p.report,\n    complication: p.complication,\n    complicationDetail: p.complicationDetail,\n    followUp: p.followUp,\n    note: p.note,\n    focalDevice: ProcedureFocalDevice(p.focalDevice),\n    usedReference: p.usedReference,\n    usedCode: p.usedCode\n  }\n\ndefine function ServiceRequestResource(serviceRequest ServiceRequest, profileURLs List&lt;FHIR.canonical&gt;):\n  serviceRequest sR\n  return ServiceRequest{\n    id: FHIR.id {value: 'LCR-' + sR.id},\n    meta: MetaElement(sR, profileURLs),\n    extension: sR.extension,\n    instantiatesCanonical: sR.instantiatesCanonical,\n    instantiatesUri: sR.instantiatesUri,\n    basedOn: sR.basedOn,\n    replaces: sR.replaces,\n    requisition: sR.requisition,\n    status: sR.status,\n    intent: sR.intent,\n    category: sR.category,\n    priority: sR.priority,\n    doNotPerform: sR.doNotPerform,\n    code: sR.code,\n    orderDetail: sR.orderDetail,\n    quantity: sR.quantity,\n    subject: sR.subject,\n    encounter: sR.encounter,\n    occurrence: sR.occurrence,\n    asNeeded: sR.asNeeded,\n    authoredOn: sR.authoredOn,\n    requester: sR.requester,\n    performerType: sR.performerType,\n    performer: sR.performer,\n    locationCode: sR.locationCode,\n    locationReference: sR.locationReference,\n    reasonCode: sR.reasonCode,\n    reasonReference: sR.reasonReference,\n    insurance: sR.insurance,\n    supportingInfo: sR.supportingInfo,\n    specimen: sR.specimen,\n    bodySite: sR.bodySite,\n    note: sR.note,\n    patientInstruction: sR.patientInstruction,\n    relevantHistory: sR.relevantHistory\n  }\n\ndefine function SpecimenCollection(collection FHIR.Specimen.Collection):\n  collection c\n  return FHIR.Specimen.Collection{\n    collector: c.collector,\n    collected: c.collected,\n    &quot;duration&quot;: c.&quot;duration&quot;,\n    quantity: c.quantity,\n    method: c.method,\n    bodySite: c.bodySite,\n    fastingStatus: c.fastingStatus\n  }\n\ndefine function SpecimenProcessing(processing List&lt;FHIR.Specimen.Processing&gt;):\n  processing p\n  return FHIR.Specimen.Processing{\n    description: p.description,\n    procedure: p.procedure,\n    additive: p.additive,\n    time: p.time\n  }\n\ndefine function SpecimenContainer(container List&lt;FHIR.Specimen.Container&gt;):\n  container c\n  return FHIR.Specimen.Container{\n    description: c.description,\n    type: c.type,\n    capacity: c.capacity,\n    specimenQuantity: c.specimenQuantity,\n    additive: c.additive\n  }\n\ndefine function SpecimenResource(specimen Specimen, profileURLs List&lt;FHIR.canonical&gt;):\n  specimen s\n  return Specimen{\n    id: FHIR.id {value: 'LCR-' + s.id},\n    meta: MetaElement(s, profileURLs),\n    extension: s.extension,\n    identifier: s.identifier,\n    accessionIdentifier: s.accessionIdentifier,\n    status: s.status,\n    type: s.type,\n    subject: s.subject,\n    receivedTime: s.receivedTime,\n    parent: s.parent,\n    request: s.request,\n    collection: SpecimenCollection(s.collection),\n    processing: SpecimenProcessing(s.processing),\n    container: SpecimenContainer(s.container),\n    condition: s.condition,\n    note: s.note\n  }\n\ndefine function &quot;OperationOutcomeResource&quot;(errorId String, resourceId FHIR.id, message String):\n  OperationOutcome{\n      id: FHIR.id{value: errorId},\n      issue: {\n          FHIR.OperationOutcome.Issue{\n          severity: FHIR.IssueSeverity{value: 'error'},\n          code: FHIR.IssueType{value: 'exception'},\n          details: \n              FHIR.CodeableConcept{\n                  coding: {\n                      Coding{\n                      system: uri{value: 'https://lantanagroup.com/validation-error'},\n                      code: code{value: 'Error'},\n                      display: string{value: 'Resource ' + resourceId + ' failed validation: ' + message}\n                      }\n                  }\n              }\n          }\n      }\n  }</code></pre></td></tr>\n            </table>\n          </td>\n        </tr>\n        \n        \n        \n    </table>\n</div>\n</div>"
+        },
         "contained": [
           {
             "resourceType": "Parameters",
@@ -5727,11 +5471,18 @@
             "valueReference": {
               "reference": "#options"
             }
+          },
+          {
+            "url": "http://hl7.org/fhir/uv/crmi/StructureDefinition/crmi-softwaresystem",
+            "valueReference": {
+              "reference": "Device/cqf-tooling"
+            }
           }
         ],
         "url": "http://www.cdc.gov/nhsn/fhirportal/dqm/ig/Library/SharedResourceCreation",
-        "version": "0.1.009",
+        "version": "0.1.010",
         "name": "SharedResourceCreation",
+        "status": "draft",
         "type": {
           "coding": [
             {
@@ -5740,6 +5491,33 @@
             }
           ]
         },
+        "date": "2026-01-08T14:28:51+00:00",
+        "publisher": "CDC National Healthcare Safety Network (NHSN)",
+        "contact": [
+          {
+            "name": "CDC National Healthcare Safety Network (NHSN)",
+            "telecom": [
+              {
+                "system": "url",
+                "value": "http://www.cdc.gov/nhsn"
+              },
+              {
+                "system": "email",
+                "value": "nhsn@cdc.gov"
+              }
+            ]
+          }
+        ],
+        "jurisdiction": [
+          {
+            "coding": [
+              {
+                "system": "urn:iso:std:iso:3166",
+                "code": "US"
+              }
+            ]
+          }
+        ],
         "relatedArtifact": [
           {
             "type": "depends-on",
@@ -5755,7 +5533,8 @@
         "content": [
           {
             "contentType": "text/cql",
-            "data": "bGlicmFyeSBTaGFyZWRSZXNvdXJjZUNyZWF0aW9uIHZlcnNpb24gJzAuMS4wMDknCgppbmNsdWRlIEZISVJIZWxwZXJzIHZlcnNpb24gJzQuMC4yJwoKdXNpbmcgRkhJUiB2ZXJzaW9uICc0LjAuMScKCmRlZmluZSBmdW5jdGlvbiAiR2V0SWRFeHRlbnNpb25zIihkb21haW5SZXNvdXJjZSBEb21haW5SZXNvdXJjZSk6CiAgZG9tYWluUmVzb3VyY2UuZXh0ZW5zaW9uIEUKICB3aGVyZSBFLnVybC52YWx1ZSA9ICdodHRwOi8vd3d3LmNkYy5nb3Yvbmhzbi9maGlycG9ydGFsL2RxbS9pZy9TdHJ1Y3R1cmVEZWZpbml0aW9uL2xpbmstb3JpZ2luYWwtcmVzb3VyY2UtaWQtZXh0ZW5zaW9uJwogIHJldHVybiBFCgpkZWZpbmUgZnVuY3Rpb24gIkdldFBhdGllbnRFeHRlbnNpb25zIihkb21haW5SZXNvdXJjZSBEb21haW5SZXNvdXJjZSk6CiAgZG9tYWluUmVzb3VyY2UuZXh0ZW5zaW9uIEUKICB3aGVyZSBFLnVybC52YWx1ZSA9ICdodHRwOi8vaGw3Lm9yZy9maGlyL3VzL2NvcmUvU3RydWN0dXJlRGVmaW5pdGlvbi91cy1jb3JlLXJhY2UnCiAgICBvciBFLnVybC52YWx1ZSA9ICdodHRwOi8vaGw3Lm9yZy9maGlyL3VzL2NvcmUvU3RydWN0dXJlRGVmaW5pdGlvbi91cy1jb3JlLWV0aG5pY2l0eScKICAgIG9yIEUudXJsLnZhbHVlID0gJ2h0dHA6Ly9obDcub3JnL2ZoaXIvdXMvY29yZS9TdHJ1Y3R1cmVEZWZpbml0aW9uL3VzLWNvcmUtYmlydGhzZXgnCiAgICBvciBFLnVybC52YWx1ZSA9ICdodHRwOi8vd3d3LmNkYy5nb3Yvbmhzbi9maGlycG9ydGFsL2RxbS9pZy9TdHJ1Y3R1cmVEZWZpbml0aW9uL2xpbmstb3JpZ2luYWwtcmVzb3VyY2UtaWQtZXh0ZW5zaW9uJwogIHJldHVybiBFCgpkZWZpbmUgZnVuY3Rpb24gIk1ldGFFbGVtZW50IihyZXNvdXJjZSBSZXNvdXJjZSwgcHJvZmlsZVVSTHMgTGlzdDxGSElSLmNhbm9uaWNhbD4pOgogIHJlc291cmNlIHIKICByZXR1cm4gRkhJUi5NZXRhewogICAgZXh0ZW5zaW9uOiByLm1ldGEuZXh0ZW5zaW9uLAogICAgdmVyc2lvbklkOiByLm1ldGEudmVyc2lvbklkLAogICAgbGFzdFVwZGF0ZWQ6IHIubWV0YS5sYXN0VXBkYXRlZCwKICAgIHByb2ZpbGU6IHByb2ZpbGVVUkxzLAogICAgc2VjdXJpdHk6IHIubWV0YS5zZWN1cml0eSwKICAgIHRhZzogci5tZXRhLnRhZwogIH0KCmRlZmluZSBmdW5jdGlvbiBDb25kaXRpb25TdGFnZShzdGFnZSBMaXN0PEZISVIuQ29uZGl0aW9uLlN0YWdlPik6CiAgc3RhZ2UgcwogIHJldHVybiBGSElSLkNvbmRpdGlvbi5TdGFnZXsKICAgIHN1bW1hcnk6IHMuc3VtbWFyeSwKICAgIGFzc2Vzc21lbnQ6IHMuYXNzZXNzbWVudCwKICAgIHR5cGU6IHMudHlwZQogIH0KCmRlZmluZSBmdW5jdGlvbiBDb25kaXRpb25FdmlkZW5jZShldmlkZW5jZSBMaXN0PEZISVIuQ29uZGl0aW9uLkV2aWRlbmNlPik6CiAgZXZpZGVuY2UgZQogIHJldHVybiBGSElSLkNvbmRpdGlvbi5FdmlkZW5jZXsKICAgIGNvZGU6IGUuY29kZSwKICAgIGRldGFpbDogZS5kZXRhaWwKICB9CgpkZWZpbmUgZnVuY3Rpb24gQ29uZGl0aW9uUmVzb3VyY2UoY29uZGl0aW9uIENvbmRpdGlvbiwgcHJvZmlsZVVSTHMgTGlzdDxGSElSLmNhbm9uaWNhbD4pOgogIGNvbmRpdGlvbiBjCiAgcmV0dXJuIENvbmRpdGlvbnsKICAgIGlkOiBGSElSLmlkIHt2YWx1ZTogJ0xDUi0nICsgYy5pZH0sCiAgICBtZXRhOiBNZXRhRWxlbWVudChjLCBwcm9maWxlVVJMcyksCiAgICBleHRlbnNpb246IGMuZXh0ZW5zaW9uLAogICAgY2xpbmljYWxTdGF0dXM6IGMuY2xpbmljYWxTdGF0dXMsCiAgICB2ZXJpZmljYXRpb25TdGF0dXM6IGMudmVyaWZpY2F0aW9uU3RhdHVzLAogICAgY2F0ZWdvcnk6IGMuY2F0ZWdvcnksCiAgICBzZXZlcml0eTogYy5zZXZlcml0eSwKICAgIGNvZGU6IGMuY29kZSwKICAgIGJvZHlTaXRlOiBjLmJvZHlTaXRlLAogICAgc3ViamVjdDogYy5zdWJqZWN0LAogICAgZW5jb3VudGVyOiBjLmVuY291bnRlciwKICAgIG9uc2V0OiBjLm9uc2V0LAogICAgYWJhdGVtZW50OiBjLmFiYXRlbWVudCwKICAgIHJlY29yZGVkRGF0ZTogYy5yZWNvcmRlZERhdGUsCiAgICBzdGFnZTogQ29uZGl0aW9uU3RhZ2UoYy5zdGFnZSksCiAgICBldmlkZW5jZTogQ29uZGl0aW9uRXZpZGVuY2UoYy5ldmlkZW5jZSksCiAgICBub3RlOiBjLm5vdGUKICB9CgpkZWZpbmUgZnVuY3Rpb24gQ292ZXJhZ2VDbGFzcyhjbGFzcyBMaXN0PEZISVIuQ292ZXJhZ2UuQ2xhc3M+KToKICBjbGFzcyBjCiAgcmV0dXJuIEZISVIuQ292ZXJhZ2UuQ2xhc3N7CiAgICB2YWx1ZTogYy52YWx1ZSwKICAgIG5hbWU6IGMubmFtZQogIH0KCmRlZmluZSBmdW5jdGlvbiBDb3ZlcmFnZVJlc291cmNlKGNvdmVyYWdlIENvdmVyYWdlLCBwcm9maWxlVVJMcyBMaXN0PEZISVIuY2Fub25pY2FsPik6CiAgY292ZXJhZ2UgYwogIHJldHVybiBDb3ZlcmFnZXsKICAgIGlkOiBGSElSLmlke3ZhbHVlOiAnTENSLScgKyBjLmlkfSwKICAgIG1ldGE6IE1ldGFFbGVtZW50KGMsIHByb2ZpbGVVUkxzKSwKICAgIGV4dGVuc2lvbjogYy5leHRlbnNpb24sCiAgICBzdGF0dXM6IGMuc3RhdHVzLAogICAgdHlwZTogYy50eXBlLAogICAgcG9saWN5SG9sZGVyOiBjLnBvbGljeUhvbGRlciwKICAgIHN1YnNjcmliZXI6IGMuc3Vic2NyaWJlciwKICAgIHN1YnNjcmliZXJJZDogYy5zdWJzY3JpYmVySWQsCiAgICBiZW5lZmljaWFyeTogYy5iZW5lZmljaWFyeSwKICAgIGRlcGVuZGVudDogYy5kZXBlbmRlbnQsCiAgICByZWxhdGlvbnNoaXA6IGMucmVsYXRpb25zaGlwLAogICAgcGVyaW9kOiBjLnBlcmlvZCwKICAgIHBheW9yOiBjLnBheW9yLAogICAgY2xhc3M6IENvdmVyYWdlQ2xhc3MoYy5jbGFzcyksCiAgICBvcmRlcjogYy5vcmRlciwKICAgIG5ldHdvcms6IGMubmV0d29yaywKICAgIHN1YnJvZ2F0aW9uOiBjLnN1YnJvZ2F0aW9uLAogICAgY29udHJhY3Q6IGMuY29udHJhY3QKICB9CgpkZWZpbmUgZnVuY3Rpb24gRGlhZ25vc3RpY1JlcG9ydENvZGluZyhjb2RpbmcgTGlzdDxDb2Rpbmc+KToKICBjb2RpbmcgYwogIHJldHVybiBDb2Rpbmd7CiAgICBzeXN0ZW06IGMuc3lzdGVtLAogICAgdmVyc2lvbjogYy52ZXJzaW9uLAogICAgY29kZTogYy5jb2RlLAogICAgZGlzcGxheTogYy5kaXNwbGF5LAogICAgdXNlclNlbGVjdGVkOiBjLnVzZXJTZWxlY3RlZAogIH0KCmRlZmluZSBmdW5jdGlvbiBEaWFnbm9zdGljUmVwb3J0Q2F0ZWdvcnkoY2F0ZWdvcnkgTGlzdDxDb2RlYWJsZUNvbmNlcHQ+KToKICBjYXRlZ29yeSBjCiAgcmV0dXJuIENvZGVhYmxlQ29uY2VwdHsKICAgIGNvZGluZzogRGlhZ25vc3RpY1JlcG9ydENvZGluZyhjLmNvZGluZykKICB9CgpkZWZpbmUgZnVuY3Rpb24gRGlhZ25vc3RpY1JlcG9ydExhYlJlc291cmNlKGRpYWdub3N0aWNSZXBvcnQgRGlhZ25vc3RpY1JlcG9ydCwgcHJvZmlsZVVSTHMgTGlzdDxGSElSLmNhbm9uaWNhbD4pOgogIGRpYWdub3N0aWNSZXBvcnQgZAogIHJldHVybiBEaWFnbm9zdGljUmVwb3J0ewogICAgaWQ6IEZISVIuaWR7dmFsdWU6ICdMQ1ItJyArIGQuaWR9LAogICAgbWV0YTogTWV0YUVsZW1lbnQoZCwgcHJvZmlsZVVSTHMpLAogICAgZXh0ZW5zaW9uOiBkLmV4dGVuc2lvbiwKICAgIGJhc2VkT246IGQuYmFzZWRPbiwKICAgIHN0YXR1czogZC5zdGF0dXMsCiAgICBjYXRlZ29yeTogRGlhZ25vc3RpY1JlcG9ydENhdGVnb3J5KGQuY2F0ZWdvcnkpLAogICAgY29kZTogZC5jb2RlLAogICAgc3ViamVjdDogZC5zdWJqZWN0LAogICAgZW5jb3VudGVyOiBkLmVuY291bnRlciwKICAgIGVmZmVjdGl2ZTogZC5lZmZlY3RpdmUsCiAgICBpc3N1ZWQ6IGQuaXNzdWVkLAogICAgcGVyZm9ybWVyOiBkLnBlcmZvcm1lciwKICAgIHJlc3VsdHNJbnRlcnByZXRlcjogZC5yZXN1bHRzSW50ZXJwcmV0ZXIsCiAgICBzcGVjaW1lbjogZC5zcGVjaW1lbiwKICAgIHJlc3VsdDogZC5yZXN1bHQsCiAgICBjb25jbHVzaW9uOiBkLmNvbmNsdXNpb24sCiAgICBjb25jbHVzaW9uQ29kZTogZC5jb25jbHVzaW9uQ29kZQogIH0KCmRlZmluZSBmdW5jdGlvbiBFbmNvdW50ZXJJZGVudGlmaWVyKGlkZW50aWZpZXIgTGlzdDxGSElSLklkZW50aWZpZXI+KToKICBpZGVudGlmaWVyIGkKICByZXR1cm4gRkhJUi5JZGVudGlmaWVyewogICAgdXNlOiBpLnVzZSwKICAgIHR5cGU6IGkudHlwZSwKICAgIHN5c3RlbTogaS5zeXN0ZW0sCiAgICB2YWx1ZTogaS52YWx1ZSwKICAgIHBlcmlvZDogaS5wZXJpb2QKICB9CgpkZWZpbmUgZnVuY3Rpb24gRW5jb3VudGVyU3RhdHVzSGlzdG9yeShzdGF0dXNIaXN0b3J5IExpc3Q8RkhJUi5FbmNvdW50ZXIuU3RhdHVzSGlzdG9yeT4pOgogIHN0YXR1c0hpc3Rvcnkgc0gKICByZXR1cm4gRkhJUi5FbmNvdW50ZXIuU3RhdHVzSGlzdG9yeXsKICAgIHN0YXR1czogc0guc3RhdHVzLAogICAgcGVyaW9kOiBzSC5wZXJpb2QKICB9CgpkZWZpbmUgZnVuY3Rpb24gRW5jb3VudGVyQ2xhc3NIaXN0b3J5KGNsYXNzSGlzdG9yeSBMaXN0PEZISVIuRW5jb3VudGVyLkNsYXNzSGlzdG9yeT4pOgogIGNsYXNzSGlzdG9yeSBjSAogIHJldHVybiBGSElSLkVuY291bnRlci5DbGFzc0hpc3Rvcnl7CiAgICBjbGFzczogY0guY2xhc3MsCiAgICBwZXJpb2Q6IGNILnBlcmlvZAogIH0KCi8qTm8gbG9uZ2VyIG5lZWRlZCBidXQgc2F2aW5nIGZvciBwb3RlbnRpYWwgZnV0dXJlIHVzZQpkZWZpbmUgZnVuY3Rpb24gRW5jb3VudGVyUGFydGljaXBhbnQocGFydGljaXBhbnQgTGlzdDxGSElSLkVuY291bnRlci5QYXJ0aWNpcGFudD4pOgogIHBhcnRpY2lwYW50IHAKICByZXR1cm4gRkhJUi5FbmNvdW50ZXIuUGFydGljaXBhbnR7CiAgICB0eXBlOiBwLnR5cGUsCiAgICBwZXJpb2Q6IHAucGVyaW9kLAogICAgaW5kaXZpZHVhbDogcC5pbmRpdmlkdWFsCiAgfSovCgpkZWZpbmUgZnVuY3Rpb24gRW5jb3VudGVyRGlhZ25vc2lzKGRpYWdub3NpcyBMaXN0PEZISVIuRW5jb3VudGVyLkRpYWdub3Npcz4pOgogIGRpYWdub3NpcyBkCiAgcmV0dXJuIEZISVIuRW5jb3VudGVyLkRpYWdub3Npc3sKICAgIGNvbmRpdGlvbjogZC5jb25kaXRpb24sCiAgICB1c2U6IGQudXNlLAogICAgcmFuazogZC5yYW5rCiAgfQoKZGVmaW5lIGZ1bmN0aW9uIEVuY291bnRlckhvc3BpdGFsaXphdGlvbihob3NwaXRhbGl6YXRpb24gRkhJUi5FbmNvdW50ZXIuSG9zcGl0YWxpemF0aW9uKToKICBob3NwaXRhbGl6YXRpb24gaAogIHJldHVybiBGSElSLkVuY291bnRlci5Ib3NwaXRhbGl6YXRpb257CiAgICBwcmVBZG1pc3Npb25JZGVudGlmaWVyOiBoLnByZUFkbWlzc2lvbklkZW50aWZpZXIsCiAgICBvcmlnaW46IGgub3JpZ2luLAogICAgYWRtaXRTb3VyY2U6IGguYWRtaXRTb3VyY2UsCiAgICByZUFkbWlzc2lvbjogaC5yZUFkbWlzc2lvbiwKICAgIGRpZXRQcmVmZXJlbmNlOiBoLmRpZXRQcmVmZXJlbmNlLAogICAgc3BlY2lhbENvdXJ0ZXN5OiBoLnNwZWNpYWxDb3VydGVzeSwKICAgIHNwZWNpYWxBcnJhbmdlbWVudDogaC5zcGVjaWFsQXJyYW5nZW1lbnQsCiAgICBkZXN0aW5hdGlvbjogaC5kZXN0aW5hdGlvbiwKICAgIGRpc2NoYXJnZURpc3Bvc2l0aW9uOiBoLmRpc2NoYXJnZURpc3Bvc2l0aW9uCiAgfQoKZGVmaW5lIGZ1bmN0aW9uIEVuY291bnRlckxvY2F0aW9uKGxvY2F0aW9uIExpc3Q8RkhJUi5FbmNvdW50ZXIuTG9jYXRpb24+KToKICBsb2NhdGlvbiBsCiAgcmV0dXJuIEZISVIuRW5jb3VudGVyLkxvY2F0aW9uewogICAgbG9jYXRpb246IGwubG9jYXRpb24sCiAgICBzdGF0dXM6IGwuc3RhdHVzLAogICAgcGh5c2ljYWxUeXBlOiBsLnBoeXNpY2FsVHlwZSwKICAgIHBlcmlvZDogbC5wZXJpb2QKICB9CgpkZWZpbmUgZnVuY3Rpb24gRW5jb3VudGVyUmVzb3VyY2UoZW5jb3VudGVyIEVuY291bnRlciwgcHJvZmlsZVVSTHMgTGlzdDxGSElSLmNhbm9uaWNhbD4pOgogIGVuY291bnRlciBlCiAgcmV0dXJuIEVuY291bnRlcnsKICAgIGlkOiBGSElSLmlke3ZhbHVlOiAnTENSLScgKyBlLmlkfSwKICAgIG1ldGE6IE1ldGFFbGVtZW50KGUsIHByb2ZpbGVVUkxzKSwKICAgIGV4dGVuc2lvbjogZS5leHRlbnNpb24sCiAgICBpZGVudGlmaWVyOiBFbmNvdW50ZXJJZGVudGlmaWVyKGUuaWRlbnRpZmllciksCiAgICBzdGF0dXM6IGUuc3RhdHVzLAogICAgc3RhdHVzSGlzdG9yeTogRW5jb3VudGVyU3RhdHVzSGlzdG9yeShlLnN0YXR1c0hpc3RvcnkpLAogICAgY2xhc3M6IGUuY2xhc3MsCiAgICBjbGFzc0hpc3Rvcnk6IEVuY291bnRlckNsYXNzSGlzdG9yeShlLmNsYXNzSGlzdG9yeSksCiAgICB0eXBlOiBlLnR5cGUsCiAgICBzZXJ2aWNlVHlwZTogZS5zZXJ2aWNlVHlwZSwKICAgIHByaW9yaXR5OiBlLnByaW9yaXR5LAogICAgc3ViamVjdDogZS5zdWJqZWN0LAogICAgcGVyaW9kOiBlLnBlcmlvZCwKICAgIGxlbmd0aDogZS5sZW5ndGgsCiAgICByZWFzb25Db2RlOiBlLnJlYXNvbkNvZGUsCiAgICByZWFzb25SZWZlcmVuY2U6IGUucmVhc29uUmVmZXJlbmNlLAogICAgZGlhZ25vc2lzOiBFbmNvdW50ZXJEaWFnbm9zaXMoZS5kaWFnbm9zaXMpLAogICAgYWNjb3VudDogZS5hY2NvdW50LAogICAgaG9zcGl0YWxpemF0aW9uOiBFbmNvdW50ZXJIb3NwaXRhbGl6YXRpb24oZS5ob3NwaXRhbGl6YXRpb24pLAogICAgbG9jYXRpb246IEVuY291bnRlckxvY2F0aW9uKGUubG9jYXRpb24pLAogICAgcGFydE9mOiBlLnBhcnRPZgogIH0KCmRlZmluZSBmdW5jdGlvbiBPYnNlcnZhdGlvbkxhYkNvZGluZyhjb2RpbmcgTGlzdDxDb2Rpbmc+KToKICBjb2RpbmcgYwogIHJldHVybiBDb2Rpbmd7CiAgICBpZDogYy5pZCwKICAgIGV4dGVuc2lvbjogYy5leHRlbnNpb24sCiAgICBzeXN0ZW06IGMuc3lzdGVtLAogICAgdmVyc2lvbjogYy52ZXJzaW9uLAogICAgY29kZTogYy5jb2RlLAogICAgZGlzcGxheTogYy5kaXNwbGF5LAogICAgdXNlclNlbGVjdGVkOiBjLnVzZXJTZWxlY3RlZAogIH0KCmRlZmluZSBmdW5jdGlvbiBPYnNlcnZhdGlvbkxhYkNhdGVnb3J5KGNhdGVnb3J5IExpc3Q8Q29kZWFibGVDb25jZXB0Pik6CiAgY2F0ZWdvcnkgYwogIHJldHVybiBDb2RlYWJsZUNvbmNlcHR7CiAgICBjb2Rpbmc6IE9ic2VydmF0aW9uTGFiQ29kaW5nKGMuY29kaW5nKSwKICAgIHRleHQ6IGMudGV4dAogIH0KCmRlZmluZSBmdW5jdGlvbiBPYnNlcnZhdGlvblJlZmVyZW5jZVJhbmdlKHJlZmVyZW5jZVJhbmdlIExpc3Q8RkhJUi5PYnNlcnZhdGlvbi5SZWZlcmVuY2VSYW5nZT4pOgogIHJlZmVyZW5jZVJhbmdlIHJSCiAgcmV0dXJuIEZISVIuT2JzZXJ2YXRpb24uUmVmZXJlbmNlUmFuZ2V7CiAgICBsb3c6IHJSLmxvdywKICAgIGhpZ2g6IHJSLmhpZ2gsCiAgICB0eXBlOiByUi50eXBlLAogICAgYXBwbGllc1RvOiByUi5hcHBsaWVzVG8sCiAgICBhZ2U6IHJSLmFnZSwKICAgIHRleHQ6IHJSLnRleHQKICB9CgpkZWZpbmUgZnVuY3Rpb24gT2JzZXJ2YXRpb25Db21wb25lbnQoY29tcG9uZW50IExpc3Q8RkhJUi5PYnNlcnZhdGlvbi5Db21wb25lbnQ+KToKICBjb21wb25lbnQgYwogIHJldHVybiBGSElSLk9ic2VydmF0aW9uLkNvbXBvbmVudHsKICAgIGNvZGU6IGMuY29kZSwKICAgIHZhbHVlOiBjLnZhbHVlLAogICAgZGF0YUFic2VudFJlYXNvbjogYy5kYXRhQWJzZW50UmVhc29uLAogICAgaW50ZXJwcmV0YXRpb246IGMuaW50ZXJwcmV0YXRpb24sCiAgICByZWZlcmVuY2VSYW5nZTogYy5yZWZlcmVuY2VSYW5nZQogIH0KCmRlZmluZSBmdW5jdGlvbiBPYnNlcnZhdGlvbkxhYlJlc291cmNlKG9ic2VydmF0aW9uIE9ic2VydmF0aW9uLCBwcm9maWxlVVJMcyBMaXN0PEZISVIuY2Fub25pY2FsPik6CiAgb2JzZXJ2YXRpb24gbwogIHJldHVybiBPYnNlcnZhdGlvbnsKICAgIGlkOiBGSElSLmlkIHt2YWx1ZTogJ0xDUi0nICsgby5pZH0sCiAgICBtZXRhOiBNZXRhRWxlbWVudChvLCBwcm9maWxlVVJMcyksCiAgICBleHRlbnNpb246IG8uZXh0ZW5zaW9uLAogICAgYmFzZWRPbjogby5iYXNlZE9uLAogICAgcGFydE9mOiBvLnBhcnRPZiwKICAgIHN0YXR1czogby5zdGF0dXMsCiAgICBjYXRlZ29yeTogT2JzZXJ2YXRpb25MYWJDYXRlZ29yeShvLmNhdGVnb3J5KSwKICAgIGNvZGU6IG8uY29kZSwKICAgIHN1YmplY3Q6IG8uc3ViamVjdCwKICAgIGZvY3VzOiBvLmZvY3VzLAogICAgZW5jb3VudGVyOiBvLmVuY291bnRlciwKICAgIGVmZmVjdGl2ZTogby5lZmZlY3RpdmUsCiAgICBpc3N1ZWQ6IG8uaXNzdWVkLAogICAgcGVyZm9ybWVyOiBvLnBlcmZvcm1lciwKICAgIHZhbHVlOiBvLnZhbHVlLAogICAgZGF0YUFic2VudFJlYXNvbjogby5kYXRhQWJzZW50UmVhc29uLAogICAgaW50ZXJwcmV0YXRpb246IG8uaW50ZXJwcmV0YXRpb24sCiAgICBub3RlOiBvLm5vdGUsCiAgICBib2R5U2l0ZTogby5ib2R5U2l0ZSwKICAgIG1ldGhvZDogby5tZXRob2QsCiAgICBzcGVjaW1lbjogby5zcGVjaW1lbiwKICAgIGRldmljZTogby5kZXZpY2UsCiAgICByZWZlcmVuY2VSYW5nZTogT2JzZXJ2YXRpb25SZWZlcmVuY2VSYW5nZShvLnJlZmVyZW5jZVJhbmdlKSwKICAgIGhhc01lbWJlcjogby5oYXNNZW1iZXIsCiAgICBkZXJpdmVkRnJvbTogby5kZXJpdmVkRnJvbSwKICAgIGNvbXBvbmVudDogT2JzZXJ2YXRpb25Db21wb25lbnQoby5jb21wb25lbnQpCiAgfQoKZGVmaW5lIGZ1bmN0aW9uIExvY2F0aW9uQWRkcmVzcyhhZGRyZXNzIEZISVIuQWRkcmVzcyk6CiAgYWRkcmVzcyBhCiAgcmV0dXJuIEZISVIuQWRkcmVzc3sKICAgIHVzZTogYS51c2UsCiAgICB0eXBlOiBhLnR5cGUsCiAgICB0ZXh0OiBhLnRleHQsCiAgICBsaW5lOiBhLmxpbmUsCiAgICBjaXR5OiBhLmNpdHksCiAgICBkaXN0cmljdDogYS5kaXN0cmljdCwKICAgIHN0YXRlOiBhLnN0YXRlLAogICAgcG9zdGFsQ29kZTogYS5wb3N0YWxDb2RlLAogICAgY291bnRyeTogYS5jb3VudHJ5LAogICAgcGVyaW9kOiBhLnBlcmlvZAogIH0KCmRlZmluZSBmdW5jdGlvbiBMb2NhdGlvblBvc2l0aW9uKHBvc2l0aW9uIEZISVIuTG9jYXRpb24uUG9zaXRpb24pOgogIHBvc2l0aW9uIHAKICByZXR1cm4gRkhJUi5Mb2NhdGlvbi5Qb3NpdGlvbnsKICAgIGxvbmdpdHVkZTogcC5sb25naXR1ZGUsCiAgICBsYXRpdHVkZTogcC5sYXRpdHVkZSwKICAgIGFsdGl0dWRlOiBwLmFsdGl0dWRlCiAgfQoKZGVmaW5lIGZ1bmN0aW9uIExvY2F0aW9uSG91cnNPZk9wZXJhdGlvbihob3Vyc09mT3BlcmF0aW9uIExpc3Q8RkhJUi5Mb2NhdGlvbi5Ib3Vyc09mT3BlcmF0aW9uPik6CiAgaG91cnNPZk9wZXJhdGlvbiBoT08KICByZXR1cm4gRkhJUi5Mb2NhdGlvbi5Ib3Vyc09mT3BlcmF0aW9uewogICAgZGF5c09mV2VlazogaE9PLmRheXNPZldlZWssCiAgICBhbGxEYXk6IGhPTy5hbGxEYXksCiAgICBvcGVuaW5nVGltZTogaE9PLm9wZW5pbmdUaW1lLAogICAgY2xvc2luZ1RpbWU6IGhPTy5jbG9zaW5nVGltZQogIH0KCmRlZmluZSBmdW5jdGlvbiBMb2NhdGlvblJlc291cmNlKGxvY2F0aW9uIExvY2F0aW9uLCBwcm9maWxlVVJMcyBMaXN0PEZISVIuY2Fub25pY2FsPik6CiAgbG9jYXRpb24gbAogIHJldHVybiBMb2NhdGlvbnsKICAgIGlkOiBGSElSLmlkIHt2YWx1ZTogJ0xDUi0nICsgbC5pZH0sCiAgICBtZXRhOiBNZXRhRWxlbWVudChsLCBwcm9maWxlVVJMcyksCiAgICBleHRlbnNpb246IGwuZXh0ZW5zaW9uLAogICAgc3RhdHVzOiBsLnN0YXR1cywKICAgIG9wZXJhdGlvbmFsU3RhdHVzOiBsLm9wZXJhdGlvbmFsU3RhdHVzLAogICAgbmFtZTogbC5uYW1lLAogICAgYWxpYXM6IGwuYWxpYXMsCiAgICBkZXNjcmlwdGlvbjogbC5kZXNjcmlwdGlvbiwKICAgIG1vZGU6IGwubW9kZSwKICAgIHR5cGU6IGwudHlwZSwKICAgIHRlbGVjb206IGwudGVsZWNvbSwKICAgIGFkZHJlc3M6IExvY2F0aW9uQWRkcmVzcyhsLmFkZHJlc3MpLAogICAgcGh5c2ljYWxUeXBlOiBsLnBoeXNpY2FsVHlwZSwKICAgIHBvc2l0aW9uOiBMb2NhdGlvblBvc2l0aW9uKGwucG9zaXRpb24pLAogICAgbWFuYWdpbmdPcmdhbml6YXRpb246IGwubWFuYWdpbmdPcmdhbml6YXRpb24sCiAgICBwYXJ0T2Y6IGwucGFydE9mLAogICAgaG91cnNPZk9wZXJhdGlvbjogTG9jYXRpb25Ib3Vyc09mT3BlcmF0aW9uKGwuaG91cnNPZk9wZXJhdGlvbiksCiAgICBhdmFpbGFiaWxpdHlFeGNlcHRpb25zOiBsLmF2YWlsYWJpbGl0eUV4Y2VwdGlvbnMsCiAgICBlbmRwb2ludDogbC5lbmRwb2ludAogIH0KCmRlZmluZSBmdW5jdGlvbiBNZWRpY2F0aW9uSW5ncmVkaWVudChpbmdyZWRpZW50IExpc3Q8RkhJUi5NZWRpY2F0aW9uLkluZ3JlZGllbnQ+KToKICBpbmdyZWRpZW50IGkKICByZXR1cm4gRkhJUi5NZWRpY2F0aW9uLkluZ3JlZGllbnR7CiAgICBpdGVtOiBpLml0ZW0sCiAgICBzdHJlbmd0aDogaS5zdHJlbmd0aAogIH0KCmRlZmluZSBmdW5jdGlvbiBNZWRpY2F0aW9uQmF0Y2goYmF0Y2ggRkhJUi5NZWRpY2F0aW9uLkJhdGNoKToKICBiYXRjaCBiCiAgcmV0dXJuIEZISVIuTWVkaWNhdGlvbi5CYXRjaHsKICAgIGxvdE51bWJlcjogYi5sb3ROdW1iZXIsCiAgICBleHBpcmF0aW9uRGF0ZTogYi5leHBpcmF0aW9uRGF0ZQogIH0KCmRlZmluZSBmdW5jdGlvbiBNZWRpY2F0aW9uUmVzb3VyY2UobWVkaWNhdGlvbiBNZWRpY2F0aW9uLCBwcm9maWxlVVJMcyBMaXN0PEZISVIuY2Fub25pY2FsPik6CiAgbWVkaWNhdGlvbiBtCiAgcmV0dXJuIE1lZGljYXRpb257CiAgICBpZDogRkhJUi5pZCB7dmFsdWU6ICdMQ1ItJyArIG0uaWR9LAogICAgbWV0YTogTWV0YUVsZW1lbnQobSwgcHJvZmlsZVVSTHMpLAogICAgZXh0ZW5zaW9uOiBtLmV4dGVuc2lvbiwKICAgIGNvZGU6IG0uY29kZSwKICAgIHN0YXR1czogbS5zdGF0dXMsCiAgICBtYW51ZmFjdHVyZXI6IG0ubWFudWZhY3R1cmVyLAogICAgZm9ybTogbS5mb3JtLAogICAgYW1vdW50OiBtLmFtb3VudCwKICAgIGluZ3JlZGllbnQ6IE1lZGljYXRpb25JbmdyZWRpZW50KG0uaW5ncmVkaWVudCksCiAgICBiYXRjaDogTWVkaWNhdGlvbkJhdGNoKG0uYmF0Y2gpCiAgfQoKZGVmaW5lIGZ1bmN0aW9uIE1lZGljYXRpb25BZG1pbmlzdHJhdGlvblBlcmZvcm1lcihwZXJmb3JtZXIgTGlzdDxGSElSLk1lZGljYXRpb25BZG1pbmlzdHJhdGlvbi5QZXJmb3JtZXI+KToKICBwZXJmb3JtZXIgcAogIHJldHVybiBGSElSLk1lZGljYXRpb25BZG1pbmlzdHJhdGlvbi5QZXJmb3JtZXJ7CiAgICBmdW5jdGlvbjogcC5mdW5jdGlvbiwKICAgIGFjdG9yOiBwLmFjdG9yCiAgfQoKZGVmaW5lIGZ1bmN0aW9uIE1lZGljYXRpb25BZG1pbmlzdHJhdGlvbkRvc2FnZShkb3NhZ2UgRkhJUi5NZWRpY2F0aW9uQWRtaW5pc3RyYXRpb24uRG9zYWdlKToKICBkb3NhZ2UgZAogIHJldHVybiBGSElSLk1lZGljYXRpb25BZG1pbmlzdHJhdGlvbi5Eb3NhZ2V7CiAgICB0ZXh0OiBkLnRleHQsCiAgICBzaXRlOiBkLnNpdGUsCiAgICByb3V0ZTogZC5yb3V0ZSwKICAgIG1ldGhvZDogZC5tZXRob2QsCiAgICBkb3NlOiBkLmRvc2UsCiAgICByYXRlOiBkLnJhdGUKICB9CgpkZWZpbmUgZnVuY3Rpb24gTWVkaWNhdGlvbkFkbWluaXN0cmF0aW9uUmVzb3VyY2UobWVkaWNhdGlvbkFkbWluaXN0cmF0aW9uIE1lZGljYXRpb25BZG1pbmlzdHJhdGlvbiwgcHJvZmlsZVVSTHMgTGlzdDxGSElSLmNhbm9uaWNhbD4pOgogIG1lZGljYXRpb25BZG1pbmlzdHJhdGlvbiBtCiAgcmV0dXJuIE1lZGljYXRpb25BZG1pbmlzdHJhdGlvbnsKICAgIGlkOiBGSElSLmlkIHt2YWx1ZTogJ0xDUi0nICsgbS5pZH0sCiAgICBtZXRhOiBNZXRhRWxlbWVudChtLCBwcm9maWxlVVJMcyksCiAgICBleHRlbnNpb246IG0uZXh0ZW5zaW9uLAogICAgaW5zdGFudGlhdGVzOiBtLmluc3RhbnRpYXRlcywKICAgIHBhcnRPZjogbS5wYXJ0T2YsCiAgICBzdGF0dXM6IG0uc3RhdHVzLAogICAgc3RhdHVzUmVhc29uOiBtLnN0YXR1c1JlYXNvbiwKICAgIGNhdGVnb3J5OiBtLmNhdGVnb3J5LAogICAgbWVkaWNhdGlvbjogbS5tZWRpY2F0aW9uLAogICAgc3ViamVjdDogbS5zdWJqZWN0LAogICAgY29udGV4dDogbS5jb250ZXh0LAogICAgc3VwcG9ydGluZ0luZm9ybWF0aW9uOiBtLnN1cHBvcnRpbmdJbmZvcm1hdGlvbiwKICAgIGVmZmVjdGl2ZTogbS5lZmZlY3RpdmUsCiAgICBwZXJmb3JtZXI6IE1lZGljYXRpb25BZG1pbmlzdHJhdGlvblBlcmZvcm1lcihtLnBlcmZvcm1lciksCiAgICByZWFzb25Db2RlOiBtLnJlYXNvbkNvZGUsCiAgICByZWFzb25SZWZlcmVuY2U6IG0ucmVhc29uUmVmZXJlbmNlLAogICAgcmVxdWVzdDogbS5yZXF1ZXN0LAogICAgZGV2aWNlOiBtLmRldmljZSwKICAgIG5vdGU6IG0ubm90ZSwKICAgIGRvc2FnZTogTWVkaWNhdGlvbkFkbWluaXN0cmF0aW9uRG9zYWdlKG0uZG9zYWdlKSwKICAgIGV2ZW50SGlzdG9yeTogbS5ldmVudEhpc3RvcnkKICB9CgpkZWZpbmUgZnVuY3Rpb24gTWVkaWNhdGlvblJlcXVlc3REb3NlQW5kUmF0ZShkb3NlQW5kUmF0ZSBMaXN0PEZISVIuRG9zYWdlLkRvc2VBbmRSYXRlPik6CiAgZG9zZUFuZFJhdGUgZFIKICByZXR1cm4gRkhJUi5Eb3NhZ2UuRG9zZUFuZFJhdGV7CiAgICB0eXBlOiBkUi50eXBlLAogICAgZG9zZTogZFIuZG9zZSwKICAgIHJhdGU6IGRSLnJhdGUKICB9CgpkZWZpbmUgZnVuY3Rpb24gTWVkaWNhdGlvblJlcXVlc3REb3NhZ2VJbnN0cnVjdGlvbihkb3NhZ2VJbnN0cnVjdGlvbiBMaXN0PEZISVIuRG9zYWdlPik6CiAgZG9zYWdlSW5zdHJ1Y3Rpb24gZEkKICByZXR1cm4gRkhJUi5Eb3NhZ2V7CiAgICB0ZXh0OiBkSS50ZXh0LAogICAgcGF0aWVudEluc3RydWN0aW9uOiBkSS5wYXRpZW50SW5zdHJ1Y3Rpb24sCiAgICB0aW1pbmc6IGRJLnRpbWluZywKICAgIGFzTmVlZGVkOiBkSS5hc05lZWRlZCwKICAgIHNpdGU6IGRJLnNpdGUsCiAgICByb3V0ZTogZEkucm91dGUsCiAgICBtZXRob2Q6IGRJLm1ldGhvZCwKICAgIGRvc2VBbmRSYXRlOiBNZWRpY2F0aW9uUmVxdWVzdERvc2VBbmRSYXRlKGRJLmRvc2VBbmRSYXRlKQogIH0KCmRlZmluZSBmdW5jdGlvbiBNZWRpY2F0aW9uUmVxdWVzdFJlc291cmNlKG1lZGljYXRpb25SZXF1ZXN0IE1lZGljYXRpb25SZXF1ZXN0LCBwcm9maWxlVVJMcyBMaXN0PEZISVIuY2Fub25pY2FsPik6CiAgbWVkaWNhdGlvblJlcXVlc3QgbQogIHJldHVybiBNZWRpY2F0aW9uUmVxdWVzdHsKICAgIGlkOiBGSElSLmlkIHt2YWx1ZTogJ0xDUi0nICsgbS5pZH0sCiAgICBtZXRhOiBNZXRhRWxlbWVudChtZWRpY2F0aW9uUmVxdWVzdCwgcHJvZmlsZVVSTHMpLAogICAgZXh0ZW5zaW9uOiBtLmV4dGVuc2lvbiwKICAgIHN0YXR1czogbS5zdGF0dXMsCiAgICBzdGF0dXNSZWFzb246IG0uc3RhdHVzUmVhc29uLAogICAgaW50ZW50OiBtLmludGVudCwKICAgIGNhdGVnb3J5OiBtLmNhdGVnb3J5LAogICAgcHJpb3JpdHk6IG0ucHJpb3JpdHksCiAgICBkb05vdFBlcmZvcm06IG0uZG9Ob3RQZXJmb3JtLAogICAgcmVwb3J0ZWQ6IG0ucmVwb3J0ZWQsCiAgICBtZWRpY2F0aW9uOiBtLm1lZGljYXRpb24sCiAgICBzdWJqZWN0OiBtLnN1YmplY3QsCiAgICBlbmNvdW50ZXI6IG0uZW5jb3VudGVyLAogICAgYXV0aG9yZWRPbjogbS5hdXRob3JlZE9uLAogICAgcmVxdWVzdGVyOiBtLnJlcXVlc3RlciwKICAgIHJlY29yZGVyOiBtLnJlY29yZGVyLAogICAgcmVhc29uQ29kZTogbS5yZWFzb25Db2RlLAogICAgcmVhc29uUmVmZXJlbmNlOiBtLnJlYXNvblJlZmVyZW5jZSwKICAgIGluc3RhbnRpYXRlc0Nhbm9uaWNhbDogbS5pbnN0YW50aWF0ZXNDYW5vbmljYWwsCiAgICBpbnN0YW50aWF0ZXNVcmk6IG0uaW5zdGFudGlhdGVzVXJpLAogICAgY291cnNlT2ZUaGVyYXB5VHlwZTogbS5jb3Vyc2VPZlRoZXJhcHlUeXBlLAogICAgZG9zYWdlSW5zdHJ1Y3Rpb246IE1lZGljYXRpb25SZXF1ZXN0RG9zYWdlSW5zdHJ1Y3Rpb24obS5kb3NhZ2VJbnN0cnVjdGlvbikKICB9CgovKiBObyBsb25nZXIgbmVlZGVkIGJ1dCBzYXZpbmcgaW4gY2FzZSBpdCdzIHVzZWZ1bCBsYXRlcgpkZWZpbmUgZnVuY3Rpb24gUGF0aWVudElkZW50aWZpZXIoaWRlbnRpZmllciBMaXN0PEZISVIuSWRlbnRpZmllcj4pOgogIGlkZW50aWZpZXIgaQogIHJldHVybiBGSElSLklkZW50aWZpZXJ7CiAgICBpZDogaS5pZCwKICAgIGV4dGVuc2lvbjogaS5leHRlbnNpb24sCiAgICB1c2U6IGkudXNlLAogICAgdHlwZTogaS50eXBlLAogICAgc3lzdGVtOiBpLnN5c3RlbSwKICAgIHZhbHVlOiBpLnZhbHVlLAogICAgcGVyaW9kOiBpLnBlcmlvZCwKICAgIGFzc2lnbmVyOiBpLmFzc2lnbmVyCiAgfSovCgpkZWZpbmUgZnVuY3Rpb24gUGF0aWVudE5hbWUobmFtZSBMaXN0PEZISVIuSHVtYW5OYW1lPik6CiAgbmFtZSBuCiAgcmV0dXJuIEZISVIuSHVtYW5OYW1lewogICAgaWQ6IG4uaWQsCiAgICBleHRlbnNpb246IG4uZXh0ZW5zaW9uLAogICAgdXNlOiBuLnVzZSwKICAgIHRleHQ6IG4udGV4dCwKICAgIGZhbWlseTogbi5mYW1pbHksCiAgICBnaXZlbjogbi5naXZlbiwKICAgIHByZWZpeDogbi5wcmVmaXgsCiAgICBzdWZmaXg6IG4uc3VmZml4LAogICAgcGVyaW9kOiBuLnBlcmlvZAogIH0KCmRlZmluZSBmdW5jdGlvbiBQYXRpZW50VGVsZWNvbSh0ZWxlY29tIExpc3Q8RkhJUi5Db250YWN0UG9pbnQ+KToKICB0ZWxlY29tIHQKICByZXR1cm4gRkhJUi5Db250YWN0UG9pbnR7CiAgICBzeXN0ZW06IHQuc3lzdGVtLAogICAgdmFsdWU6IHQudmFsdWUsCiAgICB1c2U6IHQudXNlLAogICAgcmFuazogdC5yYW5rLAogICAgcGVyaW9kOiB0LnBlcmlvZAogIH0KCmRlZmluZSBmdW5jdGlvbiBQYXRpZW50QWRkcmVzcyhhZGRyZXNzIExpc3Q8RkhJUi5BZGRyZXNzPik6CiAgYWRkcmVzcyBhCiAgcmV0dXJuIEZISVIuQWRkcmVzc3sKICAgIGlkOiBhLmlkLAogICAgZXh0ZW5zaW9uOiBhLmV4dGVuc2lvbiwKICAgIHVzZTogYS51c2UsCiAgICB0eXBlOiBhLnR5cGUsCiAgICB0ZXh0OiBhLnRleHQsCiAgICBsaW5lOiBhLmxpbmUsCiAgICBjaXR5OiBhLmNpdHksCiAgICBkaXN0cmljdDogYS5kaXN0cmljdCwKICAgIHN0YXRlOiBhLnN0YXRlLAogICAgcG9zdGFsQ29kZTogYS5wb3N0YWxDb2RlLAogICAgY291bnRyeTogYS5jb3VudHJ5LAogICAgcGVyaW9kOiBhLnBlcmlvZAogIH0KCmRlZmluZSBmdW5jdGlvbiBQYXRpZW50Q29udGFjdChjb250YWN0IExpc3Q8RkhJUi5QYXRpZW50LkNvbnRhY3Q+KToKICBjb250YWN0IGMKICByZXR1cm4gRkhJUi5QYXRpZW50LkNvbnRhY3R7CiAgICBpZDogYy5pZCwKICAgIGV4dGVuc2lvbjogYy5leHRlbnNpb24sCiAgICByZWxhdGlvbnNoaXA6IGMucmVsYXRpb25zaGlwLAogICAgbmFtZTogYy5uYW1lLAogICAgdGVsZWNvbTogYy50ZWxlY29tLAogICAgYWRkcmVzczogYy5hZGRyZXNzLAogICAgZ2VuZGVyOiBjLmdlbmRlciwKICAgIG9yZ2FuaXphdGlvbjogYy5vcmdhbml6YXRpb24sCiAgICBwZXJpb2Q6IGMucGVyaW9kCiAgfQoKZGVmaW5lIGZ1bmN0aW9uIFBhdGllbnRDb21tdW5pY2F0aW9uKGNvbW11bmljYXRpb24gTGlzdDxGSElSLlBhdGllbnQuQ29tbXVuaWNhdGlvbj4pOgogIGNvbW11bmljYXRpb24gYwogIHJldHVybiBGSElSLlBhdGllbnQuQ29tbXVuaWNhdGlvbnsKICAgIGlkOiBjLmlkLAogICAgZXh0ZW5zaW9uOiBjLmV4dGVuc2lvbiwKICAgIGxhbmd1YWdlOiBjLmxhbmd1YWdlLAogICAgcHJlZmVycmVkOiBjLnByZWZlcnJlZAogIH0KCmRlZmluZSBmdW5jdGlvbiBQYXRpZW50TGluayhsaW5rIExpc3Q8RkhJUi5QYXRpZW50Lkxpbms+KToKICBsaW5rIGwKICByZXR1cm4gRkhJUi5QYXRpZW50Lkxpbmt7CiAgICBpZDogbC5pZCwKICAgIGV4dGVuc2lvbjogbC5leHRlbnNpb24sCiAgICBtb2RpZmllckV4dGVuc2lvbjogbC5tb2RpZmllckV4dGVuc2lvbiwKICAgIG90aGVyOiBsLm90aGVyLAogICAgdHlwZTogbC50eXBlCiAgfQoKZGVmaW5lIGZ1bmN0aW9uIFBhdGllbnRSZXNvdXJjZShwYXRpZW50IFBhdGllbnQsIHByb2ZpbGVVUkxzIExpc3Q8RkhJUi5jYW5vbmljYWw+KToKICBwYXRpZW50IHAKICByZXR1cm4gUGF0aWVudHsKICAgIGlkOiBGSElSLmlke3ZhbHVlOiAnTENSLScgKyBwLmlkfSwKICAgIG1ldGE6IE1ldGFFbGVtZW50KHAsIHByb2ZpbGVVUkxzKSwKICAgIGV4dGVuc2lvbjogR2V0UGF0aWVudEV4dGVuc2lvbnMocCkgdW5pb24gR2V0SWRFeHRlbnNpb25zKHApLAogICAgaWRlbnRpZmllcjogcC5pZGVudGlmaWVyLAogICAgYWN0aXZlOiBwLmFjdGl2ZSwKICAgIG5hbWU6IFBhdGllbnROYW1lKHAubmFtZSksCiAgICB0ZWxlY29tOiBQYXRpZW50VGVsZWNvbShwLnRlbGVjb20pLAogICAgZ2VuZGVyOiBwLmdlbmRlciwKICAgIGJpcnRoRGF0ZTogcC5iaXJ0aERhdGUsCiAgICBkZWNlYXNlZDogcC5kZWNlYXNlZCwKICAgIGFkZHJlc3M6IFBhdGllbnRBZGRyZXNzKHAuYWRkcmVzcyksCiAgICBtYXJpdGFsU3RhdHVzOiBwLm1hcml0YWxTdGF0dXMsCiAgICBtdWx0aXBsZUJpcnRoOiBwLm11bHRpcGxlQmlydGgsCiAgICBwaG90bzogcC5waG90bywKICAgIGNvbnRhY3Q6IFBhdGllbnRDb250YWN0KHAuY29udGFjdCksCiAgICBjb21tdW5pY2F0aW9uOiBQYXRpZW50Q29tbXVuaWNhdGlvbihwLmNvbW11bmljYXRpb24pLAogICAgZ2VuZXJhbFByYWN0aXRpb25lcjogcC5nZW5lcmFsUHJhY3RpdGlvbmVyLAogICAgbWFuYWdpbmdPcmdhbml6YXRpb246IHAubWFuYWdpbmdPcmdhbml6YXRpb24sCiAgICBsaW5rOiBQYXRpZW50TGluayhwLmxpbmspCiAgfQoKZGVmaW5lIGZ1bmN0aW9uIFByb2NlZHVyZVBlcmZvcm1lcihwZXJmb3JtZXIgTGlzdDxGSElSLlByb2NlZHVyZS5QZXJmb3JtZXI+KToKICBwZXJmb3JtZXIgcAogIHJldHVybiBGSElSLlByb2NlZHVyZS5QZXJmb3JtZXJ7CiAgICBmdW5jdGlvbjogcC5mdW5jdGlvbiwKICAgIGFjdG9yOiBwLmFjdG9yLAogICAgb25CZWhhbGZPZjogcC5vbkJlaGFsZk9mCiAgfQoKZGVmaW5lIGZ1bmN0aW9uIFByb2NlZHVyZUZvY2FsRGV2aWNlKGRldmljZSBMaXN0PEZISVIuUHJvY2VkdXJlLkZvY2FsRGV2aWNlPik6CiAgZGV2aWNlIGQKICByZXR1cm4gRkhJUi5Qcm9jZWR1cmUuRm9jYWxEZXZpY2V7CiAgICBhY3Rpb246IGQuYWN0aW9uLAogICAgbWFuaXB1bGF0ZWQ6IGQubWFuaXB1bGF0ZWQKICB9CgpkZWZpbmUgZnVuY3Rpb24gUHJvY2VkdXJlUmVzb3VyY2UocHJvY2VkdXJlIFByb2NlZHVyZSwgcHJvZmlsZVVSTHMgTGlzdDxGSElSLmNhbm9uaWNhbD4pOgogIHByb2NlZHVyZSBwCiAgcmV0dXJuIFByb2NlZHVyZXsKICAgIGlkOiBGSElSLmlkIHt2YWx1ZTogJ0xDUi0nICsgcC5pZH0sCiAgICBtZXRhOiBNZXRhRWxlbWVudChwLCBwcm9maWxlVVJMcyksCiAgICBleHRlbnNpb246IHAuZXh0ZW5zaW9uLAogICAgaW5zdGFudGlhdGVzQ2Fub25pY2FsOiBwLmluc3RhbnRpYXRlc0Nhbm9uaWNhbCwKICAgIGluc3RhbnRpYXRlc1VyaTogcC5pbnN0YW50aWF0ZXNVcmksCiAgICBiYXNlZE9uOiBwLmJhc2VkT24sCiAgICBwYXJ0T2Y6IHAucGFydE9mLAogICAgc3RhdHVzOiBwLnN0YXR1cywKICAgIHN0YXR1c1JlYXNvbjogcC5zdGF0dXNSZWFzb24sCiAgICBjYXRlZ29yeTogcC5jYXRlZ29yeSwKICAgIGNvZGU6IHAuY29kZSwKICAgIHN1YmplY3Q6IHAuc3ViamVjdCwKICAgIGVuY291bnRlcjogcC5lbmNvdW50ZXIsCiAgICBwZXJmb3JtZWQ6IHAucGVyZm9ybWVkLAogICAgcmVjb3JkZXI6IHAucmVjb3JkZXIsCiAgICBhc3NlcnRlcjogcC5hc3NlcnRlciwKICAgIHBlcmZvcm1lcjogUHJvY2VkdXJlUGVyZm9ybWVyKHAucGVyZm9ybWVyKSwKICAgIGxvY2F0aW9uOiBwLmxvY2F0aW9uLAogICAgcmVhc29uQ29kZTogcC5yZWFzb25Db2RlLAogICAgcmVhc29uUmVmZXJlbmNlOiBwLnJlYXNvblJlZmVyZW5jZSwKICAgIGJvZHlTaXRlOiBwLmJvZHlTaXRlLAogICAgb3V0Y29tZTogcC5vdXRjb21lLAogICAgcmVwb3J0OiBwLnJlcG9ydCwKICAgIGNvbXBsaWNhdGlvbjogcC5jb21wbGljYXRpb24sCiAgICBjb21wbGljYXRpb25EZXRhaWw6IHAuY29tcGxpY2F0aW9uRGV0YWlsLAogICAgZm9sbG93VXA6IHAuZm9sbG93VXAsCiAgICBub3RlOiBwLm5vdGUsCiAgICBmb2NhbERldmljZTogUHJvY2VkdXJlRm9jYWxEZXZpY2UocC5mb2NhbERldmljZSksCiAgICB1c2VkUmVmZXJlbmNlOiBwLnVzZWRSZWZlcmVuY2UsCiAgICB1c2VkQ29kZTogcC51c2VkQ29kZQogIH0KCmRlZmluZSBmdW5jdGlvbiBTZXJ2aWNlUmVxdWVzdFJlc291cmNlKHNlcnZpY2VSZXF1ZXN0IFNlcnZpY2VSZXF1ZXN0LCBwcm9maWxlVVJMcyBMaXN0PEZISVIuY2Fub25pY2FsPik6CiAgc2VydmljZVJlcXVlc3Qgc1IKICByZXR1cm4gU2VydmljZVJlcXVlc3R7CiAgICBpZDogRkhJUi5pZCB7dmFsdWU6ICdMQ1ItJyArIHNSLmlkfSwKICAgIG1ldGE6IE1ldGFFbGVtZW50KHNSLCBwcm9maWxlVVJMcyksCiAgICBleHRlbnNpb246IHNSLmV4dGVuc2lvbiwKICAgIGluc3RhbnRpYXRlc0Nhbm9uaWNhbDogc1IuaW5zdGFudGlhdGVzQ2Fub25pY2FsLAogICAgaW5zdGFudGlhdGVzVXJpOiBzUi5pbnN0YW50aWF0ZXNVcmksCiAgICBiYXNlZE9uOiBzUi5iYXNlZE9uLAogICAgcmVwbGFjZXM6IHNSLnJlcGxhY2VzLAogICAgcmVxdWlzaXRpb246IHNSLnJlcXVpc2l0aW9uLAogICAgc3RhdHVzOiBzUi5zdGF0dXMsCiAgICBpbnRlbnQ6IHNSLmludGVudCwKICAgIGNhdGVnb3J5OiBzUi5jYXRlZ29yeSwKICAgIHByaW9yaXR5OiBzUi5wcmlvcml0eSwKICAgIGRvTm90UGVyZm9ybTogc1IuZG9Ob3RQZXJmb3JtLAogICAgY29kZTogc1IuY29kZSwKICAgIG9yZGVyRGV0YWlsOiBzUi5vcmRlckRldGFpbCwKICAgIHF1YW50aXR5OiBzUi5xdWFudGl0eSwKICAgIHN1YmplY3Q6IHNSLnN1YmplY3QsCiAgICBlbmNvdW50ZXI6IHNSLmVuY291bnRlciwKICAgIG9jY3VycmVuY2U6IHNSLm9jY3VycmVuY2UsCiAgICBhc05lZWRlZDogc1IuYXNOZWVkZWQsCiAgICBhdXRob3JlZE9uOiBzUi5hdXRob3JlZE9uLAogICAgcmVxdWVzdGVyOiBzUi5yZXF1ZXN0ZXIsCiAgICBwZXJmb3JtZXJUeXBlOiBzUi5wZXJmb3JtZXJUeXBlLAogICAgcGVyZm9ybWVyOiBzUi5wZXJmb3JtZXIsCiAgICBsb2NhdGlvbkNvZGU6IHNSLmxvY2F0aW9uQ29kZSwKICAgIGxvY2F0aW9uUmVmZXJlbmNlOiBzUi5sb2NhdGlvblJlZmVyZW5jZSwKICAgIHJlYXNvbkNvZGU6IHNSLnJlYXNvbkNvZGUsCiAgICByZWFzb25SZWZlcmVuY2U6IHNSLnJlYXNvblJlZmVyZW5jZSwKICAgIGluc3VyYW5jZTogc1IuaW5zdXJhbmNlLAogICAgc3VwcG9ydGluZ0luZm86IHNSLnN1cHBvcnRpbmdJbmZvLAogICAgc3BlY2ltZW46IHNSLnNwZWNpbWVuLAogICAgYm9keVNpdGU6IHNSLmJvZHlTaXRlLAogICAgbm90ZTogc1Iubm90ZSwKICAgIHBhdGllbnRJbnN0cnVjdGlvbjogc1IucGF0aWVudEluc3RydWN0aW9uLAogICAgcmVsZXZhbnRIaXN0b3J5OiBzUi5yZWxldmFudEhpc3RvcnkKICB9CgpkZWZpbmUgZnVuY3Rpb24gU3BlY2ltZW5Db2xsZWN0aW9uKGNvbGxlY3Rpb24gRkhJUi5TcGVjaW1lbi5Db2xsZWN0aW9uKToKICBjb2xsZWN0aW9uIGMKICByZXR1cm4gRkhJUi5TcGVjaW1lbi5Db2xsZWN0aW9uewogICAgY29sbGVjdG9yOiBjLmNvbGxlY3RvciwKICAgIGNvbGxlY3RlZDogYy5jb2xsZWN0ZWQsCiAgICAiZHVyYXRpb24iOiBjLiJkdXJhdGlvbiIsCiAgICBxdWFudGl0eTogYy5xdWFudGl0eSwKICAgIG1ldGhvZDogYy5tZXRob2QsCiAgICBib2R5U2l0ZTogYy5ib2R5U2l0ZSwKICAgIGZhc3RpbmdTdGF0dXM6IGMuZmFzdGluZ1N0YXR1cwogIH0KCmRlZmluZSBmdW5jdGlvbiBTcGVjaW1lblByb2Nlc3NpbmcocHJvY2Vzc2luZyBMaXN0PEZISVIuU3BlY2ltZW4uUHJvY2Vzc2luZz4pOgogIHByb2Nlc3NpbmcgcAogIHJldHVybiBGSElSLlNwZWNpbWVuLlByb2Nlc3Npbmd7CiAgICBkZXNjcmlwdGlvbjogcC5kZXNjcmlwdGlvbiwKICAgIHByb2NlZHVyZTogcC5wcm9jZWR1cmUsCiAgICBhZGRpdGl2ZTogcC5hZGRpdGl2ZSwKICAgIHRpbWU6IHAudGltZQogIH0KCmRlZmluZSBmdW5jdGlvbiBTcGVjaW1lbkNvbnRhaW5lcihjb250YWluZXIgTGlzdDxGSElSLlNwZWNpbWVuLkNvbnRhaW5lcj4pOgogIGNvbnRhaW5lciBjCiAgcmV0dXJuIEZISVIuU3BlY2ltZW4uQ29udGFpbmVyewogICAgZGVzY3JpcHRpb246IGMuZGVzY3JpcHRpb24sCiAgICB0eXBlOiBjLnR5cGUsCiAgICBjYXBhY2l0eTogYy5jYXBhY2l0eSwKICAgIHNwZWNpbWVuUXVhbnRpdHk6IGMuc3BlY2ltZW5RdWFudGl0eSwKICAgIGFkZGl0aXZlOiBjLmFkZGl0aXZlCiAgfQoKZGVmaW5lIGZ1bmN0aW9uIFNwZWNpbWVuUmVzb3VyY2Uoc3BlY2ltZW4gU3BlY2ltZW4sIHByb2ZpbGVVUkxzIExpc3Q8RkhJUi5jYW5vbmljYWw+KToKICBzcGVjaW1lbiBzCiAgcmV0dXJuIFNwZWNpbWVuewogICAgaWQ6IEZISVIuaWQge3ZhbHVlOiAnTENSLScgKyBzLmlkfSwKICAgIG1ldGE6IE1ldGFFbGVtZW50KHMsIHByb2ZpbGVVUkxzKSwKICAgIGV4dGVuc2lvbjogcy5leHRlbnNpb24sCiAgICBpZGVudGlmaWVyOiBzLmlkZW50aWZpZXIsCiAgICBhY2Nlc3Npb25JZGVudGlmaWVyOiBzLmFjY2Vzc2lvbklkZW50aWZpZXIsCiAgICBzdGF0dXM6IHMuc3RhdHVzLAogICAgdHlwZTogcy50eXBlLAogICAgc3ViamVjdDogcy5zdWJqZWN0LAogICAgcmVjZWl2ZWRUaW1lOiBzLnJlY2VpdmVkVGltZSwKICAgIHBhcmVudDogcy5wYXJlbnQsCiAgICByZXF1ZXN0OiBzLnJlcXVlc3QsCiAgICBjb2xsZWN0aW9uOiBTcGVjaW1lbkNvbGxlY3Rpb24ocy5jb2xsZWN0aW9uKSwKICAgIHByb2Nlc3Npbmc6IFNwZWNpbWVuUHJvY2Vzc2luZyhzLnByb2Nlc3NpbmcpLAogICAgY29udGFpbmVyOiBTcGVjaW1lbkNvbnRhaW5lcihzLmNvbnRhaW5lciksCiAgICBjb25kaXRpb246IHMuY29uZGl0aW9uLAogICAgbm90ZTogcy5ub3RlCiAgfQoKZGVmaW5lIGZ1bmN0aW9uICJPcGVyYXRpb25PdXRjb21lUmVzb3VyY2UiKGVycm9ySWQgU3RyaW5nLCByZXNvdXJjZUlkIEZISVIuaWQsIG1lc3NhZ2UgU3RyaW5nKToKICBPcGVyYXRpb25PdXRjb21lewogICAgICBpZDogRkhJUi5pZHt2YWx1ZTogZXJyb3JJZH0sCiAgICAgIGlzc3VlOiB7CiAgICAgICAgICBGSElSLk9wZXJhdGlvbk91dGNvbWUuSXNzdWV7CiAgICAgICAgICBzZXZlcml0eTogRkhJUi5Jc3N1ZVNldmVyaXR5e3ZhbHVlOiAnZXJyb3InfSwKICAgICAgICAgIGNvZGU6IEZISVIuSXNzdWVUeXBle3ZhbHVlOiAnZXhjZXB0aW9uJ30sCiAgICAgICAgICBkZXRhaWxzOiAKICAgICAgICAgICAgICBGSElSLkNvZGVhYmxlQ29uY2VwdHsKICAgICAgICAgICAgICAgICAgY29kaW5nOiB7CiAgICAgICAgICAgICAgICAgICAgICBDb2Rpbmd7CiAgICAgICAgICAgICAgICAgICAgICBzeXN0ZW06IHVyaXt2YWx1ZTogJ2h0dHBzOi8vbGFudGFuYWdyb3VwLmNvbS92YWxpZGF0aW9uLWVycm9yJ30sCiAgICAgICAgICAgICAgICAgICAgICBjb2RlOiBjb2Rle3ZhbHVlOiAnRXJyb3InfSwKICAgICAgICAgICAgICAgICAgICAgIGRpc3BsYXk6IHN0cmluZ3t2YWx1ZTogJ1Jlc291cmNlICcgKyByZXNvdXJjZUlkICsgJyBmYWlsZWQgdmFsaWRhdGlvbjogJyArIG1lc3NhZ2V9CiAgICAgICAgICAgICAgICAgICAgICB9CiAgICAgICAgICAgICAgICAgIH0KICAgICAgICAgICAgICB9CiAgICAgICAgICB9CiAgICAgIH0KICB9"
+            "data": "bGlicmFyeSBTaGFyZWRSZXNvdXJjZUNyZWF0aW9uIHZlcnNpb24gJzAuMS4wMTAnCgppbmNsdWRlIEZISVJIZWxwZXJzIHZlcnNpb24gJzQuMC4yJwoKdXNpbmcgRkhJUiB2ZXJzaW9uICc0LjAuMScKCmRlZmluZSBmdW5jdGlvbiAiR2V0UGF0aWVudEV4dGVuc2lvbnMiKGRvbWFpblJlc291cmNlIERvbWFpblJlc291cmNlKToKICBkb21haW5SZXNvdXJjZS5leHRlbnNpb24gRQogIHdoZXJlIEUudXJsID0gJ2h0dHA6Ly9obDcub3JnL2ZoaXIvdXMvY29yZS9TdHJ1Y3R1cmVEZWZpbml0aW9uL3VzLWNvcmUtcmFjZScKICAgIG9yIEUudXJsID0gJ2h0dHA6Ly9obDcub3JnL2ZoaXIvdXMvY29yZS9TdHJ1Y3R1cmVEZWZpbml0aW9uL3VzLWNvcmUtZXRobmljaXR5JwogICAgb3IgRS51cmwgPSAnaHR0cDovL2hsNy5vcmcvZmhpci91cy9jb3JlL1N0cnVjdHVyZURlZmluaXRpb24vdXMtY29yZS10cmliYWwtYWZmaWxpYXRpb24nCiAgICBvciBFLnVybCA9ICdodHRwOi8vaGw3Lm9yZy9maGlyL3VzL2NvcmUvU3RydWN0dXJlRGVmaW5pdGlvbi91cy1jb3JlLWJpcnRoc2V4JwogICAgb3IgRS51cmwgPSAnaHR0cDovL2hsNy5vcmcvZmhpci91cy9jb3JlL1N0cnVjdHVyZURlZmluaXRpb24vdXMtY29yZS1zZXgnCiAgICBvciBFLnVybCA9ICdodHRwOi8vd3d3LmNkYy5nb3Yvbmhzbi9maGlycG9ydGFsL2RxbS9pZy9TdHJ1Y3R1cmVEZWZpbml0aW9uL2xpbmstb3JpZ2luYWwtcmVzb3VyY2UtaWQtZXh0ZW5zaW9uJwogIHJldHVybiBFCgpkZWZpbmUgZnVuY3Rpb24gIk1ldGFFbGVtZW50IihyZXNvdXJjZSBSZXNvdXJjZSwgcHJvZmlsZVVSTHMgTGlzdDxGSElSLmNhbm9uaWNhbD4pOgogIHJlc291cmNlIHIKICByZXR1cm4gRkhJUi5NZXRhewogICAgZXh0ZW5zaW9uOiByLm1ldGEuZXh0ZW5zaW9uLAogICAgdmVyc2lvbklkOiByLm1ldGEudmVyc2lvbklkLAogICAgbGFzdFVwZGF0ZWQ6IHIubWV0YS5sYXN0VXBkYXRlZCwKICAgIHByb2ZpbGU6IHByb2ZpbGVVUkxzLAogICAgc2VjdXJpdHk6IHIubWV0YS5zZWN1cml0eSwKICAgIHRhZzogci5tZXRhLnRhZwogIH0KCmRlZmluZSBmdW5jdGlvbiBDb25kaXRpb25TdGFnZShzdGFnZSBMaXN0PEZISVIuQ29uZGl0aW9uLlN0YWdlPik6CiAgc3RhZ2UgcwogIHJldHVybiBGSElSLkNvbmRpdGlvbi5TdGFnZXsKICAgIHN1bW1hcnk6IHMuc3VtbWFyeSwKICAgIGFzc2Vzc21lbnQ6IHMuYXNzZXNzbWVudCwKICAgIHR5cGU6IHMudHlwZQogIH0KCmRlZmluZSBmdW5jdGlvbiBDb25kaXRpb25FdmlkZW5jZShldmlkZW5jZSBMaXN0PEZISVIuQ29uZGl0aW9uLkV2aWRlbmNlPik6CiAgZXZpZGVuY2UgZQogIHJldHVybiBGSElSLkNvbmRpdGlvbi5FdmlkZW5jZXsKICAgIGNvZGU6IGUuY29kZSwKICAgIGRldGFpbDogZS5kZXRhaWwKICB9CgpkZWZpbmUgZnVuY3Rpb24gQ29uZGl0aW9uUmVzb3VyY2UoY29uZGl0aW9uIENvbmRpdGlvbiwgcHJvZmlsZVVSTHMgTGlzdDxGSElSLmNhbm9uaWNhbD4pOgogIGNvbmRpdGlvbiBjCiAgcmV0dXJuIENvbmRpdGlvbnsKICAgIGlkOiBGSElSLmlkIHt2YWx1ZTogJ0xDUi0nICsgYy5pZH0sCiAgICBtZXRhOiBNZXRhRWxlbWVudChjLCBwcm9maWxlVVJMcyksCiAgICBleHRlbnNpb246IGMuZXh0ZW5zaW9uLAogICAgY2xpbmljYWxTdGF0dXM6IGMuY2xpbmljYWxTdGF0dXMsCiAgICB2ZXJpZmljYXRpb25TdGF0dXM6IGMudmVyaWZpY2F0aW9uU3RhdHVzLAogICAgY2F0ZWdvcnk6IGMuY2F0ZWdvcnksCiAgICBzZXZlcml0eTogYy5zZXZlcml0eSwKICAgIGNvZGU6IGMuY29kZSwKICAgIGJvZHlTaXRlOiBjLmJvZHlTaXRlLAogICAgc3ViamVjdDogYy5zdWJqZWN0LAogICAgZW5jb3VudGVyOiBjLmVuY291bnRlciwKICAgIG9uc2V0OiBjLm9uc2V0LAogICAgYWJhdGVtZW50OiBjLmFiYXRlbWVudCwKICAgIHJlY29yZGVkRGF0ZTogYy5yZWNvcmRlZERhdGUsCiAgICBzdGFnZTogQ29uZGl0aW9uU3RhZ2UoYy5zdGFnZSksCiAgICBldmlkZW5jZTogQ29uZGl0aW9uRXZpZGVuY2UoYy5ldmlkZW5jZSksCiAgICBub3RlOiBjLm5vdGUKICB9CgpkZWZpbmUgZnVuY3Rpb24gQ292ZXJhZ2VDbGFzcyhjbGFzcyBMaXN0PEZISVIuQ292ZXJhZ2UuQ2xhc3M+KToKICBjbGFzcyBjCiAgcmV0dXJuIEZISVIuQ292ZXJhZ2UuQ2xhc3N7CiAgICB2YWx1ZTogYy52YWx1ZSwKICAgIG5hbWU6IGMubmFtZQogIH0KCmRlZmluZSBmdW5jdGlvbiBDb3ZlcmFnZVJlc291cmNlKGNvdmVyYWdlIENvdmVyYWdlLCBwcm9maWxlVVJMcyBMaXN0PEZISVIuY2Fub25pY2FsPik6CiAgY292ZXJhZ2UgYwogIHJldHVybiBDb3ZlcmFnZXsKICAgIGlkOiBGSElSLmlke3ZhbHVlOiAnTENSLScgKyBjLmlkfSwKICAgIG1ldGE6IE1ldGFFbGVtZW50KGMsIHByb2ZpbGVVUkxzKSwKICAgIGV4dGVuc2lvbjogYy5leHRlbnNpb24sCiAgICBzdGF0dXM6IGMuc3RhdHVzLAogICAgdHlwZTogYy50eXBlLAogICAgcG9saWN5SG9sZGVyOiBjLnBvbGljeUhvbGRlciwKICAgIHN1YnNjcmliZXI6IGMuc3Vic2NyaWJlciwKICAgIHN1YnNjcmliZXJJZDogYy5zdWJzY3JpYmVySWQsCiAgICBiZW5lZmljaWFyeTogYy5iZW5lZmljaWFyeSwKICAgIGRlcGVuZGVudDogYy5kZXBlbmRlbnQsCiAgICByZWxhdGlvbnNoaXA6IGMucmVsYXRpb25zaGlwLAogICAgcGVyaW9kOiBjLnBlcmlvZCwKICAgIHBheW9yOiBjLnBheW9yLAogICAgY2xhc3M6IENvdmVyYWdlQ2xhc3MoYy5jbGFzcyksCiAgICBvcmRlcjogYy5vcmRlciwKICAgIG5ldHdvcms6IGMubmV0d29yaywKICAgIHN1YnJvZ2F0aW9uOiBjLnN1YnJvZ2F0aW9uLAogICAgY29udHJhY3Q6IGMuY29udHJhY3QKICB9CgpkZWZpbmUgZnVuY3Rpb24gRGlhZ25vc3RpY1JlcG9ydENvZGluZyhjb2RpbmcgTGlzdDxDb2Rpbmc+KToKICBjb2RpbmcgYwogIHJldHVybiBDb2Rpbmd7CiAgICBzeXN0ZW06IGMuc3lzdGVtLAogICAgdmVyc2lvbjogYy52ZXJzaW9uLAogICAgY29kZTogYy5jb2RlLAogICAgZGlzcGxheTogYy5kaXNwbGF5LAogICAgdXNlclNlbGVjdGVkOiBjLnVzZXJTZWxlY3RlZAogIH0KCmRlZmluZSBmdW5jdGlvbiBEaWFnbm9zdGljUmVwb3J0Q2F0ZWdvcnkoY2F0ZWdvcnkgTGlzdDxDb2RlYWJsZUNvbmNlcHQ+KToKICBjYXRlZ29yeSBjCiAgcmV0dXJuIENvZGVhYmxlQ29uY2VwdHsKICAgIGNvZGluZzogRGlhZ25vc3RpY1JlcG9ydENvZGluZyhjLmNvZGluZykKICB9CgpkZWZpbmUgZnVuY3Rpb24gRGlhZ25vc3RpY1JlcG9ydExhYlJlc291cmNlKGRpYWdub3N0aWNSZXBvcnQgRGlhZ25vc3RpY1JlcG9ydCwgcHJvZmlsZVVSTHMgTGlzdDxGSElSLmNhbm9uaWNhbD4pOgogIGRpYWdub3N0aWNSZXBvcnQgZAogIHJldHVybiBEaWFnbm9zdGljUmVwb3J0ewogICAgaWQ6IEZISVIuaWR7dmFsdWU6ICdMQ1ItJyArIGQuaWR9LAogICAgbWV0YTogTWV0YUVsZW1lbnQoZCwgcHJvZmlsZVVSTHMpLAogICAgZXh0ZW5zaW9uOiBkLmV4dGVuc2lvbiwKICAgIGJhc2VkT246IGQuYmFzZWRPbiwKICAgIHN0YXR1czogZC5zdGF0dXMsCiAgICBjYXRlZ29yeTogRGlhZ25vc3RpY1JlcG9ydENhdGVnb3J5KGQuY2F0ZWdvcnkpLAogICAgY29kZTogZC5jb2RlLAogICAgc3ViamVjdDogZC5zdWJqZWN0LAogICAgZW5jb3VudGVyOiBkLmVuY291bnRlciwKICAgIGVmZmVjdGl2ZTogZC5lZmZlY3RpdmUsCiAgICBpc3N1ZWQ6IGQuaXNzdWVkLAogICAgcGVyZm9ybWVyOiBkLnBlcmZvcm1lciwKICAgIHJlc3VsdHNJbnRlcnByZXRlcjogZC5yZXN1bHRzSW50ZXJwcmV0ZXIsCiAgICBzcGVjaW1lbjogZC5zcGVjaW1lbiwKICAgIHJlc3VsdDogZC5yZXN1bHQsCiAgICBjb25jbHVzaW9uOiBkLmNvbmNsdXNpb24sCiAgICBjb25jbHVzaW9uQ29kZTogZC5jb25jbHVzaW9uQ29kZQogIH0KCmRlZmluZSBmdW5jdGlvbiBFbmNvdW50ZXJJZGVudGlmaWVyKGlkZW50aWZpZXIgTGlzdDxGSElSLklkZW50aWZpZXI+KToKICBpZGVudGlmaWVyIGkKICByZXR1cm4gRkhJUi5JZGVudGlmaWVyewogICAgdXNlOiBpLnVzZSwKICAgIHR5cGU6IGkudHlwZSwKICAgIHN5c3RlbTogaS5zeXN0ZW0sCiAgICB2YWx1ZTogaS52YWx1ZSwKICAgIHBlcmlvZDogaS5wZXJpb2QKICB9CgpkZWZpbmUgZnVuY3Rpb24gRW5jb3VudGVyU3RhdHVzSGlzdG9yeShzdGF0dXNIaXN0b3J5IExpc3Q8RkhJUi5FbmNvdW50ZXIuU3RhdHVzSGlzdG9yeT4pOgogIHN0YXR1c0hpc3Rvcnkgc0gKICByZXR1cm4gRkhJUi5FbmNvdW50ZXIuU3RhdHVzSGlzdG9yeXsKICAgIHN0YXR1czogc0guc3RhdHVzLAogICAgcGVyaW9kOiBzSC5wZXJpb2QKICB9CgpkZWZpbmUgZnVuY3Rpb24gRW5jb3VudGVyQ2xhc3NIaXN0b3J5KGNsYXNzSGlzdG9yeSBMaXN0PEZISVIuRW5jb3VudGVyLkNsYXNzSGlzdG9yeT4pOgogIGNsYXNzSGlzdG9yeSBjSAogIHJldHVybiBGSElSLkVuY291bnRlci5DbGFzc0hpc3Rvcnl7CiAgICBjbGFzczogY0guY2xhc3MsCiAgICBwZXJpb2Q6IGNILnBlcmlvZAogIH0KCi8qTm8gbG9uZ2VyIG5lZWRlZCBidXQgc2F2aW5nIGZvciBwb3RlbnRpYWwgZnV0dXJlIHVzZQpkZWZpbmUgZnVuY3Rpb24gRW5jb3VudGVyUGFydGljaXBhbnQocGFydGljaXBhbnQgTGlzdDxGSElSLkVuY291bnRlci5QYXJ0aWNpcGFudD4pOgogIHBhcnRpY2lwYW50IHAKICByZXR1cm4gRkhJUi5FbmNvdW50ZXIuUGFydGljaXBhbnR7CiAgICB0eXBlOiBwLnR5cGUsCiAgICBwZXJpb2Q6IHAucGVyaW9kLAogICAgaW5kaXZpZHVhbDogcC5pbmRpdmlkdWFsCiAgfSovCgpkZWZpbmUgZnVuY3Rpb24gRW5jb3VudGVyRGlhZ25vc2lzKGRpYWdub3NpcyBMaXN0PEZISVIuRW5jb3VudGVyLkRpYWdub3Npcz4pOgogIGRpYWdub3NpcyBkCiAgcmV0dXJuIEZISVIuRW5jb3VudGVyLkRpYWdub3Npc3sKICAgIGNvbmRpdGlvbjogZC5jb25kaXRpb24sCiAgICB1c2U6IGQudXNlLAogICAgcmFuazogZC5yYW5rCiAgfQoKZGVmaW5lIGZ1bmN0aW9uIEVuY291bnRlckhvc3BpdGFsaXphdGlvbihob3NwaXRhbGl6YXRpb24gRkhJUi5FbmNvdW50ZXIuSG9zcGl0YWxpemF0aW9uKToKICBob3NwaXRhbGl6YXRpb24gaAogIHJldHVybiBGSElSLkVuY291bnRlci5Ib3NwaXRhbGl6YXRpb257CiAgICBwcmVBZG1pc3Npb25JZGVudGlmaWVyOiBoLnByZUFkbWlzc2lvbklkZW50aWZpZXIsCiAgICBvcmlnaW46IGgub3JpZ2luLAogICAgYWRtaXRTb3VyY2U6IGguYWRtaXRTb3VyY2UsCiAgICByZUFkbWlzc2lvbjogaC5yZUFkbWlzc2lvbiwKICAgIGRpZXRQcmVmZXJlbmNlOiBoLmRpZXRQcmVmZXJlbmNlLAogICAgc3BlY2lhbENvdXJ0ZXN5OiBoLnNwZWNpYWxDb3VydGVzeSwKICAgIHNwZWNpYWxBcnJhbmdlbWVudDogaC5zcGVjaWFsQXJyYW5nZW1lbnQsCiAgICBkZXN0aW5hdGlvbjogaC5kZXN0aW5hdGlvbiwKICAgIGRpc2NoYXJnZURpc3Bvc2l0aW9uOiBoLmRpc2NoYXJnZURpc3Bvc2l0aW9uCiAgfQoKZGVmaW5lIGZ1bmN0aW9uIEVuY291bnRlckxvY2F0aW9uKGxvY2F0aW9uIExpc3Q8RkhJUi5FbmNvdW50ZXIuTG9jYXRpb24+KToKICBsb2NhdGlvbiBsCiAgcmV0dXJuIEZISVIuRW5jb3VudGVyLkxvY2F0aW9uewogICAgbG9jYXRpb246IGwubG9jYXRpb24sCiAgICBzdGF0dXM6IGwuc3RhdHVzLAogICAgcGh5c2ljYWxUeXBlOiBsLnBoeXNpY2FsVHlwZSwKICAgIHBlcmlvZDogbC5wZXJpb2QKICB9CgpkZWZpbmUgZnVuY3Rpb24gRW5jb3VudGVyUmVzb3VyY2UoZW5jb3VudGVyIEVuY291bnRlciwgcHJvZmlsZVVSTHMgTGlzdDxGSElSLmNhbm9uaWNhbD4pOgogIGVuY291bnRlciBlCiAgcmV0dXJuIEVuY291bnRlcnsKICAgIGlkOiBGSElSLmlke3ZhbHVlOiAnTENSLScgKyBlLmlkfSwKICAgIG1ldGE6IE1ldGFFbGVtZW50KGUsIHByb2ZpbGVVUkxzKSwKICAgIGV4dGVuc2lvbjogZS5leHRlbnNpb24sCiAgICBpZGVudGlmaWVyOiBFbmNvdW50ZXJJZGVudGlmaWVyKGUuaWRlbnRpZmllciksCiAgICBzdGF0dXM6IGUuc3RhdHVzLAogICAgc3RhdHVzSGlzdG9yeTogRW5jb3VudGVyU3RhdHVzSGlzdG9yeShlLnN0YXR1c0hpc3RvcnkpLAogICAgY2xhc3M6IGUuY2xhc3MsCiAgICBjbGFzc0hpc3Rvcnk6IEVuY291bnRlckNsYXNzSGlzdG9yeShlLmNsYXNzSGlzdG9yeSksCiAgICB0eXBlOiBlLnR5cGUsCiAgICBzZXJ2aWNlVHlwZTogZS5zZXJ2aWNlVHlwZSwKICAgIHByaW9yaXR5OiBlLnByaW9yaXR5LAogICAgc3ViamVjdDogZS5zdWJqZWN0LAogICAgcGVyaW9kOiBlLnBlcmlvZCwKICAgIGxlbmd0aDogZS5sZW5ndGgsCiAgICByZWFzb25Db2RlOiBlLnJlYXNvbkNvZGUsCiAgICByZWFzb25SZWZlcmVuY2U6IGUucmVhc29uUmVmZXJlbmNlLAogICAgZGlhZ25vc2lzOiBFbmNvdW50ZXJEaWFnbm9zaXMoZS5kaWFnbm9zaXMpLAogICAgYWNjb3VudDogZS5hY2NvdW50LAogICAgaG9zcGl0YWxpemF0aW9uOiBFbmNvdW50ZXJIb3NwaXRhbGl6YXRpb24oZS5ob3NwaXRhbGl6YXRpb24pLAogICAgbG9jYXRpb246IEVuY291bnRlckxvY2F0aW9uKGUubG9jYXRpb24pLAogICAgcGFydE9mOiBlLnBhcnRPZgogIH0KCmRlZmluZSBmdW5jdGlvbiBPYnNlcnZhdGlvbkxhYkNvZGluZyhjb2RpbmcgTGlzdDxDb2Rpbmc+KToKICBjb2RpbmcgYwogIHJldHVybiBDb2Rpbmd7CiAgICBpZDogYy5pZCwKICAgIGV4dGVuc2lvbjogYy5leHRlbnNpb24sCiAgICBzeXN0ZW06IGMuc3lzdGVtLAogICAgdmVyc2lvbjogYy52ZXJzaW9uLAogICAgY29kZTogYy5jb2RlLAogICAgZGlzcGxheTogYy5kaXNwbGF5LAogICAgdXNlclNlbGVjdGVkOiBjLnVzZXJTZWxlY3RlZAogIH0KCmRlZmluZSBmdW5jdGlvbiBPYnNlcnZhdGlvbkxhYkNhdGVnb3J5KGNhdGVnb3J5IExpc3Q8Q29kZWFibGVDb25jZXB0Pik6CiAgY2F0ZWdvcnkgYwogIHJldHVybiBDb2RlYWJsZUNvbmNlcHR7CiAgICBjb2Rpbmc6IE9ic2VydmF0aW9uTGFiQ29kaW5nKGMuY29kaW5nKSwKICAgIHRleHQ6IGMudGV4dAogIH0KCmRlZmluZSBmdW5jdGlvbiBPYnNlcnZhdGlvblJlZmVyZW5jZVJhbmdlKHJlZmVyZW5jZVJhbmdlIExpc3Q8RkhJUi5PYnNlcnZhdGlvbi5SZWZlcmVuY2VSYW5nZT4pOgogIHJlZmVyZW5jZVJhbmdlIHJSCiAgcmV0dXJuIEZISVIuT2JzZXJ2YXRpb24uUmVmZXJlbmNlUmFuZ2V7CiAgICBsb3c6IHJSLmxvdywKICAgIGhpZ2g6IHJSLmhpZ2gsCiAgICB0eXBlOiByUi50eXBlLAogICAgYXBwbGllc1RvOiByUi5hcHBsaWVzVG8sCiAgICBhZ2U6IHJSLmFnZSwKICAgIHRleHQ6IHJSLnRleHQKICB9CgpkZWZpbmUgZnVuY3Rpb24gT2JzZXJ2YXRpb25Db21wb25lbnQoY29tcG9uZW50IExpc3Q8RkhJUi5PYnNlcnZhdGlvbi5Db21wb25lbnQ+KToKICBjb21wb25lbnQgYwogIHJldHVybiBGSElSLk9ic2VydmF0aW9uLkNvbXBvbmVudHsKICAgIGNvZGU6IGMuY29kZSwKICAgIHZhbHVlOiBjLnZhbHVlLAogICAgZGF0YUFic2VudFJlYXNvbjogYy5kYXRhQWJzZW50UmVhc29uLAogICAgaW50ZXJwcmV0YXRpb246IGMuaW50ZXJwcmV0YXRpb24sCiAgICByZWZlcmVuY2VSYW5nZTogYy5yZWZlcmVuY2VSYW5nZQogIH0KCmRlZmluZSBmdW5jdGlvbiBPYnNlcnZhdGlvbkxhYlJlc291cmNlKG9ic2VydmF0aW9uIE9ic2VydmF0aW9uLCBwcm9maWxlVVJMcyBMaXN0PEZISVIuY2Fub25pY2FsPik6CiAgb2JzZXJ2YXRpb24gbwogIHJldHVybiBPYnNlcnZhdGlvbnsKICAgIGlkOiBGSElSLmlkIHt2YWx1ZTogJ0xDUi0nICsgby5pZH0sCiAgICBtZXRhOiBNZXRhRWxlbWVudChvLCBwcm9maWxlVVJMcyksCiAgICBleHRlbnNpb246IG8uZXh0ZW5zaW9uLAogICAgYmFzZWRPbjogby5iYXNlZE9uLAogICAgcGFydE9mOiBvLnBhcnRPZiwKICAgIHN0YXR1czogby5zdGF0dXMsCiAgICBjYXRlZ29yeTogT2JzZXJ2YXRpb25MYWJDYXRlZ29yeShvLmNhdGVnb3J5KSwKICAgIGNvZGU6IG8uY29kZSwKICAgIHN1YmplY3Q6IG8uc3ViamVjdCwKICAgIGZvY3VzOiBvLmZvY3VzLAogICAgZW5jb3VudGVyOiBvLmVuY291bnRlciwKICAgIGVmZmVjdGl2ZTogby5lZmZlY3RpdmUsCiAgICBpc3N1ZWQ6IG8uaXNzdWVkLAogICAgcGVyZm9ybWVyOiBvLnBlcmZvcm1lciwKICAgIHZhbHVlOiBvLnZhbHVlLAogICAgZGF0YUFic2VudFJlYXNvbjogby5kYXRhQWJzZW50UmVhc29uLAogICAgaW50ZXJwcmV0YXRpb246IG8uaW50ZXJwcmV0YXRpb24sCiAgICBub3RlOiBvLm5vdGUsCiAgICBib2R5U2l0ZTogby5ib2R5U2l0ZSwKICAgIG1ldGhvZDogby5tZXRob2QsCiAgICBzcGVjaW1lbjogby5zcGVjaW1lbiwKICAgIGRldmljZTogby5kZXZpY2UsCiAgICByZWZlcmVuY2VSYW5nZTogT2JzZXJ2YXRpb25SZWZlcmVuY2VSYW5nZShvLnJlZmVyZW5jZVJhbmdlKSwKICAgIGhhc01lbWJlcjogby5oYXNNZW1iZXIsCiAgICBkZXJpdmVkRnJvbTogby5kZXJpdmVkRnJvbSwKICAgIGNvbXBvbmVudDogT2JzZXJ2YXRpb25Db21wb25lbnQoby5jb21wb25lbnQpCiAgfQoKZGVmaW5lIGZ1bmN0aW9uIExvY2F0aW9uQWRkcmVzcyhhZGRyZXNzIEZISVIuQWRkcmVzcyk6CiAgYWRkcmVzcyBhCiAgcmV0dXJuIEZISVIuQWRkcmVzc3sKICAgIHVzZTogYS51c2UsCiAgICB0eXBlOiBhLnR5cGUsCiAgICB0ZXh0OiBhLnRleHQsCiAgICBsaW5lOiBhLmxpbmUsCiAgICBjaXR5OiBhLmNpdHksCiAgICBkaXN0cmljdDogYS5kaXN0cmljdCwKICAgIHN0YXRlOiBhLnN0YXRlLAogICAgcG9zdGFsQ29kZTogYS5wb3N0YWxDb2RlLAogICAgY291bnRyeTogYS5jb3VudHJ5LAogICAgcGVyaW9kOiBhLnBlcmlvZAogIH0KCmRlZmluZSBmdW5jdGlvbiBMb2NhdGlvblBvc2l0aW9uKHBvc2l0aW9uIEZISVIuTG9jYXRpb24uUG9zaXRpb24pOgogIHBvc2l0aW9uIHAKICByZXR1cm4gRkhJUi5Mb2NhdGlvbi5Qb3NpdGlvbnsKICAgIGxvbmdpdHVkZTogcC5sb25naXR1ZGUsCiAgICBsYXRpdHVkZTogcC5sYXRpdHVkZSwKICAgIGFsdGl0dWRlOiBwLmFsdGl0dWRlCiAgfQoKZGVmaW5lIGZ1bmN0aW9uIExvY2F0aW9uSG91cnNPZk9wZXJhdGlvbihob3Vyc09mT3BlcmF0aW9uIExpc3Q8RkhJUi5Mb2NhdGlvbi5Ib3Vyc09mT3BlcmF0aW9uPik6CiAgaG91cnNPZk9wZXJhdGlvbiBoT08KICByZXR1cm4gRkhJUi5Mb2NhdGlvbi5Ib3Vyc09mT3BlcmF0aW9uewogICAgZGF5c09mV2VlazogaE9PLmRheXNPZldlZWssCiAgICBhbGxEYXk6IGhPTy5hbGxEYXksCiAgICBvcGVuaW5nVGltZTogaE9PLm9wZW5pbmdUaW1lLAogICAgY2xvc2luZ1RpbWU6IGhPTy5jbG9zaW5nVGltZQogIH0KCmRlZmluZSBmdW5jdGlvbiBMb2NhdGlvblJlc291cmNlKGxvY2F0aW9uIExvY2F0aW9uLCBwcm9maWxlVVJMcyBMaXN0PEZISVIuY2Fub25pY2FsPik6CiAgbG9jYXRpb24gbAogIHJldHVybiBMb2NhdGlvbnsKICAgIGlkOiBGSElSLmlkIHt2YWx1ZTogJ0xDUi0nICsgbC5pZH0sCiAgICBtZXRhOiBNZXRhRWxlbWVudChsLCBwcm9maWxlVVJMcyksCiAgICBleHRlbnNpb246IGwuZXh0ZW5zaW9uLAogICAgc3RhdHVzOiBsLnN0YXR1cywKICAgIG9wZXJhdGlvbmFsU3RhdHVzOiBsLm9wZXJhdGlvbmFsU3RhdHVzLAogICAgbmFtZTogbC5uYW1lLAogICAgYWxpYXM6IGwuYWxpYXMsCiAgICBkZXNjcmlwdGlvbjogbC5kZXNjcmlwdGlvbiwKICAgIG1vZGU6IGwubW9kZSwKICAgIHR5cGU6IGwudHlwZSwKICAgIHRlbGVjb206IGwudGVsZWNvbSwKICAgIGFkZHJlc3M6IExvY2F0aW9uQWRkcmVzcyhsLmFkZHJlc3MpLAogICAgcGh5c2ljYWxUeXBlOiBsLnBoeXNpY2FsVHlwZSwKICAgIHBvc2l0aW9uOiBMb2NhdGlvblBvc2l0aW9uKGwucG9zaXRpb24pLAogICAgbWFuYWdpbmdPcmdhbml6YXRpb246IGwubWFuYWdpbmdPcmdhbml6YXRpb24sCiAgICBwYXJ0T2Y6IGwucGFydE9mLAogICAgaG91cnNPZk9wZXJhdGlvbjogTG9jYXRpb25Ib3Vyc09mT3BlcmF0aW9uKGwuaG91cnNPZk9wZXJhdGlvbiksCiAgICBhdmFpbGFiaWxpdHlFeGNlcHRpb25zOiBsLmF2YWlsYWJpbGl0eUV4Y2VwdGlvbnMsCiAgICBlbmRwb2ludDogbC5lbmRwb2ludAogIH0KCmRlZmluZSBmdW5jdGlvbiBNZWRpY2F0aW9uSW5ncmVkaWVudChpbmdyZWRpZW50IExpc3Q8RkhJUi5NZWRpY2F0aW9uLkluZ3JlZGllbnQ+KToKICBpbmdyZWRpZW50IGkKICByZXR1cm4gRkhJUi5NZWRpY2F0aW9uLkluZ3JlZGllbnR7CiAgICBpdGVtOiBpLml0ZW0sCiAgICBzdHJlbmd0aDogaS5zdHJlbmd0aAogIH0KCmRlZmluZSBmdW5jdGlvbiBNZWRpY2F0aW9uQmF0Y2goYmF0Y2ggRkhJUi5NZWRpY2F0aW9uLkJhdGNoKToKICBiYXRjaCBiCiAgcmV0dXJuIEZISVIuTWVkaWNhdGlvbi5CYXRjaHsKICAgIGxvdE51bWJlcjogYi5sb3ROdW1iZXIsCiAgICBleHBpcmF0aW9uRGF0ZTogYi5leHBpcmF0aW9uRGF0ZQogIH0KCmRlZmluZSBmdW5jdGlvbiBNZWRpY2F0aW9uUmVzb3VyY2UobWVkaWNhdGlvbiBNZWRpY2F0aW9uLCBwcm9maWxlVVJMcyBMaXN0PEZISVIuY2Fub25pY2FsPik6CiAgbWVkaWNhdGlvbiBtCiAgcmV0dXJuIE1lZGljYXRpb257CiAgICBpZDogRkhJUi5pZCB7dmFsdWU6ICdMQ1ItJyArIG0uaWR9LAogICAgbWV0YTogTWV0YUVsZW1lbnQobSwgcHJvZmlsZVVSTHMpLAogICAgZXh0ZW5zaW9uOiBtLmV4dGVuc2lvbiwKICAgIGNvZGU6IG0uY29kZSwKICAgIHN0YXR1czogbS5zdGF0dXMsCiAgICBtYW51ZmFjdHVyZXI6IG0ubWFudWZhY3R1cmVyLAogICAgZm9ybTogbS5mb3JtLAogICAgYW1vdW50OiBtLmFtb3VudCwKICAgIGluZ3JlZGllbnQ6IE1lZGljYXRpb25JbmdyZWRpZW50KG0uaW5ncmVkaWVudCksCiAgICBiYXRjaDogTWVkaWNhdGlvbkJhdGNoKG0uYmF0Y2gpCiAgfQoKZGVmaW5lIGZ1bmN0aW9uIE1lZGljYXRpb25BZG1pbmlzdHJhdGlvblBlcmZvcm1lcihwZXJmb3JtZXIgTGlzdDxGSElSLk1lZGljYXRpb25BZG1pbmlzdHJhdGlvbi5QZXJmb3JtZXI+KToKICBwZXJmb3JtZXIgcAogIHJldHVybiBGSElSLk1lZGljYXRpb25BZG1pbmlzdHJhdGlvbi5QZXJmb3JtZXJ7CiAgICBmdW5jdGlvbjogcC5mdW5jdGlvbiwKICAgIGFjdG9yOiBwLmFjdG9yCiAgfQoKZGVmaW5lIGZ1bmN0aW9uIE1lZGljYXRpb25BZG1pbmlzdHJhdGlvbkRvc2FnZShkb3NhZ2UgRkhJUi5NZWRpY2F0aW9uQWRtaW5pc3RyYXRpb24uRG9zYWdlKToKICBkb3NhZ2UgZAogIHJldHVybiBGSElSLk1lZGljYXRpb25BZG1pbmlzdHJhdGlvbi5Eb3NhZ2V7CiAgICB0ZXh0OiBkLnRleHQsCiAgICBzaXRlOiBkLnNpdGUsCiAgICByb3V0ZTogZC5yb3V0ZSwKICAgIG1ldGhvZDogZC5tZXRob2QsCiAgICBkb3NlOiBkLmRvc2UsCiAgICByYXRlOiBkLnJhdGUKICB9CgpkZWZpbmUgZnVuY3Rpb24gTWVkaWNhdGlvbkFkbWluaXN0cmF0aW9uUmVzb3VyY2UobWVkaWNhdGlvbkFkbWluaXN0cmF0aW9uIE1lZGljYXRpb25BZG1pbmlzdHJhdGlvbiwgcHJvZmlsZVVSTHMgTGlzdDxGSElSLmNhbm9uaWNhbD4pOgogIG1lZGljYXRpb25BZG1pbmlzdHJhdGlvbiBtCiAgcmV0dXJuIE1lZGljYXRpb25BZG1pbmlzdHJhdGlvbnsKICAgIGlkOiBGSElSLmlkIHt2YWx1ZTogJ0xDUi0nICsgbS5pZH0sCiAgICBtZXRhOiBNZXRhRWxlbWVudChtLCBwcm9maWxlVVJMcyksCiAgICBleHRlbnNpb246IG0uZXh0ZW5zaW9uLAogICAgaW5zdGFudGlhdGVzOiBtLmluc3RhbnRpYXRlcywKICAgIHBhcnRPZjogbS5wYXJ0T2YsCiAgICBzdGF0dXM6IG0uc3RhdHVzLAogICAgc3RhdHVzUmVhc29uOiBtLnN0YXR1c1JlYXNvbiwKICAgIGNhdGVnb3J5OiBtLmNhdGVnb3J5LAogICAgbWVkaWNhdGlvbjogbS5tZWRpY2F0aW9uLAogICAgc3ViamVjdDogbS5zdWJqZWN0LAogICAgY29udGV4dDogbS5jb250ZXh0LAogICAgc3VwcG9ydGluZ0luZm9ybWF0aW9uOiBtLnN1cHBvcnRpbmdJbmZvcm1hdGlvbiwKICAgIGVmZmVjdGl2ZTogbS5lZmZlY3RpdmUsCiAgICBwZXJmb3JtZXI6IE1lZGljYXRpb25BZG1pbmlzdHJhdGlvblBlcmZvcm1lcihtLnBlcmZvcm1lciksCiAgICByZWFzb25Db2RlOiBtLnJlYXNvbkNvZGUsCiAgICByZWFzb25SZWZlcmVuY2U6IG0ucmVhc29uUmVmZXJlbmNlLAogICAgcmVxdWVzdDogbS5yZXF1ZXN0LAogICAgZGV2aWNlOiBtLmRldmljZSwKICAgIG5vdGU6IG0ubm90ZSwKICAgIGRvc2FnZTogTWVkaWNhdGlvbkFkbWluaXN0cmF0aW9uRG9zYWdlKG0uZG9zYWdlKSwKICAgIGV2ZW50SGlzdG9yeTogbS5ldmVudEhpc3RvcnkKICB9CgpkZWZpbmUgZnVuY3Rpb24gTWVkaWNhdGlvblJlcXVlc3REb3NlQW5kUmF0ZShkb3NlQW5kUmF0ZSBMaXN0PEZISVIuRG9zYWdlLkRvc2VBbmRSYXRlPik6CiAgZG9zZUFuZFJhdGUgZFIKICByZXR1cm4gRkhJUi5Eb3NhZ2UuRG9zZUFuZFJhdGV7CiAgICB0eXBlOiBkUi50eXBlLAogICAgZG9zZTogZFIuZG9zZSwKICAgIHJhdGU6IGRSLnJhdGUKICB9CgpkZWZpbmUgZnVuY3Rpb24gTWVkaWNhdGlvblJlcXVlc3REb3NhZ2VJbnN0cnVjdGlvbihkb3NhZ2VJbnN0cnVjdGlvbiBMaXN0PEZISVIuRG9zYWdlPik6CiAgZG9zYWdlSW5zdHJ1Y3Rpb24gZEkKICByZXR1cm4gRkhJUi5Eb3NhZ2V7CiAgICB0ZXh0OiBkSS50ZXh0LAogICAgcGF0aWVudEluc3RydWN0aW9uOiBkSS5wYXRpZW50SW5zdHJ1Y3Rpb24sCiAgICB0aW1pbmc6IGRJLnRpbWluZywKICAgIGFzTmVlZGVkOiBkSS5hc05lZWRlZCwKICAgIHNpdGU6IGRJLnNpdGUsCiAgICByb3V0ZTogZEkucm91dGUsCiAgICBtZXRob2Q6IGRJLm1ldGhvZCwKICAgIGRvc2VBbmRSYXRlOiBNZWRpY2F0aW9uUmVxdWVzdERvc2VBbmRSYXRlKGRJLmRvc2VBbmRSYXRlKQogIH0KCmRlZmluZSBmdW5jdGlvbiBNZWRpY2F0aW9uUmVxdWVzdFJlc291cmNlKG1lZGljYXRpb25SZXF1ZXN0IE1lZGljYXRpb25SZXF1ZXN0LCBwcm9maWxlVVJMcyBMaXN0PEZISVIuY2Fub25pY2FsPik6CiAgbWVkaWNhdGlvblJlcXVlc3QgbQogIHJldHVybiBNZWRpY2F0aW9uUmVxdWVzdHsKICAgIGlkOiBGSElSLmlkIHt2YWx1ZTogJ0xDUi0nICsgbS5pZH0sCiAgICBtZXRhOiBNZXRhRWxlbWVudChtZWRpY2F0aW9uUmVxdWVzdCwgcHJvZmlsZVVSTHMpLAogICAgZXh0ZW5zaW9uOiBtLmV4dGVuc2lvbiwKICAgIHN0YXR1czogbS5zdGF0dXMsCiAgICBzdGF0dXNSZWFzb246IG0uc3RhdHVzUmVhc29uLAogICAgaW50ZW50OiBtLmludGVudCwKICAgIGNhdGVnb3J5OiBtLmNhdGVnb3J5LAogICAgcHJpb3JpdHk6IG0ucHJpb3JpdHksCiAgICBkb05vdFBlcmZvcm06IG0uZG9Ob3RQZXJmb3JtLAogICAgcmVwb3J0ZWQ6IG0ucmVwb3J0ZWQsCiAgICBtZWRpY2F0aW9uOiBtLm1lZGljYXRpb24sCiAgICBzdWJqZWN0OiBtLnN1YmplY3QsCiAgICBlbmNvdW50ZXI6IG0uZW5jb3VudGVyLAogICAgYXV0aG9yZWRPbjogbS5hdXRob3JlZE9uLAogICAgcmVxdWVzdGVyOiBtLnJlcXVlc3RlciwKICAgIHJlY29yZGVyOiBtLnJlY29yZGVyLAogICAgcmVhc29uQ29kZTogbS5yZWFzb25Db2RlLAogICAgcmVhc29uUmVmZXJlbmNlOiBtLnJlYXNvblJlZmVyZW5jZSwKICAgIGluc3RhbnRpYXRlc0Nhbm9uaWNhbDogbS5pbnN0YW50aWF0ZXNDYW5vbmljYWwsCiAgICBpbnN0YW50aWF0ZXNVcmk6IG0uaW5zdGFudGlhdGVzVXJpLAogICAgY291cnNlT2ZUaGVyYXB5VHlwZTogbS5jb3Vyc2VPZlRoZXJhcHlUeXBlLAogICAgZG9zYWdlSW5zdHJ1Y3Rpb246IE1lZGljYXRpb25SZXF1ZXN0RG9zYWdlSW5zdHJ1Y3Rpb24obS5kb3NhZ2VJbnN0cnVjdGlvbikKICB9CgovKiBObyBsb25nZXIgbmVlZGVkIGJ1dCBzYXZpbmcgaW4gY2FzZSBpdCdzIHVzZWZ1bCBsYXRlcgpkZWZpbmUgZnVuY3Rpb24gUGF0aWVudElkZW50aWZpZXIoaWRlbnRpZmllciBMaXN0PEZISVIuSWRlbnRpZmllcj4pOgogIGlkZW50aWZpZXIgaQogIHJldHVybiBGSElSLklkZW50aWZpZXJ7CiAgICBpZDogaS5pZCwKICAgIGV4dGVuc2lvbjogaS5leHRlbnNpb24sCiAgICB1c2U6IGkudXNlLAogICAgdHlwZTogaS50eXBlLAogICAgc3lzdGVtOiBpLnN5c3RlbSwKICAgIHZhbHVlOiBpLnZhbHVlLAogICAgcGVyaW9kOiBpLnBlcmlvZCwKICAgIGFzc2lnbmVyOiBpLmFzc2lnbmVyCiAgfSovCgpkZWZpbmUgZnVuY3Rpb24gUGF0aWVudE5hbWUobmFtZSBMaXN0PEZISVIuSHVtYW5OYW1lPik6CiAgbmFtZSBuCiAgcmV0dXJuIEZISVIuSHVtYW5OYW1lewogICAgaWQ6IG4uaWQsCiAgICBleHRlbnNpb246IG4uZXh0ZW5zaW9uLAogICAgdXNlOiBuLnVzZSwKICAgIHRleHQ6IG4udGV4dCwKICAgIGZhbWlseTogbi5mYW1pbHksCiAgICBnaXZlbjogbi5naXZlbiwKICAgIHByZWZpeDogbi5wcmVmaXgsCiAgICBzdWZmaXg6IG4uc3VmZml4LAogICAgcGVyaW9kOiBuLnBlcmlvZAogIH0KCmRlZmluZSBmdW5jdGlvbiBQYXRpZW50VGVsZWNvbSh0ZWxlY29tIExpc3Q8RkhJUi5Db250YWN0UG9pbnQ+KToKICB0ZWxlY29tIHQKICByZXR1cm4gRkhJUi5Db250YWN0UG9pbnR7CiAgICBzeXN0ZW06IHQuc3lzdGVtLAogICAgdmFsdWU6IHQudmFsdWUsCiAgICB1c2U6IHQudXNlLAogICAgcmFuazogdC5yYW5rLAogICAgcGVyaW9kOiB0LnBlcmlvZAogIH0KCmRlZmluZSBmdW5jdGlvbiBQYXRpZW50QWRkcmVzcyhhZGRyZXNzIExpc3Q8RkhJUi5BZGRyZXNzPik6CiAgYWRkcmVzcyBhCiAgcmV0dXJuIEZISVIuQWRkcmVzc3sKICAgIHVzZTogYS51c2UsCiAgICB0eXBlOiBhLnR5cGUsCiAgICB0ZXh0OiBhLnRleHQsCiAgICBsaW5lOiBhLmxpbmUsCiAgICBjaXR5OiBhLmNpdHksCiAgICBkaXN0cmljdDogYS5kaXN0cmljdCwKICAgIHN0YXRlOiBhLnN0YXRlLAogICAgcG9zdGFsQ29kZTogYS5wb3N0YWxDb2RlLAogICAgY291bnRyeTogYS5jb3VudHJ5LAogICAgcGVyaW9kOiBhLnBlcmlvZAogIH0KCmRlZmluZSBmdW5jdGlvbiBQYXRpZW50Q29udGFjdChjb250YWN0IExpc3Q8RkhJUi5QYXRpZW50LkNvbnRhY3Q+KToKICBjb250YWN0IGMKICByZXR1cm4gRkhJUi5QYXRpZW50LkNvbnRhY3R7CiAgICByZWxhdGlvbnNoaXA6IGMucmVsYXRpb25zaGlwLAogICAgbmFtZTogYy5uYW1lLAogICAgdGVsZWNvbTogYy50ZWxlY29tLAogICAgYWRkcmVzczogYy5hZGRyZXNzLAogICAgZ2VuZGVyOiBjLmdlbmRlciwKICAgIG9yZ2FuaXphdGlvbjogYy5vcmdhbml6YXRpb24sCiAgICBwZXJpb2Q6IGMucGVyaW9kCiAgfQoKZGVmaW5lIGZ1bmN0aW9uIFBhdGllbnRDb21tdW5pY2F0aW9uKGNvbW11bmljYXRpb24gTGlzdDxGSElSLlBhdGllbnQuQ29tbXVuaWNhdGlvbj4pOgogIGNvbW11bmljYXRpb24gYwogIHJldHVybiBGSElSLlBhdGllbnQuQ29tbXVuaWNhdGlvbnsKICAgIGxhbmd1YWdlOiBjLmxhbmd1YWdlLAogICAgcHJlZmVycmVkOiBjLnByZWZlcnJlZAogIH0KCmRlZmluZSBmdW5jdGlvbiBQYXRpZW50TGluayhsaW5rIExpc3Q8RkhJUi5QYXRpZW50Lkxpbms+KToKICBsaW5rIGwKICByZXR1cm4gRkhJUi5QYXRpZW50Lkxpbmt7CiAgICBleHRlbnNpb246IGwuZXh0ZW5zaW9uLAogICAgbW9kaWZpZXJFeHRlbnNpb246IGwubW9kaWZpZXJFeHRlbnNpb24sCiAgICBvdGhlcjogbC5vdGhlciwKICAgIHR5cGU6IGwudHlwZQogIH0KCmRlZmluZSBmdW5jdGlvbiBQYXRpZW50UmVzb3VyY2UocGF0aWVudCBQYXRpZW50LCBwcm9maWxlVVJMcyBMaXN0PEZISVIuY2Fub25pY2FsPik6CiAgcGF0aWVudCBwCiAgcmV0dXJuIFBhdGllbnR7CiAgICBpZDogRkhJUi5pZHt2YWx1ZTogJ0xDUi0nICsgcC5pZH0sCiAgICBtZXRhOiBNZXRhRWxlbWVudChwLCBwcm9maWxlVVJMcyksCiAgICBleHRlbnNpb246IEdldFBhdGllbnRFeHRlbnNpb25zKHApLAogICAgaWRlbnRpZmllcjogcC5pZGVudGlmaWVyLAogICAgYWN0aXZlOiBwLmFjdGl2ZSwKICAgIG5hbWU6IFBhdGllbnROYW1lKHAubmFtZSksCiAgICB0ZWxlY29tOiBQYXRpZW50VGVsZWNvbShwLnRlbGVjb20pLAogICAgZ2VuZGVyOiBwLmdlbmRlciwKICAgIGJpcnRoRGF0ZTogcC5iaXJ0aERhdGUsCiAgICBkZWNlYXNlZDogcC5kZWNlYXNlZCwKICAgIGFkZHJlc3M6IFBhdGllbnRBZGRyZXNzKHAuYWRkcmVzcyksCiAgICBtYXJpdGFsU3RhdHVzOiBwLm1hcml0YWxTdGF0dXMsCiAgICBtdWx0aXBsZUJpcnRoOiBwLm11bHRpcGxlQmlydGgsCiAgICBjb250YWN0OiBQYXRpZW50Q29udGFjdChwLmNvbnRhY3QpLAogICAgY29tbXVuaWNhdGlvbjogUGF0aWVudENvbW11bmljYXRpb24ocC5jb21tdW5pY2F0aW9uKSwKICAgIGxpbms6IFBhdGllbnRMaW5rKHAubGluaykKICB9CgpkZWZpbmUgZnVuY3Rpb24gUHJvY2VkdXJlUGVyZm9ybWVyKHBlcmZvcm1lciBMaXN0PEZISVIuUHJvY2VkdXJlLlBlcmZvcm1lcj4pOgogIHBlcmZvcm1lciBwCiAgcmV0dXJuIEZISVIuUHJvY2VkdXJlLlBlcmZvcm1lcnsKICAgIGZ1bmN0aW9uOiBwLmZ1bmN0aW9uLAogICAgYWN0b3I6IHAuYWN0b3IsCiAgICBvbkJlaGFsZk9mOiBwLm9uQmVoYWxmT2YKICB9CgpkZWZpbmUgZnVuY3Rpb24gUHJvY2VkdXJlRm9jYWxEZXZpY2UoZGV2aWNlIExpc3Q8RkhJUi5Qcm9jZWR1cmUuRm9jYWxEZXZpY2U+KToKICBkZXZpY2UgZAogIHJldHVybiBGSElSLlByb2NlZHVyZS5Gb2NhbERldmljZXsKICAgIGFjdGlvbjogZC5hY3Rpb24sCiAgICBtYW5pcHVsYXRlZDogZC5tYW5pcHVsYXRlZAogIH0KCmRlZmluZSBmdW5jdGlvbiBQcm9jZWR1cmVSZXNvdXJjZShwcm9jZWR1cmUgUHJvY2VkdXJlLCBwcm9maWxlVVJMcyBMaXN0PEZISVIuY2Fub25pY2FsPik6CiAgcHJvY2VkdXJlIHAKICByZXR1cm4gUHJvY2VkdXJlewogICAgaWQ6IEZISVIuaWQge3ZhbHVlOiAnTENSLScgKyBwLmlkfSwKICAgIG1ldGE6IE1ldGFFbGVtZW50KHAsIHByb2ZpbGVVUkxzKSwKICAgIGV4dGVuc2lvbjogcC5leHRlbnNpb24sCiAgICBpbnN0YW50aWF0ZXNDYW5vbmljYWw6IHAuaW5zdGFudGlhdGVzQ2Fub25pY2FsLAogICAgaW5zdGFudGlhdGVzVXJpOiBwLmluc3RhbnRpYXRlc1VyaSwKICAgIGJhc2VkT246IHAuYmFzZWRPbiwKICAgIHBhcnRPZjogcC5wYXJ0T2YsCiAgICBzdGF0dXM6IHAuc3RhdHVzLAogICAgc3RhdHVzUmVhc29uOiBwLnN0YXR1c1JlYXNvbiwKICAgIGNhdGVnb3J5OiBwLmNhdGVnb3J5LAogICAgY29kZTogcC5jb2RlLAogICAgc3ViamVjdDogcC5zdWJqZWN0LAogICAgZW5jb3VudGVyOiBwLmVuY291bnRlciwKICAgIHBlcmZvcm1lZDogcC5wZXJmb3JtZWQsCiAgICByZWNvcmRlcjogcC5yZWNvcmRlciwKICAgIGFzc2VydGVyOiBwLmFzc2VydGVyLAogICAgcGVyZm9ybWVyOiBQcm9jZWR1cmVQZXJmb3JtZXIocC5wZXJmb3JtZXIpLAogICAgbG9jYXRpb246IHAubG9jYXRpb24sCiAgICByZWFzb25Db2RlOiBwLnJlYXNvbkNvZGUsCiAgICByZWFzb25SZWZlcmVuY2U6IHAucmVhc29uUmVmZXJlbmNlLAogICAgYm9keVNpdGU6IHAuYm9keVNpdGUsCiAgICBvdXRjb21lOiBwLm91dGNvbWUsCiAgICByZXBvcnQ6IHAucmVwb3J0LAogICAgY29tcGxpY2F0aW9uOiBwLmNvbXBsaWNhdGlvbiwKICAgIGNvbXBsaWNhdGlvbkRldGFpbDogcC5jb21wbGljYXRpb25EZXRhaWwsCiAgICBmb2xsb3dVcDogcC5mb2xsb3dVcCwKICAgIG5vdGU6IHAubm90ZSwKICAgIGZvY2FsRGV2aWNlOiBQcm9jZWR1cmVGb2NhbERldmljZShwLmZvY2FsRGV2aWNlKSwKICAgIHVzZWRSZWZlcmVuY2U6IHAudXNlZFJlZmVyZW5jZSwKICAgIHVzZWRDb2RlOiBwLnVzZWRDb2RlCiAgfQoKZGVmaW5lIGZ1bmN0aW9uIFNlcnZpY2VSZXF1ZXN0UmVzb3VyY2Uoc2VydmljZVJlcXVlc3QgU2VydmljZVJlcXVlc3QsIHByb2ZpbGVVUkxzIExpc3Q8RkhJUi5jYW5vbmljYWw+KToKICBzZXJ2aWNlUmVxdWVzdCBzUgogIHJldHVybiBTZXJ2aWNlUmVxdWVzdHsKICAgIGlkOiBGSElSLmlkIHt2YWx1ZTogJ0xDUi0nICsgc1IuaWR9LAogICAgbWV0YTogTWV0YUVsZW1lbnQoc1IsIHByb2ZpbGVVUkxzKSwKICAgIGV4dGVuc2lvbjogc1IuZXh0ZW5zaW9uLAogICAgaW5zdGFudGlhdGVzQ2Fub25pY2FsOiBzUi5pbnN0YW50aWF0ZXNDYW5vbmljYWwsCiAgICBpbnN0YW50aWF0ZXNVcmk6IHNSLmluc3RhbnRpYXRlc1VyaSwKICAgIGJhc2VkT246IHNSLmJhc2VkT24sCiAgICByZXBsYWNlczogc1IucmVwbGFjZXMsCiAgICByZXF1aXNpdGlvbjogc1IucmVxdWlzaXRpb24sCiAgICBzdGF0dXM6IHNSLnN0YXR1cywKICAgIGludGVudDogc1IuaW50ZW50LAogICAgY2F0ZWdvcnk6IHNSLmNhdGVnb3J5LAogICAgcHJpb3JpdHk6IHNSLnByaW9yaXR5LAogICAgZG9Ob3RQZXJmb3JtOiBzUi5kb05vdFBlcmZvcm0sCiAgICBjb2RlOiBzUi5jb2RlLAogICAgb3JkZXJEZXRhaWw6IHNSLm9yZGVyRGV0YWlsLAogICAgcXVhbnRpdHk6IHNSLnF1YW50aXR5LAogICAgc3ViamVjdDogc1Iuc3ViamVjdCwKICAgIGVuY291bnRlcjogc1IuZW5jb3VudGVyLAogICAgb2NjdXJyZW5jZTogc1Iub2NjdXJyZW5jZSwKICAgIGFzTmVlZGVkOiBzUi5hc05lZWRlZCwKICAgIGF1dGhvcmVkT246IHNSLmF1dGhvcmVkT24sCiAgICByZXF1ZXN0ZXI6IHNSLnJlcXVlc3RlciwKICAgIHBlcmZvcm1lclR5cGU6IHNSLnBlcmZvcm1lclR5cGUsCiAgICBwZXJmb3JtZXI6IHNSLnBlcmZvcm1lciwKICAgIGxvY2F0aW9uQ29kZTogc1IubG9jYXRpb25Db2RlLAogICAgbG9jYXRpb25SZWZlcmVuY2U6IHNSLmxvY2F0aW9uUmVmZXJlbmNlLAogICAgcmVhc29uQ29kZTogc1IucmVhc29uQ29kZSwKICAgIHJlYXNvblJlZmVyZW5jZTogc1IucmVhc29uUmVmZXJlbmNlLAogICAgaW5zdXJhbmNlOiBzUi5pbnN1cmFuY2UsCiAgICBzdXBwb3J0aW5nSW5mbzogc1Iuc3VwcG9ydGluZ0luZm8sCiAgICBzcGVjaW1lbjogc1Iuc3BlY2ltZW4sCiAgICBib2R5U2l0ZTogc1IuYm9keVNpdGUsCiAgICBub3RlOiBzUi5ub3RlLAogICAgcGF0aWVudEluc3RydWN0aW9uOiBzUi5wYXRpZW50SW5zdHJ1Y3Rpb24sCiAgICByZWxldmFudEhpc3Rvcnk6IHNSLnJlbGV2YW50SGlzdG9yeQogIH0KCmRlZmluZSBmdW5jdGlvbiBTcGVjaW1lbkNvbGxlY3Rpb24oY29sbGVjdGlvbiBGSElSLlNwZWNpbWVuLkNvbGxlY3Rpb24pOgogIGNvbGxlY3Rpb24gYwogIHJldHVybiBGSElSLlNwZWNpbWVuLkNvbGxlY3Rpb257CiAgICBjb2xsZWN0b3I6IGMuY29sbGVjdG9yLAogICAgY29sbGVjdGVkOiBjLmNvbGxlY3RlZCwKICAgICJkdXJhdGlvbiI6IGMuImR1cmF0aW9uIiwKICAgIHF1YW50aXR5OiBjLnF1YW50aXR5LAogICAgbWV0aG9kOiBjLm1ldGhvZCwKICAgIGJvZHlTaXRlOiBjLmJvZHlTaXRlLAogICAgZmFzdGluZ1N0YXR1czogYy5mYXN0aW5nU3RhdHVzCiAgfQoKZGVmaW5lIGZ1bmN0aW9uIFNwZWNpbWVuUHJvY2Vzc2luZyhwcm9jZXNzaW5nIExpc3Q8RkhJUi5TcGVjaW1lbi5Qcm9jZXNzaW5nPik6CiAgcHJvY2Vzc2luZyBwCiAgcmV0dXJuIEZISVIuU3BlY2ltZW4uUHJvY2Vzc2luZ3sKICAgIGRlc2NyaXB0aW9uOiBwLmRlc2NyaXB0aW9uLAogICAgcHJvY2VkdXJlOiBwLnByb2NlZHVyZSwKICAgIGFkZGl0aXZlOiBwLmFkZGl0aXZlLAogICAgdGltZTogcC50aW1lCiAgfQoKZGVmaW5lIGZ1bmN0aW9uIFNwZWNpbWVuQ29udGFpbmVyKGNvbnRhaW5lciBMaXN0PEZISVIuU3BlY2ltZW4uQ29udGFpbmVyPik6CiAgY29udGFpbmVyIGMKICByZXR1cm4gRkhJUi5TcGVjaW1lbi5Db250YWluZXJ7CiAgICBkZXNjcmlwdGlvbjogYy5kZXNjcmlwdGlvbiwKICAgIHR5cGU6IGMudHlwZSwKICAgIGNhcGFjaXR5OiBjLmNhcGFjaXR5LAogICAgc3BlY2ltZW5RdWFudGl0eTogYy5zcGVjaW1lblF1YW50aXR5LAogICAgYWRkaXRpdmU6IGMuYWRkaXRpdmUKICB9CgpkZWZpbmUgZnVuY3Rpb24gU3BlY2ltZW5SZXNvdXJjZShzcGVjaW1lbiBTcGVjaW1lbiwgcHJvZmlsZVVSTHMgTGlzdDxGSElSLmNhbm9uaWNhbD4pOgogIHNwZWNpbWVuIHMKICByZXR1cm4gU3BlY2ltZW57CiAgICBpZDogRkhJUi5pZCB7dmFsdWU6ICdMQ1ItJyArIHMuaWR9LAogICAgbWV0YTogTWV0YUVsZW1lbnQocywgcHJvZmlsZVVSTHMpLAogICAgZXh0ZW5zaW9uOiBzLmV4dGVuc2lvbiwKICAgIGlkZW50aWZpZXI6IHMuaWRlbnRpZmllciwKICAgIGFjY2Vzc2lvbklkZW50aWZpZXI6IHMuYWNjZXNzaW9uSWRlbnRpZmllciwKICAgIHN0YXR1czogcy5zdGF0dXMsCiAgICB0eXBlOiBzLnR5cGUsCiAgICBzdWJqZWN0OiBzLnN1YmplY3QsCiAgICByZWNlaXZlZFRpbWU6IHMucmVjZWl2ZWRUaW1lLAogICAgcGFyZW50OiBzLnBhcmVudCwKICAgIHJlcXVlc3Q6IHMucmVxdWVzdCwKICAgIGNvbGxlY3Rpb246IFNwZWNpbWVuQ29sbGVjdGlvbihzLmNvbGxlY3Rpb24pLAogICAgcHJvY2Vzc2luZzogU3BlY2ltZW5Qcm9jZXNzaW5nKHMucHJvY2Vzc2luZyksCiAgICBjb250YWluZXI6IFNwZWNpbWVuQ29udGFpbmVyKHMuY29udGFpbmVyKSwKICAgIGNvbmRpdGlvbjogcy5jb25kaXRpb24sCiAgICBub3RlOiBzLm5vdGUKICB9CgpkZWZpbmUgZnVuY3Rpb24gIk9wZXJhdGlvbk91dGNvbWVSZXNvdXJjZSIoZXJyb3JJZCBTdHJpbmcsIHJlc291cmNlSWQgRkhJUi5pZCwgbWVzc2FnZSBTdHJpbmcpOgogIE9wZXJhdGlvbk91dGNvbWV7CiAgICAgIGlkOiBGSElSLmlke3ZhbHVlOiBlcnJvcklkfSwKICAgICAgaXNzdWU6IHsKICAgICAgICAgIEZISVIuT3BlcmF0aW9uT3V0Y29tZS5Jc3N1ZXsKICAgICAgICAgIHNldmVyaXR5OiBGSElSLklzc3VlU2V2ZXJpdHl7dmFsdWU6ICdlcnJvcid9LAogICAgICAgICAgY29kZTogRkhJUi5Jc3N1ZVR5cGV7dmFsdWU6ICdleGNlcHRpb24nfSwKICAgICAgICAgIGRldGFpbHM6IAogICAgICAgICAgICAgIEZISVIuQ29kZWFibGVDb25jZXB0ewogICAgICAgICAgICAgICAgICBjb2Rpbmc6IHsKICAgICAgICAgICAgICAgICAgICAgIENvZGluZ3sKICAgICAgICAgICAgICAgICAgICAgIHN5c3RlbTogdXJpe3ZhbHVlOiAnaHR0cHM6Ly9sYW50YW5hZ3JvdXAuY29tL3ZhbGlkYXRpb24tZXJyb3InfSwKICAgICAgICAgICAgICAgICAgICAgIGNvZGU6IGNvZGV7dmFsdWU6ICdFcnJvcid9LAogICAgICAgICAgICAgICAgICAgICAgZGlzcGxheTogc3RyaW5ne3ZhbHVlOiAnUmVzb3VyY2UgJyArIHJlc291cmNlSWQgKyAnIGZhaWxlZCB2YWxpZGF0aW9uOiAnICsgbWVzc2FnZX0KICAgICAgICAgICAgICAgICAgICAgIH0KICAgICAgICAgICAgICAgICAgfQogICAgICAgICAgICAgIH0KICAgICAgICAgIH0KICAgICAgfQogIH0=",
+            "url": "http://www.cdc.gov/nhsn/fhirportal/dqm/ig/Library-SharedResourceCreation.cql"
           }
         ]
       },

--- a/DotNet/ServiceTests/UnitTests/Automation/CqlFilterSimulatorTests.cs
+++ b/DotNet/ServiceTests/UnitTests/Automation/CqlFilterSimulatorTests.cs
@@ -647,4 +647,119 @@ public class CqlFilterSimulatorTests
 
         Assert.DoesNotContain("Specimen/S-mixed", excluded);
     }
+
+    // ---------- DiagnosticReport SDE Others (`not` category) ----------
+
+    private static CqlFilterSimulator.PatientCqlInput InputWithDiagnosticReports(
+        params CqlFilterSimulator.DiagnosticReportContext[] reports)
+        => new(
+            PatientId: "P1",
+            EncounterId: "E1",
+            EncounterStart: EncStart,
+            EncounterEnd: EncEnd,
+            Conditions: Array.Empty<CqlFilterSimulator.ConditionContext>(),
+            Observations: Array.Empty<CqlFilterSimulator.ObservationContext>())
+        { DiagnosticReports = reports };
+
+    [Fact]
+    public void AchMonthly_DiagnosticReport_EmptyCategoryOverlappingIp_IsKeptByOthers()
+    {
+        var report = new CqlFilterSimulator.DiagnosticReportContext("DR-empty", EncStart.AddHours(1), EncStart.AddHours(2));
+
+        var excluded = CqlFilterSimulator.ComputeFilteredKeys(
+            [ProfiledMeasureType.NhsnAcuteCareHospitalMonthlyInitialPopulation],
+            InputWithDiagnosticReports(report));
+
+        Assert.DoesNotContain("DiagnosticReport/DR-empty", excluded);
+    }
+
+    [Fact]
+    public void AchMonthly_DiagnosticReport_LabCategoryOverlappingIp_IsKept()
+    {
+        var report = new CqlFilterSimulator.DiagnosticReportContext("DR-lab", EncStart.AddHours(1), EncStart.AddHours(2))
+        {
+            CategoryCodes = ["LAB"]
+        };
+
+        var excluded = CqlFilterSimulator.ComputeFilteredKeys(
+            [ProfiledMeasureType.NhsnAcuteCareHospitalMonthlyInitialPopulation],
+            InputWithDiagnosticReports(report));
+
+        Assert.DoesNotContain("DiagnosticReport/DR-lab", excluded);
+    }
+
+    [Fact]
+    public void AchMonthly_DiagnosticReport_EmptyCategoryOutsideIp_IsExcluded()
+    {
+        var report = new CqlFilterSimulator.DiagnosticReportContext("DR-out", EncEnd.AddDays(2), EncEnd.AddDays(2).AddHours(1));
+
+        var excluded = CqlFilterSimulator.ComputeFilteredKeys(
+            [ProfiledMeasureType.NhsnAcuteCareHospitalMonthlyInitialPopulation],
+            InputWithDiagnosticReports(report));
+
+        Assert.Contains("DiagnosticReport/DR-out", excluded);
+    }
+
+    // ---------- Location SDE: GetLocation(IP.location) vs [Location] ----------
+
+    private static CqlFilterSimulator.PatientCqlInput InputWithLocations(
+        CqlFilterSimulator.EncounterContext encounter,
+        params CqlFilterSimulator.LocationContext[] locations)
+        => new(
+            PatientId: "P1",
+            EncounterId: encounter.EncounterId,
+            EncounterStart: encounter.PeriodStart,
+            EncounterEnd: encounter.PeriodEnd,
+            Conditions: Array.Empty<CqlFilterSimulator.ConditionContext>(),
+            Observations: Array.Empty<CqlFilterSimulator.ObservationContext>())
+        {
+            Encounters = [encounter],
+            Locations = locations
+        };
+
+    [Fact]
+    public void AchMonthly_Location_ExcludesHospitalNotOnIpEncounter()
+    {
+        var encounter = new CqlFilterSimulator.EncounterContext("E1", EncStart, EncEnd, "IMP", "finished")
+        {
+            LocationReferences = ["Location/ED", "Location/ICU", "Location/StepDown"]
+        };
+
+        var excluded = CqlFilterSimulator.ComputeFilteredKeys(
+            [ProfiledMeasureType.NhsnAcuteCareHospitalMonthlyInitialPopulation],
+            InputWithLocations(
+                encounter,
+                new CqlFilterSimulator.LocationContext("ED"),
+                new CqlFilterSimulator.LocationContext("ICU"),
+                new CqlFilterSimulator.LocationContext("StepDown"),
+                new CqlFilterSimulator.LocationContext("Hospital")));
+
+        Assert.DoesNotContain("Location/ED", excluded);
+        Assert.DoesNotContain("Location/ICU", excluded);
+        Assert.DoesNotContain("Location/StepDown", excluded);
+        Assert.Contains("Location/Hospital", excluded);
+    }
+
+    [Fact]
+    public void AchDaily_Location_KeepsAllLocationsWhenIpExists()
+    {
+        var encounter = new CqlFilterSimulator.EncounterContext("E1", EncStart, EncEnd, "IMP", "finished")
+        {
+            LocationReferences = ["Location/ED", "Location/ICU", "Location/StepDown"]
+        };
+
+        var excluded = CqlFilterSimulator.ComputeFilteredKeys(
+            [ProfiledMeasureType.NhsnAcuteCareHospitalDailyInitialPopulation],
+            InputWithLocations(
+                encounter,
+                new CqlFilterSimulator.LocationContext("ED"),
+                new CqlFilterSimulator.LocationContext("ICU"),
+                new CqlFilterSimulator.LocationContext("StepDown"),
+                new CqlFilterSimulator.LocationContext("Hospital")));
+
+        Assert.DoesNotContain("Location/ED", excluded);
+        Assert.DoesNotContain("Location/ICU", excluded);
+        Assert.DoesNotContain("Location/StepDown", excluded);
+        Assert.DoesNotContain("Location/Hospital", excluded);
+    }
 }

--- a/DotNet/ServiceTests/UnitTests/Automation/CqlFilterSimulatorTests.cs
+++ b/DotNet/ServiceTests/UnitTests/Automation/CqlFilterSimulatorTests.cs
@@ -33,37 +33,58 @@ public class CqlFilterSimulatorTests
 
     // ---------- ACH (Monthly + Daily) ----------
 
-    [Theory]
-    [InlineData(ProfiledMeasureType.NhsnAcuteCareHospitalMonthlyInitialPopulation)]
-    [InlineData(ProfiledMeasureType.NhsnAcuteCareHospitalDailyInitialPopulation)]
-    public void Ach_IncludesAllSupportedCategoriesWithinEncounter(ProfiledMeasureType measure)
+    [Fact]
+    public void AchMonthly_KeepsLabAndVitals_ExcludesSocialHistoryAndSurvey()
     {
+        // Current ACH Monthly CQL comments social-history/survey out of SDE Observation Category.
         var input = InputWith(
             Obs("o-lab", "laboratory", "718-7", EncStart.AddHours(1)),
             Obs("o-vitals", "vital-signs", "8867-4", EncStart.AddHours(2)),
             Obs("o-social", "social-history", "72166-2", EncStart.AddHours(3)),
             Obs("o-survey", "survey", "44249-1", EncStart.AddHours(4)));
 
-        var excluded = CqlFilterSimulator.ComputeFilteredKeys(new[] { measure }, input);
+        var excluded = CqlFilterSimulator.ComputeFilteredKeys(
+            [ProfiledMeasureType.NhsnAcuteCareHospitalMonthlyInitialPopulation],
+            input);
 
-        Assert.Empty(excluded);
+        Assert.DoesNotContain("Observation/o-lab", excluded);
+        Assert.DoesNotContain("Observation/o-vitals", excluded);
+        Assert.Contains("Observation/o-social", excluded);
+        Assert.Contains("Observation/o-survey", excluded);
     }
 
-    [Theory]
-    [InlineData(ProfiledMeasureType.NhsnAcuteCareHospitalMonthlyInitialPopulation)]
-    [InlineData(ProfiledMeasureType.NhsnAcuteCareHospitalDailyInitialPopulation)]
-    public void Ach_ExcludesUnsupportedCategoriesEvenWithinEncounter(ProfiledMeasureType measure)
+    [Fact]
+    public void AchDaily_SdeAllObservations_KeepsEveryObservationWhenIpExists()
+    {
+        var input = InputWith(
+            Obs("o-lab", "laboratory", "718-7", EncStart.AddHours(1)),
+            Obs("o-social", "social-history", "72166-2", EncStart.AddHours(3)),
+            Obs("o-exam", "exam", "8867-4", EncStart.AddHours(1)));
+
+        var excluded = CqlFilterSimulator.ComputeFilteredKeys(
+            [ProfiledMeasureType.NhsnAcuteCareHospitalDailyInitialPopulation],
+            input);
+
+        Assert.DoesNotContain("Observation/o-lab", excluded);
+        Assert.DoesNotContain("Observation/o-social", excluded);
+        Assert.DoesNotContain("Observation/o-exam", excluded);
+    }
+
+    [Fact]
+    public void AchMonthly_ExcludesUnsupportedCategoriesEvenWithinEncounter()
     {
         var input = InputWith(
             Obs("o-exam", "exam", "8867-4", EncStart.AddHours(1)),
             Obs("o-therapy", "therapy", "8867-4", EncStart.AddHours(2)),
             Obs("o-activity", "activity", "8867-4", EncStart.AddHours(3)));
 
-        var excluded = CqlFilterSimulator.ComputeFilteredKeys(new[] { measure }, input);
+        var excluded = CqlFilterSimulator.ComputeFilteredKeys(
+            [ProfiledMeasureType.NhsnAcuteCareHospitalMonthlyInitialPopulation],
+            input);
 
-        Assert.Equal(
-            new HashSet<string> { "Observation/o-exam", "Observation/o-therapy", "Observation/o-activity" },
-            excluded);
+        Assert.Contains("Observation/o-exam", excluded);
+        Assert.Contains("Observation/o-therapy", excluded);
+        Assert.Contains("Observation/o-activity", excluded);
     }
 
     [Fact]
@@ -291,7 +312,6 @@ public class CqlFilterSimulatorTests
 
     [Theory]
     [InlineData(ProfiledMeasureType.NhsnAcuteCareHospitalMonthlyInitialPopulation)]
-    [InlineData(ProfiledMeasureType.NhsnAcuteCareHospitalDailyInitialPopulation)]
     [InlineData(ProfiledMeasureType.NhsnGlycemicControlHypoglycemicInitialPopulation)]
     public void MedicationRequest_AuthoredDuringEncounter_IsKept(ProfiledMeasureType measure)
     {
@@ -300,6 +320,18 @@ public class CqlFilterSimulatorTests
         var excluded = CqlFilterSimulator.ComputeFilteredKeys(new[] { measure }, InputWithMedicationRequests(mr));
 
         Assert.DoesNotContain("MedicationRequest/MR-001", excluded);
+    }
+
+    [Fact]
+    public void AchDaily_MedicationRequest_WithoutMatchingValueSet_IsExcluded()
+    {
+        var mr = new CqlFilterSimulator.MedicationRequestContext("MR-001", EncStart.AddHours(2), $"Encounter/E1");
+
+        var excluded = CqlFilterSimulator.ComputeFilteredKeys(
+            [ProfiledMeasureType.NhsnAcuteCareHospitalDailyInitialPopulation],
+            InputWithMedicationRequests(mr));
+
+        Assert.Contains("MedicationRequest/MR-001", excluded);
     }
 
     [Theory]
@@ -351,7 +383,7 @@ public class CqlFilterSimulatorTests
     }
 
     [Fact]
-    public void Ach_MedicationAdministration_HasNoSdeRetrieve_DoesNotApply()
+    public void AchMonthly_MedicationAdministration_OutsideEncounter_IsExcluded()
     {
         var ma = new CqlFilterSimulator.MedicationAdministrationContext("MA-003", EncEnd.AddDays(2), EncEnd.AddDays(2).AddHours(1), "Encounter/E1");
 
@@ -364,7 +396,7 @@ public class CqlFilterSimulatorTests
         var excluded = CqlFilterSimulator.ComputeFilteredKeys(
             new[] { ProfiledMeasureType.NhsnAcuteCareHospitalMonthlyInitialPopulation }, input);
 
-        Assert.DoesNotContain("MedicationAdministration/MA-003", excluded);
+        Assert.Contains("MedicationAdministration/MA-003", excluded);
     }
 
     // ---------- Coverage profile ----------

--- a/DotNet/ServiceTests/UnitTests/Automation/CqlFilterSimulatorTests.cs
+++ b/DotNet/ServiceTests/UnitTests/Automation/CqlFilterSimulatorTests.cs
@@ -700,6 +700,18 @@ public class CqlFilterSimulatorTests
         Assert.Contains("DiagnosticReport/DR-out", excluded);
     }
 
+    [Fact]
+    public void AchMonthly_DiagnosticReport_UnknownEffectiveInterval_IsExcluded()
+    {
+        var report = new CqlFilterSimulator.DiagnosticReportContext("DR-unknown", DateTime.MinValue, DateTime.MaxValue);
+
+        var excluded = CqlFilterSimulator.ComputeFilteredKeys(
+            [ProfiledMeasureType.NhsnAcuteCareHospitalMonthlyInitialPopulation],
+            InputWithDiagnosticReports(report));
+
+        Assert.Contains("DiagnosticReport/DR-unknown", excluded);
+    }
+
     // ---------- Location SDE: GetLocation(IP.location) vs [Location] ----------
 
     private static CqlFilterSimulator.PatientCqlInput InputWithLocations(

--- a/DotNet/ServiceTests/UnitTests/Automation/EmbeddedAchMeasureBundleTests.cs
+++ b/DotNet/ServiceTests/UnitTests/Automation/EmbeddedAchMeasureBundleTests.cs
@@ -1,0 +1,58 @@
+using System.Text;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using FluentAssertions;
+using LantanaGroup.Automation.Generation;
+
+namespace UnitTests.Automation;
+
+[Trait("Category", "UnitTests")]
+public class EmbeddedAchMeasureBundleTests
+{
+    [Theory]
+    [InlineData(ProfiledMeasureType.NhsnAcuteCareHospitalMonthlyInitialPopulation)]
+    [InlineData(ProfiledMeasureType.NhsnAcuteCareHospitalDailyInitialPopulation)]
+    public void Embedded_ach_bundles_include_every_cql_valueset(ProfiledMeasureType family)
+    {
+        using var doc = JsonDocument.Parse(ReadEmbeddedBundle(family));
+        var vsUrls = new HashSet<string>(StringComparer.Ordinal);
+        var cql = new StringBuilder();
+        foreach (var entry in doc.RootElement.GetProperty("entry").EnumerateArray())
+        {
+            if (!entry.TryGetProperty("resource", out var resource))
+                continue;
+            var type = resource.GetProperty("resourceType").GetString();
+            if (type == "ValueSet" && resource.TryGetProperty("url", out var url))
+                vsUrls.Add(url.GetString()!);
+            if (type != "Library" || !resource.TryGetProperty("content", out var content))
+                continue;
+            foreach (var attachment in content.EnumerateArray())
+            {
+                var contentType = attachment.TryGetProperty("contentType", out var ct) ? ct.GetString() : null;
+                if (contentType is null || !contentType.StartsWith("text/cql", StringComparison.OrdinalIgnoreCase))
+                    continue;
+                if (!attachment.TryGetProperty("data", out var data))
+                    continue;
+                cql.AppendLine(Encoding.UTF8.GetString(Convert.FromBase64String(data.GetString()!)));
+            }
+        }
+
+        var missing = Regex.Matches(cql.ToString(), """valueset "[^"]+": '([^']+)'""")
+            .Select(m => m.Groups[1].Value)
+            .Distinct(StringComparer.Ordinal)
+            .Where(u => !vsUrls.Contains(u))
+            .ToList();
+
+        missing.Should().BeEmpty("CQL valueset URLs must be present in the evaluation bundle");
+    }
+
+    private static string ReadEmbeddedBundle(ProfiledMeasureType family)
+    {
+        var location = ProfiledMeasureCatalog.GetBundleLocation(family);
+        var resourceName = location["resource://".Length..];
+        using var stream = typeof(ProfiledMeasureCatalog).Assembly.GetManifestResourceStream(resourceName)
+            ?? throw new FileNotFoundException(resourceName);
+        using var reader = new StreamReader(stream);
+        return reader.ReadToEnd();
+    }
+}

--- a/DotNet/ServiceTests/UnitTests/Automation/FhirBundleGeneratorTests.cs
+++ b/DotNet/ServiceTests/UnitTests/Automation/FhirBundleGeneratorTests.cs
@@ -383,9 +383,9 @@ public class FhirBundleGeneratorTests
             [ProfiledMeasureType.NhsnAcuteCareHospitalMonthlyInitialPopulation],
             input);
 
+        Assert.Contains("Condition/TestPatient-Condition-001", excluded);
         Assert.Contains("Condition/TestPatient-Condition-002", excluded);
         Assert.Contains("Condition/TestPatient-Condition-004", excluded);
-        Assert.DoesNotContain("Condition/TestPatient-Condition-001", excluded);
         Assert.DoesNotContain("Condition/TestPatient-Condition-003", excluded);
     }
 
@@ -399,7 +399,7 @@ public class FhirBundleGeneratorTests
             [],
             []);
 
-        Assert.Empty(CqlFilterSimulator.ComputeFilteredKeys([], input));
+        Assert.Empty(CqlFilterSimulator.ComputeFilteredKeys(Array.Empty<ProfiledMeasureType>(), input));
     }
 
     [Fact]
@@ -409,10 +409,10 @@ public class FhirBundleGeneratorTests
         // contained resources across the per-measure .mr files. So a resource is only truly
         // absent from ABS when EVERY applicable measure excludes it.
         //
-        // ACH requires active + recordedDate < encounterEnd for problem-list items.
-        // Hypoglycemic only requires recordedDate <= encounterEnd.
-        // A resolved (non-active) problem-list Condition recorded during the encounter is
-        // excluded by ACH but INCLUDED by Hypoglycemic -> must NOT appear in the excluded set.
+        // ACH Monthly SDE Condition keeps only encounter-diagnosis linked to IP.
+        // Hypoglycemic SDE Condition keeps conditions whose onset overlaps IP.
+        // A resolved problem-list Condition recorded during the encounter is excluded by
+        // ACH but included by Hypoglycemic -> must NOT appear in the excluded set.
 
         var encounterId = "P-Enc-001";
         var encStart = new DateTime(2024, 5, 10, 0, 0, 0, DateTimeKind.Utc);

--- a/DotNet/ServiceTests/UnitTests/Automation/OrgResourceMapPredictionFilterTests.cs
+++ b/DotNet/ServiceTests/UnitTests/Automation/OrgResourceMapPredictionFilterTests.cs
@@ -50,8 +50,7 @@ public class OrgResourceMapPredictionFilterTests
             sharedResourceEntries: null,
             organizationLocationConditionFhirPaths: [orgCondition]);
 
-        filtered.Should().Contain(["Encounter/E-1", "Location/L-ROOM"]);
-        filtered.Should().NotContain("Location/L-ROOT");
+        filtered.Should().Contain(["Encounter/E-1", "Location/L-ROOM", "Location/L-ROOT"]);
     }
 
     [Fact]
@@ -105,8 +104,8 @@ public class OrgResourceMapPredictionFilterTests
             sharedResourceEntries: null,
             organizationLocationConditionFhirPaths: [orgCondition]);
 
-        filtered.Should().Contain(["Encounter/E-1", "Location/L-ROOM"]);
-        filtered.Should().NotContain(["Location/L-ROOT", "Location/L-UNUSED"]);
+        filtered.Should().Contain(["Encounter/E-1", "Location/L-ROOM", "Location/L-ROOT"]);
+        filtered.Should().NotContain("Location/L-UNUSED");
     }
 
     [Fact]

--- a/DotNet/ServiceTests/UnitTests/Automation/QueryPlanAcquisitionSimulatorTests.cs
+++ b/DotNet/ServiceTests/UnitTests/Automation/QueryPlanAcquisitionSimulatorTests.cs
@@ -358,4 +358,65 @@ public class QueryPlanAcquisitionSimulatorTests
         // bounds the date check is vacuous; resource is included.
         Assert.Contains("Observation/O-NoDate3", acquired);
     }
+
+    [Fact]
+    public void Location_ReferenceQuery_FollowsPartOfParent()
+    {
+        var encounter = Entry("Encounter", "E1", """
+            { "resourceType":"Encounter","id":"E1",
+              "period": { "start":"2024-06-01T08:00:00Z", "end":"2024-06-05T08:00:00Z" },
+              "location":[{"location":{"reference":"Location/L-ROOM"}}] }
+            """);
+        var room = Entry("Location", "L-ROOM", """
+            { "resourceType":"Location","id":"L-ROOM",
+              "partOf":{"reference":"Location/L-HOSP"} }
+            """);
+        var hospital = Entry("Location", "L-HOSP", """
+            { "resourceType":"Location","id":"L-HOSP" }
+            """);
+        var unused = Entry("Location", "L-UNUSED", """
+            { "resourceType":"Location","id":"L-UNUSED",
+              "partOf":{"reference":"Location/L-HOSP"} }
+            """);
+
+        var plan = new QueryPlanInput
+        {
+            EhrDescription = "Test",
+            LookBack = "P0D",
+            InitialQueries =
+            [
+                new QueryPlanQueryEntry
+                {
+                    ResourceType = "Encounter",
+                    QueryConfigType = "Parameter",
+                    Parameters =
+                    [
+                        new QueryPlanParameterEntry { ParameterType = "Variable", Name = "patient", Variable = 0 },
+                        new QueryPlanParameterEntry { ParameterType = "Variable", Name = "date", Variable = 2, Format = "ge{0}" },
+                        new QueryPlanParameterEntry { ParameterType = "Variable", Name = "date", Variable = 3, Format = "le{0}" }
+                    ]
+                },
+                new QueryPlanQueryEntry
+                {
+                    ResourceType = "Location",
+                    QueryConfigType = "Reference",
+                    OperationType = 1,
+                    Paged = 100
+                }
+            ]
+        };
+
+        var acquired = QueryPlanAcquisitionSimulator.SimulateAcquiredKeysForPatient(
+            "P1",
+            [encounter],
+            [room, hospital, unused],
+            plan,
+            PeriodStart,
+            PeriodEnd);
+
+        Assert.Contains("Encounter/E1", acquired);
+        Assert.Contains("Location/L-ROOM", acquired);
+        Assert.Contains("Location/L-HOSP", acquired);
+        Assert.DoesNotContain("Location/L-UNUSED", acquired);
+    }
 }

--- a/DotNet/ServiceTests/UnitTests/Automation/QueryPlanAcquisitionSimulatorTests.cs
+++ b/DotNet/ServiceTests/UnitTests/Automation/QueryPlanAcquisitionSimulatorTests.cs
@@ -1,5 +1,8 @@
 ﻿using LantanaGroup.Automation.Generation;
+using LantanaGroup.Automation.Generation.ResourceFactories;
 using LantanaGroup.Automation.Helpers;
+using Hl7.Fhir.Introspection;
+using System.Globalization;
 using System.Text.Json;
 
 namespace UnitTests.Automation;
@@ -154,8 +157,8 @@ public class QueryPlanAcquisitionSimulatorTests
     [Fact]
     public void Observation_EffectivePeriod_OverlapsPeriod_IsAcquired()
     {
-        // Lab observations in the synthetic generator (and many real EHRs) use
-        // effectivePeriod, not effectiveDateTime.
+        // Imported/EHR lab observations may use effectivePeriod rather than
+        // effectiveDateTime. The simulator must still apply FHIR overlap.
         var entry = Entry("Observation", "O1", """
             { "resourceType":"Observation","id":"O1",
               "category":[{"coding":[{"code":"laboratory"}]}],
@@ -479,5 +482,99 @@ public class QueryPlanAcquisitionSimulatorTests
 
         Assert.Contains("Encounter/E1", acquired);
         Assert.DoesNotContain("DiagnosticReport/DxRpt-042", acquired);
+    }
+
+    [Fact]
+    public void DailyWindow_FhirBundleGeneratorObservations_SimulatorMatchesPeriodOverlap()
+    {
+        var mpStart = new DateTimeOffset(2023, 1, 15, 0, 0, 0, TimeSpan.Zero);
+        var mpEnd = new DateTimeOffset(2023, 1, 15, 23, 59, 59, TimeSpan.Zero);
+        var encStart = mpStart.AddHours(-6).UtcDateTime;
+        var encEnd = mpEnd.AddHours(6).UtcDateTime;
+
+        var serializerOptions = new JsonSerializerOptions();
+        serializerOptions.ForFhir(ModelInfo.ModelInspector);
+
+        var encounterJson = JsonSerializer.Serialize(
+            new Encounter
+            {
+                Id = "E1",
+                Period = new Period
+                {
+                    StartElement = new FhirDateTime(encStart),
+                    EndElement = new FhirDateTime(encEnd)
+                }
+            },
+            serializerOptions);
+
+        var entries = new List<(string ResourceType, string ResourceId, string Key, JsonElement Resource)>
+        {
+            Entry("Encounter", "E1", encounterJson)
+        };
+
+        var observationIds = new List<string>();
+        var specimenIds = new List<string> { "S1" };
+        const int observationCount = 80;
+        for (var i = 0; i < observationCount; i++)
+        {
+            var offset = TimeSpan.FromMinutes((double)i / observationCount * (encEnd - encStart).TotalMinutes);
+            var effective = encStart.Add(offset);
+            var id = $"O-{i:D3}";
+            var obs = ObservationFactory.Generate(id, "P1", "E1", effective, seed: 20260825 + i, specimenIds, observationIds);
+            var json = JsonSerializer.Serialize(obs, obs.GetType(), serializerOptions);
+            entries.Add(Entry("Observation", id, json));
+        }
+
+        var acquired = QueryPlanAcquisitionSimulator.SimulateAcquiredKeysForPatient(
+            "P1",
+            entries,
+            null,
+            QueryPlanDefaults.GetDefaultAsInput(),
+            "2023-01-15T00:00:00Z",
+            "2023-01-15T23:59:59Z",
+            allowEncounterAnchoredDateOverrideForOutOfRange: false);
+
+        var mismatches = new List<string>();
+        foreach (var entry in entries.Where(e => e.ResourceType == "Observation"))
+        {
+            var overlaps = ObservationJsonOverlaps(entry.Resource, mpStart, mpEnd);
+            var simHas = acquired.Contains(entry.Key);
+            if (overlaps != simHas)
+                mismatches.Add($"{entry.Key} overlaps={overlaps} sim={simHas} json={entry.Resource.GetRawText()}");
+        }
+
+        Assert.True(mismatches.Count == 0,
+            $"Simulator/overlap mismatches ({mismatches.Count}):\n" + string.Join("\n", mismatches.Take(8)));
+    }
+
+    private static bool ObservationJsonOverlaps(JsonElement resource, DateTimeOffset mpStart, DateTimeOffset mpEnd)
+    {
+        DateTimeOffset start = default;
+        DateTimeOffset end = default;
+        if (resource.TryGetProperty("effectiveDateTime", out var dt)
+            && dt.ValueKind == JsonValueKind.String
+            && DateTimeOffset.TryParse(dt.GetString(), CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal, out start))
+        {
+            end = start;
+        }
+        else if (resource.TryGetProperty("effectivePeriod", out var period) && period.ValueKind == JsonValueKind.Object)
+        {
+            var hasStart = period.TryGetProperty("start", out var s)
+                           && s.ValueKind == JsonValueKind.String
+                           && DateTimeOffset.TryParse(s.GetString(), CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal, out start);
+            var hasEnd = period.TryGetProperty("end", out var e)
+                         && e.ValueKind == JsonValueKind.String
+                         && DateTimeOffset.TryParse(e.GetString(), CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal, out end);
+            if (!hasStart && !hasEnd)
+                return false;
+            if (!hasStart) start = DateTimeOffset.MinValue;
+            if (!hasEnd) end = DateTimeOffset.MaxValue;
+        }
+        else
+        {
+            return false;
+        }
+
+        return end >= mpStart && start <= mpEnd;
     }
 }

--- a/DotNet/ServiceTests/UnitTests/Automation/QueryPlanAcquisitionSimulatorTests.cs
+++ b/DotNet/ServiceTests/UnitTests/Automation/QueryPlanAcquisitionSimulatorTests.cs
@@ -419,4 +419,65 @@ public class QueryPlanAcquisitionSimulatorTests
         Assert.Contains("Location/L-HOSP", acquired);
         Assert.DoesNotContain("Location/L-UNUSED", acquired);
     }
+
+    [Fact]
+    public void DiagnosticReport_IssuedInPeriod_EffectiveBeforePeriod_IsExcluded()
+    {
+        var encounter = Entry("Encounter", "E1", """
+            { "resourceType":"Encounter","id":"E1",
+              "period": { "start":"2024-06-01T08:00:00Z", "end":"2024-06-05T08:00:00Z" } }
+            """);
+        var report = Entry("DiagnosticReport", "DxRpt-042", """
+            { "resourceType":"DiagnosticReport","id":"DxRpt-042",
+              "encounter":{"reference":"Encounter/E1"},
+              "effectiveDateTime":"2023-12-01T08:00:00Z",
+              "issued":"2024-06-15T08:00:00Z" }
+            """);
+
+        var plan = new QueryPlanInput
+        {
+            EhrDescription = "Test",
+            LookBack = "P0D",
+            InitialQueries =
+            [
+                new QueryPlanQueryEntry
+                {
+                    ResourceType = "Encounter",
+                    QueryConfigType = "Parameter",
+                    Parameters =
+                    [
+                        new QueryPlanParameterEntry { ParameterType = "Variable", Name = "patient", Variable = 0 },
+                        new QueryPlanParameterEntry { ParameterType = "Variable", Name = "date", Variable = 2, Format = "ge{0}" },
+                        new QueryPlanParameterEntry { ParameterType = "Variable", Name = "date", Variable = 3, Format = "le{0}" }
+                    ]
+                }
+            ],
+            SupplementalQueries =
+            [
+                new QueryPlanQueryEntry
+                {
+                    ResourceType = "DiagnosticReport",
+                    QueryConfigType = "Parameter",
+                    Parameters =
+                    [
+                        new QueryPlanParameterEntry { ParameterType = "Variable", Name = "patient", Variable = 0 },
+                        new QueryPlanParameterEntry { ParameterType = "Variable", Name = "date", Variable = 2, Format = "ge{0}" },
+                        new QueryPlanParameterEntry { ParameterType = "Variable", Name = "date", Variable = 3, Format = "le{0}" }
+                    ]
+                }
+            ]
+        };
+
+        var acquired = QueryPlanAcquisitionSimulator.SimulateAcquiredKeysForPatient(
+            "P1",
+            [encounter, report],
+            null,
+            plan,
+            PeriodStart,
+            PeriodEnd,
+            allowEncounterAnchoredDateOverrideForOutOfRange: false);
+
+        Assert.Contains("Encounter/E1", acquired);
+        Assert.DoesNotContain("DiagnosticReport/DxRpt-042", acquired);
+    }
 }

--- a/DotNet/ServiceTests/UnitTests/Automation/QueryPlanAcquisitionSimulatorTests.cs
+++ b/DotNet/ServiceTests/UnitTests/Automation/QueryPlanAcquisitionSimulatorTests.cs
@@ -2,6 +2,7 @@
 using LantanaGroup.Automation.Generation.ResourceFactories;
 using LantanaGroup.Automation.Helpers;
 using Hl7.Fhir.Introspection;
+using Hl7.Fhir.Model;
 using System.Globalization;
 using System.Text.Json;
 
@@ -576,5 +577,41 @@ public class QueryPlanAcquisitionSimulatorTests
         }
 
         return end >= mpStart && start <= mpEnd;
+    }
+
+    [Fact]
+    public void Observation_EffectiveInLastSecondOfPeriodEnd_IsAcquired()
+    {
+        // Daily ACH PeriodEnd is formatted as le2023-01-15T23:59:59Z (second precision).
+        // HAPI treats that bound as covering [23:59:59.000, 24:00:00). A generated
+        // Observation at 23:59:59.167 is included by DA and must be predicted.
+        var encounter = Entry("Encounter", "E1", """
+            { "resourceType":"Encounter","id":"E1",
+              "period": { "start":"2023-01-14T18:00:00Z", "end":"2023-01-16T05:59:59Z" } }
+            """);
+        var inLastSecond = Entry("Observation", "O-last-second", """
+            { "resourceType":"Observation","id":"O-last-second",
+              "category":[{"coding":[{"system":"http://terminology.hl7.org/CodeSystem/observation-category","code":"vital-signs"}]}],
+              "encounter":{"reference":"Encounter/E1"},
+              "effectiveDateTime":"2023-01-15T23:59:59.167Z" }
+            """);
+        var atNextMidnight = Entry("Observation", "O-next-midnight", """
+            { "resourceType":"Observation","id":"O-next-midnight",
+              "category":[{"coding":[{"system":"http://terminology.hl7.org/CodeSystem/observation-category","code":"vital-signs"}]}],
+              "encounter":{"reference":"Encounter/E1"},
+              "effectiveDateTime":"2023-01-16T00:00:00Z" }
+            """);
+
+        var acquired = QueryPlanAcquisitionSimulator.SimulateAcquiredKeysForPatient(
+            "P1",
+            [encounter, inLastSecond, atNextMidnight],
+            null,
+            QueryPlanDefaults.GetDefaultAsInput(),
+            "2023-01-15T00:00:00Z",
+            "2023-01-15T23:59:59Z",
+            allowEncounterAnchoredDateOverrideForOutOfRange: false);
+
+        Assert.Contains("Observation/O-last-second", acquired);
+        Assert.DoesNotContain("Observation/O-next-midnight", acquired);
     }
 }

--- a/DotNet/ServiceTests/UnitTests/AutomationUI/ScenarioSeedServiceTests.cs
+++ b/DotNet/ServiceTests/UnitTests/AutomationUI/ScenarioSeedServiceTests.cs
@@ -10,7 +10,45 @@ namespace UnitTests.AutomationUI;
 [Trait("Category", "UnitTests")]
 public class ScenarioSeedServiceTests
 {
+    private static readonly Guid AdhocReportScenarioId = new("00000000-0000-0000-0000-000000000001");
+    private static readonly Guid AdhocReportDailyAchScenarioId = new("00000000-0000-0000-0000-000000000009");
     private static readonly Guid MultiMeasureScenarioId = new("00000000-0000-0000-0000-000000000006");
+
+    [Fact]
+    public async global::System.Threading.Tasks.Task Adhoc_report_daily_ach_scenario_uses_daily_measure_and_distinct_org_id()
+    {
+        var store = new InMemoryScenarioStore();
+        var sut = new ScenarioSeedService(store, NullLogger<ScenarioSeedService>.Instance);
+
+        await sut.StartAsync(CancellationToken.None);
+
+        var monthly = await store.GetByIdAsync(AdhocReportScenarioId, CancellationToken.None);
+        monthly.Should().NotBeNull();
+        monthly!.IsSystemScenario.Should().BeTrue();
+        monthly.SelectedMeasures.Should().ContainSingle()
+            .Which.Should().Be(ProfiledMeasureType.NhsnAcuteCareHospitalMonthlyInitialPopulation);
+        monthly.NhsnOrganizationId.Should().Be("10756");
+
+        var daily = await store.GetByIdAsync(AdhocReportDailyAchScenarioId, CancellationToken.None);
+        daily.Should().NotBeNull();
+        daily!.IsSystemScenario.Should().BeTrue();
+        daily.Name.Should().Be("Adhoc Report Daily ACH Test");
+        daily.ReportMethod.Should().Be(ReportMethod.Adhoc);
+        daily.SelectedMeasures.Should().ContainSingle()
+            .Which.Should().Be(ProfiledMeasureType.NhsnAcuteCareHospitalDailyInitialPopulation);
+        daily.NhsnOrganizationId.Should().Be("10764");
+        daily.NhsnOrganizationId.Should().NotBe(monthly.NhsnOrganizationId);
+        daily.PatientCount.Should().Be(1);
+        daily.ResourcesPerPatientMin.Should().Be(1000);
+        daily.ResourcesPerPatientMax.Should().Be(1000);
+        daily.ReportPeriodStart.Should().Be(new DateTimeOffset(2023, 1, 15, 0, 0, 0, TimeSpan.Zero));
+        daily.ReportPeriodEnd.Should().Be(new DateTimeOffset(2023, 1, 15, 23, 59, 59, TimeSpan.Zero));
+        daily.PatientCohorts.Should().ContainSingle();
+        daily.PatientCohorts[0].MeasureEligibilities.Should().ContainKey(
+            ProfiledMeasureType.NhsnAcuteCareHospitalDailyInitialPopulation);
+        daily.PatientCohorts[0].ScheduledInpatientPattern.Should().Be(
+            ScheduledInpatientPattern.AdmittedBeforePeriodRemainsInpatientAfterPeriod);
+    }
 
     [Fact]
     public async global::System.Threading.Tasks.Task Multi_measure_seeded_scenario_sets_inpatient_pattern_for_each_cohort()

--- a/Tests/AutomationUI.Pipeline/azure-pipelines.yml
+++ b/Tests/AutomationUI.Pipeline/azure-pipelines.yml
@@ -99,6 +99,11 @@ parameters:
     type: boolean
     default: true
 
+  - name: runAdHocDailyAchReportSuite
+    displayName: "Run Ad Hoc Daily ACH Report Generation Suite"
+    type: boolean
+    default: true
+
   - name: runRegenerateReportSuite
     displayName: "Run Ad Hoc Report Re-generation Suite"
     type: boolean
@@ -134,8 +139,9 @@ variables:
 
   # System scenario IDs are deterministic and seeded by Automation.UI's
   # ScenarioSeedService -- same value in every environment.
-  SCENARIO_ID_AdHocReport:       "00000000-0000-0000-0000-000000000001"
-  SCENARIO_ID_ScheduledReport:   "00000000-0000-0000-0000-000000000004"
+  SCENARIO_ID_AdHocReport:            "00000000-0000-0000-0000-000000000001"
+  SCENARIO_ID_AdHocDailyAchReport:    "00000000-0000-0000-0000-000000000009"
+  SCENARIO_ID_ScheduledReport:        "00000000-0000-0000-0000-000000000004"
   SCENARIO_ID_RegenerateReport:  "00000000-0000-0000-0000-000000000005"
 
   # Slack webhook is fetched at runtime from Azure App Configuration so the
@@ -289,6 +295,7 @@ stages:
                 Write-Host "Requested suites:"
                 Write-Host "  API Stability          : ${{ parameters.runApiStabilitySuite }}"
                 Write-Host "  Ad Hoc Report          : ${{ parameters.runAdHocReportSuite }}"
+                Write-Host "  Ad Hoc Daily ACH Report: ${{ parameters.runAdHocDailyAchReportSuite }}"
                 Write-Host "  Regenerate Report      : ${{ parameters.runRegenerateReportSuite }}"
                 Write-Host "  Scheduled Report       : ${{ parameters.runScheduledReportSuite }}"
 
@@ -501,6 +508,16 @@ stages:
                     Name     = "Ad Hoc Report Generation Suite"
                     Type     = "Scenario"
                     ScenarioId = "$(SCENARIO_ID_AdHocReport)"
+                    StartPath  = "/api/runs/start"
+                    StatusPathTemplate = "/api/runs/{0}/status"
+                    DetailsPathTemplate = "/Runs/Details/{0}"
+                  }
+                }
+                if ("${{ parameters.runAdHocDailyAchReportSuite }}" -eq "True") {
+                  $suites += [pscustomobject]@{
+                    Name     = "Ad Hoc Daily ACH Report Generation Suite"
+                    Type     = "Scenario"
+                    ScenarioId = "$(SCENARIO_ID_AdHocDailyAchReport)"
                     StartPath  = "/api/runs/start"
                     StatusPathTemplate = "/api/runs/{0}/status"
                     DetailsPathTemplate = "/Runs/Details/{0}"
@@ -856,8 +873,9 @@ stages:
                 Write-Host ""
                 Write-Host "Suite flags:"
                 Write-Host "  API Stability     : ${{ parameters.runApiStabilitySuite }}"
-                Write-Host "  Ad Hoc Report     : ${{ parameters.runAdHocReportSuite }}"
-                Write-Host "  Regenerate Report : ${{ parameters.runRegenerateReportSuite }}"
+                Write-Host "  Ad Hoc Report          : ${{ parameters.runAdHocReportSuite }}"
+                Write-Host "  Ad Hoc Daily ACH Report: ${{ parameters.runAdHocDailyAchReportSuite }}"
+                Write-Host "  Regenerate Report      : ${{ parameters.runRegenerateReportSuite }}"
                 Write-Host "  Scheduled Report  : ${{ parameters.runScheduledReportSuite }}"
                 Write-Host ""
 

--- a/Tests/BackendE2ETests/AdhocReportDailyAchTest.cs
+++ b/Tests/BackendE2ETests/AdhocReportDailyAchTest.cs
@@ -1,0 +1,27 @@
+using Xunit;
+
+namespace LantanaGroup.Link.Tests.E2ETests;
+
+public sealed class AdhocReportDailyAchTest : IClassFixture<BackendE2ETestFixture>
+{
+    private readonly IServiceProvider _sp;
+
+    public AdhocReportDailyAchTest(BackendE2ETestFixture fixture)
+    {
+        _sp = fixture.ServiceProvider;
+    }
+
+    [Fact]
+    [Trait("Category", "AdhocReportDailyAchTest")]
+    public async Task ExecuteAdhocReportDailyAchTest()
+    {
+        using var timeoutCts = new CancellationTokenSource(TimeSpan.FromMinutes(20));
+
+        await AutomationUiScenarioRunner.RunScenarioAsync(
+            _sp,
+            AutomationUiScenarioRunner.AdhocReportDailyAchScenarioId,
+            "Adhoc Report Daily ACH Test",
+            "BackendE2ETests.AdhocReportDailyAchTest",
+            timeoutCts.Token);
+    }
+}

--- a/Tests/BackendE2ETests/AutomationUiScenarioRunner.cs
+++ b/Tests/BackendE2ETests/AutomationUiScenarioRunner.cs
@@ -79,6 +79,7 @@ internal static class AutomationUiScenarioRunner
     internal static Guid RegenerateReportScenarioId => new("00000000-0000-0000-0000-000000000005");
     internal static Guid MultiMeasureScenarioId => new("00000000-0000-0000-0000-000000000006");
     internal static Guid MegaMultiPatientScenarioId => new("00000000-0000-0000-0000-000000000007");
+    internal static Guid AdhocReportDailyAchScenarioId => new("00000000-0000-0000-0000-000000000009");
 
     private sealed class StartScenarioApiRequest
     {

--- a/Tests/BackendE2ETests/README.md
+++ b/Tests/BackendE2ETests/README.md
@@ -34,7 +34,8 @@ These tests use `AutomationUiScenarioRunner` to start a seeded scenario and poll
 
 | Suite | System scenario id | Notes |
 |---|---|---|
-| `AdhocReportTest` | `00000000-0000-0000-0000-000000000001` | PR-safe |
+| `AdhocReportTest` | `00000000-0000-0000-0000-000000000001` | PR-safe (ACH Monthly) |
+| `AdhocReportDailyAchTest` | `00000000-0000-0000-0000-000000000009` | PR-safe (ACH Daily) |
 | `MultiPatientTest` | `00000000-0000-0000-0000-000000000002` | PR-safe |
 | `MegaPatientTest` | `00000000-0000-0000-0000-000000000003` | `Category=LongRunning` |
 | `ReportScheduledWorkflowTest` (`ReportScheduledTest`) | `00000000-0000-0000-0000-000000000004` | PR-safe |
@@ -99,6 +100,7 @@ Backend E2E categories and excludes long-running mega stress tests.
 Current PR list includes:
 
 - `AdhocReportTest`
+- `AdhocReportDailyAchTest`
 - `ApiStabilityTest`
 - `AutomationUiSmokeTest`
 - `ReportScheduledTest`


### PR DESCRIPTION
### 🛠️ Description of Changes

LEGLINK-1068. Align Automation ACH Daily and Monthly measure bundles with Validation 2.0.0-cibuild, and derive ABS instance-level CQL prediction from those embedded bundles instead of frozen family profiles.

Measure bundles: Validation Measure + primary Library, FHIRHelpers 4.0.2 and NHSNHelpers 0.0.002 kept so CQF can resolve includes, Daily Discharge Disposition ValueSet URL aligned with CQL (`clinical-discharge-disposition`).

ABS prediction: `CqlInstanceFilterAnalyzer` / `CqlMeasureBundleModel` parse reachable SDE defines from the measure-bundle CQL. DiagnosticReport Others (empty-category / not-category), Location.partOf follow during acquisition, Monthly SDE Location limited to IP encounter locations, DiagnosticReport dates match `effective[x]` only, default Observation category query includes `survey`, and Daily Observations on the last second of PeriodEnd are predicted. Lab Observations are stamped with point `effectiveDateTime` (Thetis shape) so they fall inside a one-day Daily window.

Adds `AdhocReportDailyAchTest` and unit coverage for the CQL simulator, acquisition simulator, and embedded ACH bundles. No Measure Eval Java changes.

### 🧪 Testing Performed

- Unit tests: `CqlFilterSimulatorTests`, `EmbeddedAchMeasureBundleTests`, `QueryPlanAcquisitionSimulatorTests`, `FhirBundleGeneratorTests`, `OrgResourceMapPredictionFilterTests`, `ScenarioSeedServiceTests`.
- Backend `AdhocReportDailyAchTest` added for Daily ACH.
- Silo Daily adhoc on the first measure-only swap still scored IP=0 until the discharge ValueSet was aligned. Silo Monthly adhoc `a84718ed` on the aligned Monthly package scored `initial-population=[1]` / `REPORTABLE=[true]`.

### 🧑‍🔬 Unit Testing

- [x] I have written or updated unit tests to cover my changes
- Coverage: CqlFilterSimulatorTests, EmbeddedAchMeasureBundleTests, QueryPlanAcquisitionSimulatorTests, FhirBundleGeneratorTests, OrgResourceMapPredictionFilterTests, ScenarioSeedServiceTests

### 📓 Documentation Updated

Automation README CQL filter simulator section (prediction now reads embedded measure-bundle CQL). Short notes in Automation.Link, Automation.UI, and BackendE2ETests READMEs.