### PR TITLE
LEGLINK-1097: Read Hybrid ABS cache append blobs so patients stay reportable

### DIFF
--- a/DotNet/Normalization/Listeners/ResourcesAcquiredListener.cs
+++ b/DotNet/Normalization/Listeners/ResourcesAcquiredListener.cs
@@ -213,10 +213,12 @@ public class ResourcesAcquiredListener : BackgroundService
         ValidateResourcesAcquiredEvent(result, out string correlationId);
 
         IResourceCache resourceCache = _resourceCache.GetImplementation(result.Message.Value.CacheType);
+        var cacheKeys = result.Message.Value.CacheKeys ?? [];
+        var copiedKeys = new List<string>(cacheKeys.Count);
 
         using (var scope = _scopeFactory.CreateScope())
         {
-            foreach (var cacheKey in result.Message.Value.CacheKeys)
+            foreach (var cacheKey in cacheKeys)
             {
                 ResourceType resourceType = resourceCache.GetResourceTypeByCacheKey(cacheKey);
 
@@ -229,6 +231,16 @@ public class ResourcesAcquiredListener : BackgroundService
                 }, cancellationToken: cancellationToken);
 
                 List<DomainResource> resources = await resourceCache.GetAsync(cacheKey, cancellationToken);
+                if (resources.Count == 0)
+                {
+                    // Data Acquisition only lists a cache key when it acquired at least one
+                    // resource of that type. An empty read means the cache copy is not ready
+                    // (or used a blob type the reader could not see). Fail transiently so the
+                    // source keys are NOT deleted and MeasureEval does not evaluate an empty bundle.
+                    throw new TransientException(
+                        $"Resource cache key '{cacheKey.SanitizeForLog()}' was listed on ResourcesAcquired but contained no resources. " +
+                        $"CacheType={result.Message.Value.CacheType}, FacilityId={result.Message.Key.FacilityId.SanitizeForLog()}.");
+                }
 
                 if (sequences == null || sequences.Count == 0)
                 {
@@ -316,11 +328,12 @@ public class ResourcesAcquiredListener : BackgroundService
                 }
 
                 await resourceCache.UpdateCorrelationCacheAsync(correlationId, resources, resourceType, cancellationToken);
+                copiedKeys.Add(cacheKey);
             }
 
             await ProduceResourcesNormalizedMessage(result, result.Message.Key.FacilityId, correlationId, cancellationToken);
 
-            await resourceCache.DeleteAsync(result.Message.Value.CacheKeys, cancellationToken);
+            await resourceCache.DeleteAsync(copiedKeys, cancellationToken);
         }
     }
 

--- a/DotNet/ServiceTests/IntegrationTests/Normalization/ResourcesAcquiredListenerTests.cs
+++ b/DotNet/ServiceTests/IntegrationTests/Normalization/ResourcesAcquiredListenerTests.cs
@@ -1,4 +1,6 @@
 using Azure.Storage.Blobs;
+using Azure.Storage.Blobs.Specialized;
+using LantanaGroup.Link.Shared.Application.Error.Exceptions;
 using Confluent.Kafka;
 using LantanaGroup.Link.DataAcquisition.Domain.Application.Models.Api.Configuration;
 using LantanaGroup.Link.DataAcquisition.Domain.Infrastructure.Context;
@@ -139,6 +141,59 @@ namespace IntegrationTests.Normalization
                 Times.Once);
         }
 
