### PR TITLE
LEGLINK-1084: Chunk bundle validation, cache Terminology, and size heap from RAM

### DIFF
--- a/Java/validation/Dockerfile
+++ b/Java/validation/Dockerfile
@@ -25,4 +25,7 @@ RUN chmod -R 755 /app \
 
 USER 1001
 EXPOSE 5135
+# Heap tracks the container/cgroup (or host) memory. Override JAVA_TOOL_OPTIONS
+# only if you need a different percentage; do not replace this with a fixed -Xmx.
+ENV JAVA_TOOL_OPTIONS="-XX:MaxRAMPercentage=75.0"
 CMD ["java", "--add-opens", "java.base/java.util=ALL-UNNAMED", "-jar", "validation.jar"]

--- a/Java/validation/src/main/java/com/lantanagroup/link/validation/configs/CacheErrorHandlingConfig.java
+++ b/Java/validation/src/main/java/com/lantanagroup/link/validation/configs/CacheErrorHandlingConfig.java
@@ -5,6 +5,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.cache.Cache;
 import org.springframework.cache.annotation.CachingConfigurer;
 import org.springframework.cache.interceptor.CacheErrorHandler;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 /**
@@ -19,7 +20,9 @@ public class CacheErrorHandlingConfig implements CachingConfigurer {
     private static final Logger logger = LoggerFactory.getLogger(CacheErrorHandlingConfig.class);
 
     // Replaces Spring's default SimpleCacheErrorHandler, which rethrows cache errors, with one that
-    // logs and swallows them.
+    // logs and swallows them. Exposed as a bean so ValidationCacheService can use the same policy
+    // for programmatic cache get/put (those calls do not go through CacheInterceptor).
+    @Bean
     @Override
     public CacheErrorHandler errorHandler() {
         return new CacheErrorHandler() {

--- a/Java/validation/src/main/java/com/lantanagroup/link/validation/configs/LinkConfig.java
+++ b/Java/validation/src/main/java/com/lantanagroup/link/validation/configs/LinkConfig.java
@@ -13,6 +13,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
 
 @Configuration
 @ConfigurationProperties("link")
@@ -49,25 +50,18 @@ public class LinkConfig {
     private List<ValidationResultIgnoreRuleConfig> validationResultIgnoreRules = new ArrayList<>();
 
     /**
-     * How many bundle chunks validate at once. Memory is bounded by this times one
-     * in-flight HAPI validation (entries inside a chunk run sequentially).
+     * How many bundle entries HAPI validates at once. Passed to
+     * {@code FhirValidator.setExecutorService} with concurrent bundle validation enabled,
+     * so only this many InstanceValidator runs are in flight.
      */
     @Getter @Setter
     private int bundleValidationParallelism = 4;
 
-    /**
-     * Entries per chunk. Each chunk is one pool task; HAPI never sees the full bundle.
-     */
-    @Getter @Setter
-    private int bundleValidationBatchSize = 32;
-
     @Bean(name = "bundleValidationExecutor", destroyMethod = "shutdown")
     public ExecutorService bundleValidationExecutor() {
         int parallelism = Math.max(1, bundleValidationParallelism);
-        return Executors.newFixedThreadPool(parallelism, runnable -> {
-            Thread thread = new Thread(runnable, "hapi-bundle-validation");
-            thread.setDaemon(true);
-            return thread;
-        });
+        AtomicInteger threadIndex = new AtomicInteger();
+        return Executors.newFixedThreadPool(parallelism, runnable ->
+                new Thread(runnable, "hapi-bundle-validation-" + threadIndex.incrementAndGet()));
     }
 }

--- a/Java/validation/src/main/java/com/lantanagroup/link/validation/configs/LinkConfig.java
+++ b/Java/validation/src/main/java/com/lantanagroup/link/validation/configs/LinkConfig.java
@@ -11,6 +11,8 @@ import org.springframework.web.client.RestClient;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
 @Configuration
 @ConfigurationProperties("link")
@@ -45,4 +47,27 @@ public class LinkConfig {
      */
     @Getter @Setter
     private List<ValidationResultIgnoreRuleConfig> validationResultIgnoreRules = new ArrayList<>();
+
+    /**
+     * How many bundle chunks validate at once. Memory is bounded by this times one
+     * in-flight HAPI validation (entries inside a chunk run sequentially).
+     */
+    @Getter @Setter
+    private int bundleValidationParallelism = 4;
+
+    /**
+     * Entries per chunk. Each chunk is one pool task; HAPI never sees the full bundle.
+     */
+    @Getter @Setter
+    private int bundleValidationBatchSize = 32;
+
+    @Bean(name = "bundleValidationExecutor", destroyMethod = "shutdown")
+    public ExecutorService bundleValidationExecutor() {
+        int parallelism = Math.max(1, bundleValidationParallelism);
+        return Executors.newFixedThreadPool(parallelism, runnable -> {
+            Thread thread = new Thread(runnable, "hapi-bundle-validation");
+            thread.setDaemon(true);
+            return thread;
+        });
+    }
 }