+        [Fact]
+        public async Task ConsumeABSEvent_MissingSourceBlob_DoesNotProduceNormalized()
+        {
+            _fixture.ResourcesNormalizedProducerMock.Reset();
+
+            using var scope = _fixture.ScopeFactory.CreateScope();
+            var listener = scope.ServiceProvider.GetRequiredService<ResourcesAcquiredListener>();
+
+            string facilityId = "Facility1";
+            string patientId = "Patient1";
+            var correlationId = Guid.NewGuid().ToString();
+
+            await LoadFacilityLocationConfig(facilityId, scope);
+
+            var consumeResult = new ConsumeResult<ResourceKey, ResourcesAcquiredValue>
+            {
+                Message = new Message<ResourceKey, ResourcesAcquiredValue>
+                {
+                    Key = new ResourceKey { FacilityId = facilityId, PatientId = patientId },
+                    Value = new ResourcesAcquiredValue
+                    {
+                        QueryType = QueryType.Initial.ToString(),
+                        CacheType = ResourceCacheType.ABS,
+                        CacheKeys = new List<string> { correlationId + ":Location" },
+                        ReportableEvent = ReportableEvent.Discharge.ToString(),
+                        ScheduledReports = new List<ScheduledReport>
+                        {
+                            new()
+                            {
+                                ReportTrackingId = "Report1",
+                                StartDate = DateTime.Now,
+                                EndDate = DateTime.Now,
+                                Frequency = Frequency.Discharge,
+                                ReportTypes = new List<string> { "NHSNAcuteCareHospitalMonthlyInitialPopulation" }
+                            }
+                        }
+                    },
+                    Headers = new Headers { { "X-Correlation-Id", Encoding.UTF8.GetBytes(correlationId) } }
+                }
+            };
+
+            var ex = await Assert.ThrowsAsync<TransientException>(() =>
+                listener.ProcessMessageAsync(consumeResult, CancellationToken.None));
+
+            Assert.Contains(correlationId + ":Location", ex.Message);
+            _fixture.ResourcesNormalizedProducerMock.Verify(
+                p => p.ProduceAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<Message<ResourceKey, ResourcesNormalizedValue>>(),
+                    It.IsAny<CancellationToken>()),
+                Times.Never);
+        }
+
         private void UploadResourceCacheRedis(string correlationId) 
         {
             var options = ConfigurationOptions.Parse(_fixture.RedisConnectionString);
@@ -176,17 +231,15 @@ namespace IntegrationTests.Normalization
                 }
             };
 
-            var blobClient = _containerClient.GetBlobClient(correlationId + ":Location");
+            // Match production Data Acquisition: Hybrid ABS writes are append blobs, not block blobs.
+            var appendClient = _containerClient.GetAppendBlobClient(correlationId + ":Location");
+            appendClient.CreateIfNotExists();
 
-            StringBuilder sb = new StringBuilder();
-
-            sb.Append(location.TypeName + "/" + location.Id);
-            sb.Append(Environment.NewLine);
-            sb.Append(location.ToJson());
-            
-            using var stream = new MemoryStream(Encoding.UTF8.GetBytes(sb.ToString()));
-
-            blobClient.Upload(stream, overwrite: true);
+            using var stream = appendClient.OpenWrite(overwrite: false);
+            using var writer = new StreamWriter(stream);
+            writer.WriteLine(location.TypeName + "/" + location.Id);
+            writer.WriteLine(location.ToJson());
+            writer.Flush();
         }
 
         private async Task LoadFacilityLocationConfig(string facilityId, IServiceScope scope) 

--- a/DotNet/ServiceTests/UnitTests/Normalization/ResourcesAcquiredListenerEmptyCacheTests.cs
+++ b/DotNet/ServiceTests/UnitTests/Normalization/ResourcesAcquiredListenerEmptyCacheTests.cs
@@ -1,0 +1,210 @@
+using Confluent.Kafka;
+using Hl7.Fhir.Model;
+using LantanaGroup.Link.Normalization.Application.Models.Messages;
+using LantanaGroup.Link.Normalization.Application.Models.Operations.Business;
+using LantanaGroup.Link.Normalization.Application.Models.Operations.Business.Query;
+using LantanaGroup.Link.Normalization.Application.Services;
+using LantanaGroup.Link.Normalization.Application.Services.Operations;
+using LantanaGroup.Link.Normalization.Application.Settings;
+using LantanaGroup.Link.Normalization.Domain.Queries;
+using LantanaGroup.Link.Normalization.Listeners;
+using LantanaGroup.Link.Shared.Application.Enums;
+using LantanaGroup.Link.Shared.Application.Error.Exceptions;
+using LantanaGroup.Link.Shared.Application.Error.Interfaces;
+using LantanaGroup.Link.Shared.Application.Interfaces;
+using LantanaGroup.Link.Shared.Application.Models;
+using LantanaGroup.Link.Shared.Application.Models.Kafka;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Moq;
+using System.Text;
+using FhirResourceType = Hl7.Fhir.Model.ResourceType;
+using Task = System.Threading.Tasks.Task;
+
+namespace UnitTests.Normalization;
+
+/// <summary>
+/// Data Acquisition lists a cache key only after acquiring at least one resource of that type.
+/// An empty read must fail the copy without deleting source keys or emitting ResourcesNormalized.
+/// </summary>
+[Trait("Category", "UnitTests")]
+public class ResourcesAcquiredListenerEmptyCacheTests
+{
+    private const string FacilityId = "facility-1";
+    private const string PatientId = "patient-1";
+    private const string CorrelationId = "3fa85f64-5717-4562-b3fc-2c963f66afa6";
+    private static readonly string PatientCacheKey = $"{CorrelationId}:Patient";
+
+    [Fact]
+    public async Task ProcessMessageAsync_ListedCacheKeyEmpty_ThrowsTransientAndDoesNotDeleteOrProduce()
+    {
+        var resourceCache = new Mock<IResourceCache>();
+        resourceCache
+            .Setup(item => item.GetImplementation(ResourceCacheType.ABS))
+            .Returns(resourceCache.Object);
+        resourceCache
+            .Setup(item => item.GetResourceTypeByCacheKey(PatientCacheKey))
+            .Returns(FhirResourceType.Patient);
+        resourceCache
+            .Setup(item => item.GetAsync(PatientCacheKey, It.IsAny<CancellationToken>()))
+            .ReturnsAsync([]);
+
+        var producer = new Mock<IProducer<ResourceKey, ResourcesNormalizedValue>>();
+        var listener = BuildListener(resourceCache, producer);
+
+        var ex = await Assert.ThrowsAsync<TransientException>(() =>
+            listener.ProcessMessageAsync(BuildConsumeResult(), CancellationToken.None));
+
+        Assert.Contains(PatientCacheKey, ex.Message);
+        resourceCache.Verify(
+            item => item.DeleteAsync(It.IsAny<List<string>>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        resourceCache.Verify(
+            item => item.UpdateCorrelationCacheAsync(
+                It.IsAny<string>(),
+                It.IsAny<List<DomainResource>>(),
+                It.IsAny<FhirResourceType>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
+        producer.Verify(
+            item => item.ProduceAsync(
+                It.IsAny<string>(),
+                It.IsAny<Message<ResourceKey, ResourcesNormalizedValue>>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task ProcessMessageAsync_ListedCacheKeyPopulated_CopiesThenDeletesSourceKey()
+    {
+        var patient = new Patient { Id = "patient-1" };
+        var resourceCache = new Mock<IResourceCache>();
+        resourceCache
+            .Setup(item => item.GetImplementation(ResourceCacheType.ABS))
+            .Returns(resourceCache.Object);
+        resourceCache
+            .Setup(item => item.GetResourceTypeByCacheKey(PatientCacheKey))
+            .Returns(FhirResourceType.Patient);
+        resourceCache
+            .Setup(item => item.GetAsync(PatientCacheKey, It.IsAny<CancellationToken>()))
+            .ReturnsAsync([patient]);
+        resourceCache
+            .Setup(item => item.UpdateCorrelationCacheAsync(
+                CorrelationId,
+                It.IsAny<List<DomainResource>>(),
+                FhirResourceType.Patient,
+                It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        resourceCache
+            .Setup(item => item.DeleteAsync(It.IsAny<List<string>>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var producer = new Mock<IProducer<ResourceKey, ResourcesNormalizedValue>>();
+        producer
+            .Setup(item => item.ProduceAsync(
+                It.IsAny<string>(),
+                It.IsAny<Message<ResourceKey, ResourcesNormalizedValue>>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new DeliveryResult<ResourceKey, ResourcesNormalizedValue>());
+
+        var listener = BuildListener(resourceCache, producer);
+
+        await listener.ProcessMessageAsync(BuildConsumeResult(), CancellationToken.None);
+
+        resourceCache.Verify(
+            item => item.UpdateCorrelationCacheAsync(
+                CorrelationId,
+                It.Is<List<DomainResource>>(resources => resources.Count == 1),
+                FhirResourceType.Patient,
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+        resourceCache.Verify(
+            item => item.DeleteAsync(
+                It.Is<List<string>>(keys => keys.Count == 1 && keys[0] == PatientCacheKey),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+        producer.Verify(
+            item => item.ProduceAsync(
+                KafkaTopic.ResourcesNormalized.ToString(),
+                It.IsAny<Message<ResourceKey, ResourcesNormalizedValue>>(),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    private static ResourcesAcquiredListener BuildListener(
+        Mock<IResourceCache> resourceCache,
+        Mock<IProducer<ResourceKey, ResourcesNormalizedValue>> producer)
+    {
+        var sequenceQueries = new Mock<IOperationSequenceQueries>();
+        sequenceQueries
+            .Setup(item => item.Search(
+                It.IsAny<OperationSequenceSearchModel>(),
+                It.IsAny<bool>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<OperationSequenceModel>());
+
+        var services = new ServiceCollection();
+        services.AddSingleton(sequenceQueries.Object);
+        var serviceProvider = services.BuildServiceProvider();
+
+        var scope = new Mock<IServiceScope>();
+        scope.SetupGet(item => item.ServiceProvider).Returns(serviceProvider);
+
+        var scopeFactory = new Mock<IServiceScopeFactory>();
+        scopeFactory.Setup(item => item.CreateScope()).Returns(scope.Object);
+
+        var deadLetterHandler = new Mock<IDeadLetterExceptionHandler<ResourcesAcquiredListener, ResourceKey, ResourcesAcquiredValue>>();
+        deadLetterHandler.SetupProperty(item => item.Topic);
+        var transientHandler = new Mock<ITransientExceptionHandler<ResourcesAcquiredListener, ResourceKey, ResourcesAcquiredValue>>();
+        transientHandler.SetupProperty(item => item.Topic);
+        var consumeExceptionHandler = new Mock<IDeadLetterExceptionHandler<ResourcesAcquiredListener, ResourceKey, string>>();
+        consumeExceptionHandler.SetupProperty(item => item.Topic);
+
+        return new ResourcesAcquiredListener(
+            Mock.Of<ILogger<ResourcesAcquiredListener>>(),
+            new ServiceInformation { ServiceConfigName = "Normalization" },
+            scopeFactory.Object,
+            Mock.Of<IKafkaConsumerFactory<ResourceKey, ResourcesAcquiredValue>>(),
+            consumeExceptionHandler.Object,
+            deadLetterHandler.Object,
+            transientHandler.Object,
+            Mock.Of<INormalizationServiceMetrics>(),
+            producer.Object,
+            new CopyPropertyOperationService(Mock.Of<ILogger<CopyPropertyOperationService>>()),
+            new CodeMapOperationService(Mock.Of<ILogger<CodeMapOperationService>>()),
+            new ConditionalTransformOperationService(Mock.Of<ILogger<ConditionalTransformOperationService>>()),
+            new CopyLocationOperationService(Mock.Of<ILogger<CopyLocationOperationService>>()),
+            new CopyLocationAliasToTypeIterativelyOperationService(Mock.Of<ILogger<CopyLocationAliasToTypeIterativelyOperationService>>()),
+            new RemoveExtensionsOperationService(Mock.Of<ILogger<RemoveExtensionsOperationService>>()),
+            resourceCache.Object,
+            Mock.Of<IResourceCachePurger>());
+    }
+
+    private static ConsumeResult<ResourceKey, ResourcesAcquiredValue> BuildConsumeResult()
+    {
+        var headers = new Headers
+        {
+            new Header(NormalizationConstants.HeaderNames.CorrelationId, Encoding.UTF8.GetBytes(CorrelationId))
+        };
+
+        return new ConsumeResult<ResourceKey, ResourcesAcquiredValue>
+        {
+            Topic = "ResourcesAcquired",
+            Partition = new Partition(0),
+            Offset = new Offset(0),
+            Message = new Message<ResourceKey, ResourcesAcquiredValue>
+            {
+                Headers = headers,
+                Key = new ResourceKey { FacilityId = FacilityId, PatientId = PatientId },
+                Value = new ResourcesAcquiredValue
+                {
+                    QueryType = "Initial",
+                    ReportableEvent = "Adhoc",
+                    ScheduledReports = new List<ScheduledReport> { new() { ReportTrackingId = "tracking-1" } },
+                    CacheType = ResourceCacheType.ABS,
+                    CacheKeys = new List<string> { PatientCacheKey }
+                }
+            }
+        };
+    }
+}

--- a/DotNet/Shared/Application/Services/ResourceCache/ABSResourceCache.cs
+++ b/DotNet/Shared/Application/Services/ResourceCache/ABSResourceCache.cs
@@ -18,9 +18,9 @@ namespace LantanaGroup.Link.Shared.Application.Services.ResourceCache
     {
         private readonly BlobContainerClient _containerClient;
         private readonly ResourceCacheBlobStorageSettings _settings;
-        private readonly ILogger<RedisResourceCache> _logger;
+        private readonly ILogger<ABSResourceCache> _logger;
 
-        public ABSResourceCache(IOptions<ResourceCacheBlobStorageSettings> settings, ILogger<RedisResourceCache> logger)
+        public ABSResourceCache(IOptions<ResourceCacheBlobStorageSettings> settings, ILogger<ABSResourceCache> logger)
         {
             _settings = settings.Value;
             _logger = logger;
@@ -91,6 +91,8 @@ namespace LantanaGroup.Link.Shared.Application.Services.ResourceCache
                     await writer.WriteLineAsync(resourceToWrite.Key.AsMemory(), cancellationToken);
                     await writer.WriteLineAsync(resourceToWrite.Value.ToJson().AsMemory(), cancellationToken);
                 }
+
+                await writer.FlushAsync(cancellationToken);
             }
 
             await using (Stream idsWriteStream = await writeIdsBlobClient.OpenWriteAsync(false, cancellationToken: cancellationToken))
@@ -100,6 +102,8 @@ namespace LantanaGroup.Link.Shared.Application.Services.ResourceCache
                 {
                     await idsWriter.WriteLineAsync(id.AsMemory(), cancellationToken);
                 }
+
+                await idsWriter.FlushAsync(cancellationToken);
             }
         }
 
@@ -112,7 +116,10 @@ namespace LantanaGroup.Link.Shared.Application.Services.ResourceCache
 
             List<DomainResource> resources = new List<DomainResource>();
 
-            BlockBlobClient readBlobClient = _containerClient.GetBlockBlobClient(GetBlobKey(cacheKey));
+            // Writes use AppendBlobClient. Reads must use the generic BlobClient: BlockBlobClient
+            // ExistsAsync/OpenReadAsync against an append blob reports not-found, which
+            // Normalization then treated as an empty cache and deleted the real source blobs.
+            BlobClient readBlobClient = _containerClient.GetBlobClient(GetBlobKey(cacheKey));
 
             if (!(await readBlobClient.ExistsAsync(cancellationToken)).Value)
             {

--- a/Java/measureeval/src/main/java/com/lantanagroup/link/measureeval/services/AbstractResourceConsumer.java
+++ b/Java/measureeval/src/main/java/com/lantanagroup/link/measureeval/services/AbstractResourceConsumer.java
@@ -167,7 +167,10 @@ public abstract class AbstractResourceConsumer<T extends AbstractResourceRecord>
             }
 
             if (resources.isEmpty()) {
-                logger.info("Cache empty for correlationId={}; evaluating with empty bundle to produce a not-reportable report", correlationId);
+                logger.warn(
+                        "Cache empty for correlationId={}; evaluating with empty bundle to produce a not-reportable report. " +
+                        "If this patient had acquired resources, the resource-cache write/copy path failed.",
+                        LogUtils.sanitize(correlationId));
             }
 
             logger.trace("Beginning patient status update");


### PR DESCRIPTION
### 🛠️ Description of Changes

LEGLINK-1097. Hybrid ABS resource-cache reads used `BlockBlobClient`, so append blobs written by Data Acquisition were treated as missing. Normalization copied nothing, published `ResourcesNormalized`, and deleted the source keys. Measure Eval then evaluated an empty bundle and marked patients not-reportable.

This PR reads ABS cache blobs with the generic `BlobClient` so append blobs are visible. If a listed `ResourcesAcquired` cache key is empty, Normalization throws `TransientException` and does not delete source keys or produce `ResourcesNormalized`. Measure Eval warns when INITIAL evaluation sees an empty cache. The Azurite ABS fixture uses `AppendBlobClient` (same write path as DA). Unit tests cover empty-key failure and successful copy/delete.

### 🧪 Testing Performed

- Unit tests: `ResourcesAcquiredListenerEmptyCacheTests`, `ResourcesAcquiredListenerTests`.
- Azurite fixture pointed at append-blob writes to match DA.

### 🧑‍🔬 Unit Testing

- [x] I have written or updated unit tests to cover my changes
- Coverage: 50.0%

### 📓 Documentation Updated

None. Cache read path and empty-cache handling only.