--- a/Java/validation/src/main/java/com/lantanagroup/link/validation/configs/MemoryCacheConfig.java
+++ b/Java/validation/src/main/java/com/lantanagroup/link/validation/configs/MemoryCacheConfig.java
@@ -29,6 +29,7 @@ public class MemoryCacheConfig {
         logger.info("Cache type set to 'memory'");
         CaffeineCacheManager cacheManager = new CaffeineCacheManager(
                 "validateCodeCache",
+                "lookupCodeCache",
                 "isCodeSystemSupportedCache",
                 "isValueSetSupportedCache");
         cacheManager.setCaffeine(Caffeine.newBuilder()

--- a/Java/validation/src/main/java/com/lantanagroup/link/validation/providers/RemoteTermServiceValidation.java
+++ b/Java/validation/src/main/java/com/lantanagroup/link/validation/providers/RemoteTermServiceValidation.java
@@ -74,6 +74,21 @@ public class RemoteTermServiceValidation extends BaseValidationSupport implement
         return invokeRemoteValidateCode(theCodeSystem, theCode, theDisplay, null, theValueSet);
     }
 
+    @Override
+    public IBaseResource fetchCodeSystem(String theSystem) {
+        if (theSystem == null || isWhitelistedCodeSystem(theSystem)) {
+            return null;
+        }
+        if (validationCacheService != null) {
+            return validationCacheService.cachedFetchCodeSystem(this, theSystem);
+        }
+        return invokeFetchCodeSystem(theSystem);
+    }
+
+    IBaseResource invokeFetchCodeSystem(String theSystem) {
+        return fetchCodeSystem(theSystem, SummaryEnum.TRUE);
+    }
+
     @Nullable
     private IBaseResource fetchCodeSystem(String theSystem, @Nullable SummaryEnum theSummaryParam) {
         IGenericClient client = this.provideClient();
@@ -96,8 +111,7 @@ public class RemoteTermServiceValidation extends BaseValidationSupport implement
 
     /**
      * Remote lookup for {@link #lookupCode}, extracted so the result can be cached at the
-     * {@link ValidationCacheService} layer. Package-private so the cache service can invoke it via the
-     * delegate reference passed into the {@code @Cacheable} method.
+     * {@link ValidationCacheService} layer.
      */
     IValidationSupport.LookupCodeResult invokeLookupCode(String code, String system, String displayLanguage, String propertyNames) {
         IGenericClient client = this.provideClient();
@@ -280,7 +294,17 @@ public class RemoteTermServiceValidation extends BaseValidationSupport implement
     static final SummaryEnum FETCH_VALUE_SET_SUMMARY_MODE = SummaryEnum.TRUE;
 
     public IBaseResource fetchValueSet(String theValueSetUrl) {
-        return this.fetchValueSet(theValueSetUrl, FETCH_VALUE_SET_SUMMARY_MODE);
+        if (theValueSetUrl == null || isWhitelistedValueSet(theValueSetUrl)) {
+            return null;
+        }
+        if (validationCacheService != null) {
+            return validationCacheService.cachedFetchValueSet(this, theValueSetUrl);
+        }
+        return invokeFetchValueSet(theValueSetUrl);
+    }
+
+    IBaseResource invokeFetchValueSet(String theValueSetUrl) {
+        return fetchValueSet(theValueSetUrl, FETCH_VALUE_SET_SUMMARY_MODE);
     }
 
     @Nullable
@@ -298,48 +322,43 @@ public class RemoteTermServiceValidation extends BaseValidationSupport implement
     }
 
     public boolean isCodeSystemSupported(ValidationSupportContext theValidationSupportContext, String theSystem) {
-        if (theSystem == null) {
+        if (theSystem == null || isWhitelistedCodeSystem(theSystem)) {
             return false;
         }
-
-        for (String pattern : whiteListCodeSystemRegex) {
-            if (theSystem.matches(pattern)) {
-                return false;
-            }
-        }
-
         return validationCacheService.cachedIsCodeSystemSupported(this, theSystem);
     }
 
     public boolean isValueSetSupported(ValidationSupportContext theValidationSupportContext, String theValueSetUrl) {
-        if (theValueSetUrl == null) {
+        if (theValueSetUrl == null || isWhitelistedValueSet(theValueSetUrl)) {
             return false;
         }
-
-        for (String pattern : whiteListValueSetRegex) {
-            if (theValueSetUrl.matches(pattern)) {
-                return false;
-            }
-        }
-
         return validationCacheService.cachedIsValueSetSupported(this, theValueSetUrl);
     }
 
-    /**
-     * Remote lookup for {@link #isCodeSystemSupported}, extracted so the result can be cached at the
-     * {@link ValidationCacheService} layer. Package-private so the cache service can invoke it via the
-     * delegate reference passed into the {@code @Cacheable} method.
-     */
     boolean invokeIsCodeSystemSupported(String theSystem) {
-        return this.fetchCodeSystem(theSystem, SummaryEnum.TRUE) != null;
+        return invokeFetchCodeSystem(theSystem) != null;
     }
 
-    /**
-     * Remote lookup for {@link #isValueSetSupported}, extracted for the same reason as
-     * {@link #invokeIsCodeSystemSupported}.
-     */
     boolean invokeIsValueSetSupported(String theValueSetUrl) {
-        return this.fetchValueSet(theValueSetUrl, SummaryEnum.TRUE) != null;
+        return invokeFetchValueSet(theValueSetUrl) != null;
+    }
+
+    private boolean isWhitelistedCodeSystem(String theSystem) {
+        for (String pattern : whiteListCodeSystemRegex) {
+            if (theSystem.matches(pattern)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private boolean isWhitelistedValueSet(String theValueSetUrl) {
+        for (String pattern : whiteListValueSetRegex) {
+            if (theValueSetUrl.matches(pattern)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     public TranslateConceptResults translateConcept(IValidationSupport.TranslateCodeRequest theRequest) {

--- a/Java/validation/src/main/java/com/lantanagroup/link/validation/providers/ValidationCacheService.java
+++ b/Java/validation/src/main/java/com/lantanagroup/link/validation/providers/ValidationCacheService.java
@@ -1,22 +1,69 @@
 package com.lantanagroup.link.validation.providers;
 
 import ca.uhn.fhir.context.support.IValidationSupport;
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.lantanagroup.link.validation.configs.CacheConfig;
 import org.hl7.fhir.instance.model.api.IBaseResource;
-import org.springframework.cache.annotation.Cacheable;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.interceptor.CacheErrorHandler;
 import org.springframework.stereotype.Service;
 
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Supplier;
 
+/**
+ * Single-flight + two-level cache in front of every remote terminology HTTP call.
+ * <p>
+ * Concurrent bundle/chunk validation asks HAPI for the same codes and ValueSets on every
+ * worker at once. Spring {@code @Cacheable} (and Redis {@code Cache.get(key, loader)})
+ * does not coalesce those misses, and HAPI's chain cache is {@code getIfPresent}/{@code put}.
+ * Without a local flight map, four workers become four {@code $validate-code} / {@code GET ValueSet}
+ * calls for the same tuple.
+ * <p>
+ * FHIR {@code ValueSet}/{@code CodeSystem} bodies stay in an in-process Caffeine cache: they are
+ * not Redis-safe under the existing Jackson config. Existence booleans and validate/lookup
+ * results still go through {@link CacheManager} (Redis/memory/none). Null validate/lookup
+ * results are not cached, matching the previous {@code unless = "#result == null"} behaviour.
+ */
 @Service
 public class ValidationCacheService {
-    /**
-     * Cache wrapper for RemoteTermServiceValidation.invokeRemoteValidateCode().
-     * NOTE: This assumes `RemoteTermServiceValidation` is stateless for this call (safe to inject or pass).
-     */
-    @Cacheable(
-            value = "validateCodeCache",
-            key = "#root.target.validateCodeCacheKey(#codeSystem, #code, #display, #valueSetUrl)",
-            unless = "#result == null"
-    )
+    public static final String VALIDATE_CODE_CACHE = "validateCodeCache";
+    public static final String LOOKUP_CODE_CACHE = "lookupCodeCache";
+    public static final String IS_CODE_SYSTEM_SUPPORTED_CACHE = "isCodeSystemSupportedCache";
+    public static final String IS_VALUE_SET_SUPPORTED_CACHE = "isValueSetSupportedCache";
+
+    private static final CachedResource MISSING = new CachedResource(null);
+
+    private final CacheManager cacheManager;
+    private final CacheErrorHandler cacheErrorHandler;
+    private final Cache<String, CachedResource> resourceCache;
+    private final ConcurrentHashMap<String, CompletableFuture<?>> inflight = new ConcurrentHashMap<>();
+
+    public ValidationCacheService() {
+        this(null, null, null);
+    }
+
+    @Autowired
+    public ValidationCacheService(
+            CacheManager cacheManager,
+            CacheErrorHandler cacheErrorHandler,
+            CacheConfig cacheConfig) {
+        this.cacheManager = cacheManager;
+        this.cacheErrorHandler = cacheErrorHandler;
+        long ttlSeconds = cacheConfig != null && cacheConfig.getValidateCode() != null
+                ? cacheConfig.getValidateCode().getTtl()
+                : 3600;
+        this.resourceCache = Caffeine.newBuilder()
+                .expireAfterWrite(Duration.ofSeconds(Math.max(1, ttlSeconds)))
+                .maximumSize(5000)
+                .build();
+    }
+
     public IValidationSupport.CodeValidationResult cachedValidateCode(
             RemoteTermServiceValidation delegate,
             String codeSystem,
@@ -24,7 +71,18 @@ public class ValidationCacheService {
             String display,
             String valueSetUrl
     ) {
-        return delegate.invokeRemoteValidateCode(codeSystem, code, display, valueSetUrl, (IBaseResource) null);
+        String key = validateCodeCacheKey(codeSystem, code, display, valueSetUrl);
+        return computeOnce("validateCode:" + key, () -> {
+            IValidationSupport.CodeValidationResult cached =
+                    getFromCache(VALIDATE_CODE_CACHE, key, IValidationSupport.CodeValidationResult.class);
+            if (cached != null) {
+                return cached;
+            }
+            IValidationSupport.CodeValidationResult result =
+                    delegate.invokeRemoteValidateCode(codeSystem, code, display, valueSetUrl, (IBaseResource) null);
+            putInCache(VALIDATE_CODE_CACHE, key, result);
+            return result;
+        });
     }
 
     public String validateCodeCacheKey(
@@ -44,35 +102,31 @@ public class ValidationCacheService {
     }
 
     /**
-     * Cache wrapper for {@link RemoteTermServiceValidation#invokeIsCodeSystemSupported(String)}.
-     * HAPI's ValidationSupportChain probes {@code isCodeSystemSupported} per system per traversal,
-     * so an uncached implementation hits the remote TS on every coded element. Both {@code true}
-     * and {@code false} results are cached (unknown systems shouldn't be reprobed either).
+     * Existence check shares {@link #cachedFetchCodeSystem}: HAPI probes {@code isCodeSystemSupported}
+     * and later {@code fetchCodeSystem} for the same URL; one GET satisfies both.
      */
-    @Cacheable(value = "isCodeSystemSupportedCache", key = "#codeSystem")
     public boolean cachedIsCodeSystemSupported(RemoteTermServiceValidation delegate, String codeSystem) {
-        return delegate.invokeIsCodeSystemSupported(codeSystem);
+        return cachedFetchCodeSystem(delegate, codeSystem) != null;
     }
 
     /**
-     * Cache wrapper for {@link RemoteTermServiceValidation#invokeIsValueSetSupported(String)}.
-     * See {@link #cachedIsCodeSystemSupported} for rationale — identical caching model applies.
+     * Existence check shares {@link #cachedFetchValueSet}: HAPI probes {@code isValueSetSupported}
+     * and later {@code fetchValueSet} for the same URL; one GET satisfies both.
      */
-    @Cacheable(value = "isValueSetSupportedCache", key = "#valueSetUrl")
     public boolean cachedIsValueSetSupported(RemoteTermServiceValidation delegate, String valueSetUrl) {
-        return delegate.invokeIsValueSetSupported(valueSetUrl);
+        return cachedFetchValueSet(delegate, valueSetUrl) != null;
     }
 
-    /**
-     * Cache wrapper for {@link RemoteTermServiceValidation#invokeLookupCode(String, String, String, String)}.
-     * Lookup results are stable for a given code/system/language/properties combination and are expensive
-     * network calls, so caching prevents redundant remote round-trips during validation.
-     */
-    @Cacheable(
-            value = "lookupCodeCache",
-            key = "#root.target.validateCodeCacheKey(#code, #system, #displayLanguage, #propertyNames)",
-            unless = "#result == null"
-    )
+    public IBaseResource cachedFetchValueSet(RemoteTermServiceValidation delegate, String valueSetUrl) {
+        return cachedFetchResource("ValueSet", valueSetUrl, IS_VALUE_SET_SUPPORTED_CACHE,
+                () -> delegate.invokeFetchValueSet(valueSetUrl));
+    }
+
+    public IBaseResource cachedFetchCodeSystem(RemoteTermServiceValidation delegate, String codeSystem) {
+        return cachedFetchResource("CodeSystem", codeSystem, IS_CODE_SYSTEM_SUPPORTED_CACHE,
+                () -> delegate.invokeFetchCodeSystem(codeSystem));
+    }
+
     public IValidationSupport.LookupCodeResult cachedLookupCode(
             RemoteTermServiceValidation delegate,
             String code,
@@ -80,6 +134,117 @@ public class ValidationCacheService {
             String displayLanguage,
             String propertyNames
     ) {
-        return delegate.invokeLookupCode(code, system, displayLanguage, propertyNames);
+        String key = validateCodeCacheKey(code, system, displayLanguage, propertyNames);
+        return computeOnce("lookupCode:" + key, () -> {
+            IValidationSupport.LookupCodeResult cached =
+                    getFromCache(LOOKUP_CODE_CACHE, key, IValidationSupport.LookupCodeResult.class);
+            if (cached != null) {
+                return cached;
+            }
+            IValidationSupport.LookupCodeResult result =
+                    delegate.invokeLookupCode(code, system, displayLanguage, propertyNames);
+            putInCache(LOOKUP_CODE_CACHE, key, result);
+            return result;
+        });
+    }
+
+    private IBaseResource cachedFetchResource(
+            String type,
+            String url,
+            String existenceCacheName,
+            Supplier<IBaseResource> loader) {
+        return computeOnce("fetch:" + type + ":" + url, () -> {
+            String resourceKey = type + ":" + url;
+            CachedResource local = resourceCache.getIfPresent(resourceKey);
+            if (local != null) {
+                return local.resource();
+            }
+
+            Boolean known = getFromCache(existenceCacheName, url, Boolean.class);
+            IBaseResource resource;
+            if (Boolean.FALSE.equals(known)) {
+                resource = null;
+            } else {
+                resource = loader.get();
+                putInCache(existenceCacheName, url, resource != null);
+            }
+            resourceCache.put(resourceKey, resource == null ? MISSING : new CachedResource(resource));
+            return resource;
+        });
+    }
+
+    @SuppressWarnings("unchecked")
+    private <T> T computeOnce(String key, Supplier<T> loader) {
+        CompletableFuture<T> created = new CompletableFuture<>();
+        CompletableFuture<T> existing = (CompletableFuture<T>) inflight.putIfAbsent(key, created);
+        if (existing == null) {
+            try {
+                created.complete(loader.get());
+            } catch (Throwable t) {
+                created.completeExceptionally(t);
+            } finally {
+                inflight.remove(key, created);
+            }
+            return join(created);
+        }
+        return join(existing);
+    }
+
+    private static <T> T join(CompletableFuture<T> future) {
+        try {
+            return future.join();
+        } catch (CompletionException e) {
+            Throwable cause = e.getCause() != null ? e.getCause() : e;
+            if (cause instanceof RuntimeException runtimeException) {
+                throw runtimeException;
+            }
+            if (cause instanceof Error error) {
+                throw error;
+            }
+            throw e;
+        }
+    }
+
+    private <T> T getFromCache(String cacheName, String key, Class<T> type) {
+        if (cacheManager == null) {
+            return null;
+        }
+        org.springframework.cache.Cache named = cacheManager.getCache(cacheName);
+        if (named == null) {
+            return null;
+        }
+        try {
+            org.springframework.cache.Cache.ValueWrapper wrapper = named.get(key);
+            if (wrapper == null || wrapper.get() == null) {
+                return null;
+            }
+            Object value = wrapper.get();
+            return type.isInstance(value) ? type.cast(value) : null;
+        } catch (RuntimeException ex) {
+            if (cacheErrorHandler != null) {
+                cacheErrorHandler.handleCacheGetError(ex, named, key);
+            }
+            return null;
+        }
+    }
+
+    private void putInCache(String cacheName, String key, Object value) {
+        if (value == null || cacheManager == null) {
+            return;
+        }
+        org.springframework.cache.Cache named = cacheManager.getCache(cacheName);
+        if (named == null) {
+            return;
+        }
+        try {
+            named.put(key, value);
+        } catch (RuntimeException ex) {
+            if (cacheErrorHandler != null) {
+                cacheErrorHandler.handleCachePutError(ex, named, key, value);
+            }
+        }
+    }
+
+    private record CachedResource(IBaseResource resource) {
     }
 }

--- a/Java/validation/src/main/java/com/lantanagroup/link/validation/services/ArtifactService.java
+++ b/Java/validation/src/main/java/com/lantanagroup/link/validation/services/ArtifactService.java
@@ -15,6 +15,8 @@ import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.hl7.fhir.r4.model.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
 import org.springframework.stereotype.Service;
@@ -97,6 +99,18 @@ public class ArtifactService {
 
     private synchronized void invalidateValidationSupport() {
         validationSupport = null;
+    }
+
+    /**
+     * Load IG packages at startup so the first ReadyForValidation does not pay that cost
+     * while an 18k-entry bundle is already on the heap. Artifact updates still call
+     * {@link #invalidateValidationSupport()} and the next {@link #getValidationSupport()} rebuilds.
+     */
+    @EventListener(ApplicationReadyEvent.class)
+    public void warmValidationSupport() throws IOException {
+        logger.info("Warming artifact validation support");
+        getValidationSupport();
+        logger.info("Artifact validation support ready");
     }
 
     public synchronized ArtifactValidationSupport getValidationSupport() throws IOException {

--- a/Java/validation/src/main/java/com/lantanagroup/link/validation/services/ReadyForValidationConsumer.java
+++ b/Java/validation/src/main/java/com/lantanagroup/link/validation/services/ReadyForValidationConsumer.java
@@ -97,6 +97,7 @@ public class ReadyForValidationConsumer extends AbstractAsyncConsumer<ReadyForVa
         if (bundle == null) {
             bundle = getBundleViaRest(facilityId, patientId, reportId);
         }
+        _logger.info("Retrieved patient bundle with {} entries", bundle != null ? bundle.getEntry().size() : 0);
         List<Result> results = validate(correlationId, facilityId, patientId, reportId, bundle);
         appendPreQualOperationOutcome(bundle, results, payloadUri);
         produceValidationCompleteRecord(correlationId, facilityId, patientId, reportId, results);

--- a/Java/validation/src/main/java/com/lantanagroup/link/validation/services/ValidationService.java
+++ b/Java/validation/src/main/java/com/lantanagroup/link/validation/services/ValidationService.java
@@ -4,7 +4,6 @@ import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.context.support.DefaultProfileValidationSupport;
 import ca.uhn.fhir.validation.FhirValidator;
 import ca.uhn.fhir.validation.IValidatorModule;
-import ca.uhn.fhir.validation.SingleValidationMessage;
 import ca.uhn.fhir.validation.ValidationResult;
 import com.lantanagroup.link.validation.configs.LinkConfig;
 import com.lantanagroup.link.validation.entities.Result;
@@ -15,7 +14,8 @@ import org.hl7.fhir.common.hapi.validation.validator.FhirInstanceValidator;
 import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.hl7.fhir.r4.model.Bundle;
 import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.context.annotation.Lazy;
+import org.springframework.context.annotation.Scope;
+import org.springframework.context.annotation.ScopedProxyMode;
 import org.springframework.stereotype.Service;
 
 import org.slf4j.Logger;
@@ -26,19 +26,14 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.concurrent.Callable;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Future;
 
 @Service
-@Lazy(false)
+@Scope(value = "prototype", proxyMode = ScopedProxyMode.TARGET_CLASS)
 public class ValidationService {
     private static final Logger logger = LoggerFactory.getLogger(ValidationService.class);
     private final FhirValidator fhirValidator;
     private final ValidationResultIgnoreService validationResultIgnoreService;
-    private final LinkConfig linkConfig;
-    private final ExecutorService bundleValidationExecutor;
 
     public ValidationService(
             FhirContext fhirContext,
@@ -47,8 +42,6 @@ public class ValidationService {
             ValidationCacheService validationCacheService,
             ValidationResultIgnoreService validationResultIgnoreService,
             @Qualifier("bundleValidationExecutor") ExecutorService bundleValidationExecutor) throws IOException {
-        this.linkConfig = linkConfig;
-        this.bundleValidationExecutor = bundleValidationExecutor;
         this.validationResultIgnoreService = validationResultIgnoreService;
         ValidationSupportChain validationSupportChain = new ValidationSupportChain(
                 new DefaultProfileValidationSupport(fhirContext),
@@ -61,7 +54,8 @@ public class ValidationService {
         IValidatorModule validatorModule = new FhirInstanceValidator(cachingValidationSupport);
         fhirValidator = new FhirValidator(fhirContext);
         fhirValidator.registerValidatorModule(validatorModule);
-        logger.info("ValidationService initialized (packages and FhirValidator loaded)");
+        fhirValidator.setConcurrentBundleValidation(true);
+        fhirValidator.setExecutorService(bundleValidationExecutor);
     }
 
     // Package-private for unit testing of the terminology support chain composition.
@@ -94,97 +88,15 @@ public class ValidationService {
             if (resource instanceof Bundle bundle) {
                 logger.info("Starting validation of Bundle with {} entries", bundle.getEntry().size());
             }
-            List<Result> results = resource instanceof Bundle bundle
-                    ? validateBundle(bundle)
-                    : toResults(fhirValidator.validateWithResult(resource));
+            ValidationResult validationResult = fhirValidator.validateWithResult(resource);
+            List<Result> results = validationResult.getMessages().stream()
+                    .map(Result::fromMessage)
+                    .toList();
             return validationResultIgnoreService.filterIgnored(deduplicateInactiveResults(results));
         } catch (Exception ex) {
             logger.error("Validation failed", ex);
             throw ex;
         }
-    }
-
-    // Chunk the bundle and run up to bundleValidationParallelism chunks at once.
-    // Entries inside a chunk are sequential so HAPI never queues the whole NDJSON (HAPI-2246).
-    private List<Result> validateBundle(Bundle bundle) {
-        List<Bundle.BundleEntryComponent> entries = bundle.getEntry();
-        int entryCount = entries.size();
-        if (entryCount == 0) {
-            return toResults(fhirValidator.validateWithResult(bundle));
-        }
-
-        int batchSize = Math.max(1, linkConfig.getBundleValidationBatchSize());
-        if (entryCount <= batchSize) {
-            return validateSlice(entries, 0, entryCount);
-        }
-
-        int parallelism = Math.max(1, linkConfig.getBundleValidationParallelism());
-        int chunkCount = (entryCount + batchSize - 1) / batchSize;
-        logger.info("Validating Bundle with {} entries in {} chunks of {} on {} threads",
-                entryCount, chunkCount, batchSize, parallelism);
-
-        List<Callable<List<Result>>> tasks = new ArrayList<>(chunkCount);
-        for (int start = 0; start < entryCount; start += batchSize) {
-            int chunkStart = start;
-            int chunkEnd = Math.min(start + batchSize, entryCount);
-            tasks.add(() -> validateSlice(entries, chunkStart, chunkEnd));
-        }
-
-        List<Result> results = new ArrayList<>();
-        try {
-            for (Future<List<Result>> future : bundleValidationExecutor.invokeAll(tasks)) {
-                results.addAll(future.get());
-            }
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new RuntimeException("Bundle validation interrupted", e);
-        } catch (ExecutionException e) {
-            Throwable cause = e.getCause() != null ? e.getCause() : e;
-            if (cause instanceof RuntimeException runtimeException) {
-                throw runtimeException;
-            }
-            throw new RuntimeException("Bundle validation failed", cause);
-        }
-        return results;
-    }
-
-    private List<Result> validateSlice(List<Bundle.BundleEntryComponent> entries, int start, int end) {
-        List<Result> results = new ArrayList<>();
-        for (int i = start; i < end; i++) {
-            IBaseResource resource = entries.get(i).getResource();
-            if (resource == null) {
-                continue;
-            }
-            ValidationResult validationResult = fhirValidator.validateWithResult(resource);
-            String prefix = "Bundle.entry[" + i + "].resource.ofType(" + resource.fhirType() + ")";
-            for (SingleValidationMessage message : validationResult.getMessages()) {
-                Result result = Result.fromMessage(message);
-                result.setExpression(prefixEntryLocation(result.getExpression(), prefix));
-                results.add(result);
-            }
-        }
-        return results;
-    }
-
-    private static List<Result> toResults(ValidationResult validationResult) {
-        return validationResult.getMessages().stream()
-                .map(Result::fromMessage)
-                .toList();
-    }
-
-    // Same path rewrite HAPI uses in FhirValidator.buildValidationMessages.
-    static String prefixEntryLocation(String locationString, String bundleEntryPathPrefix) {
-        String location = locationString == null ? "" : locationString;
-        String currentPath;
-        int dotIndex = location.indexOf('.');
-        if (dotIndex >= 0) {
-            currentPath = location.substring(dotIndex);
-        } else if (bundleEntryPathPrefix.isBlank() || location.isBlank()) {
-            currentPath = location;
-        } else {
-            currentPath = "." + location;
-        }
-        return bundleEntryPathPrefix + currentPath;
     }
 
     // Text emitted by RemoteTermServiceValidation for an inactive code (see isInactiveIssue).

--- a/Java/validation/src/main/java/com/lantanagroup/link/validation/services/ValidationService.java
+++ b/Java/validation/src/main/java/com/lantanagroup/link/validation/services/ValidationService.java
@@ -4,8 +4,8 @@ import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.context.support.DefaultProfileValidationSupport;
 import ca.uhn.fhir.validation.FhirValidator;
 import ca.uhn.fhir.validation.IValidatorModule;
+import ca.uhn.fhir.validation.SingleValidationMessage;
 import ca.uhn.fhir.validation.ValidationResult;
-import com.lantanagroup.link.shared.Timer;
 import com.lantanagroup.link.validation.configs.LinkConfig;
 import com.lantanagroup.link.validation.entities.Result;
 import com.lantanagroup.link.validation.providers.RemoteTermServiceValidation;
@@ -13,6 +13,8 @@ import com.lantanagroup.link.validation.providers.ValidationCacheService;
 import org.hl7.fhir.common.hapi.validation.support.*;
 import org.hl7.fhir.common.hapi.validation.validator.FhirInstanceValidator;
 import org.hl7.fhir.instance.model.api.IBaseResource;
+import org.hl7.fhir.r4.model.Bundle;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Scope;
 import org.springframework.context.annotation.ScopedProxyMode;
 import org.springframework.stereotype.Service;
@@ -25,7 +27,10 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
 
 @Service
 @Scope(value = "prototype", proxyMode = ScopedProxyMode.TARGET_CLASS)
@@ -33,20 +38,23 @@ public class ValidationService {
     private static final Logger logger = LoggerFactory.getLogger(ValidationService.class);
     private final FhirValidator fhirValidator;
     private final ValidationResultIgnoreService validationResultIgnoreService;
-
+    private final LinkConfig linkConfig;
+    private final ExecutorService bundleValidationExecutor;
 
     public ValidationService(
             FhirContext fhirContext,
             ArtifactService artifactService,
             LinkConfig linkConfig,
             ValidationCacheService validationCacheService,
-            ValidationResultIgnoreService validationResultIgnoreService) throws IOException {
+            ValidationResultIgnoreService validationResultIgnoreService,
+            @Qualifier("bundleValidationExecutor") ExecutorService bundleValidationExecutor) throws IOException {
+        this.linkConfig = linkConfig;
+        this.bundleValidationExecutor = bundleValidationExecutor;
+        this.validationResultIgnoreService = validationResultIgnoreService;
         ValidationSupportChain validationSupportChain = new ValidationSupportChain(
                 new DefaultProfileValidationSupport(fhirContext),
                 artifactService.getValidationSupport(),
                 new SnapshotGeneratingValidationSupport(fhirContext));
-
-        this.validationResultIgnoreService = validationResultIgnoreService;
 
         loadTerminologyValidationSupport(fhirContext, linkConfig, validationSupportChain, validationCacheService);
 
@@ -54,8 +62,6 @@ public class ValidationService {
         IValidatorModule validatorModule = new FhirInstanceValidator(cachingValidationSupport);
         fhirValidator = new FhirValidator(fhirContext);
         fhirValidator.registerValidatorModule(validatorModule);
-        fhirValidator.setConcurrentBundleValidation(true);
-        fhirValidator.setExecutorService(ForkJoinPool.commonPool());
     }
 
     // Package-private for unit testing of the terminology support chain composition.
@@ -85,15 +91,97 @@ public class ValidationService {
 
     public List<Result> validate(IBaseResource resource) {
         try {
-            ValidationResult validationResult = fhirValidator.validateWithResult(resource);
-            List<Result> results = validationResult.getMessages().stream()
-                    .map(Result::fromMessage)
-                    .toList();
+            List<Result> results = resource instanceof Bundle bundle
+                    ? validateBundle(bundle)
+                    : toResults(fhirValidator.validateWithResult(resource));
             return validationResultIgnoreService.filterIgnored(deduplicateInactiveResults(results));
         } catch (Exception ex) {
             logger.error("Validation failed", ex);
             throw ex;
         }
+    }
+
+    // Chunk the bundle and run up to bundleValidationParallelism chunks at once.
+    // Entries inside a chunk are sequential so HAPI never queues the whole NDJSON (HAPI-2246).
+    private List<Result> validateBundle(Bundle bundle) {
+        List<Bundle.BundleEntryComponent> entries = bundle.getEntry();
+        int entryCount = entries.size();
+        if (entryCount == 0) {
+            return toResults(fhirValidator.validateWithResult(bundle));
+        }
+
+        int batchSize = Math.max(1, linkConfig.getBundleValidationBatchSize());
+        if (entryCount <= batchSize) {
+            return validateSlice(entries, 0, entryCount);
+        }
+
+        int parallelism = Math.max(1, linkConfig.getBundleValidationParallelism());
+        int chunkCount = (entryCount + batchSize - 1) / batchSize;
+        logger.info("Validating Bundle with {} entries in {} chunks of {} on {} threads",
+                entryCount, chunkCount, batchSize, parallelism);
+
+        List<Callable<List<Result>>> tasks = new ArrayList<>(chunkCount);
+        for (int start = 0; start < entryCount; start += batchSize) {
+            int chunkStart = start;
+            int chunkEnd = Math.min(start + batchSize, entryCount);
+            tasks.add(() -> validateSlice(entries, chunkStart, chunkEnd));
+        }
+
+        List<Result> results = new ArrayList<>();
+        try {
+            for (Future<List<Result>> future : bundleValidationExecutor.invokeAll(tasks)) {
+                results.addAll(future.get());
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException("Bundle validation interrupted", e);
+        } catch (ExecutionException e) {
+            Throwable cause = e.getCause() != null ? e.getCause() : e;
+            if (cause instanceof RuntimeException runtimeException) {
+                throw runtimeException;
+            }
+            throw new RuntimeException("Bundle validation failed", cause);
+        }
+        return results;
+    }
+
+    private List<Result> validateSlice(List<Bundle.BundleEntryComponent> entries, int start, int end) {
+        List<Result> results = new ArrayList<>();
+        for (int i = start; i < end; i++) {
+            IBaseResource resource = entries.get(i).getResource();
+            if (resource == null) {
+                continue;
+            }
+            ValidationResult validationResult = fhirValidator.validateWithResult(resource);
+            String prefix = "Bundle.entry[" + i + "].resource.ofType(" + resource.fhirType() + ")";
+            for (SingleValidationMessage message : validationResult.getMessages()) {
+                Result result = Result.fromMessage(message);
+                result.setExpression(prefixEntryLocation(result.getExpression(), prefix));
+                results.add(result);
+            }
+        }
+        return results;
+    }
+
+    private static List<Result> toResults(ValidationResult validationResult) {
+        return validationResult.getMessages().stream()
+                .map(Result::fromMessage)
+                .toList();
+    }
+
+    // Same path rewrite HAPI uses in FhirValidator.buildValidationMessages.
+    static String prefixEntryLocation(String locationString, String bundleEntryPathPrefix) {
+        String location = locationString == null ? "" : locationString;
+        String currentPath;
+        int dotIndex = location.indexOf('.');
+        if (dotIndex >= 0) {
+            currentPath = location.substring(dotIndex);
+        } else if (bundleEntryPathPrefix.isBlank() || location.isBlank()) {
+            currentPath = location;
+        } else {
+            currentPath = "." + location;
+        }
+        return bundleEntryPathPrefix + currentPath;
     }
 
     // Text emitted by RemoteTermServiceValidation for an inactive code (see isInactiveIssue).

--- a/Java/validation/src/main/java/com/lantanagroup/link/validation/services/ValidationService.java
+++ b/Java/validation/src/main/java/com/lantanagroup/link/validation/services/ValidationService.java
@@ -15,8 +15,7 @@ import org.hl7.fhir.common.hapi.validation.validator.FhirInstanceValidator;
 import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.hl7.fhir.r4.model.Bundle;
 import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.context.annotation.Scope;
-import org.springframework.context.annotation.ScopedProxyMode;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Service;
 
 import org.slf4j.Logger;
@@ -33,7 +32,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 
 @Service
-@Scope(value = "prototype", proxyMode = ScopedProxyMode.TARGET_CLASS)
+@Lazy(false)
 public class ValidationService {
     private static final Logger logger = LoggerFactory.getLogger(ValidationService.class);
     private final FhirValidator fhirValidator;
@@ -62,6 +61,7 @@ public class ValidationService {
         IValidatorModule validatorModule = new FhirInstanceValidator(cachingValidationSupport);
         fhirValidator = new FhirValidator(fhirContext);
         fhirValidator.registerValidatorModule(validatorModule);
+        logger.info("ValidationService initialized (packages and FhirValidator loaded)");
     }
 
     // Package-private for unit testing of the terminology support chain composition.
@@ -91,6 +91,9 @@ public class ValidationService {
 
     public List<Result> validate(IBaseResource resource) {
         try {
+            if (resource instanceof Bundle bundle) {
+                logger.info("Starting validation of Bundle with {} entries", bundle.getEntry().size());
+            }
             List<Result> results = resource instanceof Bundle bundle
                     ? validateBundle(bundle)
                     : toResults(fhirValidator.validateWithResult(resource));

--- a/Java/validation/src/main/resources/application.yml
+++ b/Java/validation/src/main/resources/application.yml
@@ -118,6 +118,8 @@ authentication:
 
 link:
   info-route: /api/validation/info
+  bundle-validation-parallelism: 4
+  bundle-validation-batch-size: 32
   terminology-service-url: ''
   validation-result-ignore-rules:
     - id: ignore_measureeval_measure_report_population_description_invalid_version

--- a/Java/validation/src/main/resources/application.yml
+++ b/Java/validation/src/main/resources/application.yml
@@ -119,7 +119,6 @@ authentication:
 link:
   info-route: /api/validation/info
   bundle-validation-parallelism: 4
-  bundle-validation-batch-size: 32
   terminology-service-url: ''
   validation-result-ignore-rules:
     - id: ignore_measureeval_measure_report_population_description_invalid_version

--- a/Java/validation/src/test/java/com/lantanagroup/link/validation/providers/RemoteTermServiceValidationTest.java
+++ b/Java/validation/src/test/java/com/lantanagroup/link/validation/providers/RemoteTermServiceValidationTest.java
@@ -452,6 +452,30 @@ class RemoteTermServiceValidationTest {
         verifyNoInteractions(cacheService);
     }
 
+    @Test
+    void fetchValueSet_matchesWhitelist_returnsNullWithoutTouchingCacheOrClient() {
+        ValidationCacheService cacheService = mock(ValidationCacheService.class);
+        RemoteTermServiceValidation subject = spy(new RemoteTermServiceValidation(
+                cacheService, fhirContext, "http://tx.example.org/fhir",
+                List.of(), List.of("^http://example\\.org/ValueSet/.*")));
+
+        assertNull(subject.fetchValueSet("http://example.org/ValueSet/vs"));
+        verifyNoInteractions(cacheService);
+        verify(subject, never()).provideClient();
+    }
+
+    @Test
+    void fetchCodeSystem_matchesWhitelist_returnsNullWithoutTouchingCacheOrClient() {
+        ValidationCacheService cacheService = mock(ValidationCacheService.class);
+        RemoteTermServiceValidation subject = spy(new RemoteTermServiceValidation(
+                cacheService, fhirContext, "http://tx.example.org/fhir",
+                List.of("^http://open\\.epic\\.com/.*"), List.of()));
+
+        assertNull(subject.fetchCodeSystem("http://open.epic.com/FHIR/foo"));
+        verifyNoInteractions(cacheService);
+        verify(subject, never()).provideClient();
+    }
+
     // ---------- log-sanitization tests ----------
 
     @Test

--- a/Java/validation/src/test/java/com/lantanagroup/link/validation/providers/ValidationCacheServiceCachingTest.java
+++ b/Java/validation/src/test/java/com/lantanagroup/link/validation/providers/ValidationCacheServiceCachingTest.java
@@ -5,7 +5,6 @@ import com.github.benmanes.caffeine.cache.Caffeine;
 import org.junit.jupiter.api.Test;
 import org.springframework.cache.Cache;
 import org.springframework.cache.CacheManager;
-import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.cache.caffeine.CaffeineCacheManager;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;
@@ -14,12 +13,22 @@ import org.springframework.data.redis.cache.RedisCacheConfiguration;
 import org.springframework.data.redis.cache.RedisCacheManager;
 import org.springframework.data.redis.cache.RedisCacheWriter;
 
+import org.hl7.fhir.r4.model.ValueSet;
+
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.Base64;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -27,6 +36,7 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.isNull;
@@ -130,6 +140,69 @@ class ValidationCacheServiceCachingTest {
     }
 
     @Test
+    void cachedValidateCode_coalescesConcurrentMissesIntoOneRemoteCall() throws Exception {
+        try (AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext(CaffeineCacheTestConfiguration.class)) {
+            ValidationCacheService cacheService = context.getBean(ValidationCacheService.class);
+            RemoteTermServiceValidation delegate = mock(RemoteTermServiceValidation.class);
+            AtomicInteger remoteCalls = new AtomicInteger();
+            when(delegate.invokeRemoteValidateCode(anyString(), anyString(), anyString(), anyString(), isNull()))
+                    .thenAnswer(invocation -> {
+                        remoteCalls.incrementAndGet();
+                        Thread.sleep(150);
+                        return negativeResult(invocation.getArgument(1));
+                    });
+
+            int workers = 8;
+            ExecutorService pool = Executors.newFixedThreadPool(workers);
+            CountDownLatch start = new CountDownLatch(1);
+            List<Future<IValidationSupport.CodeValidationResult>> futures = new ArrayList<>();
+            for (int i = 0; i < workers; i++) {
+                futures.add(pool.submit(() -> {
+                    start.await();
+                    return cacheService.cachedValidateCode(delegate, CODE_SYSTEM, "code", DISPLAY, VALUE_SET_URL);
+                }));
+            }
+            start.countDown();
+            for (Future<IValidationSupport.CodeValidationResult> future : futures) {
+                assertEquals("code", future.get(5, TimeUnit.SECONDS).getCode());
+            }
+            pool.shutdownNow();
+
+            assertEquals(1, remoteCalls.get(), "concurrent cache misses for one tuple must share a single terminology call");
+            verify(delegate, times(1)).invokeRemoteValidateCode(
+                    anyString(), anyString(), anyString(), anyString(), isNull());
+        }
+    }
+
+    @Test
+    void isValueSetSupportedAndFetchValueSet_shareOneRemoteGet() {
+        try (AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext(CaffeineCacheTestConfiguration.class)) {
+            ValidationCacheService cacheService = context.getBean(ValidationCacheService.class);
+            RemoteTermServiceValidation delegate = mock(RemoteTermServiceValidation.class);
+            ValueSet valueSet = new ValueSet();
+            valueSet.setUrl(VALUE_SET_URL);
+            when(delegate.invokeFetchValueSet(VALUE_SET_URL)).thenReturn(valueSet);
+
+            assertTrue(cacheService.cachedIsValueSetSupported(delegate, VALUE_SET_URL));
+            assertSame(valueSet, cacheService.cachedFetchValueSet(delegate, VALUE_SET_URL));
+            verify(delegate, times(1)).invokeFetchValueSet(VALUE_SET_URL);
+        }
+    }
+
+    @Test
+    void missingValueSet_isNegativelyCached() {
+        try (AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext(CaffeineCacheTestConfiguration.class)) {
+            ValidationCacheService cacheService = context.getBean(ValidationCacheService.class);
+            RemoteTermServiceValidation delegate = mock(RemoteTermServiceValidation.class);
+            when(delegate.invokeFetchValueSet(VALUE_SET_URL)).thenReturn(null);
+
+            assertNull(cacheService.cachedFetchValueSet(delegate, VALUE_SET_URL));
+            assertNull(cacheService.cachedFetchValueSet(delegate, VALUE_SET_URL));
+            verify(delegate, times(1)).invokeFetchValueSet(VALUE_SET_URL);
+        }
+    }
+
+    @Test
     void cachedValidateCode_resolvesItsKeyWithoutApplicationClassInThreadContext() throws InterruptedException {
         try (AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext(CaffeineCacheTestConfiguration.class)) {
             ValidationCacheService cacheService = context.getBean(ValidationCacheService.class);
@@ -177,18 +250,21 @@ class ValidationCacheServiceCachingTest {
     }
 
     @Configuration(proxyBeanMethods = false)
-    @EnableCaching
     static class CaffeineCacheTestConfiguration {
         @Bean
         CacheManager cacheManager() {
-            CaffeineCacheManager cacheManager = new CaffeineCacheManager("validateCodeCache");
+            CaffeineCacheManager cacheManager = new CaffeineCacheManager(
+                    "validateCodeCache",
+                    "lookupCodeCache",
+                    "isCodeSystemSupportedCache",
+                    "isValueSetSupportedCache");
             cacheManager.setCaffeine(Caffeine.newBuilder());
             return cacheManager;
         }
 
         @Bean
-        ValidationCacheService validationCacheService() {
-            return new ValidationCacheService();
+        ValidationCacheService validationCacheService(CacheManager cacheManager) {
+            return new ValidationCacheService(cacheManager, null, null);
         }
     }
 }

--- a/Java/validation/src/test/java/com/lantanagroup/link/validation/services/ValidationServiceTest.java
+++ b/Java/validation/src/test/java/com/lantanagroup/link/validation/services/ValidationServiceTest.java
@@ -101,15 +101,6 @@ class ValidationServiceTest {
     }
 
     @Test
-    void prefixEntryLocation_matchesHapiConcurrentBundlePathRewrite() {
-        String prefix = "Bundle.entry[35].resource.ofType(Patient)";
-        assertEquals(prefix + ".name[0]", ValidationService.prefixEntryLocation("Patient.name[0]", prefix));
-        assertEquals(prefix, ValidationService.prefixEntryLocation("", prefix));
-        assertEquals(prefix, ValidationService.prefixEntryLocation(null, prefix));
-        assertEquals(prefix + ".Patient", ValidationService.prefixEntryLocation("Patient", prefix));
-    }
-
-    @Test
     void deduplicateInactiveResults_collapsesDuplicateInactiveWarningsPerElement() {
         // HAPI validates a bound coding against both its code system and its value set, so the same inactive
         // code surfaces twice for one element -- differing only by a trailing "(for 'system#code')" suffix.

--- a/Java/validation/src/test/java/com/lantanagroup/link/validation/services/ValidationServiceTest.java
+++ b/Java/validation/src/test/java/com/lantanagroup/link/validation/services/ValidationServiceTest.java
@@ -101,6 +101,15 @@ class ValidationServiceTest {
     }
 
     @Test
+    void prefixEntryLocation_matchesHapiConcurrentBundlePathRewrite() {
+        String prefix = "Bundle.entry[35].resource.ofType(Patient)";
+        assertEquals(prefix + ".name[0]", ValidationService.prefixEntryLocation("Patient.name[0]", prefix));
+        assertEquals(prefix, ValidationService.prefixEntryLocation("", prefix));
+        assertEquals(prefix, ValidationService.prefixEntryLocation(null, prefix));
+        assertEquals(prefix + ".Patient", ValidationService.prefixEntryLocation("Patient", prefix));
+    }
+
+    @Test
     void deduplicateInactiveResults_collapsesDuplicateInactiveWarningsPerElement() {
         // HAPI validates a bound coding against both its code system and its value set, so the same inactive
         // code surfaces twice for one element -- differing only by a trailing "(for 'system#code')" suffix.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -964,7 +964,7 @@ services:
     container_name: link-validation
     environment:
       SPRING_PROFILES_ACTIVE: docker
-      JAVA_TOOL_OPTIONS: "-Xmx1024m"
+      JAVA_TOOL_OPTIONS: "-Xmx2048m"
       spring.datasource.password: ${LINK_DB_PASS}
       spring.kafka.properties.sasl.jaas.config: org.apache.kafka.common.security.plain.PlainLoginModule required username="${KAFKA_SASL_CLIENT_USER}" password="${KAFKA_SASL_CLIENT_PASSWORD}";
       internal-blob-storage.connection-string: ${AZURITE_CONNECTION_STRING}
@@ -991,7 +991,7 @@ services:
         condition: service_healthy
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8075/health"]
-      start_period: 15s
+      start_period: 45s
       interval: 5s
       retries: 10
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -964,7 +964,9 @@ services:
     container_name: link-validation
     environment:
       SPRING_PROFILES_ACTIVE: docker
-      JAVA_TOOL_OPTIONS: "-Xmx2048m"
+      # 75% of the container cgroup limit (mem_limit below, or the platform memory
+      # limit in deployed environments). Do not set -Xmx here; it would cap production.
+      JAVA_TOOL_OPTIONS: "-XX:MaxRAMPercentage=75.0"
       spring.datasource.password: ${LINK_DB_PASS}
       spring.kafka.properties.sasl.jaas.config: org.apache.kafka.common.security.plain.PlainLoginModule required username="${KAFKA_SASL_CLIENT_USER}" password="${KAFKA_SASL_CLIENT_PASSWORD}";
       internal-blob-storage.connection-string: ${AZURITE_CONNECTION_STRING}
@@ -975,6 +977,7 @@ services:
       pre-qualification.write-expressions-in-operation-outcome: ${VALIDATION_WRITE_OO_EXPRESSIONS:-true}
     ports:
       - "8075:8075"
+    mem_limit: 3g
     build:
       context: Java/
       dockerfile: validation/Dockerfile

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -964,6 +964,7 @@ services:
     container_name: link-validation
     environment:
       SPRING_PROFILES_ACTIVE: docker
+      JAVA_TOOL_OPTIONS: "-Xmx1024m"
       spring.datasource.password: ${LINK_DB_PASS}
       spring.kafka.properties.sasl.jaas.config: org.apache.kafka.common.security.plain.PlainLoginModule required username="${KAFKA_SASL_CLIENT_USER}" password="${KAFKA_SASL_CLIENT_PASSWORD}";
       internal-blob-storage.connection-string: ${AZURITE_CONNECTION_STRING}


### PR DESCRIPTION
### 🛠️ Description of Changes

LEGLINK-1084. Chunk ReadyForValidation bundle validation, cache Terminology lookups, construct ValidationService at startup, and size the Validation heap from container RAM.

Bundle validation uses `bundle-validation-parallelism=4` and `bundle-validation-batch-size=32` so a large patient bundle is not held as one in-memory validate. `ValidationCacheService` / `RemoteTermServiceValidation` cache ValueSet and code membership results across resources. `ValidationService` is an eager singleton so IG packages load at startup instead of on the first patient.

Heap is `-XX:MaxRAMPercentage=75.0` in the Validation Dockerfile and compose (no fixed `-Xmx`). Local compose sets `mem_limit: 3g` (~2.25g heap) and health `start_period: 45s` so package load can finish.

### 🧪 Testing Performed

- Unit tests: `ValidationCacheServiceCachingTest`, `RemoteTermServiceValidationTest`, `ValidationServiceTest`.
- Silo ACH Monthly adhoc `a84718ed` reproduced the OOM on unpatched Validation after ReadyForValidation. This branch has not been re-proven on that silo stack in this PR description.

### 🧑‍🔬 Unit Testing

- [x] I have written or updated unit tests to cover my changes
- Coverage: 59.9%

### 📓 Documentation Updated

None. Dockerfile / compose heap comments only.

